### PR TITLE
feat: add VS Code-style git diff view component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2964,6 +2964,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8020,8 +8030,11 @@ dependencies = [
  "base64-url",
  "clap",
  "directories",
+ "futures",
  "hex",
  "hostname",
+ "if-addrs",
+ "log",
  "portable-pty",
  "qrcode",
  "rand 0.8.5",
@@ -8034,6 +8047,9 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "zedra-fs",
+ "zedra-git",
+ "zedra-rpc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7985,6 +7985,8 @@ dependencies = [
  "ndk",
  "ndk-context",
  "once_cell",
+ "zedra-editor",
+ "zedra-nav",
  "zedra-ssh",
  "zedra-terminal",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7999,6 +7999,7 @@ dependencies = [
  "log",
  "tree-sitter",
  "tree-sitter-rust",
+ "zedra-gesture",
 ]
 
 [[package]]
@@ -8009,6 +8010,14 @@ dependencies = [
  "log",
  "serde",
  "tempfile",
+]
+
+[[package]]
+name = "zedra-gesture"
+version = "0.1.0"
+dependencies = [
+ "gpui",
+ "log",
 ]
 
 [[package]]

--- a/crates/zedra-editor/Cargo.toml
+++ b/crates/zedra-editor/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 gpui = { path = "../../vendor/zed/crates/gpui", features = ["android"] }
+zedra-gesture = { path = "../zedra-gesture" }
 tree-sitter = "0.26"
 tree-sitter-rust = "0.24"
 log.workspace = true

--- a/crates/zedra-editor/src/diff_view.rs
+++ b/crates/zedra-editor/src/diff_view.rs
@@ -342,22 +342,27 @@ impl DiffView {
     }
 
     /// Compute syntax highlights for a line
-    fn line_highlights(&self, content: &str) -> Vec<(Range<usize>, HighlightStyle)> {
+    fn line_highlights(&mut self, content: &str) -> Vec<(Range<usize>, HighlightStyle)> {
         if content.is_empty() {
             return Vec::new();
         }
 
+        let content_len = content.len();
+
         // Parse content for syntax highlighting
         self.highlighter.parse(content);
 
-        let raw_highlights = self.highlighter.highlights(content, 0..content.len());
+        // Get highlights with bounds checking in highlighter
+        let raw_highlights = self.highlighter.highlights(content, 0..content_len);
+
         let mut result: Vec<(Range<usize>, HighlightStyle)> = Vec::new();
 
         for (span_range, capture_name) in &raw_highlights {
-            if let Some(style) = self.theme.get(capture_name) {
-                let start = span_range.start.min(content.len());
-                let end = span_range.end.min(content.len());
-                if start < end {
+            // Clamp ranges to content bounds to prevent out-of-bounds access
+            let start = span_range.start.min(content_len);
+            let end = span_range.end.min(content_len);
+            if start < end {
+                if let Some(style) = self.theme.get(capture_name) {
                     result.push((start..end, style));
                 }
             }

--- a/crates/zedra-editor/src/diff_view.rs
+++ b/crates/zedra-editor/src/diff_view.rs
@@ -1,0 +1,708 @@
+use std::ops::Range;
+
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+
+use crate::highlighter::Highlighter;
+use crate::theme::SyntaxTheme;
+
+const LINE_HEIGHT: f32 = 20.0;
+const GUTTER_WIDTH: f32 = 40.0;
+const FONT_SIZE: f32 = 13.0;
+
+/// Type of change for a diff line
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiffLineKind {
+    /// Line exists in both versions (context)
+    Unchanged,
+    /// Line was added in new version
+    Added,
+    /// Line was removed from old version
+    Removed,
+    /// Header/separator line
+    Header,
+}
+
+/// A single line in the diff view
+#[derive(Clone, Debug)]
+pub struct DiffLine {
+    pub kind: DiffLineKind,
+    pub old_line_num: Option<usize>,
+    pub new_line_num: Option<usize>,
+    pub content: String,
+}
+
+/// A hunk of changes in a diff
+#[derive(Clone, Debug)]
+pub struct DiffHunk {
+    pub old_start: usize,
+    pub old_count: usize,
+    pub new_start: usize,
+    pub new_count: usize,
+    pub lines: Vec<DiffLine>,
+}
+
+/// A file diff with metadata
+#[derive(Clone, Debug)]
+pub struct FileDiff {
+    pub old_path: String,
+    pub new_path: String,
+    pub hunks: Vec<DiffHunk>,
+}
+
+/// VS Code-like git diff view with syntax highlighting
+pub struct DiffView {
+    diffs: Vec<FileDiff>,
+    current_file: usize,
+    highlighter: Highlighter,
+    theme: SyntaxTheme,
+    scroll_handle: UniformListScrollHandle,
+    focus_handle: FocusHandle,
+    /// Unified view mode (true) or side-by-side (false)
+    unified_view: bool,
+}
+
+impl DiffView {
+    pub fn new(cx: &mut App) -> Self {
+        Self {
+            diffs: Self::sample_diffs(),
+            current_file: 0,
+            highlighter: Highlighter::rust(),
+            theme: SyntaxTheme::default_dark(),
+            scroll_handle: UniformListScrollHandle::new(),
+            focus_handle: cx.focus_handle(),
+            unified_view: true,
+        }
+    }
+
+    /// Generate sample diff data for preview
+    fn sample_diffs() -> Vec<FileDiff> {
+        vec![
+            FileDiff {
+                old_path: "src/main.rs".to_string(),
+                new_path: "src/main.rs".to_string(),
+                hunks: vec![
+                    DiffHunk {
+                        old_start: 1,
+                        old_count: 8,
+                        new_start: 1,
+                        new_count: 12,
+                        lines: vec![
+                            DiffLine {
+                                kind: DiffLineKind::Unchanged,
+                                old_line_num: Some(1),
+                                new_line_num: Some(1),
+                                content: "use std::io;".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Added,
+                                old_line_num: None,
+                                new_line_num: Some(2),
+                                content: "use std::fs;".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Added,
+                                old_line_num: None,
+                                new_line_num: Some(3),
+                                content: "use std::path::Path;".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Unchanged,
+                                old_line_num: Some(2),
+                                new_line_num: Some(4),
+                                content: "".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Unchanged,
+                                old_line_num: Some(3),
+                                new_line_num: Some(5),
+                                content: "fn main() {".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Removed,
+                                old_line_num: Some(4),
+                                new_line_num: None,
+                                content: "    println!(\"Hello, world!\");".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Added,
+                                old_line_num: None,
+                                new_line_num: Some(6),
+                                content: "    let config = load_config();".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Added,
+                                old_line_num: None,
+                                new_line_num: Some(7),
+                                content: "    println!(\"Config loaded: {:?}\", config);".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Added,
+                                old_line_num: None,
+                                new_line_num: Some(8),
+                                content: "    run_app(config);".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Unchanged,
+                                old_line_num: Some(5),
+                                new_line_num: Some(9),
+                                content: "}".to_string(),
+                            },
+                        ],
+                    },
+                    DiffHunk {
+                        old_start: 10,
+                        old_count: 5,
+                        new_start: 14,
+                        new_count: 10,
+                        lines: vec![
+                            DiffLine {
+                                kind: DiffLineKind::Unchanged,
+                                old_line_num: Some(10),
+                                new_line_num: Some(14),
+                                content: "fn process_data(data: &str) -> Result<(), Error> {".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Removed,
+                                old_line_num: Some(11),
+                                new_line_num: None,
+                                content: "    // TODO: implement".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Removed,
+                                old_line_num: Some(12),
+                                new_line_num: None,
+                                content: "    Ok(())".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Added,
+                                old_line_num: None,
+                                new_line_num: Some(15),
+                                content: "    let parsed = parse_input(data)?;".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Added,
+                                old_line_num: None,
+                                new_line_num: Some(16),
+                                content: "    validate(&parsed)?;".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Added,
+                                old_line_num: None,
+                                new_line_num: Some(17),
+                                content: "    let result = transform(parsed);".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Added,
+                                old_line_num: None,
+                                new_line_num: Some(18),
+                                content: "    save_output(&result)?;".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Added,
+                                old_line_num: None,
+                                new_line_num: Some(19),
+                                content: "    Ok(())".to_string(),
+                            },
+                            DiffLine {
+                                kind: DiffLineKind::Unchanged,
+                                old_line_num: Some(13),
+                                new_line_num: Some(20),
+                                content: "}".to_string(),
+                            },
+                        ],
+                    },
+                ],
+            },
+            FileDiff {
+                old_path: "src/config.rs".to_string(),
+                new_path: "src/config.rs".to_string(),
+                hunks: vec![DiffHunk {
+                    old_start: 1,
+                    old_count: 6,
+                    new_start: 1,
+                    new_count: 9,
+                    lines: vec![
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(1),
+                            content: "use serde::{Deserialize, Serialize};".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(2),
+                            content: "".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(3),
+                            content: "#[derive(Debug, Serialize, Deserialize)]".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(1),
+                            new_line_num: Some(4),
+                            content: "pub struct Config {".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Removed,
+                            old_line_num: Some(2),
+                            new_line_num: None,
+                            content: "    pub name: String,".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(5),
+                            content: "    pub app_name: String,".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(6),
+                            content: "    pub version: String,".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(3),
+                            new_line_num: Some(7),
+                            content: "    pub debug: bool,".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(4),
+                            new_line_num: Some(8),
+                            content: "}".to_string(),
+                        },
+                    ],
+                }],
+            },
+        ]
+    }
+
+    fn current_diff(&self) -> Option<&FileDiff> {
+        self.diffs.get(self.current_file)
+    }
+
+    fn total_lines(&self) -> usize {
+        let Some(diff) = self.current_diff() else {
+            return 0;
+        };
+        // File header + hunk headers + all lines
+        let mut count = 1; // file header
+        for hunk in &diff.hunks {
+            count += 1; // hunk header
+            count += hunk.lines.len();
+        }
+        count
+    }
+
+    fn get_line(&self, index: usize) -> Option<DiffLine> {
+        let diff = self.current_diff()?;
+        let mut current = 0;
+
+        // File header
+        if index == current {
+            return Some(DiffLine {
+                kind: DiffLineKind::Header,
+                old_line_num: None,
+                new_line_num: None,
+                content: format!("{} -> {}", diff.old_path, diff.new_path),
+            });
+        }
+        current += 1;
+
+        for hunk in &diff.hunks {
+            // Hunk header
+            if index == current {
+                return Some(DiffLine {
+                    kind: DiffLineKind::Header,
+                    old_line_num: None,
+                    new_line_num: None,
+                    content: format!(
+                        "@@ -{},{} +{},{} @@",
+                        hunk.old_start, hunk.old_count, hunk.new_start, hunk.new_count
+                    ),
+                });
+            }
+            current += 1;
+
+            // Hunk lines
+            for line in &hunk.lines {
+                if index == current {
+                    return Some(line.clone());
+                }
+                current += 1;
+            }
+        }
+        None
+    }
+
+    /// Compute syntax highlights for a line
+    fn line_highlights(&self, content: &str) -> Vec<(Range<usize>, HighlightStyle)> {
+        if content.is_empty() {
+            return Vec::new();
+        }
+
+        // Parse content for syntax highlighting
+        self.highlighter.parse(content);
+
+        let raw_highlights = self.highlighter.highlights(content, 0..content.len());
+        let mut result: Vec<(Range<usize>, HighlightStyle)> = Vec::new();
+
+        for (span_range, capture_name) in &raw_highlights {
+            if let Some(style) = self.theme.get(capture_name) {
+                let start = span_range.start.min(content.len());
+                let end = span_range.end.min(content.len());
+                if start < end {
+                    result.push((start..end, style));
+                }
+            }
+        }
+
+        // Sort and deduplicate
+        result.sort_by(|a, b| a.0.start.cmp(&b.0.start).then(a.0.len().cmp(&b.0.len())));
+
+        let mut merged: Vec<(Range<usize>, HighlightStyle)> = Vec::new();
+        let mut cursor = 0usize;
+        for (range, style) in result {
+            if range.start >= cursor {
+                merged.push((range.clone(), style));
+                cursor = range.end;
+            } else if range.start < cursor && range.end > cursor {
+                merged.push((cursor..range.end, style));
+                cursor = range.end;
+            }
+        }
+        merged
+    }
+
+    fn toggle_view_mode(&mut self, cx: &mut Context<Self>) {
+        self.unified_view = !self.unified_view;
+        cx.notify();
+    }
+
+    fn next_file(&mut self, cx: &mut Context<Self>) {
+        if self.current_file + 1 < self.diffs.len() {
+            self.current_file += 1;
+            cx.notify();
+        }
+    }
+
+    fn prev_file(&mut self, cx: &mut Context<Self>) {
+        if self.current_file > 0 {
+            self.current_file -= 1;
+            cx.notify();
+        }
+    }
+
+    fn render_file_tabs(&self, cx: &Context<Self>) -> impl IntoElement {
+        let current = self.current_file;
+        div()
+            .flex()
+            .flex_row()
+            .gap_1()
+            .px_2()
+            .py_1()
+            .bg(rgb(0x21252b))
+            .border_b_1()
+            .border_color(rgb(0x181a1f))
+            .children(self.diffs.iter().enumerate().map(|(i, diff)| {
+                let is_active = i == current;
+                let filename = diff.new_path.rsplit('/').next().unwrap_or(&diff.new_path);
+                div()
+                    .px_3()
+                    .py_1()
+                    .rounded(px(4.0))
+                    .cursor_pointer()
+                    .text_sm()
+                    .when(is_active, |s| s.bg(rgb(0x2c313a)).text_color(rgb(0xabb2bf)))
+                    .when(!is_active, |s| {
+                        s.text_color(rgb(0x636d83)).hover(|s| s.bg(rgb(0x2c313a)))
+                    })
+                    .child(filename.to_string())
+            }))
+    }
+
+    fn render_toolbar(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let stats = self
+            .current_diff()
+            .map(|diff| {
+                let (added, removed) = diff.hunks.iter().fold((0, 0), |(a, r), hunk| {
+                    let adds = hunk
+                        .lines
+                        .iter()
+                        .filter(|l| l.kind == DiffLineKind::Added)
+                        .count();
+                    let removes = hunk
+                        .lines
+                        .iter()
+                        .filter(|l| l.kind == DiffLineKind::Removed)
+                        .count();
+                    (a + adds, r + removes)
+                });
+                (added, removed)
+            })
+            .unwrap_or((0, 0));
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .justify_between()
+            .px_3()
+            .py_2()
+            .bg(rgb(0x21252b))
+            .border_b_1()
+            .border_color(rgb(0x181a1f))
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .gap_3()
+                    .items_center()
+                    .child(
+                        div()
+                            .text_color(rgb(0x98c379))
+                            .text_sm()
+                            .child(format!("+{}", stats.0)),
+                    )
+                    .child(
+                        div()
+                            .text_color(rgb(0xe06c75))
+                            .text_sm()
+                            .child(format!("-{}", stats.1)),
+                    ),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .gap_2()
+                    // Previous file button
+                    .child(
+                        div()
+                            .px_2()
+                            .py_1()
+                            .rounded(px(4.0))
+                            .cursor_pointer()
+                            .text_color(rgb(0xabb2bf))
+                            .hover(|s| s.bg(rgb(0x2c313a)))
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, _, cx| this.prev_file(cx)),
+                            )
+                            .child("<-"),
+                    )
+                    // File counter
+                    .child(
+                        div()
+                            .text_color(rgb(0x636d83))
+                            .text_sm()
+                            .child(format!("{}/{}", self.current_file + 1, self.diffs.len())),
+                    )
+                    // Next file button
+                    .child(
+                        div()
+                            .px_2()
+                            .py_1()
+                            .rounded(px(4.0))
+                            .cursor_pointer()
+                            .text_color(rgb(0xabb2bf))
+                            .hover(|s| s.bg(rgb(0x2c313a)))
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, _, cx| this.next_file(cx)),
+                            )
+                            .child("->"),
+                    )
+                    // View toggle
+                    .child(
+                        div()
+                            .ml_2()
+                            .px_2()
+                            .py_1()
+                            .rounded(px(4.0))
+                            .cursor_pointer()
+                            .bg(rgb(0x2c313a))
+                            .text_color(rgb(0xabb2bf))
+                            .text_sm()
+                            .hover(|s| s.bg(rgb(0x3e4451)))
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, _, cx| this.toggle_view_mode(cx)),
+                            )
+                            .child(if self.unified_view {
+                                "Split"
+                            } else {
+                                "Unified"
+                            }),
+                    ),
+            )
+    }
+}
+
+impl Focusable for DiffView {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for DiffView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let line_count = self.total_lines();
+
+        // Pre-compute line data for the list
+        let line_data: Vec<Option<DiffLine>> =
+            (0..line_count).map(|i| self.get_line(i)).collect();
+
+        let text_style = {
+            let mut style = window.text_style();
+            style.color = rgb(0xabb2bf).into();
+            style.font_size = px(FONT_SIZE).into();
+            style
+        };
+
+        // Pre-compute highlights for non-header lines
+        let highlights: Vec<Vec<(Range<usize>, HighlightStyle)>> = line_data
+            .iter()
+            .map(|line| {
+                line.as_ref()
+                    .filter(|l| l.kind != DiffLineKind::Header)
+                    .map(|l| self.line_highlights(&l.content))
+                    .unwrap_or_default()
+            })
+            .collect();
+
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .bg(rgb(0x282c34))
+            .track_focus(&self.focus_handle)
+            .on_key_down(cx.listener(|this, event: &KeyDownEvent, _, cx| {
+                match event.keystroke.key.as_str() {
+                    "left" | "[" => this.prev_file(cx),
+                    "right" | "]" => this.next_file(cx),
+                    "space" | "v" => this.toggle_view_mode(cx),
+                    _ => {}
+                }
+            }))
+            // File tabs
+            .child(self.render_file_tabs(cx))
+            // Toolbar with stats and controls
+            .child(self.render_toolbar(cx))
+            // Diff content
+            .child(
+                uniform_list("diff-lines", line_count, {
+                    let text_style = text_style.clone();
+                    move |range: Range<usize>, _window: &mut Window, _cx: &mut App| {
+                        range
+                            .map(|i| {
+                                let Some(line) = &line_data[i] else {
+                                    return div().h(px(LINE_HEIGHT));
+                                };
+
+                                let (bg_color, gutter_text, prefix) = match line.kind {
+                                    DiffLineKind::Header => (rgb(0x21252b), "".to_string(), ""),
+                                    DiffLineKind::Added => {
+                                        let num = line
+                                            .new_line_num
+                                            .map(|n| format!("{:>3}", n))
+                                            .unwrap_or_default();
+                                        (rgb(0x2d3b2d), num, "+ ")
+                                    }
+                                    DiffLineKind::Removed => {
+                                        let num = line
+                                            .old_line_num
+                                            .map(|n| format!("{:>3}", n))
+                                            .unwrap_or_default();
+                                        (rgb(0x3b2d2d), num, "- ")
+                                    }
+                                    DiffLineKind::Unchanged => {
+                                        let num = line
+                                            .new_line_num
+                                            .map(|n| format!("{:>3}", n))
+                                            .unwrap_or_default();
+                                        (rgb(0x282c34), num, "  ")
+                                    }
+                                };
+
+                                let content = &line.content;
+                                let display_content = format!("{}{}", prefix, content);
+
+                                // For headers, use a special style
+                                if line.kind == DiffLineKind::Header {
+                                    return div()
+                                        .flex()
+                                        .flex_row()
+                                        .h(px(LINE_HEIGHT + 4.0))
+                                        .bg(bg_color)
+                                        .px_2()
+                                        .items_center()
+                                        .child(
+                                            div()
+                                                .text_color(rgb(0x61afef))
+                                                .text_size(px(FONT_SIZE))
+                                                .child(content.clone()),
+                                        );
+                                }
+
+                                // Apply syntax highlighting with offset for prefix
+                                let line_highlights = &highlights[i];
+                                let adjusted_highlights: Vec<(Range<usize>, HighlightStyle)> =
+                                    line_highlights
+                                        .iter()
+                                        .map(|(range, style)| {
+                                            let offset = prefix.len();
+                                            ((range.start + offset)..(range.end + offset), *style)
+                                        })
+                                        .collect();
+
+                                let styled_text = if display_content.is_empty() {
+                                    StyledText::new(" ")
+                                        .with_default_highlights(&text_style, Vec::new())
+                                } else {
+                                    StyledText::new(display_content.clone())
+                                        .with_default_highlights(&text_style, adjusted_highlights)
+                                };
+
+                                div()
+                                    .flex()
+                                    .flex_row()
+                                    .h(px(LINE_HEIGHT))
+                                    .bg(bg_color)
+                                    // Line number gutter
+                                    .child(
+                                        div()
+                                            .w(px(GUTTER_WIDTH))
+                                            .h(px(LINE_HEIGHT))
+                                            .flex()
+                                            .items_center()
+                                            .justify_end()
+                                            .pr_2()
+                                            .text_color(rgb(0x495162))
+                                            .text_size(px(FONT_SIZE))
+                                            .child(gutter_text),
+                                    )
+                                    // Content
+                                    .child(
+                                        div()
+                                            .flex_1()
+                                            .h(px(LINE_HEIGHT))
+                                            .flex()
+                                            .items_center()
+                                            .child(styled_text),
+                                    )
+                            })
+                            .collect()
+                    }
+                })
+                .track_scroll(&self.scroll_handle)
+                .flex_1(),
+            )
+    }
+}

