### PR TITLE
perf: gesture arena and scroll line caching

### DIFF
--- a/crates/zedra-nav/src/drawer.rs
+++ b/crates/zedra-nav/src/drawer.rs
@@ -13,6 +13,54 @@ pub fn is_drawer_overlay_visible() -> bool {
     DRAWER_OVERLAY_VISIBLE.load(Ordering::Relaxed)
 }
 
+// ---------------------------------------------------------------------------
+// Drawer gesture bridge — android_app.rs writes, DrawerHost reads
+// ---------------------------------------------------------------------------
+// DrawerPan events bypass GPUI scroll dispatch entirely. android_app.rs
+// pushes horizontal deltas here; DrawerHost drains them each render frame.
+// This avoids a full-screen overlay that would intercept content scroll.
+
+struct DrawerGestureBridge {
+    /// Accumulated horizontal delta since last drain
+    pending_dx: f32,
+    /// Most recent individual delta (for snap direction bias)
+    last_dx: f32,
+    /// Whether a drawer pan gesture is currently active
+    dragging: bool,
+}
+
+static DRAWER_BRIDGE: Mutex<DrawerGestureBridge> = Mutex::new(DrawerGestureBridge {
+    pending_dx: 0.0,
+    last_dx: 0.0,
+    dragging: false,
+});
+
+/// Push a horizontal delta from the gesture arena (called from android_app.rs).
+pub fn push_drawer_pan_delta(dx: f32) {
+    if let Ok(mut bridge) = DRAWER_BRIDGE.lock() {
+        bridge.pending_dx += dx;
+        bridge.last_dx = dx;
+        bridge.dragging = true;
+    }
+}
+
+/// Reset the bridge (called from android_app.rs on ACTION_DOWN).
+pub fn reset_drawer_gesture() {
+    if let Ok(mut bridge) = DRAWER_BRIDGE.lock() {
+        bridge.pending_dx = 0.0;
+        bridge.last_dx = 0.0;
+        bridge.dragging = false;
+    }
+}
+
+/// Check whether a drawer pan gesture is currently active.
+pub fn is_drawer_pan_active() -> bool {
+    DRAWER_BRIDGE
+        .lock()
+        .map(|b| b.dragging)
+        .unwrap_or(false)
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum DrawerSide {
     Left,
@@ -51,14 +99,6 @@ impl Default for DrawerState {
     }
 }
 
-/// Once a gesture's axis is determined, lock it for the rest of the touch.
-#[derive(Clone, Copy, PartialEq)]
-enum GestureAxis {
-    Undecided,
-    Horizontal, // drawer swipe
-    Vertical,   // content scroll — ignore in drawer handler
-}
-
 // ---------------------------------------------------------------------------
 // DrawerHost
 // ---------------------------------------------------------------------------
@@ -81,12 +121,6 @@ pub struct DrawerHost {
     snap_started_at: Option<std::time::Instant>,
     /// Incremented each snap to retrigger with_animation
     animation_id: u64,
-    /// Locked gesture axis for current touch sequence
-    gesture_axis: GestureAxis,
-    /// Accumulated deltas to decide axis before locking
-    gesture_accum: (f32, f32),
-    /// Width of the left-edge trigger zone for swipe-to-open
-    edge_zone_width: Pixels,
     /// Most recent horizontal drag delta — used to bias snap direction
     last_drag_dx: f32,
 }
@@ -105,9 +139,6 @@ impl DrawerHost {
             snap_target: None,
             snap_started_at: None,
             animation_id: 0,
-            gesture_axis: GestureAxis::Undecided,
-            gesture_accum: (0.0, 0.0),
-            edge_zone_width: px(40.0),
             last_drag_dx: 0.0,
         }
     }
@@ -150,10 +181,6 @@ impl DrawerHost {
 
     pub fn set_backdrop_opacity(&mut self, opacity: f32) {
         self.backdrop_opacity = opacity;
-    }
-
-    pub fn set_edge_zone_width(&mut self, width: Pixels) {
-        self.edge_zone_width = width;
     }
 
     /// Start a snap animation to the given target offset.
@@ -203,12 +230,85 @@ impl Render for DrawerHost {
             }
         }
 