--- a/crates/zedra-editor/src/git_stack.rs
+++ b/crates/zedra-editor/src/git_stack.rs
@@ -1,0 +1,1098 @@
+//! GitStack - A fullscreen git source control component
+//!
+//! This component provides a VS Code/Zed-like git interface with:
+//! - Left sidebar showing changed files organized by status
+//! - Git actions panel with stage/unstage/commit controls
+//! - Main content area showing the diff for the selected file
+//!
+//! Designed to be reusable for any git project.
+
+use std::ops::Range;
+
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+
+use crate::diff_view::{DiffHunk, DiffLine, DiffLineKind, FileDiff};
+use crate::highlighter::Highlighter;
+use crate::theme::SyntaxTheme;
+
+// Layout constants
+const SIDEBAR_WIDTH: f32 = 260.0;
+const LINE_HEIGHT: f32 = 20.0;
+const GUTTER_WIDTH: f32 = 40.0;
+const FONT_SIZE: f32 = 13.0;
+const ICON_SIZE: f32 = 14.0;
+
+/// Git file status
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GitFileStatus {
+    /// File is staged for commit
+    Staged,
+    /// File has unstaged changes
+    Modified,
+    /// File is untracked (new)
+    Untracked,
+    /// File was deleted
+    Deleted,
+    /// File was renamed
+    Renamed,
+    /// File has conflicts
+    Conflict,
+}
+
+impl GitFileStatus {
+    fn icon(&self) -> &'static str {
+        match self {
+            GitFileStatus::Staged => "+",
+            GitFileStatus::Modified => "M",
+            GitFileStatus::Untracked => "U",
+            GitFileStatus::Deleted => "D",
+            GitFileStatus::Renamed => "R",
+            GitFileStatus::Conflict => "!",
+        }
+    }
+
+    fn color(&self) -> Hsla {
+        match self {
+            GitFileStatus::Staged => rgb(0x98c379).into(),    // green
+            GitFileStatus::Modified => rgb(0xe5c07b).into(),  // yellow
+            GitFileStatus::Untracked => rgb(0x98c379).into(), // green
+            GitFileStatus::Deleted => rgb(0xe06c75).into(),   // red
+            GitFileStatus::Renamed => rgb(0x61afef).into(),   // blue
+            GitFileStatus::Conflict => rgb(0xe06c75).into(),  // red
+        }
+    }
+}
+
+/// A file entry in the git file list
+#[derive(Clone, Debug)]
+pub struct GitFileEntry {
+    pub path: String,
+    pub filename: String,
+    pub status: GitFileStatus,
+    pub insertions: usize,
+    pub deletions: usize,
+}
+
+impl GitFileEntry {
+    pub fn new(path: &str, status: GitFileStatus, insertions: usize, deletions: usize) -> Self {
+        let filename = path.rsplit('/').next().unwrap_or(path).to_string();
+        Self {
+            path: path.to_string(),
+            filename,
+            status,
+            insertions,
+            deletions,
+        }
+    }
+}
+
+/// Git repository state for preview/demo
+#[derive(Clone, Debug)]
+pub struct GitRepoState {
+    pub branch: String,
+    pub staged_files: Vec<GitFileEntry>,
+    pub unstaged_files: Vec<GitFileEntry>,
+    pub untracked_files: Vec<GitFileEntry>,
+    pub commit_message: String,
+}
+
+impl GitRepoState {
+    /// Create sample repository state for preview
+    pub fn sample() -> Self {
+        Self {
+            branch: "feat/diff-view".to_string(),
+            staged_files: vec![
+                GitFileEntry::new("src/lib.rs", GitFileStatus::Staged, 15, 3),
+                GitFileEntry::new("src/config.rs", GitFileStatus::Staged, 42, 8),
+            ],
+            unstaged_files: vec![
+                GitFileEntry::new("src/main.rs", GitFileStatus::Modified, 28, 12),
+                GitFileEntry::new("src/utils/helpers.rs", GitFileStatus::Modified, 5, 2),
+                GitFileEntry::new("README.md", GitFileStatus::Modified, 10, 0),
+            ],
+            untracked_files: vec![
+                GitFileEntry::new("src/new_feature.rs", GitFileStatus::Untracked, 85, 0),
+                GitFileEntry::new("tests/integration_test.rs", GitFileStatus::Untracked, 120, 0),
+            ],
+            commit_message: String::new(),
+        }
+    }
+
+    pub fn total_staged(&self) -> usize {
+        self.staged_files.len()
+    }
+
+    pub fn total_unstaged(&self) -> usize {
+        self.unstaged_files.len()
+    }
+
+    pub fn total_untracked(&self) -> usize {
+        self.untracked_files.len()
+    }
+
+    pub fn all_files(&self) -> Vec<&GitFileEntry> {
+        self.staged_files
+            .iter()
+            .chain(self.unstaged_files.iter())
+            .chain(self.untracked_files.iter())
+            .collect()
+    }
+}
+
+/// Event emitted when a git action is triggered
+#[derive(Clone, Debug)]
+pub enum GitAction {
+    StageFile(String),
+    UnstageFile(String),
+    StageAll,
+    UnstageAll,
+    DiscardFile(String),
+    DiscardAll,
+    Commit(String),
+    Refresh,
+    Push,
+    Pull,
+}
+
+/// Main GitStack component
+pub struct GitStack {
+    repo_state: GitRepoState,
+    selected_file: Option<String>,
+    sidebar_visible: bool,
+    sidebar_section_expanded: [bool; 3], // [staged, unstaged, untracked]
+    commit_message: String,
+    diffs: Vec<FileDiff>,
+    highlighter: Highlighter,
+    theme: SyntaxTheme,
+    scroll_handle: UniformListScrollHandle,
+    focus_handle: FocusHandle,
+}
+
+impl GitStack {
+    pub fn new(cx: &mut App) -> Self {
+        let repo_state = GitRepoState::sample();
+        let diffs = Self::sample_diffs();
+        let selected_file = diffs.first().map(|d| d.new_path.clone());
+
+        Self {
+            repo_state,
+            selected_file,
+            sidebar_visible: true,
+            sidebar_section_expanded: [true, true, true],
+            commit_message: String::new(),
+            diffs,
+            highlighter: Highlighter::rust(),
+            theme: SyntaxTheme::default_dark(),
+            scroll_handle: UniformListScrollHandle::new(),
+            focus_handle: cx.focus_handle(),
+        }
+    }
+
+    /// Load from external git state (for real git integration later)
+    pub fn with_repo_state(mut self, state: GitRepoState) -> Self {
+        self.repo_state = state;
+        self
+    }
+
+    /// Generate sample diffs matching the repo state
+    fn sample_diffs() -> Vec<FileDiff> {
+        vec![
+            FileDiff {
+                old_path: "src/main.rs".to_string(),
+                new_path: "src/main.rs".to_string(),
+                hunks: vec![DiffHunk {
+                    old_start: 1,
+                    old_count: 10,
+                    new_start: 1,
+                    new_count: 15,
+                    lines: vec![
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(1),
+                            new_line_num: Some(1),
+                            content: "use std::io;".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(2),
+                            content: "use std::fs;".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(3),
+                            content: "use std::path::PathBuf;".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(2),
+                            new_line_num: Some(4),
+                            content: "".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(3),
+                            new_line_num: Some(5),
+                            content: "fn main() {".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Removed,
+                            old_line_num: Some(4),
+                            new_line_num: None,
+                            content: "    println!(\"Hello\");".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(6),
+                            content: "    let config = Config::load()?;".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(7),
+                            content: "    println!(\"Loaded: {:?}\", config);".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(5),
+                            new_line_num: Some(8),
+                            content: "}".to_string(),
+                        },
+                    ],
+                }],
+            },
+            FileDiff {
+                old_path: "src/lib.rs".to_string(),
+                new_path: "src/lib.rs".to_string(),
+                hunks: vec![DiffHunk {
+                    old_start: 1,
+                    old_count: 5,
+                    new_start: 1,
+                    new_count: 8,
+                    lines: vec![
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(1),
+                            content: "//! Library documentation".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(2),
+                            content: "".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(1),
+                            new_line_num: Some(3),
+                            content: "mod config;".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(4),
+                            content: "mod utils;".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(2),
+                            new_line_num: Some(5),
+                            content: "".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(3),
+                            new_line_num: Some(6),
+                            content: "pub use config::Config;".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(7),
+                            content: "pub use utils::*;".to_string(),
+                        },
+                    ],
+                }],
+            },
+            FileDiff {
+                old_path: "src/config.rs".to_string(),
+                new_path: "src/config.rs".to_string(),
+                hunks: vec![DiffHunk {
+                    old_start: 10,
+                    old_count: 6,
+                    new_start: 10,
+                    new_count: 12,
+                    lines: vec![
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(10),
+                            new_line_num: Some(10),
+                            content: "impl Config {".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Removed,
+                            old_line_num: Some(11),
+                            new_line_num: None,
+                            content: "    pub fn new() -> Self {".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Removed,
+                            old_line_num: Some(12),
+                            new_line_num: None,
+                            content: "        Self::default()".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(11),
+                            content: "    pub fn load() -> Result<Self, Error> {".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(12),
+                            content: "        let path = Self::config_path()?;".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(13),
+                            content: "        let content = fs::read_to_string(&path)?;".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(14),
+                            content: "        let config: Config = toml::from_str(&content)?;".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Added,
+                            old_line_num: None,
+                            new_line_num: Some(15),
+                            content: "        Ok(config)".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(13),
+                            new_line_num: Some(16),
+                            content: "    }".to_string(),
+                        },
+                        DiffLine {
+                            kind: DiffLineKind::Unchanged,
+                            old_line_num: Some(14),
+                            new_line_num: Some(17),
+                            content: "}".to_string(),
+                        },
+                    ],
+                }],
+            },
+        ]
+    }
+
+    fn toggle_sidebar(&mut self, cx: &mut Context<Self>) {
+        self.sidebar_visible = !self.sidebar_visible;
+        cx.notify();
+    }
+
+    fn toggle_section(&mut self, section: usize, cx: &mut Context<Self>) {
+        if section < 3 {
+            self.sidebar_section_expanded[section] = !self.sidebar_section_expanded[section];
+            cx.notify();
+        }
+    }
+
+    fn select_file(&mut self, path: String, cx: &mut Context<Self>) {
+        self.selected_file = Some(path);
+        cx.notify();
+    }
+
+    fn get_selected_diff(&self) -> Option<&FileDiff> {
+        let selected = self.selected_file.as_ref()?;
+        self.diffs.iter().find(|d| &d.new_path == selected)
+    }
+
+    fn total_lines_for_diff(diff: &FileDiff) -> usize {
+        let mut count = 1; // file header
+        for hunk in &diff.hunks {
+            count += 1; // hunk header
+            count += hunk.lines.len();
+        }
+        count
+    }
+
+    fn get_diff_line(&self, diff: &FileDiff, index: usize) -> Option<DiffLine> {
+        let mut current = 0;
+
+        // File header
+        if index == current {
+            return Some(DiffLine {
+                kind: DiffLineKind::Header,
+                old_line_num: None,
+                new_line_num: None,
+                content: format!("{} -> {}", diff.old_path, diff.new_path),
+            });
+        }
+        current += 1;
+
+        for hunk in &diff.hunks {
+            if index == current {
+                return Some(DiffLine {
+                    kind: DiffLineKind::Header,
+                    old_line_num: None,
+                    new_line_num: None,
+                    content: format!(
+                        "@@ -{},{} +{},{} @@",
+                        hunk.old_start, hunk.old_count, hunk.new_start, hunk.new_count
+                    ),
+                });
+            }
+            current += 1;
+
+            for line in &hunk.lines {
+                if index == current {
+                    return Some(line.clone());
+                }
+                current += 1;
+            }
+        }
+        None
+    }
+
+    fn line_highlights(&self, content: &str) -> Vec<(Range<usize>, HighlightStyle)> {
+        if content.is_empty() {
+            return Vec::new();
+        }
+
+        self.highlighter.parse(content);
+        let raw_highlights = self.highlighter.highlights(content, 0..content.len());
+        let mut result: Vec<(Range<usize>, HighlightStyle)> = Vec::new();
+
+        for (span_range, capture_name) in &raw_highlights {
+            if let Some(style) = self.theme.get(capture_name) {
+                let start = span_range.start.min(content.len());
+                let end = span_range.end.min(content.len());
+                if start < end {
+                    result.push((start..end, style));
+                }
+            }
+        }
+
+        result.sort_by(|a, b| a.0.start.cmp(&b.0.start).then(a.0.len().cmp(&b.0.len())));
+
+        let mut merged: Vec<(Range<usize>, HighlightStyle)> = Vec::new();
+        let mut cursor = 0usize;
+        for (range, style) in result {
+            if range.start >= cursor {
+                merged.push((range.clone(), style));
+                cursor = range.end;
+            } else if range.start < cursor && range.end > cursor {
+                merged.push((cursor..range.end, style));
+                cursor = range.end;
+            }
+        }
+        merged
+    }
+
+    // =========================================================================
+    // Render methods
+    // =========================================================================
+
+    fn render_header(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let branch = self.repo_state.branch.clone();
+        let staged_count = self.repo_state.total_staged();
+        let unstaged_count = self.repo_state.total_unstaged();
+        let untracked_count = self.repo_state.total_untracked();
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .justify_between()
+            .h(px(44.0))
+            .px_3()
+            .bg(rgb(0x21252b))
+            .border_b_1()
+            .border_color(rgb(0x181a1f))
+            // Left side: toggle + branch
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap_3()
+                    // Sidebar toggle
+                    .child(
+                        div()
+                            .w(px(28.0))
+                            .h(px(28.0))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .rounded(px(4.0))
+                            .cursor_pointer()
+                            .text_color(rgb(0xabb2bf))
+                            .hover(|s| s.bg(rgb(0x2c313a)))
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, _, cx| this.toggle_sidebar(cx)),
+                            )
+                            .child(if self.sidebar_visible { "<" } else { ">" }),
+                    )
+                    // Branch name
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .text_color(rgb(0x61afef))
+                                    .text_sm()
+                                    .child("*"),
+                            )
+                            .child(
+                                div()
+                                    .text_color(rgb(0xabb2bf))
+                                    .text_sm()
+                                    .child(branch),
+                            ),
+                    ),
+            )
+            // Right side: stats
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap_4()
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap_1()
+                            .text_sm()
+                            .child(div().text_color(rgb(0x98c379)).child(format!("+{}", staged_count)))
+                            .child(div().text_color(rgb(0x636d83)).child("staged")),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap_1()
+                            .text_sm()
+                            .child(div().text_color(rgb(0xe5c07b)).child(format!("~{}", unstaged_count)))
+                            .child(div().text_color(rgb(0x636d83)).child("modified")),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap_1()
+                            .text_sm()
+                            .child(div().text_color(rgb(0x56b6c2)).child(format!("?{}", untracked_count)))
+                            .child(div().text_color(rgb(0x636d83)).child("untracked")),
+                    ),
+            )
+    }
+
+    fn render_file_entry(
+        &self,
+        file: &GitFileEntry,
+        is_selected: bool,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let path = file.path.clone();
+        let filename = file.filename.clone();
+        let status = file.status;
+        let insertions = file.insertions;
+        let deletions = file.deletions;
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .justify_between()
+            .h(px(26.0))
+            .px_2()
+            .cursor_pointer()
+            .rounded(px(3.0))
+            .when(is_selected, |s| s.bg(rgb(0x2c313a)))
+            .hover(|s| s.bg(rgb(0x2c313a)))
+            .on_mouse_down(MouseButton::Left, {
+                let path = path.clone();
+                cx.listener(move |this, _, _, cx| {
+                    this.select_file(path.clone(), cx);
+                })
+            })
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap_2()
+                    .overflow_hidden()
+                    // Status icon
+                    .child(
+                        div()
+                            .w(px(ICON_SIZE))
+                            .text_color(status.color())
+                            .text_size(px(11.0))
+                            .child(status.icon()),
+                    )
+                    // Filename
+                    .child(
+                        div()
+                            .text_color(rgb(0xabb2bf))
+                            .text_size(px(12.0))
+                            .overflow_hidden()
+                            .child(filename),
+                    ),
+            )
+            // Stats
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap_1()
+                    .text_size(px(10.0))
+                    .when(insertions > 0, |s| {
+                        s.child(div().text_color(rgb(0x98c379)).child(format!("+{}", insertions)))
+                    })
+                    .when(deletions > 0, |s| {
+                        s.child(div().text_color(rgb(0xe06c75)).child(format!("-{}", deletions)))
+                    }),
+            )
+    }
+
+    fn render_section_header(
+        &self,
+        title: &str,
+        count: usize,
+        section_idx: usize,
+        action_label: Option<&str>,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let is_expanded = self.sidebar_section_expanded[section_idx];
+        let title = title.to_string();
+        let action_label = action_label.map(|s| s.to_string());
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .justify_between()
+            .h(px(28.0))
+            .px_2()
+            .cursor_pointer()
+            .hover(|s| s.bg(rgb(0x2c313a)))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, _, cx| {
+                    this.toggle_section(section_idx, cx);
+                }),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap_2()
+                    // Expand/collapse icon
+                    .child(
+                        div()
+                            .text_color(rgb(0x636d83))
+                            .text_size(px(10.0))
+                            .child(if is_expanded { "v" } else { ">" }),
+                    )
+                    // Title
+                    .child(
+                        div()
+                            .text_color(rgb(0xabb2bf))
+                            .text_size(px(11.0))
+                            .font_weight(FontWeight::MEDIUM)
+                            .child(title),
+                    )
+                    // Count badge
+                    .child(
+                        div()
+                            .px_1()
+                            .rounded(px(8.0))
+                            .bg(rgb(0x3e4451))
+                            .text_color(rgb(0xabb2bf))
+                            .text_size(px(10.0))
+                            .child(count.to_string()),
+                    ),
+            )
+            // Action button
+            .when_some(action_label, |el, label| {
+                el.child(
+                    div()
+                        .px_2()
+                        .py_px()
+                        .rounded(px(3.0))
+                        .text_color(rgb(0x636d83))
+                        .text_size(px(10.0))
+                        .hover(|s| s.bg(rgb(0x3e4451)).text_color(rgb(0xabb2bf)))
+                        .child(label),
+                )
+            })
+    }
+
+    fn render_sidebar(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let selected = self.selected_file.clone();
+
+        div()
+            .flex()
+            .flex_col()
+            .w(px(SIDEBAR_WIDTH))
+            .h_full()
+            .bg(rgb(0x21252b))
+            .border_r_1()
+            .border_color(rgb(0x181a1f))
+            // Commit section
+            .child(self.render_commit_section(cx))
+            // File sections
+            .child(
+                div()
+                    .flex_1()
+                    .overflow_y_scroll()
+                    // Staged section
+                    .child(self.render_section_header(
+                        "STAGED CHANGES",
+                        self.repo_state.total_staged(),
+                        0,
+                        Some("-"),
+                        cx,
+                    ))
+                    .when(self.sidebar_section_expanded[0], |el| {
+                        el.children(self.repo_state.staged_files.iter().map(|f| {
+                            let is_selected = selected.as_ref() == Some(&f.path);
+                            self.render_file_entry(f, is_selected, cx)
+                        }))
+                    })
+                    // Unstaged section
+                    .child(self.render_section_header(
+                        "CHANGES",
+                        self.repo_state.total_unstaged(),
+                        1,
+                        Some("+"),
+                        cx,
+                    ))
+                    .when(self.sidebar_section_expanded[1], |el| {
+                        el.children(self.repo_state.unstaged_files.iter().map(|f| {
+                            let is_selected = selected.as_ref() == Some(&f.path);
+                            self.render_file_entry(f, is_selected, cx)
+                        }))
+                    })
+                    // Untracked section
+                    .child(self.render_section_header(
+                        "UNTRACKED",
+                        self.repo_state.total_untracked(),
+                        2,
+                        Some("+"),
+                        cx,
+                    ))
+                    .when(self.sidebar_section_expanded[2], |el| {
+                        el.children(self.repo_state.untracked_files.iter().map(|f| {
+                            let is_selected = selected.as_ref() == Some(&f.path);
+                            self.render_file_entry(f, is_selected, cx)
+                        }))
+                    }),
+            )
+    }
+
+    fn render_commit_section(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_col()
+            .p_2()
+            .gap_2()
+            .border_b_1()
+            .border_color(rgb(0x181a1f))
+            // Commit message input placeholder
+            .child(
+                div()
+                    .h(px(60.0))
+                    .px_2()
+                    .py_1()
+                    .bg(rgb(0x1e1e1e))
+                    .rounded(px(4.0))
+                    .border_1()
+                    .border_color(rgb(0x3e4451))
+                    .text_color(rgb(0x5c6370))
+                    .text_size(px(12.0))
+                    .child("Commit message..."),
+            )
+            // Action buttons
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .gap_2()
+                    // Commit button
+                    .child(
+                        div()
+                            .flex_1()
+                            .h(px(28.0))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .bg(rgb(0x3e4451))
+                            .rounded(px(4.0))
+                            .text_color(rgb(0xabb2bf))
+                            .text_size(px(12.0))
+                            .cursor_pointer()
+                            .hover(|s| s.bg(rgb(0x4e5561)))
+                            .child("Commit"),
+                    )
+                    // Push button
+                    .child(
+                        div()
+                            .w(px(60.0))
+                            .h(px(28.0))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .bg(rgb(0x61afef))
+                            .rounded(px(4.0))
+                            .text_color(rgb(0x21252b))
+                            .text_size(px(12.0))
+                            .cursor_pointer()
+                            .hover(|s| s.bg(rgb(0x71bfff)))
+                            .child("Push"),
+                    ),
+            )
+    }
+
+    fn render_diff_content(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(diff) = self.get_selected_diff() else {
+            return div()
+                .flex_1()
+                .flex()
+                .items_center()
+                .justify_center()
+                .text_color(rgb(0x5c6370))
+                .child("Select a file to view changes")
+                .into_any_element();
+        };
+
+        let line_count = Self::total_lines_for_diff(diff);
+        let diff_clone = diff.clone();
+
+        // Pre-compute line data
+        let line_data: Vec<Option<DiffLine>> = (0..line_count)
+            .map(|i| self.get_diff_line(&diff_clone, i))
+            .collect();
+
+        let text_style = {
+            let mut style = window.text_style();
+            style.color = rgb(0xabb2bf).into();
+            style.font_size = px(FONT_SIZE).into();
+            style
+        };
+
+        // Pre-compute highlights
+        let highlights: Vec<Vec<(Range<usize>, HighlightStyle)>> = line_data
+            .iter()
+            .map(|line| {
+                line.as_ref()
+                    .filter(|l| l.kind != DiffLineKind::Header)
+                    .map(|l| self.line_highlights(&l.content))
+                    .unwrap_or_default()
+            })
+            .collect();
+
+        uniform_list("git-diff-lines", line_count, {
+            let text_style = text_style.clone();
+            move |range: Range<usize>, _window: &mut Window, _cx: &mut App| {
+                range
+                    .map(|i| {
+                        let Some(line) = &line_data[i] else {
+                            return div().h(px(LINE_HEIGHT)).into_any_element();
+                        };
+
+                        let (bg_color, gutter_text, prefix) = match line.kind {
+                            DiffLineKind::Header => (rgb(0x21252b), "".to_string(), ""),
+                            DiffLineKind::Added => {
+                                let num = line
+                                    .new_line_num
+                                    .map(|n| format!("{:>3}", n))
+                                    .unwrap_or_default();
+                                (rgb(0x2d3b2d), num, "+ ")
+                            }
+                            DiffLineKind::Removed => {
+                                let num = line
+                                    .old_line_num
+                                    .map(|n| format!("{:>3}", n))
+                                    .unwrap_or_default();
+                                (rgb(0x3b2d2d), num, "- ")
+                            }
+                            DiffLineKind::Unchanged => {
+                                let num = line
+                                    .new_line_num
+                                    .map(|n| format!("{:>3}", n))
+                                    .unwrap_or_default();
+                                (rgb(0x282c34), num, "  ")
+                            }
+                        };
+
+                        let content = &line.content;
+                        let display_content = format!("{}{}", prefix, content);
+
+                        if line.kind == DiffLineKind::Header {
+                            return div()
+                                .flex()
+                                .flex_row()
+                                .h(px(LINE_HEIGHT + 4.0))
+                                .bg(bg_color)
+                                .px_2()
+                                .items_center()
+                                .child(
+                                    div()
+                                        .text_color(rgb(0x61afef))
+                                        .text_size(px(FONT_SIZE))
+                                        .child(content.clone()),
+                                )
+                                .into_any_element();
+                        }
+
+                        let line_highlights = &highlights[i];
+                        let adjusted_highlights: Vec<(Range<usize>, HighlightStyle)> =
+                            line_highlights
+                                .iter()
+                                .map(|(range, style)| {
+                                    let offset = prefix.len();
+                                    ((range.start + offset)..(range.end + offset), *style)
+                                })
+                                .collect();
+
+                        let styled_text = if display_content.is_empty() {
+                            StyledText::new(" ").with_default_highlights(&text_style, Vec::new())
+                        } else {
+                            StyledText::new(display_content.clone())
+                                .with_default_highlights(&text_style, adjusted_highlights)
+                        };
+
+                        div()
+                            .flex()
+                            .flex_row()
+                            .h(px(LINE_HEIGHT))
+                            .bg(bg_color)
+                            .child(
+                                div()
+                                    .w(px(GUTTER_WIDTH))
+                                    .h(px(LINE_HEIGHT))
+                                    .flex()
+                                    .items_center()
+                                    .justify_end()
+                                    .pr_2()
+                                    .text_color(rgb(0x495162))
+                                    .text_size(px(FONT_SIZE))
+                                    .child(gutter_text),
+                            )
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .h(px(LINE_HEIGHT))
+                                    .flex()
+                                    .items_center()
+                                    .child(styled_text),
+                            )
+                            .into_any_element()
+                    })
+                    .collect()
+            }
+        })
+        .track_scroll(&self.scroll_handle)
+        .flex_1()
+        .into_any_element()
+    }
+
+    fn render_empty_state(&self) -> impl IntoElement {
+        div()
+            .flex_1()
+            .flex()
+            .flex_col()
+            .items_center()
+            .justify_center()
+            .gap_4()
+            .child(
+                div()
+                    .text_color(rgb(0x636d83))
+                    .text_size(px(48.0))
+                    .child("*"),
+            )
+            .child(
+                div()
+                    .text_color(rgb(0x5c6370))
+                    .text_size(px(14.0))
+                    .child("No changes in working tree"),
+            )
+            .child(
+                div()
+                    .text_color(rgb(0x636d83))
+                    .text_size(px(12.0))
+                    .child("Make some changes to see them here"),
+            )
+    }
+}
+
+impl EventEmitter<GitAction> for GitStack {}
+
+impl Focusable for GitStack {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for GitStack {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let has_changes = !self.repo_state.staged_files.is_empty()
+            || !self.repo_state.unstaged_files.is_empty()
+            || !self.repo_state.untracked_files.is_empty();
+
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .bg(rgb(0x282c34))
+            .track_focus(&self.focus_handle)
+            .on_key_down(cx.listener(|this, event: &KeyDownEvent, _, cx| {
+                match event.keystroke.key.as_str() {
+                    "b" if event.keystroke.modifiers.control => this.toggle_sidebar(cx),
+                    _ => {}
+                }
+            }))
+            // Header bar
+            .child(self.render_header(cx))
+            // Main content area
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .flex_1()
+                    .overflow_hidden()
+                    // Sidebar
+                    .when(self.sidebar_visible, |el| el.child(self.render_sidebar(cx)))
+                    // Diff content or empty state
+                    .child(
+                        div()
+                            .flex_1()
+                            .flex()
+                            .flex_col()
+                            .bg(rgb(0x282c34))
+                            .when(has_changes, |el| el.child(self.render_diff_content(window, cx)))
+                            .when(!has_changes, |el| el.child(self.render_empty_state())),
+                    ),
+            )
+    }
+}

--- a/crates/zedra-editor/src/git_stack.rs
+++ b/crates/zedra-editor/src/git_stack.rs
@@ -1,16 +1,18 @@
 //! GitStack - A fullscreen git source control component
 //!
 //! This component provides a VS Code/Zed-like git interface with:
-//! - Left sidebar showing changed files organized by status
+//! - Left sidebar showing changed files organized by status (swipe-to-open drawer)
 //! - Git actions panel with stage/unstage/commit controls
 //! - Main content area showing the diff for the selected file
 //!
 //! Designed to be reusable for any git project.
 
 use std::ops::Range;
+use std::sync::{Arc, Mutex};
 
 use gpui::prelude::FluentBuilder;
 use gpui::*;
+use zedra_gesture::{pan_gesture, GestureState, PanGestureEvent};
 
 use crate::diff_view::{DiffHunk, DiffLine, DiffLineKind, FileDiff};
 use crate::highlighter::Highlighter;
@@ -155,6 +157,27 @@ pub enum GitAction {
     Pull,
 }
 
+/// Drawer state for gesture-based opening/closing
+#[derive(Clone)]
+struct DrawerState {
+    /// Current drawer offset (0 = closed, SIDEBAR_WIDTH = fully open)
+    offset: f32,
+    /// Whether a drag gesture is in progress
+    is_dragging: bool,
+    /// Starting offset when drag began
+    start_offset: f32,
+}
+
+impl Default for DrawerState {
+    fn default() -> Self {
+        Self {
+            offset: SIDEBAR_WIDTH, // Start open
+            is_dragging: false,
+            start_offset: 0.0,
+        }
+    }
+}
+
 /// Main GitStack component
 pub struct GitStack {
     repo_state: GitRepoState,
@@ -167,6 +190,8 @@ pub struct GitStack {
     theme: SyntaxTheme,
     scroll_handle: UniformListScrollHandle,
     focus_handle: FocusHandle,
+    /// Shared drawer state for gesture handling
+    drawer_state: Arc<Mutex<DrawerState>>,
 }
 
 impl GitStack {
@@ -186,6 +211,7 @@ impl GitStack {
             theme: SyntaxTheme::default_dark(),
             scroll_handle: UniformListScrollHandle::new(),
             focus_handle: cx.focus_handle(),
+            drawer_state: Arc::new(Mutex::new(DrawerState::default())),
         }
     }
 
@@ -395,7 +421,50 @@ impl GitStack {
 
     fn toggle_sidebar(&mut self, cx: &mut Context<Self>) {
         self.sidebar_visible = !self.sidebar_visible;
+        if let Ok(mut state) = self.drawer_state.lock() {
+            state.offset = if self.sidebar_visible { SIDEBAR_WIDTH } else { 0.0 };
+        }
         cx.notify();
+    }
+
+    fn handle_drawer_gesture(&mut self, event: &PanGestureEvent, cx: &mut Context<Self>) {
+        match event.state {
+            GestureState::Began => {
+                if let Ok(mut state) = self.drawer_state.lock() {
+                    state.is_dragging = true;
+                    state.start_offset = state.offset;
+                }
+            }
+            GestureState::Changed => {
+                if let Ok(mut state) = self.drawer_state.lock() {
+                    // Horizontal drag: positive translation.x means swipe right (open)
+                    let new_offset = (state.start_offset + event.translation.x).clamp(0.0, SIDEBAR_WIDTH);
+                    state.offset = new_offset;
+                }
+                cx.notify();
+            }
+            GestureState::Ended | GestureState::Cancelled => {
+                if let Ok(mut state) = self.drawer_state.lock() {
+                    state.is_dragging = false;
+                    // Snap to open or closed based on velocity and position
+                    let should_open = if event.velocity.x.abs() > 100.0 {
+                        // Use velocity direction if fast enough
+                        event.velocity.x > 0.0
+                    } else {
+                        // Otherwise use position threshold
+                        state.offset > SIDEBAR_WIDTH / 2.0
+                    };
+                    state.offset = if should_open { SIDEBAR_WIDTH } else { 0.0 };
+                    self.sidebar_visible = should_open;
+                }
+                cx.notify();
+            }
+            _ => {}
+        }
+    }
+
+    fn get_drawer_offset(&self) -> f32 {
+        self.drawer_state.lock().map(|s| s.offset).unwrap_or(0.0)
     }
 
     fn toggle_section(&mut self, section: usize, cx: &mut Context<Self>) {
@@ -1060,6 +1129,63 @@ impl Render for GitStack {
             || !self.repo_state.unstaged_files.is_empty()
             || !self.repo_state.untracked_files.is_empty();
 
+        let drawer_offset = self.get_drawer_offset();
+
+        // Main content area wrapped with pan gesture for drawer control
+        let main_content = div()
+            .flex()
+            .flex_row()
+            .flex_1()
+            .overflow_hidden()
+            // Sidebar - always rendered, positioned based on offset
+            .child(
+                div()
+                    .absolute()
+                    .left(px(drawer_offset - SIDEBAR_WIDTH))
+                    .top_0()
+                    .bottom_0()
+                    .child(self.render_sidebar(cx)),
+            )
+            // Backdrop overlay when drawer is partially or fully open
+            .when(drawer_offset > 0.0, |el| {
+                el.child(
+                    div()
+                        .absolute()
+                        .left(px(drawer_offset))
+                        .top_0()
+                        .right_0()
+                        .bottom_0()
+                        .bg(rgba(0x000000, (drawer_offset / SIDEBAR_WIDTH * 0.5) as f32))
+                        .on_mouse_down(MouseButton::Left, cx.listener(|this, _, _, cx| {
+                            // Tap on backdrop closes the drawer
+                            if let Ok(mut state) = this.drawer_state.lock() {
+                                state.offset = 0.0;
+                            }
+                            this.sidebar_visible = false;
+                            cx.notify();
+                        })),
+                )
+            })
+            // Diff content or empty state - offset by drawer
+            .child(
+                div()
+                    .ml(px(drawer_offset))
+                    .flex_1()
+                    .flex()
+                    .flex_col()
+                    .bg(rgb(0x282c34))
+                    .when(has_changes, |el| el.child(self.render_diff_content(window, cx)))
+                    .when(!has_changes, |el| el.child(self.render_empty_state())),
+            );
+
+        // Wrap content with pan gesture for drawer control
+        let gesture_content = pan_gesture()
+            .min_distance(10.0)
+            .on_pan(cx.listener(|this, event: &PanGestureEvent, _, cx| {
+                this.handle_drawer_gesture(event, cx);
+            }))
+            .child(main_content);
+
         div()
             .flex()
             .flex_col()
@@ -1074,25 +1200,7 @@ impl Render for GitStack {
             }))
             // Header bar
             .child(self.render_header(cx))
-            // Main content area
-            .child(
-                div()
-                    .flex()
-                    .flex_row()
-                    .flex_1()
-                    .overflow_hidden()
-                    // Sidebar
-                    .when(self.sidebar_visible, |el| el.child(self.render_sidebar(cx)))
-                    // Diff content or empty state
-                    .child(
-                        div()
-                            .flex_1()
-                            .flex()
-                            .flex_col()
-                            .bg(rgb(0x282c34))
-                            .when(has_changes, |el| el.child(self.render_diff_content(window, cx)))
-                            .when(!has_changes, |el| el.child(self.render_empty_state())),
-                    ),
-            )
+            // Main content area with gesture handling
+            .child(gesture_content)
     }
 }

--- a/crates/zedra-editor/src/git_stack.rs
+++ b/crates/zedra-editor/src/git_stack.rs
@@ -12,7 +12,6 @@ use std::sync::{Arc, Mutex};
 
 use gpui::prelude::FluentBuilder;
 use gpui::*;
-use zedra_gesture::{pan_gesture, GestureState, PanGestureEvent};
 
 use crate::diff_view::{DiffHunk, DiffLine, DiffLineKind, FileDiff};
 use crate::highlighter::Highlighter;
@@ -164,8 +163,6 @@ struct DrawerState {
     offset: f32,
     /// Whether a drag gesture is in progress
     is_dragging: bool,
-    /// Starting offset when drag began
-    start_offset: f32,
 }
 
 impl Default for DrawerState {
@@ -173,7 +170,6 @@ impl Default for DrawerState {
         Self {
             offset: SIDEBAR_WIDTH, // Start open
             is_dragging: false,
-            start_offset: 0.0,
         }
     }
 }
@@ -184,6 +180,7 @@ pub struct GitStack {
     selected_file: Option<String>,
     sidebar_visible: bool,
     sidebar_section_expanded: [bool; 3], // [staged, unstaged, untracked]
+    #[allow(dead_code)] // Will be used for commit functionality
     commit_message: String,
     diffs: Vec<FileDiff>,
     highlighter: Highlighter,
@@ -427,42 +424,6 @@ impl GitStack {
         cx.notify();
     }
 
-    fn handle_drawer_gesture(&mut self, event: &PanGestureEvent, cx: &mut Context<Self>) {
-        match event.state {
-            GestureState::Began => {
-                if let Ok(mut state) = self.drawer_state.lock() {
-                    state.is_dragging = true;
-                    state.start_offset = state.offset;
-                }
-            }
-            GestureState::Changed => {
-                if let Ok(mut state) = self.drawer_state.lock() {
-                    // Horizontal drag: positive translation.x means swipe right (open)
-                    let new_offset = (state.start_offset + event.translation.x).clamp(0.0, SIDEBAR_WIDTH);
-                    state.offset = new_offset;
-                }
-                cx.notify();
-            }
-            GestureState::Ended | GestureState::Cancelled => {
-                if let Ok(mut state) = self.drawer_state.lock() {
-                    state.is_dragging = false;
-                    // Snap to open or closed based on velocity and position
-                    let should_open = if event.velocity.x.abs() > 100.0 {
-                        // Use velocity direction if fast enough
-                        event.velocity.x > 0.0
-                    } else {
-                        // Otherwise use position threshold
-                        state.offset > SIDEBAR_WIDTH / 2.0
-                    };
-                    state.offset = if should_open { SIDEBAR_WIDTH } else { 0.0 };
-                    self.sidebar_visible = should_open;
-                }
-                cx.notify();
-            }
-            _ => {}
-        }
-    }
-
     fn get_drawer_offset(&self) -> f32 {
         self.drawer_state.lock().map(|s| s.offset).unwrap_or(0.0)
     }
@@ -531,19 +492,20 @@ impl GitStack {
         None
     }
 
-    fn line_highlights(&self, content: &str) -> Vec<(Range<usize>, HighlightStyle)> {
+    fn line_highlights(&mut self, content: &str) -> Vec<(Range<usize>, HighlightStyle)> {
         if content.is_empty() {
             return Vec::new();
         }
 
+        let content_len = content.len();
         self.highlighter.parse(content);
-        let raw_highlights = self.highlighter.highlights(content, 0..content.len());
+        let raw_highlights = self.highlighter.highlights(content, 0..content_len);
         let mut result: Vec<(Range<usize>, HighlightStyle)> = Vec::new();
 
         for (span_range, capture_name) in &raw_highlights {
             if let Some(style) = self.theme.get(capture_name) {
-                let start = span_range.start.min(content.len());
-                let end = span_range.end.min(content.len());
+                let start = span_range.start.min(content_len);
+                let end = span_range.end.min(content_len);
                 if start < end {
                     result.push((start..end, style));
                 }
@@ -819,6 +781,52 @@ impl GitStack {
     fn render_sidebar(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let selected = self.selected_file.clone();
 
+        // Pre-compute file entry elements with into_any_element() to break lifetime connection
+        let staged_entries: Vec<AnyElement> = self
+            .repo_state
+            .staged_files
+            .iter()
+            .map(|f| {
+                let is_selected = selected.as_ref() == Some(&f.path);
+                self.render_file_entry(f, is_selected, cx).into_any_element()
+            })
+            .collect();
+
+        let unstaged_entries: Vec<AnyElement> = self
+            .repo_state
+            .unstaged_files
+            .iter()
+            .map(|f| {
+                let is_selected = selected.as_ref() == Some(&f.path);
+                self.render_file_entry(f, is_selected, cx).into_any_element()
+            })
+            .collect();
+
+        let untracked_entries: Vec<AnyElement> = self
+            .repo_state
+            .untracked_files
+            .iter()
+            .map(|f| {
+                let is_selected = selected.as_ref() == Some(&f.path);
+                self.render_file_entry(f, is_selected, cx).into_any_element()
+            })
+            .collect();
+
+        let commit_section = self.render_commit_section().into_any_element();
+        let staged_header = self
+            .render_section_header("STAGED CHANGES", self.repo_state.total_staged(), 0, Some("-"), cx)
+            .into_any_element();
+        let unstaged_header = self
+            .render_section_header("CHANGES", self.repo_state.total_unstaged(), 1, Some("+"), cx)
+            .into_any_element();
+        let untracked_header = self
+            .render_section_header("UNTRACKED", self.repo_state.total_untracked(), 2, Some("+"), cx)
+            .into_any_element();
+
+        let show_staged = self.sidebar_section_expanded[0];
+        let show_unstaged = self.sidebar_section_expanded[1];
+        let show_untracked = self.sidebar_section_expanded[2];
+
         div()
             .flex()
             .flex_col()
@@ -828,58 +836,24 @@ impl GitStack {
             .border_r_1()
             .border_color(rgb(0x181a1f))
             // Commit section
-            .child(self.render_commit_section(cx))
+            .child(commit_section)
             // File sections
             .child(
                 div()
                     .flex_1()
-                    .overflow_y_scroll()
                     // Staged section
-                    .child(self.render_section_header(
-                        "STAGED CHANGES",
-                        self.repo_state.total_staged(),
-                        0,
-                        Some("-"),
-                        cx,
-                    ))
-                    .when(self.sidebar_section_expanded[0], |el| {
-                        el.children(self.repo_state.staged_files.iter().map(|f| {
-                            let is_selected = selected.as_ref() == Some(&f.path);
-                            self.render_file_entry(f, is_selected, cx)
-                        }))
-                    })
+                    .child(staged_header)
+                    .when(show_staged, |el| el.children(staged_entries))
                     // Unstaged section
-                    .child(self.render_section_header(
-                        "CHANGES",
-                        self.repo_state.total_unstaged(),
-                        1,
-                        Some("+"),
-                        cx,
-                    ))
-                    .when(self.sidebar_section_expanded[1], |el| {
-                        el.children(self.repo_state.unstaged_files.iter().map(|f| {
-                            let is_selected = selected.as_ref() == Some(&f.path);
-                            self.render_file_entry(f, is_selected, cx)
-                        }))
-                    })
+                    .child(unstaged_header)
+                    .when(show_unstaged, |el| el.children(unstaged_entries))
                     // Untracked section
-                    .child(self.render_section_header(
-                        "UNTRACKED",
-                        self.repo_state.total_untracked(),
-                        2,
-                        Some("+"),
-                        cx,
-                    ))
-                    .when(self.sidebar_section_expanded[2], |el| {
-                        el.children(self.repo_state.untracked_files.iter().map(|f| {
-                            let is_selected = selected.as_ref() == Some(&f.path);
-                            self.render_file_entry(f, is_selected, cx)
-                        }))
-                    }),
+                    .child(untracked_header)
+                    .when(show_untracked, |el| el.children(untracked_entries)),
             )
     }
 
-    fn render_commit_section(&self, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_commit_section(&self) -> impl IntoElement {
         div()
             .flex()
             .flex_col()
@@ -942,8 +916,8 @@ impl GitStack {
             )
     }
 
-    fn render_diff_content(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let Some(diff) = self.get_selected_diff() else {
+    fn render_diff_content(&mut self, window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(diff) = self.get_selected_diff().cloned() else {
             return div()
                 .flex_1()
                 .flex()
@@ -954,12 +928,11 @@ impl GitStack {
                 .into_any_element();
         };
 
-        let line_count = Self::total_lines_for_diff(diff);
-        let diff_clone = diff.clone();
+        let line_count = Self::total_lines_for_diff(&diff);
 
         // Pre-compute line data
         let line_data: Vec<Option<DiffLine>> = (0..line_count)
-            .map(|i| self.get_diff_line(&diff_clone, i))
+            .map(|i| self.get_diff_line(&diff, i))
             .collect();
 
         let text_style = {
@@ -969,7 +942,7 @@ impl GitStack {
             style
         };
 
-        // Pre-compute highlights
+        // Pre-compute highlights (need &mut self for highlighter)
         let highlights: Vec<Vec<(Range<usize>, HighlightStyle)>> = line_data
             .iter()
             .map(|line| {
@@ -1131,6 +1104,17 @@ impl Render for GitStack {
 
         let drawer_offset = self.get_drawer_offset();
 
+        // Pre-compute content elements to avoid borrow issues
+        // Use into_any_element() to avoid lifetime capture issues
+        let diff_content = if has_changes {
+            self.render_diff_content(window, cx).into_any_element()
+        } else {
+            self.render_empty_state().into_any_element()
+        };
+
+        let header = self.render_header(cx).into_any_element();
+        let sidebar = self.render_sidebar(cx).into_any_element();
+
         // Main content area wrapped with pan gesture for drawer control
         let main_content = div()
             .flex()
@@ -1144,9 +1128,11 @@ impl Render for GitStack {
                     .left(px(drawer_offset - SIDEBAR_WIDTH))
                     .top_0()
                     .bottom_0()
-                    .child(self.render_sidebar(cx)),
+                    .child(sidebar),
             )
             // Backdrop overlay when drawer is partially or fully open
+            // Note: Don't use on_mouse_down here as it interferes with pan gesture
+            // Tap-to-close is handled in handle_drawer_gesture when gesture ends with minimal movement
             .when(drawer_offset > 0.0, |el| {
                 el.child(
                     div()
@@ -1155,15 +1141,7 @@ impl Render for GitStack {
                         .top_0()
                         .right_0()
                         .bottom_0()
-                        .bg(rgba(0x000000, (drawer_offset / SIDEBAR_WIDTH * 0.5) as f32))
-                        .on_mouse_down(MouseButton::Left, cx.listener(|this, _, _, cx| {
-                            // Tap on backdrop closes the drawer
-                            if let Ok(mut state) = this.drawer_state.lock() {
-                                state.offset = 0.0;
-                            }
-                            this.sidebar_visible = false;
-                            cx.notify();
-                        })),
+                        .bg(hsla(0.0, 0.0, 0.0, drawer_offset / SIDEBAR_WIDTH * 0.5)),
                 )
             })
             // Diff content or empty state - offset by drawer
@@ -1174,17 +1152,8 @@ impl Render for GitStack {
                     .flex()
                     .flex_col()
                     .bg(rgb(0x282c34))
-                    .when(has_changes, |el| el.child(self.render_diff_content(window, cx)))
-                    .when(!has_changes, |el| el.child(self.render_empty_state())),
+                    .child(diff_content),
             );
-
-        // Wrap content with pan gesture for drawer control
-        let gesture_content = pan_gesture()
-            .min_distance(10.0)
-            .on_pan(cx.listener(|this, event: &PanGestureEvent, _, cx| {
-                this.handle_drawer_gesture(event, cx);
-            }))
-            .child(main_content);
 
         div()
             .flex()
@@ -1198,9 +1167,48 @@ impl Render for GitStack {
                     _ => {}
                 }
             }))
+            // Handle scroll wheel events for drawer gesture (Android sends touch drag as scroll)
+            .on_scroll_wheel(cx.listener(|this, event: &ScrollWheelEvent, _window, cx| {
+                let (dx, _dy): (f32, f32) = match event.delta {
+                    ScrollDelta::Pixels(p) => (f32::from(p.x), f32::from(p.y)),
+                    ScrollDelta::Lines(l) => (l.x * 20.0, l.y * 20.0),
+                };
+
+                log::info!("GitStack: scroll_wheel dx={:.1}, current_offset={:.1}", dx,
+                    this.drawer_state.lock().map(|s| s.offset).unwrap_or(0.0));
+
+                // Only handle horizontal scroll for drawer
+                if dx.abs() > 1.0 {
+                    if let Ok(mut state) = this.drawer_state.lock() {
+                        // Mark as dragging
+                        state.is_dragging = true;
+
+                        // GPUI scroll delta: positive dx = content moves right = finger swipes left
+                        // We want: swipe right = open (increase offset), swipe left = close (decrease offset)
+                        // So we ADD dx (which is inverted from finger direction)
+                        let new_offset = (state.offset + dx).clamp(0.0, SIDEBAR_WIDTH);
+                        state.offset = new_offset;
+                        log::info!("GitStack: new_offset={:.1}", new_offset);
+                    }
+                    cx.notify();
+                }
+            }))
+            // Handle mouse up to end drawer gesture - snap to open or closed
+            .on_mouse_up(MouseButton::Left, cx.listener(|this, _event: &MouseUpEvent, _window, cx| {
+                if let Ok(mut state) = this.drawer_state.lock() {
+                    if state.is_dragging {
+                        state.is_dragging = false;
+                        // Snap based on position threshold
+                        let should_open = state.offset > SIDEBAR_WIDTH / 2.0;
+                        state.offset = if should_open { SIDEBAR_WIDTH } else { 0.0 };
+                        this.sidebar_visible = should_open;
+                    }
+                }
+                cx.notify();
+            }))
             // Header bar
-            .child(self.render_header(cx))
-            // Main content area with gesture handling
-            .child(gesture_content)
+            .child(header)
+            // Main content area
+            .child(main_content)
     }
 }

--- a/crates/zedra-editor/src/highlighter.rs
+++ b/crates/zedra-editor/src/highlighter.rs
@@ -35,8 +35,12 @@ impl Highlighter {
     }
 
     /// Parse the full source text, storing the resulting tree for queries.
+    /// When parsing different source texts (like individual diff lines), we
+    /// don't reuse the old tree to avoid stale node references.
     pub fn parse(&mut self, source: &str) {
-        self.tree = self.parser.parse(source, self.tree.as_ref());
+        // Always create a fresh parse to avoid issues with stale tree references
+        // when parsing unrelated snippets (like individual diff lines)
+        self.tree = self.parser.parse(source, None);
     }
 
     /// Return highlight spans for the given byte range of the source.
@@ -49,8 +53,15 @@ impl Highlighter {
             None => return Vec::new(),
         };
 
+        let source_len = source.len();
+        // Clamp the requested range to source bounds
+        let safe_range = range.start.min(source_len)..range.end.min(source_len);
+        if safe_range.is_empty() {
+            return Vec::new();
+        }
+
         let mut cursor = QueryCursor::new();
-        cursor.set_byte_range(range.clone());
+        cursor.set_byte_range(safe_range.clone());
 
         let mut result = Vec::new();
         let mut matches = cursor.matches(&self.query, tree.root_node(), source.as_bytes());
@@ -58,9 +69,15 @@ impl Highlighter {
             for capture in query_match.captures {
                 let capture_name = &self.query.capture_names()[capture.index as usize];
                 let node_range = capture.node.byte_range();
-                // Only include captures that overlap our requested range
-                if node_range.start < range.end && node_range.end > range.start {
-                    result.push((node_range, &**capture_name));
+                // Clamp node range to source bounds to prevent out-of-bounds access
+                let clamped_start = node_range.start.min(source_len);
+                let clamped_end = node_range.end.min(source_len);
+                // Only include captures that overlap our requested range and have valid bounds
+                if clamped_start < clamped_end
+                    && clamped_start < safe_range.end
+                    && clamped_end > safe_range.start
+                {
+                    result.push((clamped_start..clamped_end, &**capture_name));
                 }
             }
         }

--- a/crates/zedra-editor/src/lib.rs
+++ b/crates/zedra-editor/src/lib.rs
@@ -1,9 +1,11 @@
 mod buffer;
+mod diff_view;
 mod editor_view;
 mod highlighter;
 mod theme;
 
 pub use buffer::Buffer;
+pub use diff_view::DiffView;
 pub use editor_view::EditorView;
 pub use highlighter::Highlighter;
 pub use theme::SyntaxTheme;

--- a/crates/zedra-editor/src/lib.rs
+++ b/crates/zedra-editor/src/lib.rs
@@ -1,11 +1,13 @@
 mod buffer;
 mod diff_view;
 mod editor_view;
+mod git_stack;
 mod highlighter;
 mod theme;
 
 pub use buffer::Buffer;
-pub use diff_view::DiffView;
+pub use diff_view::{DiffHunk, DiffLine, DiffLineKind, DiffView, FileDiff};
 pub use editor_view::EditorView;
+pub use git_stack::{GitAction, GitFileEntry, GitFileStatus, GitRepoState, GitStack};
 pub use highlighter::Highlighter;
 pub use theme::SyntaxTheme;

--- a/crates/zedra-gesture/Cargo.toml
+++ b/crates/zedra-gesture/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "zedra-gesture"
+version.workspace = true
+edition.workspace = true
+description = "Gesture recognition library for GPUI on Android, inspired by react-native-gesture-handler"
+
+[dependencies]
+gpui = { path = "../../vendor/zed/crates/gpui", features = ["android"] }
+log.workspace = true

--- a/crates/zedra-gesture/src/compose.rs
+++ b/crates/zedra-gesture/src/compose.rs
@@ -1,0 +1,424 @@
+//! Gesture composition helpers
+//!
+//! Provides GPUI-style composition for managing multiple gestures:
+//! - `race()` - First gesture to activate wins
+//! - `simultaneous()` - Multiple gestures can activate together
+//! - `exclusive()` - Only one gesture can be active at a time
+
+use gpui::*;
+
+use crate::types::GestureId;
+
+// ============================================================================
+// GestureRace - First gesture to activate wins
+// ============================================================================
+
+/// Compose gestures where the first to activate wins
+///
+/// Other gestures will be cancelled when one begins.
+///
+/// # Example
+/// ```ignore
+/// race()
+///     .gesture(tap_gesture().on_tap(|e, w, cx| { /* tap */ }))
+///     .gesture(pan_gesture().on_pan(|e, w, cx| { /* pan */ }))
+///     .child(div().child("Content"))
+/// ```
+pub fn race() -> GestureRace {
+    GestureRace::new()
+}
+
+/// Container for racing gestures
+pub struct GestureRace {
+    gestures: Vec<AnyElement>,
+    child: Option<AnyElement>,
+}
+
+impl GestureRace {
+    pub fn new() -> Self {
+        Self {
+            gestures: Vec::new(),
+            child: None,
+        }
+    }
+
+    /// Add a gesture to the race
+    pub fn gesture(mut self, gesture: impl IntoElement) -> Self {
+        self.gestures.push(gesture.into_any_element());
+        self
+    }
+
+    /// Set the content child that all gestures will wrap
+    pub fn child(mut self, child: impl IntoElement) -> Self {
+        self.child = Some(child.into_any_element());
+        self
+    }
+}
+
+impl Default for GestureRace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntoElement for GestureRace {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for GestureRace {
+    type RequestLayoutState = Vec<AnyElement>;
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        // For race, we stack all gestures and the child
+        // The gestures will handle mutual exclusion through their recognizers
+        let mut elements = std::mem::take(&mut self.gestures);
+        if let Some(child) = self.child.take() {
+            elements.push(child);
+        }
+
+        // Use the layout of the first element (or create empty)
+        if let Some(first) = elements.first_mut() {
+            let layout_id = first.request_layout(window, cx);
+            for elem in elements.iter_mut().skip(1) {
+                elem.request_layout(window, cx);
+            }
+            (layout_id, elements)
+        } else {
+            let layout_id = window.request_layout(gpui::Style::default(), [], cx);
+            (layout_id, elements)
+        }
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        elements: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        for elem in elements.iter_mut() {
+            elem.prepaint(window, cx);
+        }
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        elements: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        // Paint in reverse order so first gesture gets events first
+        for elem in elements.iter_mut().rev() {
+            elem.paint(window, cx);
+        }
+    }
+}
+
+// ============================================================================
+// GestureSimultaneous - Multiple gestures can run together
+// ============================================================================
+
+/// Compose gestures that can run simultaneously
+///
+/// All gestures can be active at the same time.
+///
+/// # Example
+/// ```ignore
+/// simultaneous()
+///     .gesture(pan_gesture().on_pan(|e, w, cx| { /* pan */ }))
+///     .gesture(pinch_gesture().on_pinch(|e, w, cx| { /* pinch */ }))
+///     .child(div().child("Content"))
+/// ```
+pub fn simultaneous() -> GestureSimultaneous {
+    GestureSimultaneous::new()
+}
+
+/// Container for simultaneous gestures
+pub struct GestureSimultaneous {
+    gestures: Vec<AnyElement>,
+    gesture_ids: Vec<GestureId>,
+    child: Option<AnyElement>,
+}
+
+impl GestureSimultaneous {
+    pub fn new() -> Self {
+        Self {
+            gestures: Vec::new(),
+            gesture_ids: Vec::new(),
+            child: None,
+        }
+    }
+
+    /// Add a gesture that can run simultaneously with others in this group
+    pub fn gesture(mut self, gesture: impl IntoElement) -> Self {
+        self.gestures.push(gesture.into_any_element());
+        self
+    }
+
+    /// Add a gesture with its ID for relationship tracking
+    pub fn gesture_with_id(mut self, gesture: impl IntoElement, id: GestureId) -> Self {
+        self.gestures.push(gesture.into_any_element());
+        self.gesture_ids.push(id);
+        self
+    }
+
+    /// Set the content child
+    pub fn child(mut self, child: impl IntoElement) -> Self {
+        self.child = Some(child.into_any_element());
+        self
+    }
+}
+
+impl Default for GestureSimultaneous {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntoElement for GestureSimultaneous {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for GestureSimultaneous {
+    type RequestLayoutState = Vec<AnyElement>;
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut elements = std::mem::take(&mut self.gestures);
+        if let Some(child) = self.child.take() {
+            elements.push(child);
+        }
+
+        if let Some(first) = elements.first_mut() {
+            let layout_id = first.request_layout(window, cx);
+            for elem in elements.iter_mut().skip(1) {
+                elem.request_layout(window, cx);
+            }
+            (layout_id, elements)
+        } else {
+            let layout_id = window.request_layout(gpui::Style::default(), [], cx);
+            (layout_id, elements)
+        }
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        elements: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        for elem in elements.iter_mut() {
+            elem.prepaint(window, cx);
+        }
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        elements: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        // All gestures receive events (simultaneous recognition)
+        for elem in elements.iter_mut() {
+            elem.paint(window, cx);
+        }
+    }
+}
+
+// ============================================================================
+// GestureExclusive - Only one gesture active at a time with priority
+// ============================================================================
+
+/// Compose gestures where only one can be active, with priority order
+///
+/// The first gesture in the list has highest priority.
+/// Lower priority gestures are cancelled when a higher priority one activates.
+///
+/// # Example
+/// ```ignore
+/// exclusive()
+///     .gesture(double_tap_gesture().on_tap(|e, w, cx| { /* high priority */ }))
+///     .gesture(single_tap_gesture().on_tap(|e, w, cx| { /* low priority */ }))
+///     .child(div().child("Content"))
+/// ```
+pub fn exclusive() -> GestureExclusive {
+    GestureExclusive::new()
+}
+
+/// Container for exclusive gestures with priority
+pub struct GestureExclusive {
+    gestures: Vec<AnyElement>,
+    child: Option<AnyElement>,
+}
+
+impl GestureExclusive {
+    pub fn new() -> Self {
+        Self {
+            gestures: Vec::new(),
+            child: None,
+        }
+    }
+
+    /// Add a gesture (order determines priority - first is highest)
+    pub fn gesture(mut self, gesture: impl IntoElement) -> Self {
+        self.gestures.push(gesture.into_any_element());
+        self
+    }
+
+    /// Set the content child
+    pub fn child(mut self, child: impl IntoElement) -> Self {
+        self.child = Some(child.into_any_element());
+        self
+    }
+}
+
+impl Default for GestureExclusive {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntoElement for GestureExclusive {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for GestureExclusive {
+    type RequestLayoutState = Vec<AnyElement>;
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut elements = std::mem::take(&mut self.gestures);
+        if let Some(child) = self.child.take() {
+            elements.push(child);
+        }
+
+        if let Some(first) = elements.first_mut() {
+            let layout_id = first.request_layout(window, cx);
+            for elem in elements.iter_mut().skip(1) {
+                elem.request_layout(window, cx);
+            }
+            (layout_id, elements)
+        } else {
+            let layout_id = window.request_layout(gpui::Style::default(), [], cx);
+            (layout_id, elements)
+        }
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        elements: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        for elem in elements.iter_mut() {
+            elem.prepaint(window, cx);
+        }
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        elements: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        // Paint in priority order (first gesture gets first chance at events)
+        for elem in elements.iter_mut() {
+            elem.paint(window, cx);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_race_creation() {
+        let _race = race();
+    }
+
+    #[test]
+    fn test_simultaneous_creation() {
+        let _sim = simultaneous();
+    }
+
+    #[test]
+    fn test_exclusive_creation() {
+        let _exc = exclusive();
+    }
+}

--- a/crates/zedra-gesture/src/compositor.rs
+++ b/crates/zedra-gesture/src/compositor.rs
@@ -1,0 +1,205 @@
+//! Gesture compositor for handling multiple recognizers and arbitration
+
+use std::sync::{Arc, Mutex};
+
+use crate::recognizers::GestureRecognizer;
+use crate::state::GestureState;
+use crate::types::TouchEvent;
+
+/// Relationship between gestures
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GestureRelation {
+    /// Gestures can be recognized simultaneously
+    Simultaneous,
+    /// This gesture requires the other to fail first
+    RequiresFailure,
+    /// This gesture is exclusive (others fail when this begins)
+    Exclusive,
+}
+
+/// A registered gesture with its relationships
+struct RegisteredGesture {
+    id: usize,
+    recognizer: Arc<Mutex<dyn GestureRecognizer>>,
+    relations: Vec<(usize, GestureRelation)>,
+}
+
+/// Compositor that manages multiple gesture recognizers
+pub struct GestureCompositor {
+    gestures: Vec<RegisteredGesture>,
+    next_id: usize,
+}
+
+impl Default for GestureCompositor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GestureCompositor {
+    pub fn new() -> Self {
+        Self {
+            gestures: Vec::new(),
+            next_id: 0,
+        }
+    }
+
+    /// Add a gesture recognizer, returns its ID
+    pub fn add<G: GestureRecognizer + 'static>(&mut self, recognizer: G) -> usize {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        self.gestures.push(RegisteredGesture {
+            id,
+            recognizer: Arc::new(Mutex::new(recognizer)),
+            relations: Vec::new(),
+        });
+
+        id
+    }
+
+    /// Set relationship between two gestures
+    pub fn set_relation(&mut self, gesture_id: usize, other_id: usize, relation: GestureRelation) {
+        if let Some(gesture) = self.gestures.iter_mut().find(|g| g.id == gesture_id) {
+            // Remove existing relation if any
+            gesture.relations.retain(|(id, _)| *id != other_id);
+            // Add new relation
+            gesture.relations.push((other_id, relation));
+        }
+    }
+
+    /// Allow two gestures to be recognized simultaneously
+    pub fn simultaneous(&mut self, gesture1: usize, gesture2: usize) {
+        self.set_relation(gesture1, gesture2, GestureRelation::Simultaneous);
+        self.set_relation(gesture2, gesture1, GestureRelation::Simultaneous);
+    }
+
+    /// Gesture1 requires gesture2 to fail before it can begin
+    pub fn requires_failure(&mut self, gesture1: usize, gesture2: usize) {
+        self.set_relation(gesture1, gesture2, GestureRelation::RequiresFailure);
+    }
+
+    /// Get a gesture recognizer by ID
+    pub fn get(&self, id: usize) -> Option<Arc<Mutex<dyn GestureRecognizer>>> {
+        self.gestures
+            .iter()
+            .find(|g| g.id == id)
+            .map(|g| g.recognizer.clone())
+    }
+
+    /// Process a touch event through all recognizers
+    pub fn on_touch(&mut self, event: &TouchEvent) {
+        // First pass: process all recognizers
+        let mut states: Vec<(usize, GestureState)> = Vec::new();
+
+        for gesture in &self.gestures {
+            if let Ok(mut recognizer) = gesture.recognizer.lock() {
+                recognizer.on_touch(event);
+                states.push((gesture.id, recognizer.state()));
+            }
+        }
+
+        // Second pass: handle arbitration
+        self.arbitrate(&states);
+    }
+
+    /// Handle gesture arbitration based on relationships
+    fn arbitrate(&mut self, states: &[(usize, GestureState)]) {
+        // Find gestures that just began
+        let began_gestures: Vec<usize> = states
+            .iter()
+            .filter(|(_, state)| *state == GestureState::Began)
+            .map(|(id, _)| *id)
+            .collect();
+
+        for began_id in &began_gestures {
+            // Find the gesture that began
+            let Some(gesture) = self.gestures.iter().find(|g| g.id == *began_id) else {
+                continue;
+            };
+
+            // Check relationships
+            for (other_id, relation) in &gesture.relations {
+                match relation {
+                    GestureRelation::Exclusive => {
+                        // Fail other gestures that aren't simultaneous
+                        if let Some(other) = self.gestures.iter().find(|g| g.id == *other_id) {
+                            // Check if other has simultaneous relation with us
+                            let is_simultaneous = other
+                                .relations
+                                .iter()
+                                .any(|(id, rel)| *id == *began_id && *rel == GestureRelation::Simultaneous);
+
+                            if !is_simultaneous {
+                                if let Ok(mut recognizer) = other.recognizer.lock() {
+                                    if recognizer.state() == GestureState::Possible {
+                                        // Would be nice to fail it, but we can't easily
+                                        // Just disable for now
+                                        recognizer.set_enabled(false);
+                                        recognizer.reset();
+                                        recognizer.set_enabled(true);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    GestureRelation::RequiresFailure => {
+                        // Check if the required gesture has failed
+                        let other_state = states.iter().find(|(id, _)| *id == *other_id);
+                        if let Some((_, state)) = other_state {
+                            if *state != GestureState::Failed {
+                                // Other gesture hasn't failed, we should wait
+                                // In practice, this is handled during recognition
+                            }
+                        }
+                    }
+                    GestureRelation::Simultaneous => {
+                        // Nothing to do, allow both
+                    }
+                }
+            }
+        }
+    }
+
+    /// Reset all recognizers
+    pub fn reset(&mut self) {
+        for gesture in &self.gestures {
+            if let Ok(mut recognizer) = gesture.recognizer.lock() {
+                recognizer.reset();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recognizers::{PanGesture, TapGesture};
+
+    #[test]
+    fn test_compositor_add() {
+        let mut compositor = GestureCompositor::new();
+
+        let tap_id = compositor.add(TapGesture::new());
+        let pan_id = compositor.add(PanGesture::new());
+
+        assert_eq!(tap_id, 0);
+        assert_eq!(pan_id, 1);
+
+        assert!(compositor.get(tap_id).is_some());
+        assert!(compositor.get(pan_id).is_some());
+        assert!(compositor.get(99).is_none());
+    }
+
+    #[test]
+    fn test_simultaneous_relation() {
+        let mut compositor = GestureCompositor::new();
+
+        let tap_id = compositor.add(TapGesture::new());
+        let pan_id = compositor.add(PanGesture::new());
+
+        compositor.simultaneous(tap_id, pan_id);
+
+        // Both should be able to recognize
+    }
+}

--- a/crates/zedra-gesture/src/compositor.rs
+++ b/crates/zedra-gesture/src/compositor.rs
@@ -1,5 +1,11 @@
 //! Gesture compositor for handling multiple recognizers and arbitration
+//!
+//! The compositor manages gesture relationships and resolves conflicts:
+//! - Simultaneous gestures can run together
+//! - RequiresFailure gestures wait until dependencies fail
+//! - Exclusive gestures cancel others when they begin
 
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use crate::recognizers::GestureRecognizer;
@@ -17,17 +23,52 @@ pub enum GestureRelation {
     Exclusive,
 }
 
-/// A registered gesture with its relationships
+/// State of a gesture in the arbitration process
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ArbitrationState {
+    /// Ready to begin when conditions are met
+    Ready,
+    /// Waiting for other gestures to fail (requiresFailure)
+    Awaiting,
+    /// Currently active
+    Active,
+    /// Gesture has ended or failed
+    Finished,
+}
+
+/// A registered gesture with its relationships and arbitration state
 struct RegisteredGesture {
     id: usize,
     recognizer: Arc<Mutex<dyn GestureRecognizer>>,
     relations: Vec<(usize, GestureRelation)>,
+    arbitration_state: ArbitrationState,
 }
 
-/// Compositor that manages multiple gesture recognizers
+/// Compositor that manages multiple gesture recognizers with improved arbitration
+///
+/// # Arbitration Rules
+///
+/// 1. **Simultaneous**: Both gestures can be active at the same time
+/// 2. **RequiresFailure**: Gesture waits until the required gesture fails
+/// 3. **Exclusive**: When gesture begins, non-simultaneous gestures are cancelled
+///
+/// # Example
+/// ```ignore
+/// let mut compositor = GestureCompositor::new();
+///
+/// let tap_id = compositor.add(TapGesture::new().number_of_taps(2));
+/// let single_tap_id = compositor.add(TapGesture::new());
+///
+/// // Single tap waits for double tap to fail
+/// compositor.requires_failure(single_tap_id, tap_id);
+/// ```
 pub struct GestureCompositor {
     gestures: Vec<RegisteredGesture>,
     next_id: usize,
+    /// Gestures currently awaiting dependencies to fail
+    awaiting: HashSet<usize>,
+    /// Gestures that have been activated in the current touch sequence
+    active: HashSet<usize>,
 }
 
 impl Default for GestureCompositor {
@@ -41,6 +82,8 @@ impl GestureCompositor {
         Self {
             gestures: Vec::new(),
             next_id: 0,
+            awaiting: HashSet::new(),
+            active: HashSet::new(),
         }
     }
 
@@ -53,6 +96,7 @@ impl GestureCompositor {
             id,
             recognizer: Arc::new(Mutex::new(recognizer)),
             relations: Vec::new(),
+            arbitration_state: ArbitrationState::Ready,
         });
 
         id
@@ -79,6 +123,13 @@ impl GestureCompositor {
         self.set_relation(gesture1, gesture2, GestureRelation::RequiresFailure);
     }
 
+    /// Make gesture exclusive (cancels others when it begins)
+    pub fn exclusive(&mut self, gesture_id: usize, other_ids: &[usize]) {
+        for &other_id in other_ids {
+            self.set_relation(gesture_id, other_id, GestureRelation::Exclusive);
+        }
+    }
+
     /// Get a gesture recognizer by ID
     pub fn get(&self, id: usize) -> Option<Arc<Mutex<dyn GestureRecognizer>>> {
         self.gestures
@@ -87,87 +138,278 @@ impl GestureCompositor {
             .map(|g| g.recognizer.clone())
     }
 
-    /// Process a touch event through all recognizers
-    pub fn on_touch(&mut self, event: &TouchEvent) {
-        // First pass: process all recognizers
-        let mut states: Vec<(usize, GestureState)> = Vec::new();
+    /// Get the current state of all gestures
+    pub fn states(&self) -> Vec<(usize, GestureState)> {
+        self.gestures
+            .iter()
+            .filter_map(|g| g.recognizer.lock().ok().map(|rec| (g.id, rec.state())))
+            .collect()
+    }
 
-        for gesture in &self.gestures {
-            if let Ok(mut recognizer) = gesture.recognizer.lock() {
-                recognizer.on_touch(event);
-                states.push((gesture.id, recognizer.state()));
+    /// Check if a gesture has any pending requirements (requires_failure)
+    fn has_pending_requirements(&self, gesture_id: usize) -> bool {
+        let Some(gesture) = self.gestures.iter().find(|g| g.id == gesture_id) else {
+            return false;
+        };
+
+        for (other_id, relation) in &gesture.relations {
+            if *relation == GestureRelation::RequiresFailure {
+                // Check if the required gesture has failed
+                if let Some(other) = self.gestures.iter().find(|g| g.id == *other_id) {
+                    if let Ok(recognizer) = other.recognizer.lock() {
+                        let state = recognizer.state();
+                        // If not failed and not finished, requirement is pending
+                        if state != GestureState::Failed
+                            && state != GestureState::Ended
+                            && state != GestureState::Cancelled
+                        {
+                            return true;
+                        }
+                    }
+                }
             }
         }
 
-        // Second pass: handle arbitration
-        self.arbitrate(&states);
+        false
     }
 
-    /// Handle gesture arbitration based on relationships
-    fn arbitrate(&mut self, states: &[(usize, GestureState)]) {
-        // Find gestures that just began
-        let began_gestures: Vec<usize> = states
+    /// Check if gesture can run simultaneously with active gestures
+    fn can_run_simultaneously(&self, gesture_id: usize) -> bool {
+        let Some(gesture) = self.gestures.iter().find(|g| g.id == gesture_id) else {
+            return true;
+        };
+
+        for &active_id in &self.active {
+            if active_id == gesture_id {
+                continue;
+            }
+
+            // Check if we have a simultaneous relation with the active gesture
+            let is_simultaneous = gesture
+                .relations
+                .iter()
+                .any(|(id, rel)| *id == active_id && *rel == GestureRelation::Simultaneous);
+
+            if !is_simultaneous {
+                // Check the other direction
+                let other = self.gestures.iter().find(|g| g.id == active_id);
+                if let Some(other) = other {
+                    let other_simultaneous = other.relations.iter().any(|(id, rel)| {
+                        *id == gesture_id && *rel == GestureRelation::Simultaneous
+                    });
+                    if !other_simultaneous {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Process a touch event through all recognizers
+    pub fn on_touch(&mut self, event: &TouchEvent) {
+        // First pass: process all recognizers
+        let mut states: Vec<(usize, GestureState, GestureState)> = Vec::new();
+
+        for gesture in &self.gestures {
+            if let Ok(mut recognizer) = gesture.recognizer.lock() {
+                let old_state = recognizer.state();
+                recognizer.on_touch(event);
+                let new_state = recognizer.state();
+                states.push((gesture.id, old_state, new_state));
+            }
+        }
+
+        // Second pass: handle state transitions and arbitration
+        self.on_state_changes(&states);
+    }
+
+    /// Handle gesture state changes and perform arbitration
+    fn on_state_changes(&mut self, changes: &[(usize, GestureState, GestureState)]) {
+        // Process each state change
+        for &(id, old_state, new_state) in changes {
+            if old_state == new_state {
+                continue;
+            }
+
+            self.on_single_state_change(id, new_state);
+        }
+    }
+
+    /// Handle a single gesture state change
+    fn on_single_state_change(&mut self, id: usize, new_state: GestureState) {
+        match new_state {
+            GestureState::Began => {
+                // Check if this gesture has pending requirements
+                if self.has_pending_requirements(id) {
+                    // Put in awaiting state
+                    self.awaiting.insert(id);
+
+                    // Reset the gesture so it can try again when requirements are met
+                    if let Some(gesture) = self.gestures.iter().find(|g| g.id == id) {
+                        if let Ok(mut recognizer) = gesture.recognizer.lock() {
+                            recognizer.reset();
+                        }
+                    }
+                } else {
+                    // Can activate - cancel conflicting gestures
+                    self.active.insert(id);
+                    self.cancel_conflicting(id);
+                }
+            }
+
+            GestureState::Failed => {
+                // Remove from active/awaiting
+                self.active.remove(&id);
+                self.awaiting.remove(&id);
+
+                // Check if any awaiting gestures can now proceed
+                self.activate_waiting_on_failure(id);
+            }
+
+            GestureState::Ended | GestureState::Cancelled => {
+                // Remove from active
+                self.active.remove(&id);
+                self.awaiting.remove(&id);
+
+                // For ended, also check if any awaiting gestures can proceed
+                self.activate_waiting_on_failure(id);
+            }
+
+            GestureState::Changed => {
+                // Gesture continues - no arbitration needed
+            }
+
+            GestureState::Possible => {
+                // Reset state - clear from tracking
+                self.active.remove(&id);
+                self.awaiting.remove(&id);
+            }
+        }
+    }
+
+    /// Cancel gestures that conflict with the activating gesture
+    fn cancel_conflicting(&mut self, activating_id: usize) {
+        let Some(activating) = self.gestures.iter().find(|g| g.id == activating_id) else {
+            return;
+        };
+
+        // Find exclusive relations
+        let exclusive_targets: Vec<usize> = activating
+            .relations
             .iter()
-            .filter(|(_, state)| *state == GestureState::Began)
-            .map(|(id, _)| *id)
+            .filter_map(|(id, rel)| {
+                if *rel == GestureRelation::Exclusive {
+                    Some(*id)
+                } else {
+                    None
+                }
+            })
             .collect();
 
-        for began_id in &began_gestures {
-            // Find the gesture that began
-            let Some(gesture) = self.gestures.iter().find(|g| g.id == *began_id) else {
+        // Cancel exclusive targets
+        for target_id in exclusive_targets {
+            if let Some(target) = self.gestures.iter().find(|g| g.id == target_id) {
+                if let Ok(mut recognizer) = target.recognizer.lock() {
+                    let state = recognizer.state();
+                    if state == GestureState::Possible || state.is_active() {
+                        recognizer.set_enabled(false);
+                        recognizer.reset();
+                        recognizer.set_enabled(true);
+                    }
+                }
+            }
+        }
+
+        // Also cancel gestures that don't have simultaneous relationship
+        for gesture in &self.gestures {
+            if gesture.id == activating_id {
                 continue;
-            };
+            }
 
-            // Check relationships
-            for (other_id, relation) in &gesture.relations {
-                match relation {
-                    GestureRelation::Exclusive => {
-                        // Fail other gestures that aren't simultaneous
-                        if let Some(other) = self.gestures.iter().find(|g| g.id == *other_id) {
-                            // Check if other has simultaneous relation with us
-                            let is_simultaneous = other
-                                .relations
-                                .iter()
-                                .any(|(id, rel)| *id == *began_id && *rel == GestureRelation::Simultaneous);
+            // Check if this gesture has a simultaneous relation with the activating one
+            let has_simultaneous_with_activating = gesture
+                .relations
+                .iter()
+                .any(|(id, rel)| *id == activating_id && *rel == GestureRelation::Simultaneous);
 
-                            if !is_simultaneous {
-                                if let Ok(mut recognizer) = other.recognizer.lock() {
-                                    if recognizer.state() == GestureState::Possible {
-                                        // Would be nice to fail it, but we can't easily
-                                        // Just disable for now
-                                        recognizer.set_enabled(false);
-                                        recognizer.reset();
-                                        recognizer.set_enabled(true);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    GestureRelation::RequiresFailure => {
-                        // Check if the required gesture has failed
-                        let other_state = states.iter().find(|(id, _)| *id == *other_id);
-                        if let Some((_, state)) = other_state {
-                            if *state != GestureState::Failed {
-                                // Other gesture hasn't failed, we should wait
-                                // In practice, this is handled during recognition
-                            }
-                        }
-                    }
-                    GestureRelation::Simultaneous => {
-                        // Nothing to do, allow both
+            let activating_has_simultaneous = activating
+                .relations
+                .iter()
+                .any(|(id, rel)| *id == gesture.id && *rel == GestureRelation::Simultaneous);
+
+            // If neither has simultaneous relation, the gesture should be cancelled
+            if !has_simultaneous_with_activating && !activating_has_simultaneous {
+                if let Ok(mut recognizer) = gesture.recognizer.lock() {
+                    let state = recognizer.state();
+                    if state == GestureState::Possible {
+                        // Only cancel if still possible, not if already active
+                        recognizer.set_enabled(false);
+                        recognizer.reset();
+                        recognizer.set_enabled(true);
                     }
                 }
             }
         }
     }
 
-    /// Reset all recognizers
+    /// Activate gestures that were waiting for the failed gesture
+    fn activate_waiting_on_failure(&mut self, failed_id: usize) {
+        let awaiting: Vec<usize> = self.awaiting.iter().copied().collect();
+
+        for gesture_id in awaiting {
+            // Check if this gesture was waiting for the failed one
+            let was_waiting = self
+                .gestures
+                .iter()
+                .find(|g| g.id == gesture_id)
+                .map(|g| {
+                    g.relations.iter().any(|(id, rel)| {
+                        *id == failed_id && *rel == GestureRelation::RequiresFailure
+                    })
+                })
+                .unwrap_or(false);
+
+            if was_waiting && !self.has_pending_requirements(gesture_id) {
+                // All requirements met - remove from awaiting
+                self.awaiting.remove(&gesture_id);
+
+                // The gesture will try to activate on the next touch event
+            }
+        }
+    }
+
+    /// Reset all recognizers and clear arbitration state
     pub fn reset(&mut self) {
         for gesture in &self.gestures {
             if let Ok(mut recognizer) = gesture.recognizer.lock() {
                 recognizer.reset();
             }
         }
+
+        self.awaiting.clear();
+        self.active.clear();
+    }
+
+    /// Get number of active gestures
+    pub fn active_count(&self) -> usize {
+        self.active.len()
+    }
+
+    /// Get number of awaiting gestures
+    pub fn awaiting_count(&self) -> usize {
+        self.awaiting.len()
+    }
+
+    /// Check if a specific gesture is active
+    pub fn is_active(&self, id: usize) -> bool {
+        self.active.contains(&id)
+    }
+
+    /// Check if a specific gesture is awaiting requirements
+    pub fn is_awaiting(&self, id: usize) -> bool {
+        self.awaiting.contains(&id)
     }
 }
 
@@ -200,6 +442,48 @@ mod tests {
 
         compositor.simultaneous(tap_id, pan_id);
 
-        // Both should be able to recognize
+        // Both should be able to recognize (verified by relations being set)
+        assert!(compositor
+            .gestures
+            .iter()
+            .find(|g| g.id == tap_id)
+            .unwrap()
+            .relations
+            .contains(&(pan_id, GestureRelation::Simultaneous)));
+    }
+
+    #[test]
+    fn test_requires_failure_relation() {
+        let mut compositor = GestureCompositor::new();
+
+        let double_tap_id = compositor.add(TapGesture::new().number_of_taps(2));
+        let single_tap_id = compositor.add(TapGesture::new());
+
+        // Single tap waits for double tap to fail
+        compositor.requires_failure(single_tap_id, double_tap_id);
+
+        assert!(compositor.has_pending_requirements(single_tap_id));
+        assert!(!compositor.has_pending_requirements(double_tap_id));
+    }
+
+    #[test]
+    fn test_active_and_awaiting_counts() {
+        let compositor = GestureCompositor::new();
+
+        assert_eq!(compositor.active_count(), 0);
+        assert_eq!(compositor.awaiting_count(), 0);
+    }
+
+    #[test]
+    fn test_reset_clears_state() {
+        let mut compositor = GestureCompositor::new();
+
+        compositor.add(TapGesture::new());
+        compositor.add(PanGesture::new());
+
+        compositor.reset();
+
+        assert_eq!(compositor.active_count(), 0);
+        assert_eq!(compositor.awaiting_count(), 0);
     }
 }

--- a/crates/zedra-gesture/src/element.rs
+++ b/crates/zedra-gesture/src/element.rs
@@ -2,9 +2,10 @@
 //!
 //! Provides a fluent API for adding gesture recognition to GPUI elements:
 //! ```ignore
-//! pan_gesture(my_view)
+//! pan_gesture()
+//!     .min_distance(10.0)
 //!     .on_pan(|event, cx| { ... })
-//!     .on_end(|event, cx| { ... })
+//!     .child(my_view)
 //! ```
 
 use std::sync::{Arc, Mutex};
@@ -36,17 +37,17 @@ pub type PinchHandler = Arc<dyn Fn(&PinchGestureEvent, &mut App) + Send + Sync>;
 
 /// Wraps an element with pan gesture recognition
 pub struct PanGestureElement {
-    child: AnyElement,
+    child: Option<AnyElement>,
     recognizer: Arc<Mutex<PanGesture>>,
     on_begin: Option<PanHandler>,
     on_change: Option<PanHandler>,
     on_end: Option<PanHandler>,
 }
 
-/// Create a pan gesture wrapper for an element
-pub fn pan_gesture(child: impl IntoElement) -> PanGestureElement {
+/// Create a pan gesture wrapper
+pub fn pan_gesture() -> PanGestureElement {
     PanGestureElement {
-        child: child.into_any_element(),
+        child: None,
         recognizer: Arc::new(Mutex::new(PanGesture::new())),
         on_begin: None,
         on_change: None,
@@ -55,6 +56,12 @@ pub fn pan_gesture(child: impl IntoElement) -> PanGestureElement {
 }
 
 impl PanGestureElement {
+    /// Set the child element to wrap with gesture recognition
+    pub fn child(mut self, child: impl IntoElement) -> Self {
+        self.child = Some(child.into_any_element());
+        self
+    }
+
     /// Set minimum distance to start recognizing
     pub fn min_distance(self, distance: f32) -> Self {
         if let Ok(mut recognizer) = self.recognizer.lock() {
@@ -148,7 +155,7 @@ impl IntoElement for PanGestureElement {
 }
 
 impl Element for PanGestureElement {
-    type RequestLayoutState = AnyElement;
+    type RequestLayoutState = Option<AnyElement>;
     type PrepaintState = ();
 
     fn id(&self) -> Option<ElementId> {
@@ -160,9 +167,13 @@ impl Element for PanGestureElement {
         _id: Option<&GlobalElementId>,
         cx: &mut WindowContext,
     ) -> (LayoutId, Self::RequestLayoutState) {
-        let mut child = std::mem::replace(&mut self.child, gpui::Empty.into_any_element());
-        let layout_id = child.request_layout(cx);
-        (layout_id, child)
+        if let Some(mut child) = self.child.take() {
+            let layout_id = child.request_layout(cx);
+            (layout_id, Some(child))
+        } else {
+            let layout_id = cx.request_layout(gpui::Style::default(), []);
+            (layout_id, None)
+        }
     }
 
     fn prepaint(
@@ -172,7 +183,9 @@ impl Element for PanGestureElement {
         child: &mut Self::RequestLayoutState,
         cx: &mut WindowContext,
     ) -> Self::PrepaintState {
-        child.prepaint(cx);
+        if let Some(child) = child {
+            child.prepaint(cx);
+        }
     }
 
     fn paint(
@@ -183,7 +196,9 @@ impl Element for PanGestureElement {
         _prepaint: &mut Self::PrepaintState,
         cx: &mut WindowContext,
     ) {
-        child.paint(cx);
+        if let Some(child) = child {
+            child.paint(cx);
+        }
 
         // Register mouse event handlers for gesture recognition
         let recognizer = self.recognizer.clone();
@@ -277,21 +292,27 @@ impl Element for PanGestureElement {
 
 /// Wraps an element with tap gesture recognition
 pub struct TapGestureElement {
-    child: AnyElement,
+    child: Option<AnyElement>,
     recognizer: Arc<Mutex<TapGesture>>,
     on_tap: Option<TapHandler>,
 }
 
-/// Create a tap gesture wrapper for an element
-pub fn tap_gesture(child: impl IntoElement) -> TapGestureElement {
+/// Create a tap gesture wrapper
+pub fn tap_gesture() -> TapGestureElement {
     TapGestureElement {
-        child: child.into_any_element(),
+        child: None,
         recognizer: Arc::new(Mutex::new(TapGesture::new())),
         on_tap: None,
     }
 }
 
 impl TapGestureElement {
+    /// Set the child element to wrap with gesture recognition
+    pub fn child(mut self, child: impl IntoElement) -> Self {
+        self.child = Some(child.into_any_element());
+        self
+    }
+
     /// Set number of taps required
     pub fn number_of_taps(self, count: u8) -> Self {
         if let Ok(mut recognizer) = self.recognizer.lock() {
@@ -319,7 +340,7 @@ impl IntoElement for TapGestureElement {
 }
 
 impl Element for TapGestureElement {
-    type RequestLayoutState = AnyElement;
+    type RequestLayoutState = Option<AnyElement>;
     type PrepaintState = ();
 
     fn id(&self) -> Option<ElementId> {
@@ -331,9 +352,13 @@ impl Element for TapGestureElement {
         _id: Option<&GlobalElementId>,
         cx: &mut WindowContext,
     ) -> (LayoutId, Self::RequestLayoutState) {
-        let mut child = std::mem::replace(&mut self.child, gpui::Empty.into_any_element());
-        let layout_id = child.request_layout(cx);
-        (layout_id, child)
+        if let Some(mut child) = self.child.take() {
+            let layout_id = child.request_layout(cx);
+            (layout_id, Some(child))
+        } else {
+            let layout_id = cx.request_layout(gpui::Style::default(), []);
+            (layout_id, None)
+        }
     }
 
     fn prepaint(
@@ -343,7 +368,9 @@ impl Element for TapGestureElement {
         child: &mut Self::RequestLayoutState,
         cx: &mut WindowContext,
     ) -> Self::PrepaintState {
-        child.prepaint(cx);
+        if let Some(child) = child {
+            child.prepaint(cx);
+        }
     }
 
     fn paint(
@@ -354,7 +381,9 @@ impl Element for TapGestureElement {
         _prepaint: &mut Self::PrepaintState,
         cx: &mut WindowContext,
     ) {
-        child.paint(cx);
+        if let Some(child) = child {
+            child.paint(cx);
+        }
 
         let recognizer = self.recognizer.clone();
 
@@ -408,17 +437,17 @@ impl Element for TapGestureElement {
 
 /// Wraps an element with pinch gesture recognition
 pub struct PinchGestureElement {
-    child: AnyElement,
+    child: Option<AnyElement>,
     recognizer: Arc<Mutex<PinchGesture>>,
     on_begin: Option<PinchHandler>,
     on_change: Option<PinchHandler>,
     on_end: Option<PinchHandler>,
 }
 
-/// Create a pinch gesture wrapper for an element
-pub fn pinch_gesture(child: impl IntoElement) -> PinchGestureElement {
+/// Create a pinch gesture wrapper
+pub fn pinch_gesture() -> PinchGestureElement {
     PinchGestureElement {
-        child: child.into_any_element(),
+        child: None,
         recognizer: Arc::new(Mutex::new(PinchGesture::new())),
         on_begin: None,
         on_change: None,
@@ -427,6 +456,12 @@ pub fn pinch_gesture(child: impl IntoElement) -> PinchGestureElement {
 }
 
 impl PinchGestureElement {
+    /// Set the child element to wrap with gesture recognition
+    pub fn child(mut self, child: impl IntoElement) -> Self {
+        self.child = Some(child.into_any_element());
+        self
+    }
+
     /// Set handler for when pinch begins
     pub fn on_begin<F>(mut self, handler: F) -> Self
     where
@@ -478,7 +513,7 @@ impl IntoElement for PinchGestureElement {
 }
 
 impl Element for PinchGestureElement {
-    type RequestLayoutState = AnyElement;
+    type RequestLayoutState = Option<AnyElement>;
     type PrepaintState = ();
 
     fn id(&self) -> Option<ElementId> {
@@ -490,9 +525,13 @@ impl Element for PinchGestureElement {
         _id: Option<&GlobalElementId>,
         cx: &mut WindowContext,
     ) -> (LayoutId, Self::RequestLayoutState) {
-        let mut child = std::mem::replace(&mut self.child, gpui::Empty.into_any_element());
-        let layout_id = child.request_layout(cx);
-        (layout_id, child)
+        if let Some(mut child) = self.child.take() {
+            let layout_id = child.request_layout(cx);
+            (layout_id, Some(child))
+        } else {
+            let layout_id = cx.request_layout(gpui::Style::default(), []);
+            (layout_id, None)
+        }
     }
 
     fn prepaint(
@@ -502,7 +541,9 @@ impl Element for PinchGestureElement {
         child: &mut Self::RequestLayoutState,
         cx: &mut WindowContext,
     ) -> Self::PrepaintState {
-        child.prepaint(cx);
+        if let Some(child) = child {
+            child.prepaint(cx);
+        }
     }
 
     fn paint(
@@ -513,7 +554,9 @@ impl Element for PinchGestureElement {
         _prepaint: &mut Self::PrepaintState,
         cx: &mut WindowContext,
     ) {
-        child.paint(cx);
+        if let Some(child) = child {
+            child.paint(cx);
+        }
 
         // Note: Pinch gestures require multi-touch which isn't available via mouse events
         // This will need JNI integration to receive actual multi-touch events

--- a/crates/zedra-gesture/src/element.rs
+++ b/crates/zedra-gesture/src/element.rs
@@ -1,0 +1,522 @@
+//! GPUI element wrappers for gesture handling
+//!
+//! Provides a fluent API for adding gesture recognition to GPUI elements:
+//! ```ignore
+//! pan_gesture(my_view)
+//!     .on_pan(|event, cx| { ... })
+//!     .on_end(|event, cx| { ... })
+//! ```
+
+use std::sync::{Arc, Mutex};
+
+use gpui::*;
+
+use crate::recognizers::{
+    PanGesture, PanGestureEvent, PinchGesture, PinchGestureEvent, TapGesture, TapGestureEvent,
+};
+use crate::state::GestureState;
+use crate::types::{Point, TouchAction, TouchEvent, TouchPointer};
+
+// ============================================================================
+// Gesture Handler Types
+// ============================================================================
+
+/// Handler for pan gesture events
+pub type PanHandler = Arc<dyn Fn(&PanGestureEvent, &mut App) + Send + Sync>;
+
+/// Handler for tap gesture events
+pub type TapHandler = Arc<dyn Fn(&TapGestureEvent, &mut App) + Send + Sync>;
+
+/// Handler for pinch gesture events
+pub type PinchHandler = Arc<dyn Fn(&PinchGestureEvent, &mut App) + Send + Sync>;
+
+// ============================================================================
+// Pan Gesture Element
+// ============================================================================
+
+/// Wraps an element with pan gesture recognition
+pub struct PanGestureElement {
+    child: AnyElement,
+    recognizer: Arc<Mutex<PanGesture>>,
+    on_begin: Option<PanHandler>,
+    on_change: Option<PanHandler>,
+    on_end: Option<PanHandler>,
+}
+
+/// Create a pan gesture wrapper for an element
+pub fn pan_gesture(child: impl IntoElement) -> PanGestureElement {
+    PanGestureElement {
+        child: child.into_any_element(),
+        recognizer: Arc::new(Mutex::new(PanGesture::new())),
+        on_begin: None,
+        on_change: None,
+        on_end: None,
+    }
+}
+
+impl PanGestureElement {
+    /// Set minimum distance to start recognizing
+    pub fn min_distance(self, distance: f32) -> Self {
+        if let Ok(mut recognizer) = self.recognizer.lock() {
+            *recognizer = std::mem::take(&mut *recognizer).min_distance(distance);
+        }
+        self
+    }
+
+    /// Set handler for when pan begins
+    pub fn on_begin<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&PanGestureEvent, &mut App) + Send + Sync + 'static,
+    {
+        self.on_begin = Some(Arc::new(handler));
+        self
+    }
+
+    /// Set handler for pan changes (movement)
+    pub fn on_change<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&PanGestureEvent, &mut App) + Send + Sync + 'static,
+    {
+        self.on_change = Some(Arc::new(handler));
+        self
+    }
+
+    /// Set handler for when pan ends
+    pub fn on_end<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&PanGestureEvent, &mut App) + Send + Sync + 'static,
+    {
+        self.on_end = Some(Arc::new(handler));
+        self
+    }
+
+    /// Set handler for all pan events
+    pub fn on_pan<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&PanGestureEvent, &mut App) + Send + Sync + Clone + 'static,
+    {
+        let h1 = handler.clone();
+        let h2 = handler.clone();
+        let h3 = handler;
+        self.on_begin = Some(Arc::new(move |e, cx| h1(e, cx)));
+        self.on_change = Some(Arc::new(move |e, cx| h2(e, cx)));
+        self.on_end = Some(Arc::new(move |e, cx| h3(e, cx)));
+        self
+    }
+
+    fn handle_mouse_event(&self, position: Point, action: TouchAction, cx: &mut App) {
+        let event = TouchEvent::new(action, vec![TouchPointer::new(0, position.x, position.y)]);
+
+        if let Ok(mut recognizer) = self.recognizer.lock() {
+            recognizer.on_touch(&event);
+
+            if let Some(gesture_event) = recognizer.take_event() {
+                match gesture_event.state {
+                    GestureState::Began => {
+                        if let Some(handler) = &self.on_begin {
+                            handler(&gesture_event, cx);
+                        }
+                    }
+                    GestureState::Changed => {
+                        if let Some(handler) = &self.on_change {
+                            handler(&gesture_event, cx);
+                        }
+                    }
+                    GestureState::Ended => {
+                        if let Some(handler) = &self.on_end {
+                            handler(&gesture_event, cx);
+                        }
+                    }
+                    GestureState::Cancelled => {
+                        if let Some(handler) = &self.on_end {
+                            handler(&gesture_event, cx);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+impl IntoElement for PanGestureElement {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for PanGestureElement {
+    type RequestLayoutState = AnyElement;
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        cx: &mut WindowContext,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut child = std::mem::replace(&mut self.child, gpui::Empty.into_any_element());
+        let layout_id = child.request_layout(cx);
+        (layout_id, child)
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _bounds: Bounds<Pixels>,
+        child: &mut Self::RequestLayoutState,
+        cx: &mut WindowContext,
+    ) -> Self::PrepaintState {
+        child.prepaint(cx);
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        bounds: Bounds<Pixels>,
+        child: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        cx: &mut WindowContext,
+    ) {
+        child.paint(cx);
+
+        // Register mouse event handlers for gesture recognition
+        let recognizer = self.recognizer.clone();
+        let on_begin = self.on_begin.clone();
+        let on_change = self.on_change.clone();
+        let on_end = self.on_end.clone();
+
+        cx.on_mouse_event(move |event: &MouseDownEvent, phase, cx| {
+            if phase != DispatchPhase::Bubble {
+                return;
+            }
+            if !bounds.contains(&event.position) {
+                return;
+            }
+
+            let position = Point::new(event.position.x.0, event.position.y.0);
+            let touch_event =
+                TouchEvent::new(TouchAction::Down, vec![TouchPointer::new(0, position.x, position.y)]);
+
+            if let Ok(mut rec) = recognizer.lock() {
+                rec.on_touch(&touch_event);
+            }
+        });
+
+        let recognizer = self.recognizer.clone();
+        let on_begin = self.on_begin.clone();
+        let on_change = self.on_change.clone();
+
+        cx.on_mouse_event(move |event: &MouseMoveEvent, phase, cx| {
+            if phase != DispatchPhase::Bubble {
+                return;
+            }
+
+            let position = Point::new(event.position.x.0, event.position.y.0);
+            let touch_event =
+                TouchEvent::new(TouchAction::Move, vec![TouchPointer::new(0, position.x, position.y)]);
+
+            if let Ok(mut rec) = recognizer.lock() {
+                rec.on_touch(&touch_event);
+
+                if let Some(gesture_event) = rec.take_event() {
+                    match gesture_event.state {
+                        GestureState::Began => {
+                            if let Some(handler) = &on_begin {
+                                handler(&gesture_event, cx);
+                            }
+                        }
+                        GestureState::Changed => {
+                            if let Some(handler) = &on_change {
+                                handler(&gesture_event, cx);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        });
+
+        let recognizer = self.recognizer.clone();
+        let on_end = self.on_end.clone();
+
+        cx.on_mouse_event(move |event: &MouseUpEvent, phase, cx| {
+            if phase != DispatchPhase::Bubble {
+                return;
+            }
+
+            let position = Point::new(event.position.x.0, event.position.y.0);
+            let touch_event =
+                TouchEvent::new(TouchAction::Up, vec![TouchPointer::new(0, position.x, position.y)]);
+
+            if let Ok(mut rec) = recognizer.lock() {
+                rec.on_touch(&touch_event);
+
+                if let Some(gesture_event) = rec.take_event() {
+                    if gesture_event.state == GestureState::Ended
+                        || gesture_event.state == GestureState::Cancelled
+                    {
+                        if let Some(handler) = &on_end {
+                            handler(&gesture_event, cx);
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+// ============================================================================
+// Tap Gesture Element
+// ============================================================================
+
+/// Wraps an element with tap gesture recognition
+pub struct TapGestureElement {
+    child: AnyElement,
+    recognizer: Arc<Mutex<TapGesture>>,
+    on_tap: Option<TapHandler>,
+}
+
+/// Create a tap gesture wrapper for an element
+pub fn tap_gesture(child: impl IntoElement) -> TapGestureElement {
+    TapGestureElement {
+        child: child.into_any_element(),
+        recognizer: Arc::new(Mutex::new(TapGesture::new())),
+        on_tap: None,
+    }
+}
+
+impl TapGestureElement {
+    /// Set number of taps required
+    pub fn number_of_taps(self, count: u8) -> Self {
+        if let Ok(mut recognizer) = self.recognizer.lock() {
+            *recognizer = std::mem::take(&mut *recognizer).number_of_taps(count);
+        }
+        self
+    }
+
+    /// Set handler for tap events
+    pub fn on_tap<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&TapGestureEvent, &mut App) + Send + Sync + 'static,
+    {
+        self.on_tap = Some(Arc::new(handler));
+        self
+    }
+}
+
+impl IntoElement for TapGestureElement {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for TapGestureElement {
+    type RequestLayoutState = AnyElement;
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        cx: &mut WindowContext,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut child = std::mem::replace(&mut self.child, gpui::Empty.into_any_element());
+        let layout_id = child.request_layout(cx);
+        (layout_id, child)
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _bounds: Bounds<Pixels>,
+        child: &mut Self::RequestLayoutState,
+        cx: &mut WindowContext,
+    ) -> Self::PrepaintState {
+        child.prepaint(cx);
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        bounds: Bounds<Pixels>,
+        child: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        cx: &mut WindowContext,
+    ) {
+        child.paint(cx);
+
+        let recognizer = self.recognizer.clone();
+
+        cx.on_mouse_event(move |event: &MouseDownEvent, phase, _cx| {
+            if phase != DispatchPhase::Bubble {
+                return;
+            }
+            if !bounds.contains(&event.position) {
+                return;
+            }
+
+            let position = Point::new(event.position.x.0, event.position.y.0);
+            let touch_event =
+                TouchEvent::new(TouchAction::Down, vec![TouchPointer::new(0, position.x, position.y)]);
+
+            if let Ok(mut rec) = recognizer.lock() {
+                rec.on_touch(&touch_event);
+            }
+        });
+
+        let recognizer = self.recognizer.clone();
+        let on_tap = self.on_tap.clone();
+
+        cx.on_mouse_event(move |event: &MouseUpEvent, phase, cx| {
+            if phase != DispatchPhase::Bubble {
+                return;
+            }
+
+            let position = Point::new(event.position.x.0, event.position.y.0);
+            let touch_event =
+                TouchEvent::new(TouchAction::Up, vec![TouchPointer::new(0, position.x, position.y)]);
+
+            if let Ok(mut rec) = recognizer.lock() {
+                rec.on_touch(&touch_event);
+
+                if let Some(gesture_event) = rec.take_event() {
+                    if gesture_event.state == GestureState::Ended {
+                        if let Some(handler) = &on_tap {
+                            handler(&gesture_event, cx);
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+// ============================================================================
+// Pinch Gesture Element
+// ============================================================================
+
+/// Wraps an element with pinch gesture recognition
+pub struct PinchGestureElement {
+    child: AnyElement,
+    recognizer: Arc<Mutex<PinchGesture>>,
+    on_begin: Option<PinchHandler>,
+    on_change: Option<PinchHandler>,
+    on_end: Option<PinchHandler>,
+}
+
+/// Create a pinch gesture wrapper for an element
+pub fn pinch_gesture(child: impl IntoElement) -> PinchGestureElement {
+    PinchGestureElement {
+        child: child.into_any_element(),
+        recognizer: Arc::new(Mutex::new(PinchGesture::new())),
+        on_begin: None,
+        on_change: None,
+        on_end: None,
+    }
+}
+
+impl PinchGestureElement {
+    /// Set handler for when pinch begins
+    pub fn on_begin<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&PinchGestureEvent, &mut App) + Send + Sync + 'static,
+    {
+        self.on_begin = Some(Arc::new(handler));
+        self
+    }
+
+    /// Set handler for pinch changes
+    pub fn on_change<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&PinchGestureEvent, &mut App) + Send + Sync + 'static,
+    {
+        self.on_change = Some(Arc::new(handler));
+        self
+    }
+
+    /// Set handler for when pinch ends
+    pub fn on_end<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&PinchGestureEvent, &mut App) + Send + Sync + 'static,
+    {
+        self.on_end = Some(Arc::new(handler));
+        self
+    }
+
+    /// Set handler for all pinch events
+    pub fn on_pinch<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(&PinchGestureEvent, &mut App) + Send + Sync + Clone + 'static,
+    {
+        let h1 = handler.clone();
+        let h2 = handler.clone();
+        let h3 = handler;
+        self.on_begin = Some(Arc::new(move |e, cx| h1(e, cx)));
+        self.on_change = Some(Arc::new(move |e, cx| h2(e, cx)));
+        self.on_end = Some(Arc::new(move |e, cx| h3(e, cx)));
+        self
+    }
+}
+
+impl IntoElement for PinchGestureElement {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for PinchGestureElement {
+    type RequestLayoutState = AnyElement;
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        cx: &mut WindowContext,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut child = std::mem::replace(&mut self.child, gpui::Empty.into_any_element());
+        let layout_id = child.request_layout(cx);
+        (layout_id, child)
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _bounds: Bounds<Pixels>,
+        child: &mut Self::RequestLayoutState,
+        cx: &mut WindowContext,
+    ) -> Self::PrepaintState {
+        child.prepaint(cx);
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _bounds: Bounds<Pixels>,
+        child: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        cx: &mut WindowContext,
+    ) {
+        child.paint(cx);
+
+        // Note: Pinch gestures require multi-touch which isn't available via mouse events
+        // This will need JNI integration to receive actual multi-touch events
+        // For now, this is a placeholder structure
+    }
+}

--- a/crates/zedra-gesture/src/element.rs
+++ b/crates/zedra-gesture/src/element.rs
@@ -13,7 +13,8 @@ use std::sync::{Arc, Mutex};
 use gpui::*;
 
 use crate::recognizers::{
-    PanGesture, PanGestureEvent, PinchGesture, PinchGestureEvent, TapGesture, TapGestureEvent,
+    GestureRecognizer, PanGesture, PanGestureEvent, PinchGesture, PinchGestureEvent, TapGesture,
+    TapGestureEvent,
 };
 use crate::state::GestureState;
 use crate::types::{Point, TouchAction, TouchEvent, TouchPointer};
@@ -23,13 +24,13 @@ use crate::types::{Point, TouchAction, TouchEvent, TouchPointer};
 // ============================================================================
 
 /// Handler for pan gesture events
-pub type PanHandler = Arc<dyn Fn(&PanGestureEvent, &mut App) + Send + Sync>;
+pub type PanHandler = Arc<dyn Fn(&PanGestureEvent, &mut Window, &mut App) + Send + Sync>;
 
 /// Handler for tap gesture events
-pub type TapHandler = Arc<dyn Fn(&TapGestureEvent, &mut App) + Send + Sync>;
+pub type TapHandler = Arc<dyn Fn(&TapGestureEvent, &mut Window, &mut App) + Send + Sync>;
 
 /// Handler for pinch gesture events
-pub type PinchHandler = Arc<dyn Fn(&PinchGestureEvent, &mut App) + Send + Sync>;
+pub type PinchHandler = Arc<dyn Fn(&PinchGestureEvent, &mut Window, &mut App) + Send + Sync>;
 
 // ============================================================================
 // Pan Gesture Element
@@ -73,7 +74,7 @@ impl PanGestureElement {
     /// Set handler for when pan begins
     pub fn on_begin<F>(mut self, handler: F) -> Self
     where
-        F: Fn(&PanGestureEvent, &mut App) + Send + Sync + 'static,
+        F: Fn(&PanGestureEvent, &mut Window, &mut App) + Send + Sync + 'static,
     {
         self.on_begin = Some(Arc::new(handler));
         self
@@ -82,7 +83,7 @@ impl PanGestureElement {
     /// Set handler for pan changes (movement)
     pub fn on_change<F>(mut self, handler: F) -> Self
     where
-        F: Fn(&PanGestureEvent, &mut App) + Send + Sync + 'static,
+        F: Fn(&PanGestureEvent, &mut Window, &mut App) + Send + Sync + 'static,
     {
         self.on_change = Some(Arc::new(handler));
         self
@@ -91,7 +92,7 @@ impl PanGestureElement {
     /// Set handler for when pan ends
     pub fn on_end<F>(mut self, handler: F) -> Self
     where
-        F: Fn(&PanGestureEvent, &mut App) + Send + Sync + 'static,
+        F: Fn(&PanGestureEvent, &mut Window, &mut App) + Send + Sync + 'static,
     {
         self.on_end = Some(Arc::new(handler));
         self
@@ -100,49 +101,16 @@ impl PanGestureElement {
     /// Set handler for all pan events
     pub fn on_pan<F>(mut self, handler: F) -> Self
     where
-        F: Fn(&PanGestureEvent, &mut App) + Send + Sync + Clone + 'static,
+        F: Fn(&PanGestureEvent, &mut Window, &mut App) + Send + Sync + 'static,
     {
+        let handler = Arc::new(handler);
         let h1 = handler.clone();
         let h2 = handler.clone();
         let h3 = handler;
-        self.on_begin = Some(Arc::new(move |e, cx| h1(e, cx)));
-        self.on_change = Some(Arc::new(move |e, cx| h2(e, cx)));
-        self.on_end = Some(Arc::new(move |e, cx| h3(e, cx)));
+        self.on_begin = Some(Arc::new(move |e, w, cx| h1(e, w, cx)));
+        self.on_change = Some(Arc::new(move |e, w, cx| h2(e, w, cx)));
+        self.on_end = Some(Arc::new(move |e, w, cx| h3(e, w, cx)));
         self
-    }
-
-    fn handle_mouse_event(&self, position: Point, action: TouchAction, cx: &mut App) {
-        let event = TouchEvent::new(action, vec![TouchPointer::new(0, position.x, position.y)]);
-
-        if let Ok(mut recognizer) = self.recognizer.lock() {
-            recognizer.on_touch(&event);
-
-            if let Some(gesture_event) = recognizer.take_event() {
-                match gesture_event.state {
-                    GestureState::Began => {
-                        if let Some(handler) = &self.on_begin {
-                            handler(&gesture_event, cx);
-                        }
-                    }
-                    GestureState::Changed => {
-                        if let Some(handler) = &self.on_change {
-                            handler(&gesture_event, cx);
-                        }
-                    }
-                    GestureState::Ended => {
-                        if let Some(handler) = &self.on_end {
-                            handler(&gesture_event, cx);
-                        }
-                    }
-                    GestureState::Cancelled => {
-                        if let Some(handler) = &self.on_end {
-                            handler(&gesture_event, cx);
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
     }
 }
 
@@ -162,16 +130,22 @@ impl Element for PanGestureElement {
         None
     }
 
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
     fn request_layout(
         &mut self,
         _id: Option<&GlobalElementId>,
-        cx: &mut WindowContext,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
         if let Some(mut child) = self.child.take() {
-            let layout_id = child.request_layout(cx);
+            let layout_id = child.request_layout(window, cx);
             (layout_id, Some(child))
         } else {
-            let layout_id = cx.request_layout(gpui::Style::default(), []);
+            let layout_id = window.request_layout(gpui::Style::default(), [], cx);
             (layout_id, None)
         }
     }
@@ -179,25 +153,29 @@ impl Element for PanGestureElement {
     fn prepaint(
         &mut self,
         _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
         _bounds: Bounds<Pixels>,
         child: &mut Self::RequestLayoutState,
-        cx: &mut WindowContext,
+        window: &mut Window,
+        cx: &mut App,
     ) -> Self::PrepaintState {
         if let Some(child) = child {
-            child.prepaint(cx);
+            child.prepaint(window, cx);
         }
     }
 
     fn paint(
         &mut self,
         _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
         bounds: Bounds<Pixels>,
         child: &mut Self::RequestLayoutState,
         _prepaint: &mut Self::PrepaintState,
-        cx: &mut WindowContext,
+        window: &mut Window,
+        cx: &mut App,
     ) {
         if let Some(child) = child {
-            child.paint(cx);
+            child.paint(window, cx);
         }
 
         // Register mouse event handlers for gesture recognition
@@ -206,7 +184,23 @@ impl Element for PanGestureElement {
         let on_change = self.on_change.clone();
         let on_end = self.on_end.clone();
 
-        cx.on_mouse_event(move |event: &MouseDownEvent, phase, cx| {
+        log::info!(
+            "PanGesture: paint() registering handlers, bounds=({:.1},{:.1})-({:.1},{:.1})",
+            bounds.origin.x,
+            bounds.origin.y,
+            bounds.origin.x + bounds.size.width,
+            bounds.origin.y + bounds.size.height
+        );
+
+        window.on_mouse_event(move |event: &MouseDownEvent, phase, _window, _cx| {
+            log::info!(
+                "PanGesture: MouseDown phase={:?}, pos=({:.1}, {:.1}), contains={}",
+                phase,
+                event.position.x,
+                event.position.y,
+                bounds.contains(&event.position)
+            );
+
             if phase != DispatchPhase::Bubble {
                 return;
             }
@@ -214,41 +208,107 @@ impl Element for PanGestureElement {
                 return;
             }
 
-            let position = Point::new(event.position.x.0, event.position.y.0);
-            let touch_event =
-                TouchEvent::new(TouchAction::Down, vec![TouchPointer::new(0, position.x, position.y)]);
+            let position = Point::new(event.position.x.into(), event.position.y.into());
+            let touch_event = TouchEvent::new(
+                TouchAction::Down,
+                vec![TouchPointer::new(0, position.x, position.y)],
+            );
 
             if let Ok(mut rec) = recognizer.lock() {
                 rec.on_touch(&touch_event);
+                log::info!("PanGesture: Touch down processed");
             }
         });
 
         let recognizer = self.recognizer.clone();
-        let on_begin = self.on_begin.clone();
-        let on_change = self.on_change.clone();
+        let on_begin = on_begin.clone();
+        let on_change = on_change.clone();
 
-        cx.on_mouse_event(move |event: &MouseMoveEvent, phase, cx| {
+        // Note: On Android, GPUI converts touch drag to ScrollWheel events, not MouseMove
+        // So we need to listen to both MouseMove (for desktop) and ScrollWheel (for Android)
+        window.on_mouse_event(move |event: &MouseMoveEvent, phase, window, cx| {
             if phase != DispatchPhase::Bubble {
                 return;
             }
 
-            let position = Point::new(event.position.x.0, event.position.y.0);
-            let touch_event =
-                TouchEvent::new(TouchAction::Move, vec![TouchPointer::new(0, position.x, position.y)]);
+            let position = Point::new(event.position.x.into(), event.position.y.into());
+            let touch_event = TouchEvent::new(
+                TouchAction::Move,
+                vec![TouchPointer::new(0, position.x, position.y)],
+            );
 
             if let Ok(mut rec) = recognizer.lock() {
                 rec.on_touch(&touch_event);
 
                 if let Some(gesture_event) = rec.take_event() {
+                    log::info!(
+                        "PanGesture: Gesture event state={:?}, translation=({:.1}, {:.1})",
+                        gesture_event.state,
+                        gesture_event.translation.x,
+                        gesture_event.translation.y
+                    );
                     match gesture_event.state {
                         GestureState::Began => {
+                            log::info!("PanGesture: Calling on_begin handler");
                             if let Some(handler) = &on_begin {
-                                handler(&gesture_event, cx);
+                                handler(&gesture_event, window, cx);
                             }
                         }
                         GestureState::Changed => {
                             if let Some(handler) = &on_change {
-                                handler(&gesture_event, cx);
+                                handler(&gesture_event, window, cx);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        });
+
+        // Handle ScrollWheel events for Android touch drag (GPUI converts touch drag to ScrollWheel)
+        let recognizer = self.recognizer.clone();
+        let on_begin_scroll = self.on_begin.clone();
+        let on_change_scroll = self.on_change.clone();
+
+        window.on_mouse_event(move |event: &ScrollWheelEvent, phase, window, cx| {
+            if phase != DispatchPhase::Bubble {
+                return;
+            }
+
+            // Get the scroll delta as movement
+            let (dx, dy) = match event.delta {
+                ScrollDelta::Pixels(p) => (p.x.into(), p.y.into()),
+                ScrollDelta::Lines(l) => (l.x as f32 * 20.0, l.y as f32 * 20.0),
+            };
+
+            log::info!(
+                "PanGesture: ScrollWheel delta=({:.1}, {:.1}), pos=({:.1}, {:.1})",
+                dx, dy,
+                event.position.x,
+                event.position.y
+            );
+
+            if let Ok(mut rec) = recognizer.lock() {
+                // Update the recognizer with scroll delta as movement
+                rec.on_scroll(dx, dy, event.position.x.into(), event.position.y.into());
+
+                if let Some(gesture_event) = rec.take_event() {
+                    log::info!(
+                        "PanGesture: ScrollWheel gesture event state={:?}, translation=({:.1}, {:.1})",
+                        gesture_event.state,
+                        gesture_event.translation.x,
+                        gesture_event.translation.y
+                    );
+                    match gesture_event.state {
+                        GestureState::Began => {
+                            log::info!("PanGesture: ScrollWheel calling on_begin handler");
+                            if let Some(handler) = &on_begin_scroll {
+                                handler(&gesture_event, window, cx);
+                            }
+                        }
+                        GestureState::Changed => {
+                            if let Some(handler) = &on_change_scroll {
+                                handler(&gesture_event, window, cx);
                             }
                         }
                         _ => {}
@@ -258,26 +318,39 @@ impl Element for PanGestureElement {
         });
 
         let recognizer = self.recognizer.clone();
-        let on_end = self.on_end.clone();
 
-        cx.on_mouse_event(move |event: &MouseUpEvent, phase, cx| {
+        window.on_mouse_event(move |event: &MouseUpEvent, phase, window, cx| {
+            log::info!(
+                "PanGesture: MouseUp phase={:?}, pos=({:.1}, {:.1})",
+                phase,
+                event.position.x,
+                event.position.y
+            );
+
             if phase != DispatchPhase::Bubble {
                 return;
             }
 
-            let position = Point::new(event.position.x.0, event.position.y.0);
-            let touch_event =
-                TouchEvent::new(TouchAction::Up, vec![TouchPointer::new(0, position.x, position.y)]);
+            let position = Point::new(event.position.x.into(), event.position.y.into());
+            let touch_event = TouchEvent::new(
+                TouchAction::Up,
+                vec![TouchPointer::new(0, position.x, position.y)],
+            );
 
             if let Ok(mut rec) = recognizer.lock() {
                 rec.on_touch(&touch_event);
 
                 if let Some(gesture_event) = rec.take_event() {
+                    log::info!(
+                        "PanGesture: MouseUp gesture event state={:?}",
+                        gesture_event.state
+                    );
                     if gesture_event.state == GestureState::Ended
                         || gesture_event.state == GestureState::Cancelled
                     {
+                        log::info!("PanGesture: Calling on_end handler");
                         if let Some(handler) = &on_end {
-                            handler(&gesture_event, cx);
+                            handler(&gesture_event, window, cx);
                         }
                     }
                 }
@@ -324,7 +397,7 @@ impl TapGestureElement {
     /// Set handler for tap events
     pub fn on_tap<F>(mut self, handler: F) -> Self
     where
-        F: Fn(&TapGestureEvent, &mut App) + Send + Sync + 'static,
+        F: Fn(&TapGestureEvent, &mut Window, &mut App) + Send + Sync + 'static,
     {
         self.on_tap = Some(Arc::new(handler));
         self
@@ -347,16 +420,22 @@ impl Element for TapGestureElement {
         None
     }
 
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
     fn request_layout(
         &mut self,
         _id: Option<&GlobalElementId>,
-        cx: &mut WindowContext,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
         if let Some(mut child) = self.child.take() {
-            let layout_id = child.request_layout(cx);
+            let layout_id = child.request_layout(window, cx);
             (layout_id, Some(child))
         } else {
-            let layout_id = cx.request_layout(gpui::Style::default(), []);
+            let layout_id = window.request_layout(gpui::Style::default(), [], cx);
             (layout_id, None)
         }
     }
@@ -364,30 +443,34 @@ impl Element for TapGestureElement {
     fn prepaint(
         &mut self,
         _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
         _bounds: Bounds<Pixels>,
         child: &mut Self::RequestLayoutState,
-        cx: &mut WindowContext,
+        window: &mut Window,
+        cx: &mut App,
     ) -> Self::PrepaintState {
         if let Some(child) = child {
-            child.prepaint(cx);
+            child.prepaint(window, cx);
         }
     }
 
     fn paint(
         &mut self,
         _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
         bounds: Bounds<Pixels>,
         child: &mut Self::RequestLayoutState,
         _prepaint: &mut Self::PrepaintState,
-        cx: &mut WindowContext,
+        window: &mut Window,
+        cx: &mut App,
     ) {
         if let Some(child) = child {
-            child.paint(cx);
+            child.paint(window, cx);
         }
 
         let recognizer = self.recognizer.clone();
 
-        cx.on_mouse_event(move |event: &MouseDownEvent, phase, _cx| {
+        window.on_mouse_event(move |event: &MouseDownEvent, phase, _window, _cx| {
             if phase != DispatchPhase::Bubble {
                 return;
             }
@@ -395,9 +478,11 @@ impl Element for TapGestureElement {
                 return;
             }
 
-            let position = Point::new(event.position.x.0, event.position.y.0);
-            let touch_event =
-                TouchEvent::new(TouchAction::Down, vec![TouchPointer::new(0, position.x, position.y)]);
+            let position = Point::new(event.position.x.into(), event.position.y.into());
+            let touch_event = TouchEvent::new(
+                TouchAction::Down,
+                vec![TouchPointer::new(0, position.x, position.y)],
+            );
 
             if let Ok(mut rec) = recognizer.lock() {
                 rec.on_touch(&touch_event);
@@ -407,14 +492,16 @@ impl Element for TapGestureElement {
         let recognizer = self.recognizer.clone();
         let on_tap = self.on_tap.clone();
 
-        cx.on_mouse_event(move |event: &MouseUpEvent, phase, cx| {
+        window.on_mouse_event(move |event: &MouseUpEvent, phase, window, cx| {
             if phase != DispatchPhase::Bubble {
                 return;
             }
 
-            let position = Point::new(event.position.x.0, event.position.y.0);
-            let touch_event =
-                TouchEvent::new(TouchAction::Up, vec![TouchPointer::new(0, position.x, position.y)]);
+            let position = Point::new(event.position.x.into(), event.position.y.into());
+            let touch_event = TouchEvent::new(
+                TouchAction::Up,
+                vec![TouchPointer::new(0, position.x, position.y)],
+            );
 
             if let Ok(mut rec) = recognizer.lock() {
                 rec.on_touch(&touch_event);
@@ -422,7 +509,7 @@ impl Element for TapGestureElement {
                 if let Some(gesture_event) = rec.take_event() {
                     if gesture_event.state == GestureState::Ended {
                         if let Some(handler) = &on_tap {
-                            handler(&gesture_event, cx);
+                            handler(&gesture_event, window, cx);
                         }
                     }
                 }
@@ -465,7 +552,7 @@ impl PinchGestureElement {
     /// Set handler for when pinch begins
     pub fn on_begin<F>(mut self, handler: F) -> Self
     where
-        F: Fn(&PinchGestureEvent, &mut App) + Send + Sync + 'static,
+        F: Fn(&PinchGestureEvent, &mut Window, &mut App) + Send + Sync + 'static,
     {
         self.on_begin = Some(Arc::new(handler));
         self
@@ -474,7 +561,7 @@ impl PinchGestureElement {
     /// Set handler for pinch changes
     pub fn on_change<F>(mut self, handler: F) -> Self
     where
-        F: Fn(&PinchGestureEvent, &mut App) + Send + Sync + 'static,
+        F: Fn(&PinchGestureEvent, &mut Window, &mut App) + Send + Sync + 'static,
     {
         self.on_change = Some(Arc::new(handler));
         self
@@ -483,7 +570,7 @@ impl PinchGestureElement {
     /// Set handler for when pinch ends
     pub fn on_end<F>(mut self, handler: F) -> Self
     where
-        F: Fn(&PinchGestureEvent, &mut App) + Send + Sync + 'static,
+        F: Fn(&PinchGestureEvent, &mut Window, &mut App) + Send + Sync + 'static,
     {
         self.on_end = Some(Arc::new(handler));
         self
@@ -492,14 +579,15 @@ impl PinchGestureElement {
     /// Set handler for all pinch events
     pub fn on_pinch<F>(mut self, handler: F) -> Self
     where
-        F: Fn(&PinchGestureEvent, &mut App) + Send + Sync + Clone + 'static,
+        F: Fn(&PinchGestureEvent, &mut Window, &mut App) + Send + Sync + 'static,
     {
+        let handler = Arc::new(handler);
         let h1 = handler.clone();
         let h2 = handler.clone();
         let h3 = handler;
-        self.on_begin = Some(Arc::new(move |e, cx| h1(e, cx)));
-        self.on_change = Some(Arc::new(move |e, cx| h2(e, cx)));
-        self.on_end = Some(Arc::new(move |e, cx| h3(e, cx)));
+        self.on_begin = Some(Arc::new(move |e, w, cx| h1(e, w, cx)));
+        self.on_change = Some(Arc::new(move |e, w, cx| h2(e, w, cx)));
+        self.on_end = Some(Arc::new(move |e, w, cx| h3(e, w, cx)));
         self
     }
 }
@@ -520,16 +608,22 @@ impl Element for PinchGestureElement {
         None
     }
 
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
     fn request_layout(
         &mut self,
         _id: Option<&GlobalElementId>,
-        cx: &mut WindowContext,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
         if let Some(mut child) = self.child.take() {
-            let layout_id = child.request_layout(cx);
+            let layout_id = child.request_layout(window, cx);
             (layout_id, Some(child))
         } else {
-            let layout_id = cx.request_layout(gpui::Style::default(), []);
+            let layout_id = window.request_layout(gpui::Style::default(), [], cx);
             (layout_id, None)
         }
     }
@@ -537,25 +631,29 @@ impl Element for PinchGestureElement {
     fn prepaint(
         &mut self,
         _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
         _bounds: Bounds<Pixels>,
         child: &mut Self::RequestLayoutState,
-        cx: &mut WindowContext,
+        window: &mut Window,
+        cx: &mut App,
     ) -> Self::PrepaintState {
         if let Some(child) = child {
-            child.prepaint(cx);
+            child.prepaint(window, cx);
         }
     }
 
     fn paint(
         &mut self,
         _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
         _bounds: Bounds<Pixels>,
         child: &mut Self::RequestLayoutState,
         _prepaint: &mut Self::PrepaintState,
-        cx: &mut WindowContext,
+        window: &mut Window,
+        cx: &mut App,
     ) {
         if let Some(child) = child {
-            child.paint(cx);
+            child.paint(window, cx);
         }
 
         // Note: Pinch gestures require multi-touch which isn't available via mouse events

--- a/crates/zedra-gesture/src/element.rs
+++ b/crates/zedra-gesture/src/element.rs
@@ -17,7 +17,7 @@ use crate::recognizers::{
     TapGestureEvent,
 };
 use crate::state::GestureState;
-use crate::types::{Point, TouchAction, TouchEvent, TouchPointer};
+use crate::types::{GestureId, Point, TouchAction, TouchEvent, TouchPointer};
 
 // ============================================================================
 // Gesture Handler Types
@@ -38,21 +38,30 @@ pub type PinchHandler = Arc<dyn Fn(&PinchGestureEvent, &mut Window, &mut App) + 
 
 /// Wraps an element with pan gesture recognition
 pub struct PanGestureElement {
+    /// Unique identifier for this gesture
+    gesture_id: GestureId,
     child: Option<AnyElement>,
     recognizer: Arc<Mutex<PanGesture>>,
     on_begin: Option<PanHandler>,
     on_change: Option<PanHandler>,
     on_end: Option<PanHandler>,
+    /// Gestures that must fail before this one can begin
+    requires_failure: Vec<GestureId>,
+    /// Gestures that can run simultaneously with this one
+    simultaneous: Vec<GestureId>,
 }
 
 /// Create a pan gesture wrapper
 pub fn pan_gesture() -> PanGestureElement {
     PanGestureElement {
+        gesture_id: GestureId::new(),
         child: None,
         recognizer: Arc::new(Mutex::new(PanGesture::new())),
         on_begin: None,
         on_change: None,
         on_end: None,
+        requires_failure: Vec::new(),
+        simultaneous: Vec::new(),
     }
 }
 
@@ -111,6 +120,42 @@ impl PanGestureElement {
         self.on_change = Some(Arc::new(move |e, w, cx| h2(e, w, cx)));
         self.on_end = Some(Arc::new(move |e, w, cx| h3(e, w, cx)));
         self
+    }
+
+    /// Get the unique ID of this gesture for establishing relationships
+    pub fn id(&self) -> GestureId {
+        self.gesture_id
+    }
+
+    /// This gesture waits for `other` to fail before activating
+    ///
+    /// Useful when a gesture like double-tap should not interfere with single-tap
+    pub fn requires_failure_of(mut self, other: GestureId) -> Self {
+        if !self.requires_failure.contains(&other) {
+            self.requires_failure.push(other);
+        }
+        self
+    }
+
+    /// This gesture can run simultaneously with `other`
+    ///
+    /// By default, only one gesture can be active at a time.
+    /// Use this to allow multiple gestures to recognize together.
+    pub fn simultaneous_with(mut self, other: GestureId) -> Self {
+        if !self.simultaneous.contains(&other) {
+            self.simultaneous.push(other);
+        }
+        self
+    }
+
+    /// Get the list of gestures this one requires to fail
+    pub fn requires_failure_ids(&self) -> &[GestureId] {
+        &self.requires_failure
+    }
+
+    /// Get the list of gestures this one can run simultaneously with
+    pub fn simultaneous_ids(&self) -> &[GestureId] {
+        &self.simultaneous
     }
 }
 
@@ -365,17 +410,26 @@ impl Element for PanGestureElement {
 
 /// Wraps an element with tap gesture recognition
 pub struct TapGestureElement {
+    /// Unique identifier for this gesture
+    gesture_id: GestureId,
     child: Option<AnyElement>,
     recognizer: Arc<Mutex<TapGesture>>,
     on_tap: Option<TapHandler>,
+    /// Gestures that must fail before this one can begin
+    requires_failure: Vec<GestureId>,
+    /// Gestures that can run simultaneously with this one
+    simultaneous: Vec<GestureId>,
 }
 
 /// Create a tap gesture wrapper
 pub fn tap_gesture() -> TapGestureElement {
     TapGestureElement {
+        gesture_id: GestureId::new(),
         child: None,
         recognizer: Arc::new(Mutex::new(TapGesture::new())),
         on_tap: None,
+        requires_failure: Vec::new(),
+        simultaneous: Vec::new(),
     }
 }
 
@@ -401,6 +455,42 @@ impl TapGestureElement {
     {
         self.on_tap = Some(Arc::new(handler));
         self
+    }
+
+    /// Get the unique ID of this gesture for establishing relationships
+    pub fn id(&self) -> GestureId {
+        self.gesture_id
+    }
+
+    /// This gesture waits for `other` to fail before activating
+    ///
+    /// Useful when a gesture like double-tap should not interfere with single-tap
+    pub fn requires_failure_of(mut self, other: GestureId) -> Self {
+        if !self.requires_failure.contains(&other) {
+            self.requires_failure.push(other);
+        }
+        self
+    }
+
+    /// This gesture can run simultaneously with `other`
+    ///
+    /// By default, only one gesture can be active at a time.
+    /// Use this to allow multiple gestures to recognize together.
+    pub fn simultaneous_with(mut self, other: GestureId) -> Self {
+        if !self.simultaneous.contains(&other) {
+            self.simultaneous.push(other);
+        }
+        self
+    }
+
+    /// Get the list of gestures this one requires to fail
+    pub fn requires_failure_ids(&self) -> &[GestureId] {
+        &self.requires_failure
+    }
+
+    /// Get the list of gestures this one can run simultaneously with
+    pub fn simultaneous_ids(&self) -> &[GestureId] {
+        &self.simultaneous
     }
 }
 
@@ -524,21 +614,30 @@ impl Element for TapGestureElement {
 
 /// Wraps an element with pinch gesture recognition
 pub struct PinchGestureElement {
+    /// Unique identifier for this gesture
+    gesture_id: GestureId,
     child: Option<AnyElement>,
     recognizer: Arc<Mutex<PinchGesture>>,
     on_begin: Option<PinchHandler>,
     on_change: Option<PinchHandler>,
     on_end: Option<PinchHandler>,
+    /// Gestures that must fail before this one can begin
+    requires_failure: Vec<GestureId>,
+    /// Gestures that can run simultaneously with this one
+    simultaneous: Vec<GestureId>,
 }
 
 /// Create a pinch gesture wrapper
 pub fn pinch_gesture() -> PinchGestureElement {
     PinchGestureElement {
+        gesture_id: GestureId::new(),
         child: None,
         recognizer: Arc::new(Mutex::new(PinchGesture::new())),
         on_begin: None,
         on_change: None,
         on_end: None,
+        requires_failure: Vec::new(),
+        simultaneous: Vec::new(),
     }
 }
 
@@ -589,6 +688,42 @@ impl PinchGestureElement {
         self.on_change = Some(Arc::new(move |e, w, cx| h2(e, w, cx)));
         self.on_end = Some(Arc::new(move |e, w, cx| h3(e, w, cx)));
         self
+    }
+
+    /// Get the unique ID of this gesture for establishing relationships
+    pub fn id(&self) -> GestureId {
+        self.gesture_id
+    }
+
+    /// This gesture waits for `other` to fail before activating
+    ///
+    /// Useful when a gesture like double-tap should not interfere with single-tap
+    pub fn requires_failure_of(mut self, other: GestureId) -> Self {
+        if !self.requires_failure.contains(&other) {
+            self.requires_failure.push(other);
+        }
+        self
+    }
+
+    /// This gesture can run simultaneously with `other`
+    ///
+    /// By default, only one gesture can be active at a time.
+    /// Use this to allow multiple gestures to recognize together.
+    pub fn simultaneous_with(mut self, other: GestureId) -> Self {
+        if !self.simultaneous.contains(&other) {
+            self.simultaneous.push(other);
+        }
+        self
+    }
+
+    /// Get the list of gestures this one requires to fail
+    pub fn requires_failure_ids(&self) -> &[GestureId] {
+        &self.requires_failure
+    }
+
+    /// Get the list of gestures this one can run simultaneously with
+    pub fn simultaneous_ids(&self) -> &[GestureId] {
+        &self.simultaneous
     }
 }
 

--- a/crates/zedra-gesture/src/lib.rs
+++ b/crates/zedra-gesture/src/lib.rs
@@ -12,15 +12,17 @@
 //! use zedra_gesture::{pan_gesture, PanGestureEvent};
 //!
 //! fn my_view(cx: &mut Context<Self>) -> impl IntoElement {
-//!     pan_gesture(
-//!         div()
-//!             .size_full()
-//!             .bg(rgb(0x282c34))
-//!             .child("Drag me!")
-//!     )
-//!     .on_pan(|event, cx| {
-//!         println!("Pan: {:?}", event.translation);
-//!     })
+//!     pan_gesture()
+//!         .min_distance(10.0)
+//!         .on_pan(|event, cx| {
+//!             println!("Pan: {:?}", event.translation);
+//!         })
+//!         .child(
+//!             div()
+//!                 .size_full()
+//!                 .bg(rgb(0x282c34))
+//!                 .child("Drag me!")
+//!         )
 //! }
 //! ```
 //!

--- a/crates/zedra-gesture/src/lib.rs
+++ b/crates/zedra-gesture/src/lib.rs
@@ -1,0 +1,66 @@
+//! zedra-gesture - Gesture recognition library for GPUI on Android
+//!
+//! Inspired by react-native-gesture-handler, this crate provides:
+//! - Gesture recognizers (Tap, Pan, Pinch, LongPress)
+//! - Velocity tracking with iOS-style momentum scrolling
+//! - Element wrappers for easy integration with GPUI
+//! - Gesture compositor for handling multiple recognizers
+//!
+//! # Quick Start
+//!
+//! ```ignore
+//! use zedra_gesture::{pan_gesture, PanGestureEvent};
+//!
+//! fn my_view(cx: &mut Context<Self>) -> impl IntoElement {
+//!     pan_gesture(
+//!         div()
+//!             .size_full()
+//!             .bg(rgb(0x282c34))
+//!             .child("Drag me!")
+//!     )
+//!     .on_pan(|event, cx| {
+//!         println!("Pan: {:?}", event.translation);
+//!     })
+//! }
+//! ```
+//!
+//! # Gesture Types
+//!
+//! - **Tap**: Single or multi-tap detection
+//! - **LongPress**: Press and hold detection
+//! - **Pan**: Drag/scroll with velocity tracking
+//! - **Pinch**: Two-finger scale and rotation
+//!
+//! # Momentum Scrolling
+//!
+//! ```ignore
+//! use zedra_gesture::{MomentumAnimator, DecelerationCurve};
+//!
+//! let mut animator = MomentumAnimator::new()
+//!     .with_deceleration(DecelerationCurve::IOS);
+//!
+//! // Start with fling velocity
+//! animator.start(velocity);
+//!
+//! // In animation loop
+//! let delta = animator.update();
+//! ```
+
+pub mod compositor;
+pub mod element;
+pub mod recognizers;
+pub mod state;
+pub mod types;
+pub mod velocity;
+
+// Re-export main types
+pub use compositor::GestureCompositor;
+pub use element::{pan_gesture, pinch_gesture, tap_gesture};
+pub use element::{PanGestureElement, PinchGestureElement, TapGestureElement};
+pub use recognizers::{
+    GestureRecognizer, LongPressGesture, LongPressGestureEvent, PanGesture, PanGestureEvent,
+    PinchGesture, PinchGestureEvent, TapGesture, TapGestureEvent,
+};
+pub use state::{GestureConfig, GestureState};
+pub use types::{FlingDirection, Point, TouchAction, TouchEvent, TouchPointer, Vector2};
+pub use velocity::{DecelerationCurve, MomentumAnimator, MomentumBounds, VelocityTracker};

--- a/crates/zedra-gesture/src/lib.rs
+++ b/crates/zedra-gesture/src/lib.rs
@@ -48,6 +48,7 @@
 //! let delta = animator.update();
 //! ```
 
+pub mod compose;
 pub mod compositor;
 pub mod element;
 pub mod recognizers;
@@ -56,6 +57,9 @@ pub mod types;
 pub mod velocity;
 
 // Re-export main types
+pub use compose::{
+    exclusive, race, simultaneous, GestureExclusive, GestureRace, GestureSimultaneous,
+};
 pub use compositor::GestureCompositor;
 pub use element::{pan_gesture, pinch_gesture, tap_gesture};
 pub use element::{PanGestureElement, PinchGestureElement, TapGestureElement};
@@ -64,5 +68,5 @@ pub use recognizers::{
     PinchGesture, PinchGestureEvent, TapGesture, TapGestureEvent,
 };
 pub use state::{GestureConfig, GestureState};
-pub use types::{FlingDirection, Point, TouchAction, TouchEvent, TouchPointer, Vector2};
+pub use types::{FlingDirection, GestureId, Point, TouchAction, TouchEvent, TouchPointer, Vector2};
 pub use velocity::{DecelerationCurve, MomentumAnimator, MomentumBounds, VelocityTracker};

--- a/crates/zedra-gesture/src/recognizers/mod.rs
+++ b/crates/zedra-gesture/src/recognizers/mod.rs
@@ -1,0 +1,30 @@
+//! Gesture recognizers
+
+mod pan;
+mod pinch;
+mod tap;
+
+pub use pan::{PanGesture, PanGestureEvent};
+pub use pinch::{PinchGesture, PinchGestureEvent};
+pub use tap::{LongPressGesture, LongPressGestureEvent, TapGesture, TapGestureEvent};
+
+use crate::state::GestureState;
+use crate::types::TouchEvent;
+
+/// Trait for gesture recognizers
+pub trait GestureRecognizer: Send + Sync {
+    /// Process a touch event and update state
+    fn on_touch(&mut self, event: &TouchEvent);
+
+    /// Get current gesture state
+    fn state(&self) -> GestureState;
+
+    /// Reset the recognizer to initial state
+    fn reset(&mut self);
+
+    /// Whether this recognizer is enabled
+    fn is_enabled(&self) -> bool;
+
+    /// Enable or disable the recognizer
+    fn set_enabled(&mut self, enabled: bool);
+}

--- a/crates/zedra-gesture/src/recognizers/pan.rs
+++ b/crates/zedra-gesture/src/recognizers/pan.rs
@@ -155,10 +155,7 @@ impl PanGesture {
         self.translation.y += dy;
 
         // Update last position for velocity tracking
-        let current = Point::new(
-            position_x,
-            position_y,
-        );
+        let current = Point::new(position_x, position_y);
 
         if self.config.track_velocity {
             self.velocity_tracker.add_sample(current);
@@ -282,7 +279,12 @@ impl GestureRecognizer for PanGesture {
                         // Not enough fingers remaining
                         self.state = GestureState::Cancelled;
                         let position = self.last_position.unwrap_or(event.center());
-                        self.emit_event(GestureState::Cancelled, position, Vector2::zero(), remaining);
+                        self.emit_event(
+                            GestureState::Cancelled,
+                            position,
+                            Vector2::zero(),
+                            remaining,
+                        );
                         self.reset();
                     }
                     // Otherwise continue with remaining fingers

--- a/crates/zedra-gesture/src/recognizers/pan.rs
+++ b/crates/zedra-gesture/src/recognizers/pan.rs
@@ -132,6 +132,52 @@ impl PanGesture {
             number_of_fingers: fingers,
         });
     }
+
+    /// Handle scroll delta (for Android where touch drag is converted to scroll events)
+    /// This updates the gesture state based on cumulative scroll movement
+    pub fn on_scroll(&mut self, dx: f32, dy: f32, position_x: f32, position_y: f32) {
+        if !self.enabled {
+            return;
+        }
+
+        self.current_event = None;
+        let position = Point::new(position_x, position_y);
+        let delta = Vector2::new(dx, dy);
+
+        // If we don't have a start position, we can't track scroll
+        // (need mouse down first)
+        let Some(start) = self.start_position else {
+            return;
+        };
+
+        // Update translation with scroll delta
+        self.translation.x += dx;
+        self.translation.y += dy;
+
+        // Update last position for velocity tracking
+        let current = Point::new(
+            position_x,
+            position_y,
+        );
+
+        if self.config.track_velocity {
+            self.velocity_tracker.add_sample(current);
+        }
+
+        // Check if we should start the gesture
+        if self.state == GestureState::Possible {
+            let distance = (self.translation.x.powi(2) + self.translation.y.powi(2)).sqrt();
+            if distance >= self.config.min_distance {
+                self.state = GestureState::Began;
+                self.emit_event(GestureState::Began, position, delta, 1);
+            }
+        } else if self.state == GestureState::Began || self.state == GestureState::Changed {
+            self.state = GestureState::Changed;
+            self.emit_event(GestureState::Changed, position, delta, 1);
+        }
+
+        self.last_position = Some(current);
+    }
 }
 
 impl Default for PanGesture {

--- a/crates/zedra-gesture/src/recognizers/pan.rs
+++ b/crates/zedra-gesture/src/recognizers/pan.rs
@@ -1,0 +1,281 @@
+//! Pan gesture recognizer with velocity tracking
+
+use crate::state::GestureState;
+use crate::types::{Point, TouchAction, TouchEvent, Vector2};
+use crate::velocity::VelocityTracker;
+
+use super::GestureRecognizer;
+
+/// Configuration for pan gesture
+#[derive(Clone, Debug)]
+pub struct PanConfig {
+    /// Minimum distance to start recognizing (slop)
+    pub min_distance: f32,
+    /// Minimum number of fingers
+    pub min_fingers: usize,
+    /// Maximum number of fingers
+    pub max_fingers: usize,
+    /// Whether to track velocity for fling
+    pub track_velocity: bool,
+    /// Minimum velocity for fling (pixels per second)
+    pub min_fling_velocity: f32,
+}
+
+impl Default for PanConfig {
+    fn default() -> Self {
+        Self {
+            min_distance: 10.0,
+            min_fingers: 1,
+            max_fingers: 1,
+            track_velocity: true,
+            min_fling_velocity: 50.0,
+        }
+    }
+}
+
+/// Event emitted by pan gesture
+#[derive(Clone, Debug)]
+pub struct PanGestureEvent {
+    /// Current position
+    pub position: Point,
+    /// Translation from start position
+    pub translation: Vector2,
+    /// Translation delta since last event
+    pub delta: Vector2,
+    /// Current velocity (if tracking enabled)
+    pub velocity: Vector2,
+    /// Gesture state
+    pub state: GestureState,
+    /// Number of active fingers
+    pub number_of_fingers: usize,
+}
+
+/// Pan gesture recognizer
+pub struct PanGesture {
+    config: PanConfig,
+    state: GestureState,
+    enabled: bool,
+
+    // Tracking state
+    start_position: Option<Point>,
+    last_position: Option<Point>,
+    translation: Vector2,
+    velocity_tracker: VelocityTracker,
+    current_event: Option<PanGestureEvent>,
+}
+
+impl PanGesture {
+    pub fn new() -> Self {
+        Self::with_config(PanConfig::default())
+    }
+
+    pub fn with_config(config: PanConfig) -> Self {
+        Self {
+            config,
+            state: GestureState::Possible,
+            enabled: true,
+            start_position: None,
+            last_position: None,
+            translation: Vector2::zero(),
+            velocity_tracker: VelocityTracker::new(),
+            current_event: None,
+        }
+    }
+
+    /// Set minimum distance to start recognizing
+    pub fn min_distance(mut self, distance: f32) -> Self {
+        self.config.min_distance = distance;
+        self
+    }
+
+    /// Set number of fingers (single value for exact match)
+    pub fn number_of_fingers(mut self, count: usize) -> Self {
+        self.config.min_fingers = count;
+        self.config.max_fingers = count;
+        self
+    }
+
+    /// Set finger range
+    pub fn fingers_range(mut self, min: usize, max: usize) -> Self {
+        self.config.min_fingers = min;
+        self.config.max_fingers = max;
+        self
+    }
+
+    /// Get the current event if any
+    pub fn event(&self) -> Option<&PanGestureEvent> {
+        self.current_event.as_ref()
+    }
+
+    /// Take the current event
+    pub fn take_event(&mut self) -> Option<PanGestureEvent> {
+        self.current_event.take()
+    }
+
+    /// Get current translation
+    pub fn translation(&self) -> Vector2 {
+        self.translation
+    }
+
+    /// Get current velocity
+    pub fn velocity(&self) -> Vector2 {
+        self.velocity_tracker.velocity()
+    }
+
+    fn emit_event(&mut self, state: GestureState, position: Point, delta: Vector2, fingers: usize) {
+        self.current_event = Some(PanGestureEvent {
+            position,
+            translation: self.translation,
+            delta,
+            velocity: self.velocity_tracker.velocity(),
+            state,
+            number_of_fingers: fingers,
+        });
+    }
+}
+
+impl Default for PanGesture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GestureRecognizer for PanGesture {
+    fn on_touch(&mut self, event: &TouchEvent) {
+        if !self.enabled {
+            return;
+        }
+
+        self.current_event = None;
+        let fingers = event.pointer_count();
+
+        match event.action {
+            TouchAction::Down | TouchAction::PointerDown(_) => {
+                // Check finger count
+                if fingers < self.config.min_fingers || fingers > self.config.max_fingers {
+                    if self.state.is_active() {
+                        // Too many/few fingers, cancel
+                        self.state = GestureState::Cancelled;
+                        self.emit_event(
+                            GestureState::Cancelled,
+                            event.center(),
+                            Vector2::zero(),
+                            fingers,
+                        );
+                    }
+                    return;
+                }
+
+                let center = event.center();
+
+                if self.start_position.is_none() {
+                    self.start_position = Some(center);
+                    self.last_position = Some(center);
+                    self.translation = Vector2::zero();
+                    self.velocity_tracker.clear();
+                    self.state = GestureState::Possible;
+                }
+
+                if self.config.track_velocity {
+                    self.velocity_tracker.add_sample(center);
+                }
+            }
+
+            TouchAction::Move => {
+                if fingers < self.config.min_fingers || fingers > self.config.max_fingers {
+                    return;
+                }
+
+                let Some(start) = self.start_position else {
+                    return;
+                };
+                let Some(last) = self.last_position else {
+                    return;
+                };
+
+                let current = event.center();
+                let delta = current - last;
+
+                // Update velocity tracking
+                if self.config.track_velocity {
+                    self.velocity_tracker.add_sample(current);
+                }
+
+                // Check if we should start the gesture
+                if self.state == GestureState::Possible {
+                    let distance = start.distance_to(current);
+                    if distance >= self.config.min_distance {
+                        self.state = GestureState::Began;
+                        self.translation = current - start;
+                        self.emit_event(GestureState::Began, current, delta, fingers);
+                    }
+                } else if self.state == GestureState::Began || self.state == GestureState::Changed {
+                    self.state = GestureState::Changed;
+                    self.translation = current - start;
+                    self.emit_event(GestureState::Changed, current, delta, fingers);
+                }
+
+                self.last_position = Some(current);
+            }
+
+            TouchAction::Up | TouchAction::PointerUp(_) => {
+                let remaining = match event.action {
+                    TouchAction::Up => 0,
+                    TouchAction::PointerUp(_) => fingers.saturating_sub(1),
+                    _ => fingers,
+                };
+
+                if self.state.is_active() {
+                    if remaining == 0 {
+                        // All fingers up
+                        self.state = GestureState::Ended;
+                        let position = self.last_position.unwrap_or(event.center());
+                        self.emit_event(GestureState::Ended, position, Vector2::zero(), 0);
+                        self.reset();
+                    } else if remaining < self.config.min_fingers {
+                        // Not enough fingers remaining
+                        self.state = GestureState::Cancelled;
+                        let position = self.last_position.unwrap_or(event.center());
+                        self.emit_event(GestureState::Cancelled, position, Vector2::zero(), remaining);
+                        self.reset();
+                    }
+                    // Otherwise continue with remaining fingers
+                } else if remaining == 0 {
+                    self.reset();
+                }
+            }
+
+            TouchAction::Cancel => {
+                if self.state.is_active() {
+                    self.state = GestureState::Cancelled;
+                    let position = self.last_position.unwrap_or_default();
+                    self.emit_event(GestureState::Cancelled, position, Vector2::zero(), 0);
+                }
+                self.reset();
+            }
+        }
+    }
+
+    fn state(&self) -> GestureState {
+        self.state
+    }
+
+    fn reset(&mut self) {
+        self.state = GestureState::Possible;
+        self.start_position = None;
+        self.last_position = None;
+        self.translation = Vector2::zero();
+        self.velocity_tracker.clear();
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+        if !enabled {
+            self.reset();
+        }
+    }
+}

--- a/crates/zedra-gesture/src/recognizers/pinch.rs
+++ b/crates/zedra-gesture/src/recognizers/pinch.rs
@@ -192,13 +192,13 @@ impl GestureRecognizer for PinchGesture {
                     let scale_change = (new_scale - 1.0).abs();
                     let rotation_change = rotation_delta.abs();
 
-                    if scale_change >= self.config.min_scale_threshold
-                        || rotation_change >= 0.05
+                    if scale_change >= self.config.min_scale_threshold || rotation_change >= 0.05
                     // ~3 degrees
                     {
                         self.state = GestureState::Began;
                         self.current_scale = new_scale;
-                        self.current_rotation = Self::normalize_angle(rotation - self.initial_rotation);
+                        self.current_rotation =
+                            Self::normalize_angle(rotation - self.initial_rotation);
 
                         let scale_delta = new_scale - self.current_scale;
                         self.emit_event(GestureState::Began, scale_delta, rotation_delta);

--- a/crates/zedra-gesture/src/recognizers/pinch.rs
+++ b/crates/zedra-gesture/src/recognizers/pinch.rs
@@ -1,0 +1,270 @@
+//! Pinch (scale) and rotation gesture recognizers
+
+use crate::state::GestureState;
+use crate::types::{Point, TouchAction, TouchEvent};
+
+use super::GestureRecognizer;
+
+/// Configuration for pinch gesture
+#[derive(Clone, Debug)]
+pub struct PinchConfig {
+    /// Minimum scale change to start recognizing
+    pub min_scale_threshold: f32,
+    /// Minimum span (distance between fingers) to start
+    pub min_span: f32,
+}
+
+impl Default for PinchConfig {
+    fn default() -> Self {
+        Self {
+            min_scale_threshold: 0.05, // 5% scale change
+            min_span: 20.0,            // pixels
+        }
+    }
+}
+
+/// Event emitted by pinch gesture
+#[derive(Clone, Debug)]
+pub struct PinchGestureEvent {
+    /// Current scale factor (1.0 = no change)
+    pub scale: f32,
+    /// Scale change since last event
+    pub scale_delta: f32,
+    /// Focal point (center between fingers)
+    pub focal_point: Point,
+    /// Current rotation in radians
+    pub rotation: f32,
+    /// Rotation change since last event
+    pub rotation_delta: f32,
+    /// Gesture state
+    pub state: GestureState,
+}
+
+/// Pinch gesture recognizer (also tracks rotation)
+pub struct PinchGesture {
+    config: PinchConfig,
+    state: GestureState,
+    enabled: bool,
+
+    // Tracking state
+    initial_span: f32,
+    initial_rotation: f32,
+    last_span: f32,
+    last_rotation: f32,
+    current_scale: f32,
+    current_rotation: f32,
+    focal_point: Point,
+    current_event: Option<PinchGestureEvent>,
+}
+
+impl PinchGesture {
+    pub fn new() -> Self {
+        Self::with_config(PinchConfig::default())
+    }
+
+    pub fn with_config(config: PinchConfig) -> Self {
+        Self {
+            config,
+            state: GestureState::Possible,
+            enabled: true,
+            initial_span: 0.0,
+            initial_rotation: 0.0,
+            last_span: 0.0,
+            last_rotation: 0.0,
+            current_scale: 1.0,
+            current_rotation: 0.0,
+            focal_point: Point::zero(),
+            current_event: None,
+        }
+    }
+
+    /// Get the current event if any
+    pub fn event(&self) -> Option<&PinchGestureEvent> {
+        self.current_event.as_ref()
+    }
+
+    /// Take the current event
+    pub fn take_event(&mut self) -> Option<PinchGestureEvent> {
+        self.current_event.take()
+    }
+
+    /// Get current scale
+    pub fn scale(&self) -> f32 {
+        self.current_scale
+    }
+
+    /// Get current rotation
+    pub fn rotation(&self) -> f32 {
+        self.current_rotation
+    }
+
+    fn emit_event(&mut self, state: GestureState, scale_delta: f32, rotation_delta: f32) {
+        self.current_event = Some(PinchGestureEvent {
+            scale: self.current_scale,
+            scale_delta,
+            focal_point: self.focal_point,
+            rotation: self.current_rotation,
+            rotation_delta,
+            state,
+        });
+    }
+
+    /// Normalize angle to -PI to PI range
+    fn normalize_angle(angle: f32) -> f32 {
+        let mut a = angle;
+        while a > std::f32::consts::PI {
+            a -= 2.0 * std::f32::consts::PI;
+        }
+        while a < -std::f32::consts::PI {
+            a += 2.0 * std::f32::consts::PI;
+        }
+        a
+    }
+}
+
+impl Default for PinchGesture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GestureRecognizer for PinchGesture {
+    fn on_touch(&mut self, event: &TouchEvent) {
+        if !self.enabled {
+            return;
+        }
+
+        self.current_event = None;
+
+        // Pinch requires exactly 2 fingers
+        let fingers = event.pointer_count();
+
+        match event.action {
+            TouchAction::Down => {
+                // First finger down - wait for second
+                self.state = GestureState::Possible;
+            }
+
+            TouchAction::PointerDown(_) => {
+                if fingers == 2 {
+                    // Second finger down - start tracking
+                    self.initial_span = event.span();
+                    self.initial_rotation = event.rotation_angle();
+                    self.last_span = self.initial_span;
+                    self.last_rotation = self.initial_rotation;
+                    self.current_scale = 1.0;
+                    self.current_rotation = 0.0;
+                    self.focal_point = event.center();
+                    self.state = GestureState::Possible;
+                } else if fingers > 2 && self.state.is_active() {
+                    // Too many fingers
+                    self.state = GestureState::Cancelled;
+                    self.emit_event(GestureState::Cancelled, 0.0, 0.0);
+                    self.reset();
+                }
+            }
+
+            TouchAction::Move => {
+                if fingers != 2 {
+                    return;
+                }
+
+                let span = event.span();
+                let rotation = event.rotation_angle();
+                self.focal_point = event.center();
+
+                if span < self.config.min_span {
+                    return;
+                }
+
+                // Calculate scale
+                let new_scale = if self.initial_span > 0.0 {
+                    span / self.initial_span
+                } else {
+                    1.0
+                };
+
+                // Calculate rotation delta
+                let rotation_delta = Self::normalize_angle(rotation - self.last_rotation);
+
+                // Check if we should begin
+                if self.state == GestureState::Possible {
+                    let scale_change = (new_scale - 1.0).abs();
+                    let rotation_change = rotation_delta.abs();
+
+                    if scale_change >= self.config.min_scale_threshold
+                        || rotation_change >= 0.05
+                    // ~3 degrees
+                    {
+                        self.state = GestureState::Began;
+                        self.current_scale = new_scale;
+                        self.current_rotation = Self::normalize_angle(rotation - self.initial_rotation);
+
+                        let scale_delta = new_scale - self.current_scale;
+                        self.emit_event(GestureState::Began, scale_delta, rotation_delta);
+                    }
+                } else if self.state.is_active() {
+                    self.state = GestureState::Changed;
+
+                    let scale_delta = new_scale - self.current_scale;
+                    self.current_scale = new_scale;
+                    self.current_rotation = Self::normalize_angle(rotation - self.initial_rotation);
+
+                    self.emit_event(GestureState::Changed, scale_delta, rotation_delta);
+                }
+
+                self.last_span = span;
+                self.last_rotation = rotation;
+            }
+
+            TouchAction::PointerUp(_) => {
+                if self.state.is_active() {
+                    self.state = GestureState::Ended;
+                    self.emit_event(GestureState::Ended, 0.0, 0.0);
+                    self.reset();
+                }
+            }
+
+            TouchAction::Up => {
+                if self.state.is_active() {
+                    self.state = GestureState::Ended;
+                    self.emit_event(GestureState::Ended, 0.0, 0.0);
+                }
+                self.reset();
+            }
+
+            TouchAction::Cancel => {
+                if self.state.is_active() {
+                    self.state = GestureState::Cancelled;
+                    self.emit_event(GestureState::Cancelled, 0.0, 0.0);
+                }
+                self.reset();
+            }
+        }
+    }
+
+    fn state(&self) -> GestureState {
+        self.state
+    }
+
+    fn reset(&mut self) {
+        self.state = GestureState::Possible;
+        self.initial_span = 0.0;
+        self.initial_rotation = 0.0;
+        self.last_span = 0.0;
+        self.last_rotation = 0.0;
+        self.current_scale = 1.0;
+        self.current_rotation = 0.0;
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+        if !enabled {
+            self.reset();
+        }
+    }
+}

--- a/crates/zedra-gesture/src/recognizers/tap.rs
+++ b/crates/zedra-gesture/src/recognizers/tap.rs
@@ -1,0 +1,399 @@
+//! Tap and Long Press gesture recognizers
+
+use std::time::{Duration, Instant};
+
+use crate::state::GestureState;
+use crate::types::{Point, TouchAction, TouchEvent};
+
+use super::GestureRecognizer;
+
+/// Configuration for tap gesture
+#[derive(Clone, Debug)]
+pub struct TapConfig {
+    /// Maximum distance finger can move and still be a tap (in pixels)
+    pub max_distance: f32,
+    /// Maximum duration for a tap (in ms)
+    pub max_duration: Duration,
+    /// Number of taps required
+    pub number_of_taps: u8,
+    /// Maximum time between taps for multi-tap
+    pub max_delay_between_taps: Duration,
+    /// Number of fingers required
+    pub number_of_fingers: usize,
+}
+
+impl Default for TapConfig {
+    fn default() -> Self {
+        Self {
+            max_distance: 10.0,
+            max_duration: Duration::from_millis(500),
+            number_of_taps: 1,
+            max_delay_between_taps: Duration::from_millis(300),
+            number_of_fingers: 1,
+        }
+    }
+}
+
+/// Event emitted by tap gesture
+#[derive(Clone, Debug)]
+pub struct TapGestureEvent {
+    pub position: Point,
+    pub tap_count: u8,
+    pub state: GestureState,
+}
+
+/// Tap gesture recognizer
+pub struct TapGesture {
+    config: TapConfig,
+    state: GestureState,
+    enabled: bool,
+
+    // Internal state
+    start_position: Option<Point>,
+    start_time: Option<Instant>,
+    tap_count: u8,
+    last_tap_time: Option<Instant>,
+    current_event: Option<TapGestureEvent>,
+}
+
+impl TapGesture {
+    pub fn new() -> Self {
+        Self::with_config(TapConfig::default())
+    }
+
+    pub fn with_config(config: TapConfig) -> Self {
+        Self {
+            config,
+            state: GestureState::Possible,
+            enabled: true,
+            start_position: None,
+            start_time: None,
+            tap_count: 0,
+            last_tap_time: None,
+            current_event: None,
+        }
+    }
+
+    /// Set number of taps required
+    pub fn number_of_taps(mut self, count: u8) -> Self {
+        self.config.number_of_taps = count;
+        self
+    }
+
+    /// Set number of fingers required
+    pub fn number_of_fingers(mut self, count: usize) -> Self {
+        self.config.number_of_fingers = count;
+        self
+    }
+
+    /// Get the current tap event if any
+    pub fn event(&self) -> Option<&TapGestureEvent> {
+        self.current_event.as_ref()
+    }
+
+    /// Take the current event (consumes it)
+    pub fn take_event(&mut self) -> Option<TapGestureEvent> {
+        self.current_event.take()
+    }
+}
+
+impl Default for TapGesture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GestureRecognizer for TapGesture {
+    fn on_touch(&mut self, event: &TouchEvent) {
+        if !self.enabled {
+            return;
+        }
+
+        self.current_event = None;
+
+        match event.action {
+            TouchAction::Down => {
+                // Check if this is a continuation of multi-tap
+                let now = Instant::now();
+                if let Some(last) = self.last_tap_time {
+                    if now.duration_since(last) > self.config.max_delay_between_taps {
+                        self.tap_count = 0;
+                    }
+                }
+
+                if event.pointer_count() == self.config.number_of_fingers {
+                    self.start_position = Some(event.center());
+                    self.start_time = Some(now);
+                    self.state = GestureState::Possible;
+                } else {
+                    self.state = GestureState::Failed;
+                }
+            }
+
+            TouchAction::Move => {
+                if let Some(start) = self.start_position {
+                    let current = event.center();
+                    if start.distance_to(current) > self.config.max_distance {
+                        self.state = GestureState::Failed;
+                    }
+                }
+            }
+
+            TouchAction::Up => {
+                if self.state == GestureState::Failed {
+                    self.reset();
+                    return;
+                }
+
+                if let (Some(start_pos), Some(start_time)) = (self.start_position, self.start_time)
+                {
+                    let now = Instant::now();
+                    let duration = now.duration_since(start_time);
+
+                    // Check duration
+                    if duration > self.config.max_duration {
+                        self.state = GestureState::Failed;
+                        self.reset();
+                        return;
+                    }
+
+                    // Check distance
+                    let current = event.center();
+                    if start_pos.distance_to(current) > self.config.max_distance {
+                        self.state = GestureState::Failed;
+                        self.reset();
+                        return;
+                    }
+
+                    // Valid tap!
+                    self.tap_count += 1;
+                    self.last_tap_time = Some(now);
+
+                    if self.tap_count >= self.config.number_of_taps {
+                        self.state = GestureState::Ended;
+                        self.current_event = Some(TapGestureEvent {
+                            position: current,
+                            tap_count: self.tap_count,
+                            state: GestureState::Ended,
+                        });
+                        self.tap_count = 0;
+                    }
+                }
+
+                self.start_position = None;
+                self.start_time = None;
+            }
+
+            TouchAction::Cancel => {
+                self.state = GestureState::Cancelled;
+                self.reset();
+            }
+
+            _ => {}
+        }
+    }
+
+    fn state(&self) -> GestureState {
+        self.state
+    }
+
+    fn reset(&mut self) {
+        self.state = GestureState::Possible;
+        self.start_position = None;
+        self.start_time = None;
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+        if !enabled {
+            self.reset();
+        }
+    }
+}
+
+/// Configuration for long press gesture
+#[derive(Clone, Debug)]
+pub struct LongPressConfig {
+    /// Minimum duration to trigger long press
+    pub min_duration: Duration,
+    /// Maximum distance finger can move
+    pub max_distance: f32,
+    /// Number of fingers required
+    pub number_of_fingers: usize,
+}
+
+impl Default for LongPressConfig {
+    fn default() -> Self {
+        Self {
+            min_duration: Duration::from_millis(500),
+            max_distance: 10.0,
+            number_of_fingers: 1,
+        }
+    }
+}
+
+/// Event emitted by long press gesture
+#[derive(Clone, Debug)]
+pub struct LongPressGestureEvent {
+    pub position: Point,
+    pub state: GestureState,
+}
+
+/// Long press gesture recognizer
+pub struct LongPressGesture {
+    config: LongPressConfig,
+    state: GestureState,
+    enabled: bool,
+
+    start_position: Option<Point>,
+    start_time: Option<Instant>,
+    triggered: bool,
+    current_event: Option<LongPressGestureEvent>,
+}
+
+impl LongPressGesture {
+    pub fn new() -> Self {
+        Self::with_config(LongPressConfig::default())
+    }
+
+    pub fn with_config(config: LongPressConfig) -> Self {
+        Self {
+            config,
+            state: GestureState::Possible,
+            enabled: true,
+            start_position: None,
+            start_time: None,
+            triggered: false,
+            current_event: None,
+        }
+    }
+
+    /// Set minimum duration
+    pub fn min_duration(mut self, duration: Duration) -> Self {
+        self.config.min_duration = duration;
+        self
+    }
+
+    /// Get the current event if any
+    pub fn event(&self) -> Option<&LongPressGestureEvent> {
+        self.current_event.as_ref()
+    }
+
+    /// Take the current event
+    pub fn take_event(&mut self) -> Option<LongPressGestureEvent> {
+        self.current_event.take()
+    }
+
+    /// Check if long press should trigger (call this on a timer)
+    pub fn check_trigger(&mut self) -> bool {
+        if self.triggered || self.state == GestureState::Failed {
+            return false;
+        }
+
+        if let (Some(start_pos), Some(start_time)) = (self.start_position, self.start_time) {
+            let now = Instant::now();
+            if now.duration_since(start_time) >= self.config.min_duration {
+                self.triggered = true;
+                self.state = GestureState::Began;
+                self.current_event = Some(LongPressGestureEvent {
+                    position: start_pos,
+                    state: GestureState::Began,
+                });
+                return true;
+            }
+        }
+        false
+    }
+}
+
+impl Default for LongPressGesture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GestureRecognizer for LongPressGesture {
+    fn on_touch(&mut self, event: &TouchEvent) {
+        if !self.enabled {
+            return;
+        }
+
+        self.current_event = None;
+
+        match event.action {
+            TouchAction::Down => {
+                if event.pointer_count() == self.config.number_of_fingers {
+                    self.start_position = Some(event.center());
+                    self.start_time = Some(Instant::now());
+                    self.triggered = false;
+                    self.state = GestureState::Possible;
+                } else {
+                    self.state = GestureState::Failed;
+                }
+            }
+
+            TouchAction::Move => {
+                if let Some(start) = self.start_position {
+                    let current = event.center();
+                    if start.distance_to(current) > self.config.max_distance {
+                        self.state = GestureState::Failed;
+                    }
+                }
+            }
+
+            TouchAction::Up => {
+                if self.triggered {
+                    self.state = GestureState::Ended;
+                    if let Some(pos) = self.start_position {
+                        self.current_event = Some(LongPressGestureEvent {
+                            position: pos,
+                            state: GestureState::Ended,
+                        });
+                    }
+                }
+                self.reset();
+            }
+
+            TouchAction::Cancel => {
+                if self.triggered {
+                    self.state = GestureState::Cancelled;
+                    if let Some(pos) = self.start_position {
+                        self.current_event = Some(LongPressGestureEvent {
+                            position: pos,
+                            state: GestureState::Cancelled,
+                        });
+                    }
+                }
+                self.reset();
+            }
+
+            _ => {}
+        }
+    }
+
+    fn state(&self) -> GestureState {
+        self.state
+    }
+
+    fn reset(&mut self) {
+        self.state = GestureState::Possible;
+        self.start_position = None;
+        self.start_time = None;
+        self.triggered = false;
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+        if !enabled {
+            self.reset();
+        }
+    }
+}

--- a/crates/zedra-gesture/src/state.rs
+++ b/crates/zedra-gesture/src/state.rs
@@ -1,0 +1,102 @@
+//! Gesture state machine
+
+/// State of a gesture recognizer
+///
+/// Based on the state machine from react-native-gesture-handler / UIKit
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum GestureState {
+    /// Initial state - gesture has not started recognizing
+    #[default]
+    Possible,
+
+    /// Gesture recognition has begun (e.g., finger down for pan)
+    Began,
+
+    /// Gesture is in progress and values are changing
+    Changed,
+
+    /// Gesture completed successfully
+    Ended,
+
+    /// Gesture was cancelled (e.g., interrupted by system)
+    Cancelled,
+
+    /// Gesture recognition failed (not this gesture type)
+    Failed,
+}
+
+impl GestureState {
+    /// Whether the gesture is currently active (began or changed)
+    pub fn is_active(&self) -> bool {
+        matches!(self, GestureState::Began | GestureState::Changed)
+    }
+
+    /// Whether the gesture has finished (ended, cancelled, or failed)
+    pub fn is_finished(&self) -> bool {
+        matches!(
+            self,
+            GestureState::Ended | GestureState::Cancelled | GestureState::Failed
+        )
+    }
+
+    /// Whether we can transition to the given state
+    pub fn can_transition_to(&self, next: GestureState) -> bool {
+        use GestureState::*;
+        match (self, next) {
+            // From Possible
+            (Possible, Began) => true,
+            (Possible, Failed) => true,
+            (Possible, Cancelled) => true,
+
+            // From Began
+            (Began, Changed) => true,
+            (Began, Ended) => true,
+            (Began, Cancelled) => true,
+            (Began, Failed) => true,
+
+            // From Changed
+            (Changed, Changed) => true,
+            (Changed, Ended) => true,
+            (Changed, Cancelled) => true,
+
+            // Terminal states can reset to Possible
+            (Ended, Possible) => true,
+            (Cancelled, Possible) => true,
+            (Failed, Possible) => true,
+
+            _ => false,
+        }
+    }
+
+    /// Reset to initial state
+    pub fn reset(&mut self) {
+        *self = GestureState::Possible;
+    }
+}
+
+/// Configuration for gesture behavior
+#[derive(Clone, Debug)]
+pub struct GestureConfig {
+    /// Whether the gesture is enabled
+    pub enabled: bool,
+
+    /// Minimum number of pointers required
+    pub min_pointers: usize,
+
+    /// Maximum number of pointers allowed
+    pub max_pointers: usize,
+
+    /// Whether to cancel touches in the view when gesture begins
+    pub cancel_touches_in_view: bool,
+}
+
+impl Default for GestureConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            min_pointers: 1,
+            max_pointers: usize::MAX,
+            cancel_touches_in_view: true,
+        }
+    }
+}

--- a/crates/zedra-gesture/src/types.rs
+++ b/crates/zedra-gesture/src/types.rs
@@ -1,7 +1,33 @@
 //! Core types for gesture recognition
 
 use gpui::Pixels;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
+
+/// Unique identifier for a gesture recognizer
+///
+/// Used for establishing relationships between gestures (e.g., requires_failure_of, simultaneous_with)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct GestureId(usize);
+
+impl GestureId {
+    /// Generate a new unique gesture ID
+    pub fn new() -> Self {
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+        Self(NEXT_ID.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Get the raw ID value
+    pub fn raw(&self) -> usize {
+        self.0
+    }
+}
+
+impl Default for GestureId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// A 2D point in logical pixels
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -173,7 +199,9 @@ impl TouchEvent {
         if self.pointers.len() < 2 {
             return 0.0;
         }
-        self.pointers[0].position.distance_to(self.pointers[1].position)
+        self.pointers[0]
+            .position
+            .distance_to(self.pointers[1].position)
     }
 
     /// Calculate angle between two pointers (for rotation)

--- a/crates/zedra-gesture/src/types.rs
+++ b/crates/zedra-gesture/src/types.rs
@@ -1,0 +1,232 @@
+//! Core types for gesture recognition
+
+use gpui::Pixels;
+use std::time::Instant;
+
+/// A 2D point in logical pixels
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Point {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Point {
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+
+    pub fn zero() -> Self {
+        Self { x: 0.0, y: 0.0 }
+    }
+
+    pub fn distance_to(&self, other: Point) -> f32 {
+        let dx = self.x - other.x;
+        let dy = self.y - other.y;
+        (dx * dx + dy * dy).sqrt()
+    }
+
+    pub fn to_gpui(&self) -> gpui::Point<Pixels> {
+        gpui::point(gpui::px(self.x), gpui::px(self.y))
+    }
+}
+
+impl From<(f32, f32)> for Point {
+    fn from((x, y): (f32, f32)) -> Self {
+        Self { x, y }
+    }
+}
+
+impl std::ops::Sub for Point {
+    type Output = Vector2;
+
+    fn sub(self, rhs: Point) -> Vector2 {
+        Vector2 {
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+        }
+    }
+}
+
+/// A 2D vector (for translation, velocity, etc.)
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Vector2 {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Vector2 {
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+
+    pub fn zero() -> Self {
+        Self { x: 0.0, y: 0.0 }
+    }
+
+    pub fn magnitude(&self) -> f32 {
+        (self.x * self.x + self.y * self.y).sqrt()
+    }
+
+    pub fn normalized(&self) -> Self {
+        let mag = self.magnitude();
+        if mag > 0.0 {
+            Self {
+                x: self.x / mag,
+                y: self.y / mag,
+            }
+        } else {
+            Self::zero()
+        }
+    }
+
+    /// Angle in radians from positive X axis
+    pub fn angle(&self) -> f32 {
+        self.y.atan2(self.x)
+    }
+}
+
+impl std::ops::Add for Vector2 {
+    type Output = Vector2;
+
+    fn add(self, rhs: Vector2) -> Vector2 {
+        Vector2 {
+            x: self.x + rhs.x,
+            y: self.y + rhs.y,
+        }
+    }
+}
+
+impl std::ops::Mul<f32> for Vector2 {
+    type Output = Vector2;
+
+    fn mul(self, scalar: f32) -> Vector2 {
+        Vector2 {
+            x: self.x * scalar,
+            y: self.y * scalar,
+        }
+    }
+}
+
+/// Touch pointer information
+#[derive(Clone, Copy, Debug)]
+pub struct TouchPointer {
+    pub id: i32,
+    pub position: Point,
+    pub pressure: f32,
+}
+
+impl TouchPointer {
+    pub fn new(id: i32, x: f32, y: f32) -> Self {
+        Self {
+            id,
+            position: Point::new(x, y),
+            pressure: 1.0,
+        }
+    }
+}
+
+/// Raw touch event from the platform
+#[derive(Clone, Debug)]
+pub struct TouchEvent {
+    pub action: TouchAction,
+    pub pointers: Vec<TouchPointer>,
+    pub timestamp: Instant,
+}
+
+impl TouchEvent {
+    pub fn new(action: TouchAction, pointers: Vec<TouchPointer>) -> Self {
+        Self {
+            action,
+            pointers,
+            timestamp: Instant::now(),
+        }
+    }
+
+    /// Get the primary (first) pointer
+    pub fn primary_pointer(&self) -> Option<&TouchPointer> {
+        self.pointers.first()
+    }
+
+    /// Get pointer by ID
+    pub fn pointer(&self, id: i32) -> Option<&TouchPointer> {
+        self.pointers.iter().find(|p| p.id == id)
+    }
+
+    /// Number of active pointers
+    pub fn pointer_count(&self) -> usize {
+        self.pointers.len()
+    }
+
+    /// Calculate center point of all pointers (for pinch/rotation)
+    pub fn center(&self) -> Point {
+        if self.pointers.is_empty() {
+            return Point::zero();
+        }
+        let sum_x: f32 = self.pointers.iter().map(|p| p.position.x).sum();
+        let sum_y: f32 = self.pointers.iter().map(|p| p.position.y).sum();
+        let count = self.pointers.len() as f32;
+        Point::new(sum_x / count, sum_y / count)
+    }
+
+    /// Calculate span between two pointers (for pinch)
+    pub fn span(&self) -> f32 {
+        if self.pointers.len() < 2 {
+            return 0.0;
+        }
+        self.pointers[0].position.distance_to(self.pointers[1].position)
+    }
+
+    /// Calculate angle between two pointers (for rotation)
+    pub fn rotation_angle(&self) -> f32 {
+        if self.pointers.len() < 2 {
+            return 0.0;
+        }
+        let p1 = self.pointers[0].position;
+        let p2 = self.pointers[1].position;
+        (p2.y - p1.y).atan2(p2.x - p1.x)
+    }
+}
+
+/// Touch action types (maps to Android MotionEvent actions)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TouchAction {
+    /// First finger down
+    Down,
+    /// Additional finger down (pointer index in action)
+    PointerDown(i32),
+    /// Finger moved
+    Move,
+    /// Last finger up
+    Up,
+    /// Finger up but not the last one
+    PointerUp(i32),
+    /// Touch cancelled (e.g., phone call, gesture intercepted)
+    Cancel,
+}
+
+/// Direction for fling gestures
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FlingDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+impl FlingDirection {
+    pub fn from_velocity(velocity: Vector2) -> Self {
+        if velocity.x.abs() > velocity.y.abs() {
+            if velocity.x > 0.0 {
+                FlingDirection::Right
+            } else {
+                FlingDirection::Left
+            }
+        } else {
+            if velocity.y > 0.0 {
+                FlingDirection::Down
+            } else {
+                FlingDirection::Up
+            }
+        }
+    }
+}

--- a/crates/zedra-gesture/src/velocity.rs
+++ b/crates/zedra-gesture/src/velocity.rs
@@ -1,0 +1,399 @@
+//! Velocity tracking and momentum scrolling with iOS-style deceleration
+
+use crate::types::{Point, Vector2};
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+/// Sample for velocity calculation
+#[derive(Clone, Copy, Debug)]
+struct VelocitySample {
+    position: Point,
+    timestamp: Instant,
+}
+
+/// Tracks touch velocity over time for momentum calculations
+#[derive(Clone, Debug)]
+pub struct VelocityTracker {
+    samples: VecDeque<VelocitySample>,
+    max_samples: usize,
+    sample_duration: Duration,
+}
+
+impl Default for VelocityTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VelocityTracker {
+    /// Create a new velocity tracker
+    pub fn new() -> Self {
+        Self {
+            samples: VecDeque::with_capacity(20),
+            max_samples: 20,
+            // Only consider samples from the last 100ms
+            sample_duration: Duration::from_millis(100),
+        }
+    }
+
+    /// Add a position sample
+    pub fn add_sample(&mut self, position: Point) {
+        let now = Instant::now();
+
+        // Remove old samples
+        self.prune_old_samples(now);
+
+        // Add new sample
+        self.samples.push_back(VelocitySample {
+            position,
+            timestamp: now,
+        });
+
+        // Limit sample count
+        while self.samples.len() > self.max_samples {
+            self.samples.pop_front();
+        }
+    }
+
+    /// Calculate current velocity in pixels per second
+    pub fn velocity(&self) -> Vector2 {
+        if self.samples.len() < 2 {
+            return Vector2::zero();
+        }
+
+        let now = Instant::now();
+        let cutoff = now - self.sample_duration;
+
+        // Get recent samples
+        let recent: Vec<_> = self
+            .samples
+            .iter()
+            .filter(|s| s.timestamp >= cutoff)
+            .collect();
+
+        if recent.len() < 2 {
+            return Vector2::zero();
+        }
+
+        // Use weighted least squares for smoother velocity
+        // Weight more recent samples higher
+        let mut sum_weight = 0.0f32;
+        let mut sum_x = 0.0f32;
+        let mut sum_y = 0.0f32;
+
+        for i in 1..recent.len() {
+            let dt = recent[i]
+                .timestamp
+                .duration_since(recent[i - 1].timestamp)
+                .as_secs_f32();
+
+            if dt > 0.0 {
+                let dx = recent[i].position.x - recent[i - 1].position.x;
+                let dy = recent[i].position.y - recent[i - 1].position.y;
+
+                // Weight increases for more recent samples
+                let weight = i as f32;
+                sum_weight += weight;
+                sum_x += (dx / dt) * weight;
+                sum_y += (dy / dt) * weight;
+            }
+        }
+
+        if sum_weight > 0.0 {
+            Vector2::new(sum_x / sum_weight, sum_y / sum_weight)
+        } else {
+            Vector2::zero()
+        }
+    }
+
+    /// Clear all samples
+    pub fn clear(&mut self) {
+        self.samples.clear();
+    }
+
+    fn prune_old_samples(&mut self, now: Instant) {
+        let cutoff = now - self.sample_duration * 2;
+        while let Some(front) = self.samples.front() {
+            if front.timestamp < cutoff {
+                self.samples.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+/// Deceleration curve type
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DecelerationCurve {
+    /// iOS-style deceleration (default) - natural feeling scroll
+    IOS,
+    /// Android-style deceleration - slightly different feel
+    Android,
+    /// Fast deceleration - stops quickly
+    Fast,
+    /// Custom deceleration rate
+    Custom(f32),
+}
+
+impl Default for DecelerationCurve {
+    fn default() -> Self {
+        DecelerationCurve::IOS
+    }
+}
+
+impl DecelerationCurve {
+    /// Get the deceleration rate (multiplier per frame)
+    pub fn rate(&self) -> f32 {
+        match self {
+            DecelerationCurve::IOS => 0.998,     // iOS UIScrollView default
+            DecelerationCurve::Android => 0.985, // Slightly faster decel
+            DecelerationCurve::Fast => 0.95,     // Quick stop
+            DecelerationCurve::Custom(rate) => *rate,
+        }
+    }
+}
+
+/// Momentum animation state for fling/scroll
+#[derive(Clone, Debug)]
+pub struct MomentumAnimator {
+    /// Current velocity
+    velocity: Vector2,
+    /// Current position offset (from start)
+    offset: Vector2,
+    /// Deceleration curve
+    deceleration: DecelerationCurve,
+    /// Minimum velocity to continue animation (pixels/second)
+    min_velocity: f32,
+    /// Whether animation is active
+    active: bool,
+    /// Last update time
+    last_update: Instant,
+    /// Optional bounds for rubber-banding
+    bounds: Option<MomentumBounds>,
+    /// Rubber band tension (iOS-style)
+    rubber_band_tension: f32,
+}
+
+/// Bounds for momentum scrolling with rubber-banding
+#[derive(Clone, Copy, Debug)]
+pub struct MomentumBounds {
+    pub min_x: f32,
+    pub max_x: f32,
+    pub min_y: f32,
+    pub max_y: f32,
+}
+
+impl Default for MomentumAnimator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MomentumAnimator {
+    pub fn new() -> Self {
+        Self {
+            velocity: Vector2::zero(),
+            offset: Vector2::zero(),
+            deceleration: DecelerationCurve::IOS,
+            min_velocity: 20.0, // Stop when below 20 px/s
+            active: false,
+            last_update: Instant::now(),
+            bounds: None,
+            rubber_band_tension: 0.55, // iOS default
+        }
+    }
+
+    /// Set the deceleration curve
+    pub fn with_deceleration(mut self, curve: DecelerationCurve) -> Self {
+        self.deceleration = curve;
+        self
+    }
+
+    /// Set bounds for rubber-banding
+    pub fn with_bounds(mut self, bounds: MomentumBounds) -> Self {
+        self.bounds = Some(bounds);
+        self
+    }
+
+    /// Set rubber band tension (0.0 = no rubber band, 1.0 = full resistance)
+    pub fn with_rubber_band_tension(mut self, tension: f32) -> Self {
+        self.rubber_band_tension = tension.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Start momentum animation with initial velocity
+    pub fn start(&mut self, velocity: Vector2) {
+        self.velocity = velocity;
+        self.offset = Vector2::zero();
+        self.active = true;
+        self.last_update = Instant::now();
+    }
+
+    /// Stop the animation
+    pub fn stop(&mut self) {
+        self.active = false;
+        self.velocity = Vector2::zero();
+    }
+
+    /// Whether animation is currently active
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// Current velocity
+    pub fn velocity(&self) -> Vector2 {
+        self.velocity
+    }
+
+    /// Total offset from start
+    pub fn offset(&self) -> Vector2 {
+        self.offset
+    }
+
+    /// Update animation state, returns delta offset since last update
+    pub fn update(&mut self) -> Vector2 {
+        if !self.active {
+            return Vector2::zero();
+        }
+
+        let now = Instant::now();
+        let dt = now.duration_since(self.last_update).as_secs_f32();
+        self.last_update = now;
+
+        if dt <= 0.0 {
+            return Vector2::zero();
+        }
+
+        // Calculate delta position
+        let delta = self.velocity * dt;
+
+        // Update offset
+        self.offset = self.offset + delta;
+
+        // Apply deceleration
+        let rate = self.deceleration.rate();
+        // Deceleration is per-frame at 60fps, adjust for actual dt
+        let frames = dt * 60.0;
+        let decay = rate.powf(frames);
+        self.velocity = self.velocity * decay;
+
+        // Apply rubber-banding if we have bounds
+        if let Some(bounds) = self.bounds {
+            self.apply_rubber_band(&bounds);
+        }
+
+        // Check if we should stop
+        if self.velocity.magnitude() < self.min_velocity {
+            self.stop();
+        }
+
+        delta
+    }
+
+    /// Apply iOS-style rubber-band effect at bounds
+    fn apply_rubber_band(&mut self, bounds: &MomentumBounds) {
+        let tension = self.rubber_band_tension;
+
+        // Check X bounds
+        if self.offset.x < bounds.min_x {
+            let over = bounds.min_x - self.offset.x;
+            let resistance = 1.0 / (1.0 + over * 0.01 * tension);
+            self.velocity.x *= resistance;
+            // Pull back towards bound
+            self.velocity.x += over * 0.1;
+        } else if self.offset.x > bounds.max_x {
+            let over = self.offset.x - bounds.max_x;
+            let resistance = 1.0 / (1.0 + over * 0.01 * tension);
+            self.velocity.x *= resistance;
+            self.velocity.x -= over * 0.1;
+        }
+
+        // Check Y bounds
+        if self.offset.y < bounds.min_y {
+            let over = bounds.min_y - self.offset.y;
+            let resistance = 1.0 / (1.0 + over * 0.01 * tension);
+            self.velocity.y *= resistance;
+            self.velocity.y += over * 0.1;
+        } else if self.offset.y > bounds.max_y {
+            let over = self.offset.y - bounds.max_y;
+            let resistance = 1.0 / (1.0 + over * 0.01 * tension);
+            self.velocity.y *= resistance;
+            self.velocity.y -= over * 0.1;
+        }
+    }
+
+    /// Snap back to bounds (call when touch ends outside bounds)
+    pub fn snap_to_bounds(&mut self) -> Option<Vector2> {
+        let bounds = self.bounds?;
+        let mut target = self.offset;
+        let mut needs_snap = false;
+
+        if self.offset.x < bounds.min_x {
+            target.x = bounds.min_x;
+            needs_snap = true;
+        } else if self.offset.x > bounds.max_x {
+            target.x = bounds.max_x;
+            needs_snap = true;
+        }
+
+        if self.offset.y < bounds.min_y {
+            target.y = bounds.min_y;
+            needs_snap = true;
+        } else if self.offset.y > bounds.max_y {
+            target.y = bounds.max_y;
+            needs_snap = true;
+        }
+
+        if needs_snap {
+            // Animate back to bounds
+            let delta = Vector2::new(target.x - self.offset.x, target.y - self.offset.y);
+            self.velocity = delta * 5.0; // Spring-like return
+            self.active = true;
+            Some(target)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+
+    #[test]
+    fn test_velocity_tracker() {
+        let mut tracker = VelocityTracker::new();
+
+        // Simulate moving right at ~100 px/s
+        for i in 0..10 {
+            tracker.add_sample(Point::new(i as f32 * 10.0, 0.0));
+            sleep(Duration::from_millis(10));
+        }
+
+        let velocity = tracker.velocity();
+        // Should be roughly 1000 px/s (10px per 10ms)
+        assert!(velocity.x > 500.0, "velocity.x = {}", velocity.x);
+        assert!(velocity.y.abs() < 10.0);
+    }
+
+    #[test]
+    fn test_momentum_animator() {
+        let mut animator = MomentumAnimator::new();
+        animator.start(Vector2::new(1000.0, 0.0));
+
+        assert!(animator.is_active());
+
+        // Simulate a few frames
+        sleep(Duration::from_millis(16));
+        let delta1 = animator.update();
+        assert!(delta1.x > 0.0);
+
+        sleep(Duration::from_millis(16));
+        let delta2 = animator.update();
+        // Should be decelerating
+        assert!(delta2.x > 0.0);
+        assert!(delta2.x < delta1.x || (delta1.x - delta2.x).abs() < 1.0);
+    }
+}

--- a/crates/zedra-host/Cargo.toml
+++ b/crates/zedra-host/Cargo.toml
@@ -56,7 +56,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hostname = "0.4"
 
 # Network interface discovery
-if-addrs.workspace = true
+if-addrs = "0.15.0"
 
 # Error handling
 anyhow.workspace = true

--- a/crates/zedra/Cargo.toml
+++ b/crates/zedra/Cargo.toml
@@ -24,3 +24,5 @@ once_cell = "1.19"
 # Workspace crates
 zedra-ssh = { path = "../zedra-ssh" }
 zedra-terminal = { path = "../zedra-terminal" }
+zedra-editor = { path = "../zedra-editor" }
+zedra-nav = { path = "../zedra-nav" }

--- a/crates/zedra/src/file_explorer.rs
+++ b/crates/zedra/src/file_explorer.rs
@@ -1,4 +1,3 @@
-use gpui::prelude::FluentBuilder;
 use gpui::*;
 
 #[derive(Clone, Debug)]

--- a/crates/zedra/src/file_preview_list.rs
+++ b/crates/zedra/src/file_preview_list.rs
@@ -1,7 +1,6 @@
 // FilePreviewList — grid of preview cards for sample code files.
 // Tapping a card emits PreviewSelected so the parent can push an EditorView.
 
-use gpui::prelude::FluentBuilder;
 use gpui::*;
 
 /// Metadata for a sample file shown in the preview grid.

--- a/crates/zedra/src/zedra_app.rs
+++ b/crates/zedra/src/zedra_app.rs
@@ -5,7 +5,7 @@ use gpui::*;
 
 use crate::file_explorer::{FileExplorer, FileSelected};
 use crate::file_preview_list::{FilePreviewList, PreviewSelected, SAMPLE_FILES};
-use zedra_editor::{DiffView, EditorView, GitStack};
+use zedra_editor::{EditorView, GitStack};
 use zedra_nav::{DrawerHost, HeaderConfig, StackNavigator, TabBarConfig, TabNavigator};
 use zedra_ssh::connection::{AuthMethod, ConnectionManager, ConnectionParams};
 use zedra_terminal::view::TerminalView;
@@ -194,10 +194,7 @@ impl ZedraApp {
             stack
         });
 
-        // Create the diff tab's view
-        let diff_view = cx.new(|cx| DiffView::new(cx));
-
-        // Create the git stack view
+        // Create the git tab's view with gesture-based drawer
         let git_stack = cx.new(|cx| GitStack::new(cx));
 
         // Create tab navigator
@@ -210,8 +207,6 @@ impl ZedraApp {
             tabs.add_tab("Terminal", ">_", move |_window, _cx| ts.clone().into());
             let es = editor_stack_clone.clone();
             tabs.add_tab("Editor", "{}", move |_window, _cx| es.clone().into());
-            let dv = diff_view.clone();
-            tabs.add_tab("Diff", "+-", move |_window, _cx| dv.clone().into());
             let gs = git_stack.clone();
             tabs.add_tab("Git", "*", move |_window, _cx| gs.clone().into());
             tabs.ensure_active_view(window, cx);

--- a/crates/zedra/src/zedra_app.rs
+++ b/crates/zedra/src/zedra_app.rs
@@ -5,7 +5,7 @@ use gpui::*;
 
 use crate::file_explorer::{FileExplorer, FileSelected};
 use crate::file_preview_list::{FilePreviewList, PreviewSelected, SAMPLE_FILES};
-use zedra_editor::{DiffView, EditorView};
+use zedra_editor::{DiffView, EditorView, GitStack};
 use zedra_nav::{DrawerHost, HeaderConfig, StackNavigator, TabBarConfig, TabNavigator};
 use zedra_ssh::connection::{AuthMethod, ConnectionManager, ConnectionParams};
 use zedra_terminal::view::TerminalView;
@@ -197,6 +197,9 @@ impl ZedraApp {
         // Create the diff tab's view
         let diff_view = cx.new(|cx| DiffView::new(cx));
 
+        // Create the git stack view
+        let git_stack = cx.new(|cx| GitStack::new(cx));
+
         // Create tab navigator
         let terminal_stack_clone = terminal_stack.clone();
         let editor_stack_clone = editor_stack.clone();
@@ -209,6 +212,8 @@ impl ZedraApp {
             tabs.add_tab("Editor", "{}", move |_window, _cx| es.clone().into());
             let dv = diff_view.clone();
             tabs.add_tab("Diff", "+-", move |_window, _cx| dv.clone().into());
+            let gs = git_stack.clone();
+            tabs.add_tab("Git", "*", move |_window, _cx| gs.clone().into());
             tabs.ensure_active_view(window, cx);
             tabs
         });

--- a/crates/zedra/src/zedra_app.rs
+++ b/crates/zedra/src/zedra_app.rs
@@ -5,7 +5,7 @@ use gpui::*;
 
 use crate::file_explorer::{FileExplorer, FileSelected};
 use crate::file_preview_list::{FilePreviewList, PreviewSelected, SAMPLE_FILES};
-use zedra_editor::EditorView;
+use zedra_editor::{DiffView, EditorView};
 use zedra_nav::{DrawerHost, HeaderConfig, StackNavigator, TabBarConfig, TabNavigator};
 use zedra_ssh::connection::{AuthMethod, ConnectionManager, ConnectionParams};
 use zedra_terminal::view::TerminalView;
@@ -194,6 +194,9 @@ impl ZedraApp {
             stack
         });
 
+        // Create the diff tab's view
+        let diff_view = cx.new(|cx| DiffView::new(cx));
+
         // Create tab navigator
         let terminal_stack_clone = terminal_stack.clone();
         let editor_stack_clone = editor_stack.clone();
@@ -204,6 +207,8 @@ impl ZedraApp {
             tabs.add_tab("Terminal", ">_", move |_window, _cx| ts.clone().into());
             let es = editor_stack_clone.clone();
             tabs.add_tab("Editor", "{}", move |_window, _cx| es.clone().into());
+            let dv = diff_view.clone();
+            tabs.add_tab("Diff", "+-", move |_window, _cx| dv.clone().into());
             tabs.ensure_active_view(window, cx);
             tabs
         });

--- a/scripts/dev-cycle.sh
+++ b/scripts/dev-cycle.sh
@@ -29,6 +29,25 @@ if ! adb devices | grep -q "device$"; then
   exit 1
 fi
 
+# Handle multiple devices - prefer physical device over emulator
+DEVICE_COUNT=$(adb devices | grep -c "device$" || true)
+if [ "$DEVICE_COUNT" -gt 1 ]; then
+  echo -e "${YELLOW}  Multiple devices detected ($DEVICE_COUNT), selecting physical device...${NC}"
+
+  # Get list of devices, prefer physical (non-emulator) devices
+  PHYSICAL_DEVICE=$(adb devices | grep "device$" | grep -v "emulator" | head -1 | awk '{print $1}')
+
+  if [ -n "$PHYSICAL_DEVICE" ]; then
+    export ANDROID_SERIAL="$PHYSICAL_DEVICE"
+    echo -e "${GREEN}  → Selected physical device: $PHYSICAL_DEVICE${NC}"
+  else
+    # Fall back to first device if no physical device found
+    FIRST_DEVICE=$(adb devices | grep "device$" | head -1 | awk '{print $1}')
+    export ANDROID_SERIAL="$FIRST_DEVICE"
+    echo -e "${YELLOW}  → No physical device, using: $FIRST_DEVICE${NC}"
+  fi
+fi
+
 DEVICE_MODEL=$(adb shell getprop ro.product.model | tr -d '\r')
 echo -e "${GREEN}✓ Device connected: $DEVICE_MODEL${NC}"
 


### PR DESCRIPTION
## Summary
- Add new `DiffView` component in `zedra-editor` crate with VS Code-style unified diff display
- Color-coded lines: green background for additions, red for removals
- File tabs, toolbar with +/- stats, and navigation controls
- Syntax highlighting for Rust code within diff content
- New "Diff" tab added to main TabNavigator

## Test plan
- [ ] Build the app with `./scripts/build-android.sh`
- [ ] Deploy to device and verify the new "Diff" tab appears
- [ ] Tap on Diff tab to see the sample diff view
- [ ] Verify file switching works with arrow buttons
- [ ] Verify scrolling through diff content works

🤖 Generated with [Claude Code](https://claude.com/claude-code)