+        // Drain pending drawer gesture deltas pushed by android_app.rs.
+        // This runs before reading drawer_state so show_overlay sees the
+        // up-to-date is_dragging flag.
+        //
+        // Auto-snap: when the offset crosses a position threshold (30% of
+        // width) or the per-frame velocity exceeds 6px, the drawer auto-
+        // completes its open/close animation without waiting for finger lift.
+        let mut auto_snap_target: Option<f32> = None;
+        if let Ok(mut bridge) = DRAWER_BRIDGE.lock() {
+            if bridge.pending_dx.abs() > 0.0 {
+                // If a snap animation is already running (e.g. from a
+                // previous auto-snap), discard incoming deltas so the
+                // animation plays to completion undisturbed.
+                if self.snap_target.is_some() {
+                    bridge.pending_dx = 0.0;
+                } else {
+                    let width = f32::from(self.width);
+                    // Skip no-op: drawer already closed and swiping further left
+                    let current = self
+                        .drawer_state
+                        .lock()
+                        .map(|s| s.offset)
+                        .unwrap_or(0.0);
+                    if !(current <= 0.0 && bridge.pending_dx <= 0.0) {
+                        self.snap_target = None;
+                        self.snap_started_at = None;
+                        self.last_drag_dx = bridge.last_dx;
+                        let new_offset;
+                        if let Ok(mut state) = self.drawer_state.lock() {
+                            state.is_dragging = true;
+                            state.offset =
+                                (state.offset + bridge.pending_dx).clamp(0.0, width);
+                            new_offset = state.offset;
+                        } else {
+                            new_offset = current;
+                        }
+
+                        // Auto-snap thresholds
+                        const VELOCITY_THRESHOLD: f32 = 6.0; // px/frame
+                        let position_threshold = width * 0.3;
+                        let velocity = bridge.last_dx;
+
+                        if velocity > 0.0
+                            && (new_offset > position_threshold
+                                || velocity > VELOCITY_THRESHOLD)
+                        {
+                            // Swiping right — auto-open
+                            auto_snap_target = Some(width);
+                            bridge.dragging = false;
+                        } else if velocity < 0.0
+                            && (new_offset < width - position_threshold
+                                || velocity.abs() > VELOCITY_THRESHOLD)
+                        {
+                            // Swiping left — auto-close
+                            auto_snap_target = Some(0.0);
+                            bridge.dragging = false;
+                        }
+                    }
+                    bridge.pending_dx = 0.0;
+                }
+            }
+        }
+
+        // Trigger auto-snap outside the lock
+        if let Some(target) = auto_snap_target {
+            let width = f32::from(self.width);
+            self.start_snap(target, cx);
+            if target < width * 0.5 {
+                cx.emit(DrawerEvent::Closed);
+            } else {
+                cx.emit(DrawerEvent::Opened);
+            }
+        }
+
         let content = self.content.clone();
         let drawer_view = self.drawer_view.clone();
         let has_drawer = drawer_view.is_some();
         let drawer_width = f32::from(self.width);
         let max_opacity = self.backdrop_opacity;
-        let edge_zone_width = self.edge_zone_width;
 
         // Read drawer state
         let (drawer_offset, is_dragging) = self
@@ -223,38 +323,49 @@ impl Render for DrawerHost {
         let animation_id = self.animation_id;
         let animating = snap_target.is_some() && !is_dragging;
 
-        // Edge zone shows when drawer is closed and not animating open
-        let show_edge = has_drawer && !is_open && !snap_target.map_or(false, |t| t > 0.0);
-        // Overlay shows when drawer is visible or animating
-        let show_overlay = has_drawer && (is_open || snap_target.is_some());
+        // Drawer overlay (backdrop + panel) shows when drawer is visible, being
+        // dragged, or animating. Including is_dragging prevents the occluding
+        // overlay from disappearing mid-gesture when the offset hits 0.
+        let show_overlay = has_drawer && (is_open || is_dragging || snap_target.is_some());
         DRAWER_OVERLAY_VISIBLE.store(show_overlay, Ordering::Relaxed);
 
         div()
             .track_focus(&self.focus_handle)
             .size_full()
-            // Mouse up handler: reset gesture axis and snap on release
+            // Mouse up handler: snap drawer on release
             .on_mouse_up(
                 MouseButton::Left,
                 cx.listener(|this, _event: &MouseUpEvent, _window, cx| {
-                    this.gesture_axis = GestureAxis::Undecided;
-                    this.gesture_accum = (0.0, 0.0);
-
-                    let was_dragging = this
+                    // Check both sources: DrawerState (set during render) and
+                    // the global bridge (set immediately by push_drawer_pan_delta).
+                    let state_dragging = this
                         .drawer_state
                         .lock()
                         .map(|s| s.is_dragging)
                         .unwrap_or(false);
+                    let was_dragging = state_dragging || is_drawer_pan_active();
 
                     if was_dragging {
+                        // Drain any remaining bridge delta before snapping
+                        if let Ok(mut bridge) = DRAWER_BRIDGE.lock() {
+                            if bridge.pending_dx.abs() > 0.0 {
+                                let width = f32::from(this.width);
+                                this.last_drag_dx = bridge.last_dx;
+                                if let Ok(mut state) = this.drawer_state.lock() {
+                                    state.offset =
+                                        (state.offset + bridge.pending_dx).clamp(0.0, width);
+                                }
+                                bridge.pending_dx = 0.0;
+                            } else if bridge.last_dx.abs() > this.last_drag_dx.abs() {
+                                this.last_drag_dx = bridge.last_dx;
+                            }
+                            bridge.dragging = false;
+                        }
                         let current =
                             this.drawer_state.lock().map(|s| s.offset).unwrap_or(0.0);
                         let width = f32::from(this.width);
                         let last_dx = this.last_drag_dx;
 
-                        // Use drag direction to bias the snap decision:
-                        // - Swiping left (dx < -2): snap closed regardless of position
-                        // - Swiping right (dx > 2): snap open regardless of position
-                        // - Slow/stopped: fall back to midpoint threshold
                         let target = if last_dx < -2.0 {
                             0.0
                         } else if last_dx > 2.0 {
@@ -276,87 +387,24 @@ impl Render for DrawerHost {
             )
             // Content — always rendered full width
             .child(content)
-            // Left-edge swipe trigger zone — invisible, sits on top of content
-            .when(show_edge, |el| {
-                el.child(
-                    div()
-                        .absolute()
-                        .left_0()
-                        .top_0()
-                        .bottom_0()
-                        .w(edge_zone_width)
-                        .on_scroll_wheel(cx.listener(
-                            |this, event: &ScrollWheelEvent, _window, cx| {
-                                let (dx, dy) = match event.delta {
-                                    ScrollDelta::Pixels(p) => {
-                                        (f32::from(p.x), f32::from(p.y))
-                                    }
-                                    ScrollDelta::Lines(l) => (l.x * 20.0, l.y * 20.0),
-                                };
-
-                                if this.gesture_axis == GestureAxis::Vertical {
-                                    return;
-                                }
-
-                                let width = f32::from(this.width);
-
-                                if this.gesture_axis == GestureAxis::Horizontal {
-                                    this.snap_target = None;
-                                    this.snap_started_at = None;
-                                    this.last_drag_dx = dx;
-                                    if let Ok(mut state) = this.drawer_state.lock() {
-                                        state.is_dragging = true;
-                                        state.offset =
-                                            (state.offset + dx).clamp(0.0, width);
-                                    }
-                                    cx.notify();
-                                    return;
-                                }
-
-                                // Undecided — accumulate then lock axis
-                                this.gesture_accum.0 += dx;
-                                this.gesture_accum.1 += dy;
-                                let (ax, ay) = (
-                                    this.gesture_accum.0.abs(),
-                                    this.gesture_accum.1.abs(),
-                                );
-
-                                if ax + ay > 6.0 {
-                                    if ax > ay {
-                                        this.gesture_axis = GestureAxis::Horizontal;
-                                        this.snap_target = None;
-                                        this.snap_started_at = None;
-                                        if let Ok(mut state) = this.drawer_state.lock()
-                                        {
-                                            state.is_dragging = true;
-                                            state.offset = (state.offset
-                                                + this.gesture_accum.0)
-                                                .clamp(0.0, width);
-                                        }
-                                        cx.notify();
-                                    } else {
-                                        this.gesture_axis = GestureAxis::Vertical;
-                                    }
-                                }
-                            },
-                        )),
-                )
-            })
             // Drawer overlay: backdrop + panel (when offset > 0 or animating)
+            // .occlude() on container blocks ALL events from reaching main content.
+            // DrawerPan gestures bypass GPUI scroll dispatch — android_app.rs
+            // pushes deltas to the global DRAWER_BRIDGE, drained above in render.
             .when(show_overlay, |el| {
                 let drawer_view = match drawer_view {
                     Some(v) => v,
                     None => return el,
                 };
 
-                // Backdrop — covers full area, tappable to close, swipeable
+                // Backdrop — covers full area, tappable to close.
+                // Scroll handling is done by the drawer bridge (not GPUI).
                 let backdrop = div()
                     .absolute()
                     .inset_0()
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(|this, event: &MouseDownEvent, _window, cx| {
-                            // Ignore taps that land on the drawer panel
                             let offset =
                                 this.drawer_state.lock().map(|s| s.offset).unwrap_or(0.0);
                             if f32::from(event.position.x) < offset {
@@ -365,33 +413,7 @@ impl Render for DrawerHost {
                             cx.emit(DrawerEvent::BackdropTapped);
                             this.close(cx);
                         }),
-                    )
-                    .on_scroll_wheel(cx.listener(
-                        |this, event: &ScrollWheelEvent, _window, cx| {
-                            let dx = match event.delta {
-                                ScrollDelta::Pixels(p) => f32::from(p.x),
-                                ScrollDelta::Lines(l) => l.x * 20.0,
-                            };
-                            if dx.abs() > 1.0 {
-                                let width = f32::from(this.width);
-                                this.snap_target = None;
-                                this.snap_started_at = None;
-                                this.last_drag_dx = dx;
-                                if let Ok(mut state) = this.drawer_state.lock() {
-                                    state.is_dragging = true;
-                                    state.offset =
-                                        (state.offset + dx).clamp(0.0, width);
-                                    // If dragged all the way to 0, close immediately
-                                    // so the overlay disappears and doesn't ghost-catch
-                                    // the next touch.
-                                    if state.offset <= 0.0 {
-                                        state.is_dragging = false;
-                                    }
-                                }
-                                cx.notify();
-                            }
-                        },
-                    ));
+                    );
 
                 let backdrop: AnyElement = if animating {
                     let from = snap_from;
@@ -420,7 +442,8 @@ impl Render for DrawerHost {
                         .into_any_element()
                 };
 
-                // Drawer panel — flex col so child can use flex_1/size_full properly
+                // Drawer panel — .occlude() prevents events inside the panel
+                // from leaking to the backdrop's tap handler.
                 let panel = div()
                     .absolute()
                     .top_0()
@@ -430,6 +453,7 @@ impl Render for DrawerHost {
                     .flex()
                     .flex_col()
                     .overflow_hidden()
+                    .occlude()
                     .child(drawer_view);
 
                 let panel: AnyElement = if animating {
@@ -460,6 +484,7 @@ impl Render for DrawerHost {
                         div()
                             .absolute()
                             .inset_0()
+                            .occlude()
                             .child(backdrop)
                             .child(panel),
                     )

--- a/crates/zedra-nav/src/lib.rs
+++ b/crates/zedra-nav/src/lib.rs
@@ -6,4 +6,7 @@ mod drawer;
 pub use stack::{HeaderConfig, StackEvent, StackNavigator};
 pub use tab::{TabBarConfig, TabEvent, TabNavigator};
 pub use modal::{ModalEvent, ModalHost};
-pub use drawer::{is_drawer_overlay_visible, DrawerEvent, DrawerHost, DrawerSide};
+pub use drawer::{
+    is_drawer_overlay_visible, is_drawer_pan_active, push_drawer_pan_delta,
+    reset_drawer_gesture, DrawerEvent, DrawerHost, DrawerSide,
+};

--- a/crates/zedra/src/app_drawer.rs
+++ b/crates/zedra/src/app_drawer.rs
@@ -378,7 +378,7 @@ impl Render for AppDrawer {
             DrawerSection::Files => div()
                 .id("drawer-file-tree")
                 .flex_1()
-                .overflow_y_scroll()
+                .overflow_hidden()
                 .child(self.file_explorer.clone())
                 .into_any_element(),
             DrawerSection::Git => div()

--- a/crates/zedra/src/code_editor.rs
+++ b/crates/zedra/src/code_editor.rs
@@ -1,4 +1,5 @@
 use std::ops::Range;
+use std::rc::Rc;
 
 use gpui::prelude::FluentBuilder;
 use gpui::*;
@@ -14,6 +15,14 @@ const GUTTER_WIDTH: f32 = theme::EDITOR_GUTTER_WIDTH;
 const FONT_SIZE: f32 = theme::EDITOR_FONT_SIZE;
 const GUTTER_FONT_SIZE: f32 = theme::EDITOR_GUTTER_FONT_SIZE;
 
+/// Cached per-line data (text, line number, syntax highlights).
+/// Recomputed only when the buffer content changes, NOT on every scroll frame.
+struct CachedLine {
+    text: String,
+    number: String,
+    highlights: Vec<(Range<usize>, HighlightStyle)>,
+}
+
 /// A code editor view with syntax highlighting and virtual scrolling.
 pub struct EditorView {
     buffer: Buffer,
@@ -22,6 +31,11 @@ pub struct EditorView {
     cursor_offset: usize,
     scroll_handle: UniformListScrollHandle,
     focus_handle: FocusHandle,
+    /// Cached line data shared with the uniform_list closure via Rc.
+    /// Only rebuilt when the buffer content changes.
+    cached_lines: Rc<Vec<CachedLine>>,
+    /// Whether cached_lines needs rebuilding.
+    lines_dirty: bool,
 }
 
 impl EditorView {
@@ -36,6 +50,8 @@ impl EditorView {
             cursor_offset: 0,
             scroll_handle: UniformListScrollHandle::new(),
             focus_handle: cx.focus_handle(),
+            cached_lines: Rc::new(Vec::new()),
+            lines_dirty: true,
         }
     }
 
@@ -44,6 +60,21 @@ impl EditorView {
         self.buffer.set_text(content);
         self.highlighter.parse(self.buffer.text());
         self.cursor_offset = 0;
+        self.lines_dirty = true;
+    }
+
+    /// Rebuild the cached line data from the buffer and highlighter.
+    fn rebuild_line_cache(&mut self) {
+        let line_count = self.buffer.line_count();
+        let lines: Vec<CachedLine> = (0..line_count)
+            .map(|line| CachedLine {
+                text: self.buffer.line_text(line).to_string(),
+                number: format!("{:>4}", line + 1),
+                highlights: self.line_highlights(line),
+            })
+            .collect();
+        self.cached_lines = Rc::new(lines);
+        self.lines_dirty = false;
     }
 
     fn move_cursor_left(&mut self) {
@@ -87,12 +118,14 @@ impl EditorView {
         self.buffer.insert(self.cursor_offset, character);
         self.cursor_offset += character.len();
         self.highlighter.parse(self.buffer.text());
+        self.lines_dirty = true;
     }
 
     fn insert_newline(&mut self) {
         self.buffer.insert(self.cursor_offset, "\n");
         self.cursor_offset += 1;
         self.highlighter.parse(self.buffer.text());
+        self.lines_dirty = true;
     }
 
     fn backspace(&mut self) {
@@ -105,6 +138,7 @@ impl EditorView {
             self.buffer.delete(prev..self.cursor_offset);
             self.cursor_offset = prev;
             self.highlighter.parse(self.buffer.text());
+            self.lines_dirty = true;
         }
     }
 
@@ -118,6 +152,7 @@ impl EditorView {
                 .unwrap_or(text.len());
             self.buffer.delete(self.cursor_offset..next);
             self.highlighter.parse(self.buffer.text());
+            self.lines_dirty = true;
         }
     }
 
@@ -174,20 +209,20 @@ impl Focusable for EditorView {
 
 impl Render for EditorView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let line_count = self.buffer.line_count();
+        // Rebuild line cache only when buffer content changed.
+        // During scroll, this is skipped — the expensive tree-sitter highlight
+        // iteration and string allocations are avoided entirely.
+        if self.lines_dirty {
+            self.rebuild_line_cache();
+        }
 
-        // Capture data needed by the uniform_list closure
-        let line_highlights: Vec<(String, String, Vec<(Range<usize>, HighlightStyle)>, bool, usize)> =
-            (0..line_count)
-                .map(|line| {
-                    let line_text = self.buffer.line_text(line).to_string();
-                    let line_number = format!("{:>4}", line + 1);
-                    let highlights = self.line_highlights(line);
-                    let (cursor_row, cursor_col) = self.buffer.offset_to_point(self.cursor_offset);
-                    let show_cursor = cursor_row == line;
-                    (line_text, line_number, highlights, show_cursor, cursor_col)
-                })
-                .collect();
+        let line_count = self.cached_lines.len();
+
+        // Cursor position is cheap to compute per frame.
+        let (cursor_row, cursor_col) = self.buffer.offset_to_point(self.cursor_offset);
+
+        // Rc clone is cheap — just a reference count bump.
+        let cached_lines = self.cached_lines.clone();
 
         let text_style = {
             let mut style = window.text_style();
@@ -253,15 +288,18 @@ impl Render for EditorView {
                     move |range: Range<usize>, _window: &mut Window, _cx: &mut App| {
                         range
                             .map(|line| {
-                                let (ref line_text, ref line_number, ref highlights, show_cursor, cursor_col) =
-                                    line_highlights[line];
+                                let cached = &cached_lines[line];
+                                let show_cursor = cursor_row == line;
 
-                                let styled_text = if line_text.is_empty() {
+                                let styled_text = if cached.text.is_empty() {
                                     StyledText::new(" ")
                                         .with_default_highlights(&text_style, Vec::new())
                                 } else {
-                                    StyledText::new(line_text.clone())
-                                        .with_default_highlights(&text_style, highlights.clone())
+                                    StyledText::new(cached.text.clone())
+                                        .with_default_highlights(
+                                            &text_style,
+                                            cached.highlights.clone(),
+                                        )
                                 };
 
                                 div()
@@ -278,7 +316,7 @@ impl Render for EditorView {
                                             .pr_2()
                                             .text_color(hsla(0.0, 0.0, 0.83, 0.3))
                                             .text_size(px(GUTTER_FONT_SIZE))
-                                            .child(line_number.clone()),
+                                            .child(cached.number.clone()),
                                     )
                                     .child(
                                         div()

--- a/crates/zedra/src/diff_view.rs
+++ b/crates/zedra/src/diff_view.rs
@@ -1,4 +1,5 @@
 use std::ops::Range;
+use std::rc::Rc;
 
 use gpui::prelude::FluentBuilder;
 use gpui::*;
@@ -241,6 +242,12 @@ pub fn parse_unified_diff(diff_text: &str) -> Vec<FileDiff> {
     files
 }
 
+/// Cached per-line data for the diff view.
+struct CachedDiffLine {
+    line: Option<DiffLine>,
+    highlights: Vec<(Range<usize>, HighlightStyle)>,
+}
+
 /// VS Code-like git diff view with syntax highlighting
 pub struct DiffView {
     diffs: Vec<FileDiff>,
@@ -251,6 +258,10 @@ pub struct DiffView {
     focus_handle: FocusHandle,
     /// Unified view mode (true) or side-by-side (false)
     unified_view: bool,
+    cached_lines: Rc<Vec<CachedDiffLine>>,
+    lines_dirty: bool,
+    /// Track which file index the cache was built for.
+    cached_file_index: usize,
 }
 
 impl DiffView {
@@ -263,7 +274,28 @@ impl DiffView {
             scroll_handle: UniformListScrollHandle::new(),
             focus_handle: cx.focus_handle(),
             unified_view: true,
+            cached_lines: Rc::new(Vec::new()),
+            lines_dirty: true,
+            cached_file_index: 0,
         }
+    }
+
+    fn rebuild_line_cache(&mut self) {
+        let line_count = self.total_lines();
+        let lines: Vec<CachedDiffLine> = (0..line_count)
+            .map(|i| {
+                let line = self.get_line(i);
+                let highlights = line
+                    .as_ref()
+                    .filter(|l| l.kind != DiffLineKind::Header)
+                    .map(|l| self.line_highlights(&l.content))
+                    .unwrap_or_default();
+                CachedDiffLine { line, highlights }
+            })
+            .collect();
+        self.cached_lines = Rc::new(lines);
+        self.cached_file_index = self.current_file;
+        self.lines_dirty = false;
     }
 
     /// Generate sample diff data for preview
@@ -578,12 +610,14 @@ impl DiffView {
 
     fn toggle_view_mode(&mut self, cx: &mut Context<Self>) {
         self.unified_view = !self.unified_view;
+        self.lines_dirty = true;
         cx.notify();
     }
 
     fn next_file(&mut self, cx: &mut Context<Self>) {
         if self.current_file + 1 < self.diffs.len() {
             self.current_file += 1;
+            self.lines_dirty = true;
             cx.notify();
         }
     }
@@ -591,6 +625,7 @@ impl DiffView {
     fn prev_file(&mut self, cx: &mut Context<Self>) {
         if self.current_file > 0 {
             self.current_file -= 1;
+            self.lines_dirty = true;
             cx.notify();
         }
     }
@@ -749,11 +784,16 @@ impl Focusable for DiffView {
 
 impl Render for DiffView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let line_count = self.total_lines();
+        // Invalidate cache when switching files
+        if self.cached_file_index != self.current_file {
+            self.lines_dirty = true;
+        }
+        if self.lines_dirty {
+            self.rebuild_line_cache();
+        }
 
-        // Pre-compute line data for the list
-        let line_data: Vec<Option<DiffLine>> =
-            (0..line_count).map(|i| self.get_line(i)).collect();
+        let line_count = self.cached_lines.len();
+        let cached_lines = self.cached_lines.clone();
 
         let text_style = {
             let mut style = window.text_style();
@@ -761,17 +801,6 @@ impl Render for DiffView {
             style.font_size = px(FONT_SIZE).into();
             style
         };
-
-        // Pre-compute highlights for non-header lines
-        let highlights: Vec<Vec<(Range<usize>, HighlightStyle)>> = line_data
-            .iter()
-            .map(|line| {
-                line.as_ref()
-                    .filter(|l| l.kind != DiffLineKind::Header)
-                    .map(|l| self.line_highlights(&l.content))
-                    .unwrap_or_default()
-            })
-            .collect();
 
         div()
             .flex()
@@ -798,7 +827,8 @@ impl Render for DiffView {
                     move |range: Range<usize>, _window: &mut Window, _cx: &mut App| {
                         range
                             .map(|i| {
-                                let Some(line) = &line_data[i] else {
+                                let cached = &cached_lines[i];
+                                let Some(line) = &cached.line else {
                                     return div().h(px(LINE_HEIGHT));
                                 };
 
@@ -848,9 +878,8 @@ impl Render for DiffView {
                                 }
 
                                 // Apply syntax highlighting with offset for prefix
-                                let line_highlights = &highlights[i];
                                 let adjusted_highlights: Vec<(Range<usize>, HighlightStyle)> =
-                                    line_highlights
+                                    cached.highlights
                                         .iter()
                                         .map(|(range, style)| {
                                             let offset = prefix.len();

--- a/crates/zedra/src/gesture.rs
+++ b/crates/zedra/src/gesture.rs
@@ -1,0 +1,158 @@
+/// Lightweight gesture arena for disambiguating drawer pan vs content scroll.
+///
+/// Inspired by react-native-gesture-handler's key concepts:
+/// - State machine: Undetermined → Active / Failed per recognizer
+/// - Fail offsets: a recognizer fails early if cross-axis exceeds threshold
+/// - Active offsets: a recognizer activates when primary axis exceeds threshold
+/// - Arena: first recognizer to activate wins; losers are failed
+
+/// Gesture recognizer lifecycle.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum GestureState {
+    /// Collecting touch data, not yet decided.
+    Undetermined,
+    /// Recognizer has claimed the gesture.
+    Active,
+    /// Recognizer lost the competition or violated its constraints.
+    Failed,
+}
+
+/// What action the winning gesture drives.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum GestureKind {
+    /// Horizontal pan (drawer open/close).
+    DrawerPan,
+    /// Vertical pan (content scrolling) — also the default/fallback.
+    Scroll,
+}
+
+/// A pan gesture recognizer with activation and failure thresholds.
+///
+/// - `active_offset`: min accumulated movement on primary axis to activate
+/// - `fail_offset`: max accumulated movement on cross-axis before failing
+pub struct PanRecognizer {
+    pub kind: GestureKind,
+    pub state: GestureState,
+    /// Activate when primary-axis accumulation exceeds this (e.g. 20px for drawer).
+    pub active_offset: f32,
+    /// Fail when cross-axis accumulation exceeds this (e.g. 15px).
+    pub fail_offset: f32,
+    /// Which axis is primary (true = horizontal, false = vertical).
+    pub horizontal: bool,
+    accum_x: f32,
+    accum_y: f32,
+}
+
+impl PanRecognizer {
+    pub fn new(kind: GestureKind, horizontal: bool, active_offset: f32, fail_offset: f32) -> Self {
+        Self {
+            kind,
+            state: GestureState::Undetermined,
+            active_offset,
+            fail_offset,
+            horizontal,
+            accum_x: 0.0,
+            accum_y: 0.0,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.state = GestureState::Undetermined;
+        self.accum_x = 0.0;
+        self.accum_y = 0.0;
+    }
+
+    /// Feed a touch delta. Returns new state.
+    pub fn on_move(&mut self, dx: f32, dy: f32) -> GestureState {
+        if self.state != GestureState::Undetermined {
+            return self.state;
+        }
+        self.accum_x += dx;
+        self.accum_y += dy;
+
+        let (primary, cross) = if self.horizontal {
+            (self.accum_x.abs(), self.accum_y.abs())
+        } else {
+            (self.accum_y.abs(), self.accum_x.abs())
+        };
+
+        // Fail-fast: cross-axis exceeded limit
+        if cross > self.fail_offset {
+            self.state = GestureState::Failed;
+        }
+        // Activate: primary axis exceeded threshold
+        else if primary > self.active_offset {
+            self.state = GestureState::Active;
+        }
+        self.state
+    }
+}
+
+/// Arena that races multiple recognizers. First to activate wins.
+pub struct GestureArena {
+    recognizers: Vec<PanRecognizer>,
+    winner: Option<usize>,
+}
+
+impl GestureArena {
+    pub fn new() -> Self {
+        Self {
+            recognizers: Vec::new(),
+            winner: None,
+        }
+    }
+
+    /// Create the default arena with drawer + scroll recognizers.
+    pub fn default_drawer_scroll() -> Self {
+        let mut arena = Self::new();
+        arena.add(PanRecognizer::new(
+            GestureKind::DrawerPan,
+            true,  // horizontal
+            20.0,  // activate after 20px horizontal
+            15.0,  // fail after 15px vertical
+        ));
+        arena.add(PanRecognizer::new(
+            GestureKind::Scroll,
+            false, // vertical
+            10.0,  // activate after 10px vertical
+            15.0,  // fail after 15px horizontal
+        ));
+        arena
+    }
+
+    pub fn add(&mut self, recognizer: PanRecognizer) {
+        self.recognizers.push(recognizer);
+    }
+
+    pub fn reset(&mut self) {
+        self.winner = None;
+        for rec in &mut self.recognizers {
+            rec.reset();
+        }
+    }
+
+    pub fn winner(&self) -> Option<GestureKind> {
+        self.winner.map(|i| self.recognizers[i].kind)
+    }
+
+    /// Feed delta to all undetermined recognizers. Returns the winner if one just activated.
+    pub fn on_move(&mut self, dx: f32, dy: f32) -> Option<GestureKind> {
+        if self.winner.is_some() {
+            return self.winner();
+        }
+        for i in 0..self.recognizers.len() {
+            self.recognizers[i].on_move(dx, dy);
+            if self.recognizers[i].state == GestureState::Active {
+                self.winner = Some(i);
+                // Fail all other undetermined recognizers
+                for j in 0..self.recognizers.len() {
+                    if j != i && self.recognizers[j].state == GestureState::Undetermined {
+                        self.recognizers[j].state = GestureState::Failed;
+                    }
+                }
+                return Some(self.recognizers[i].kind);
+            }
+        }
+        None
+    }
+}

--- a/crates/zedra/src/git_diff_view.rs
+++ b/crates/zedra/src/git_diff_view.rs
@@ -3,6 +3,7 @@
 //! Pushed onto the StackNavigator when a git file is selected from GitSidebar.
 
 use std::ops::Range;
+use std::rc::Rc;
 
 use gpui::prelude::FluentBuilder;
 use gpui::*;
@@ -18,6 +19,12 @@ const GUTTER_WIDTH: f32 = theme::EDITOR_GUTTER_WIDTH;
 const FONT_SIZE: f32 = theme::EDITOR_FONT_SIZE;
 const GUTTER_FONT_SIZE: f32 = theme::EDITOR_GUTTER_FONT_SIZE;
 
+/// Cached per-line data for the diff view.
+struct CachedDiffLine {
+    line: Option<DiffLine>,
+    highlights: Vec<(Range<usize>, HighlightStyle)>,
+}
+
 pub struct GitDiffView {
     diff: FileDiff,
     file_path: String,
@@ -25,6 +32,8 @@ pub struct GitDiffView {
     theme: SyntaxTheme,
     scroll_handle: UniformListScrollHandle,
     focus_handle: FocusHandle,
+    cached_lines: Rc<Vec<CachedDiffLine>>,
+    lines_dirty: bool,
 }
 
 impl GitDiffView {
@@ -36,7 +45,26 @@ impl GitDiffView {
             theme: SyntaxTheme::default_dark(),
             scroll_handle: UniformListScrollHandle::new(),
             focus_handle: cx.focus_handle(),
+            cached_lines: Rc::new(Vec::new()),
+            lines_dirty: true,
         }
+    }
+
+    fn rebuild_line_cache(&mut self) {
+        let line_count = self.total_lines();
+        let lines: Vec<CachedDiffLine> = (0..line_count)
+            .map(|i| {
+                let line = self.get_line(i);
+                let highlights = line
+                    .as_ref()
+                    .filter(|l| l.kind != DiffLineKind::Header)
+                    .map(|l| self.line_highlights(&l.content))
+                    .unwrap_or_default();
+                CachedDiffLine { line, highlights }
+            })
+            .collect();
+        self.cached_lines = Rc::new(lines);
+        self.lines_dirty = false;
     }
 
     fn total_lines(&self) -> usize {
@@ -132,10 +160,12 @@ impl Focusable for GitDiffView {
 
 impl Render for GitDiffView {
     fn render(&mut self, window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        let line_count = self.total_lines();
+        if self.lines_dirty {
+            self.rebuild_line_cache();
+        }
 
-        let line_data: Vec<Option<DiffLine>> =
-            (0..line_count).map(|i| self.get_line(i)).collect();
+        let line_count = self.cached_lines.len();
+        let cached_lines = self.cached_lines.clone();
 
         let text_style = {
             let mut style = window.text_style();
@@ -143,16 +173,6 @@ impl Render for GitDiffView {
             style.font_size = px(FONT_SIZE).into();
             style
         };
-
-        let highlights: Vec<Vec<(Range<usize>, HighlightStyle)>> = line_data
-            .iter()
-            .map(|line| {
-                line.as_ref()
-                    .filter(|l| l.kind != DiffLineKind::Header)
-                    .map(|l| self.line_highlights(&l.content))
-                    .unwrap_or_default()
-            })
-            .collect();
 
         div()
             .flex()
@@ -166,7 +186,8 @@ impl Render for GitDiffView {
                     move |range: Range<usize>, _window: &mut Window, _cx: &mut App| {
                         range
                             .map(|i| {
-                                let Some(line) = &line_data[i] else {
+                                let cached = &cached_lines[i];
+                                let Some(line) = &cached.line else {
                                     return div().h(px(LINE_HEIGHT)).into_any_element();
                                 };
 
@@ -217,11 +238,10 @@ impl Render for GitDiffView {
                                         .into_any_element();
                                 }
 
-                                let line_highlights = &highlights[i];
                                 let adjusted_highlights: Vec<(
                                     Range<usize>,
                                     HighlightStyle,
-                                )> = line_highlights
+                                )> = cached.highlights
                                     .iter()
                                     .map(|(range, style)| {
                                         let offset = prefix.len();

--- a/crates/zedra/src/git_stack.rs
+++ b/crates/zedra/src/git_stack.rs
@@ -8,6 +8,7 @@
 //! Designed to be reusable for any git project.
 
 use std::ops::Range;
+use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 use gpui::prelude::FluentBuilder;
@@ -188,6 +189,12 @@ impl Default for DrawerState {
     }
 }
 
+/// Cached per-line data for the diff content area.
+struct CachedDiffLine {
+    line: Option<DiffLine>,
+    highlights: Vec<(Range<usize>, HighlightStyle)>,
+}
+
 /// Main GitStack component
 pub struct GitStack {
     repo_state: GitRepoState,
@@ -203,6 +210,11 @@ pub struct GitStack {
     focus_handle: FocusHandle,
     /// Shared drawer state for gesture handling
     drawer_state: Arc<Mutex<DrawerState>>,
+    /// Cached diff line data — only rebuilt when selected file changes.
+    cached_diff_lines: Rc<Vec<CachedDiffLine>>,
+    diff_lines_dirty: bool,
+    /// Track which file the cache was built for.
+    cached_selected_file: Option<String>,
 }
 
 impl GitStack {
@@ -223,6 +235,9 @@ impl GitStack {
             scroll_handle: UniformListScrollHandle::new(),
             focus_handle: cx.focus_handle(),
             drawer_state: Arc::new(Mutex::new(DrawerState::default())),
+            cached_diff_lines: Rc::new(Vec::new()),
+            diff_lines_dirty: true,
+            cached_selected_file: None,
         }
     }
 
@@ -456,6 +471,7 @@ impl GitStack {
 
     fn select_file(&mut self, path: String, cx: &mut Context<Self>) {
         self.selected_file = Some(path);
+        self.diff_lines_dirty = true;
         cx.notify();
     }
 
@@ -935,8 +951,42 @@ impl GitStack {
             )
     }
 
-    fn render_diff_content(&mut self, window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn rebuild_diff_cache(&mut self) {
         let Some(diff) = self.get_selected_diff().cloned() else {
+            self.cached_diff_lines = Rc::new(Vec::new());
+            self.cached_selected_file = self.selected_file.clone();
+            self.diff_lines_dirty = false;
+            return;
+        };
+
+        let line_count = Self::total_lines_for_diff(&diff);
+        let lines: Vec<CachedDiffLine> = (0..line_count)
+            .map(|i| {
+                let line = self.get_diff_line(&diff, i);
+                let highlights = line
+                    .as_ref()
+                    .filter(|l| l.kind != DiffLineKind::Header)
+                    .map(|l| self.line_highlights(&l.content))
+                    .unwrap_or_default();
+                CachedDiffLine { line, highlights }
+            })
+            .collect();
+        self.cached_diff_lines = Rc::new(lines);
+        self.cached_selected_file = self.selected_file.clone();
+        self.diff_lines_dirty = false;
+    }
+
+    fn render_diff_content(&mut self, window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        // Invalidate cache when selected file changes
+        if self.cached_selected_file != self.selected_file {
+            self.diff_lines_dirty = true;
+        }
+        if self.diff_lines_dirty {
+            self.rebuild_diff_cache();
+        }
+
+        let line_count = self.cached_diff_lines.len();
+        if line_count == 0 {
             return div()
                 .flex_1()
                 .flex()
@@ -945,14 +995,9 @@ impl GitStack {
                 .text_color(rgb(0x5c6370))
                 .child("Select a file to view changes")
                 .into_any_element();
-        };
+        }
 
-        let line_count = Self::total_lines_for_diff(&diff);
-
-        // Pre-compute line data
-        let line_data: Vec<Option<DiffLine>> = (0..line_count)
-            .map(|i| self.get_diff_line(&diff, i))
-            .collect();
+        let cached_lines = self.cached_diff_lines.clone();
 
         let text_style = {
             let mut style = window.text_style();
@@ -961,23 +1006,13 @@ impl GitStack {
             style
         };
 
-        // Pre-compute highlights (need &mut self for highlighter)
-        let highlights: Vec<Vec<(Range<usize>, HighlightStyle)>> = line_data
-            .iter()
-            .map(|line| {
-                line.as_ref()
-                    .filter(|l| l.kind != DiffLineKind::Header)
-                    .map(|l| self.line_highlights(&l.content))
-                    .unwrap_or_default()
-            })
-            .collect();
-
         uniform_list("git-diff-lines", line_count, {
             let text_style = text_style.clone();
             move |range: Range<usize>, _window: &mut Window, _cx: &mut App| {
                 range
                     .map(|i| {
-                        let Some(line) = &line_data[i] else {
+                        let cached = &cached_lines[i];
+                        let Some(line) = &cached.line else {
                             return div().h(px(LINE_HEIGHT)).into_any_element();
                         };
 
@@ -1026,9 +1061,8 @@ impl GitStack {
                                 .into_any_element();
                         }
 
-                        let line_highlights = &highlights[i];
                         let adjusted_highlights: Vec<(Range<usize>, HighlightStyle)> =
-                            line_highlights
+                            cached.highlights
                                 .iter()
                                 .map(|(range, style)| {
                                     let offset = prefix.len();


### PR DESCRIPTION
## Summary
- Add GestureArena with PanRecognizer state machine for drawer-vs-scroll disambiguation with asymmetric thresholds
- Route DrawerPan events through global DRAWER_BRIDGE, bypassing GPUI scroll dispatch to avoid conflicts with content scrollview
- Cache line data in Rc<Vec<CachedLine>> for uniform_list views to eliminate per-frame O(total_lines) recomputation of text, line numbers, and syntax highlights at 60fps
- Fix nested scroll container in app_drawer Files tab (overflow_y_scroll -> overflow_hidden)

## Test plan
- [ ] Verify drawer swipe opens/closes smoothly without interfering with content scroll
- [ ] Verify scroll performance in code editor, diff view, and git stack views
- [ ] Verify auto-snap behavior at 30% threshold and velocity-based snap

🤖 Generated with [Claude Code](https://claude.com/claude-code)