### PR TITLE
feat: add `zedra update` command and startup version check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
  "libc",
  "pin-project",
  "redox_syscall 0.2.16",
- "xattr",
+ "xattr 0.2.3",
 ]
 
 [[package]]
@@ -7158,6 +7158,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bdb6fa0dfa67b38c1e66b7041ba9dcf23b99d8121907cd31c807a332f7a0bbb"
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr 1.6.1",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9356,6 +9367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.3",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9517,6 +9538,7 @@ dependencies = [
  "clap",
  "directories",
  "ed25519-dalek 2.2.0",
+ "flate2",
  "hostname",
  "iroh",
  "iroh-relay",
@@ -9532,6 +9554,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sha2 0.10.9",
+ "tar",
  "tempfile",
  "tokio",
  "tracing",

--- a/crates/zedra-host/Cargo.toml
+++ b/crates/zedra-host/Cargo.toml
@@ -38,6 +38,11 @@ rand.workspace = true
 ed25519-dalek.workspace = true
 sha2.workspace = true
 
+# Archive extraction (for self-update)
+flate2 = "1"
+tar = "0.4"
+tempfile = "3"
+
 # Filesystem
 directories = "5"
 

--- a/crates/zedra-host/src/lib.rs
+++ b/crates/zedra-host/src/lib.rs
@@ -13,4 +13,5 @@ pub mod qr;
 pub mod rpc_daemon;
 pub mod session_registry;
 pub mod telemetry;
+pub mod version_check;
 pub mod workspace_lock;

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -310,12 +310,26 @@ async fn main() -> Result<()> {
             // 1a. Async version check (non-blocking, silent on failure).
             tokio::spawn(async {
                 match version_check::check_latest_version().await {
-                    Ok(Some(latest)) => eprintln!(
-                        "[update]   new version available: {} (current: v{}). Run `zedra update`.",
-                        latest,
-                        env!("CARGO_PKG_VERSION")
-                    ),
-                    _ => {}
+                    Ok(Some(ref latest)) => {
+                        eprintln!(
+                            "[update]   new version available: {} (current: v{}). Run `zedra update`.",
+                            latest,
+                            env!("CARGO_PKG_VERSION")
+                        );
+                        zedra_telemetry::send(Event::UpdateChecked {
+                            update_available: true,
+                            latest_version: latest.clone(),
+                            current_version: env!("CARGO_PKG_VERSION"),
+                        });
+                    }
+                    Ok(None) => {
+                        zedra_telemetry::send(Event::UpdateChecked {
+                            update_available: false,
+                            latest_version: String::new(),
+                            current_version: env!("CARGO_PKG_VERSION"),
+                        });
+                    }
+                    Err(_) => {}
                 }
             });
 
@@ -603,8 +617,17 @@ async fn main() -> Result<()> {
                 }
             }
 
+            let update_start = std::time::Instant::now();
             match version_check::self_update(&target_tag).await {
                 Ok(tag) => {
+                    let elapsed_ms = update_start.elapsed().as_millis() as u64;
+                    zedra_telemetry::send(Event::SelfUpdate {
+                        success: true,
+                        target_version: tag.clone(),
+                        from_version: env!("CARGO_PKG_VERSION"),
+                        error: "",
+                        elapsed_ms,
+                    });
                     eprintln!("\nUpdated to {tag}.");
                     if !alive.is_empty() {
                         eprintln!(
@@ -613,6 +636,15 @@ async fn main() -> Result<()> {
                     }
                 }
                 Err(e) => {
+                    let elapsed_ms = update_start.elapsed().as_millis() as u64;
+                    let error_label = classify_update_error(&e);
+                    zedra_telemetry::send(Event::SelfUpdate {
+                        success: false,
+                        target_version: target_tag.clone(),
+                        from_version: env!("CARGO_PKG_VERSION"),
+                        error: error_label,
+                        elapsed_ms,
+                    });
                     eprintln!("Update failed: {e}");
                     std::process::exit(1);
                 }
@@ -658,6 +690,23 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn classify_update_error(e: &anyhow::Error) -> &'static str {
+    let msg = e.to_string();
+    if msg.contains("checksum mismatch") {
+        "checksum_mismatch"
+    } else if msg.contains("download failed") || msg.contains("error sending request") {
+        "download_failed"
+    } else if msg.contains("archive did not contain") || msg.contains("failed to extract") {
+        "extract_failed"
+    } else if msg.contains("failed to install") || msg.contains("failed to rename") {
+        "install_failed"
+    } else if msg.contains("failed to resolve latest") {
+        "version_resolve_failed"
+    } else {
+        "unknown"
+    }
 }
 
 fn format_duration(secs: u64) -> String {

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -15,7 +15,8 @@ use std::sync::Arc;
 use zedra_host::client as zedra_client;
 use zedra_host::ga4::Ga4;
 use zedra_host::{
-    api, identity, iroh_listener, net_monitor, qr, rpc_daemon, session_registry, workspace_lock,
+    api, identity, iroh_listener, net_monitor, qr, rpc_daemon, session_registry, version_check,
+    workspace_lock,
 };
 use zedra_rpc::ZedraPairingTicket;
 use zedra_telemetry::Event;
@@ -102,6 +103,17 @@ enum Commands {
         /// Command to inject into the terminal on startup (e.g. "claude --resume <id>")
         #[arg(long)]
         launch_cmd: Option<String>,
+    },
+
+    /// Update zedra to the latest version
+    Update {
+        /// Install a specific version (e.g. v0.2.0)
+        #[arg(long)]
+        version: Option<String>,
+
+        /// Skip confirmation prompt
+        #[arg(long, short)]
+        yes: bool,
     },
 }
 
@@ -294,6 +306,18 @@ async fn main() -> Result<()> {
                     tracing::info!("Wrote host-info.json to {}", config_dir.display());
                 }
             }
+
+            // 1a. Async version check (non-blocking, silent on failure).
+            tokio::spawn(async {
+                match version_check::check_latest_version().await {
+                    Ok(Some(latest)) => eprintln!(
+                        "[update]   new version available: {} (current: v{}). Run `zedra update`.",
+                        latest,
+                        env!("CARGO_PKG_VERSION")
+                    ),
+                    _ => {}
+                }
+            });
 
             // 1b. Start background network diagnostics monitor.
             //     Watches for IP changes, relay changes, NAT changes, and logs
@@ -526,6 +550,71 @@ async fn main() -> Result<()> {
                         }
                     }
                     println!();
+                }
+            }
+        }
+
+        Commands::Update { version, yes } => {
+            let current = env!("CARGO_PKG_VERSION");
+            eprintln!("zedra v{current}");
+
+            // Check what's available
+            let target_tag = if let Some(ref v) = version {
+                v.clone()
+            } else {
+                eprintln!("Checking for updates...");
+                match version_check::check_latest_version().await {
+                    Ok(Some(tag)) => tag,
+                    Ok(None) => {
+                        eprintln!("Already up to date.");
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to check for updates: {e}");
+                        std::process::exit(1);
+                    }
+                }
+            };
+
+            eprintln!("Update available: {target_tag}");
+
+            // Warn about running daemons
+            let instances = workspace_lock::scan_all_instances();
+            let alive: Vec<_> = instances.iter().filter(|(_, _, alive)| *alive).collect();
+            if !alive.is_empty() {
+                eprintln!(
+                    "\nWarning: {} running daemon(s) found. Restart them after update:",
+                    alive.len()
+                );
+                for (_, lock, _) in &alive {
+                    eprintln!("  pid {}  {}", lock.pid, lock.workdir);
+                }
+                eprintln!();
+            }
+
+            // Confirm unless --yes
+            if !yes {
+                eprint!("Proceed with update? [y/N] ");
+                let mut input = String::new();
+                std::io::stdin().read_line(&mut input)?;
+                if !input.trim().eq_ignore_ascii_case("y") {
+                    eprintln!("Cancelled.");
+                    return Ok(());
+                }
+            }
+
+            match version_check::self_update(&target_tag).await {
+                Ok(tag) => {
+                    eprintln!("\nUpdated to {tag}.");
+                    if !alive.is_empty() {
+                        eprintln!(
+                            "Restart running daemons: `zedra stop -w <dir> && zedra start -w <dir>`"
+                        );
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Update failed: {e}");
+                    std::process::exit(1);
                 }
             }
         }

--- a/crates/zedra-host/src/version_check.rs
+++ b/crates/zedra-host/src/version_check.rs
@@ -53,9 +53,7 @@ pub async fn self_update(tag: &str) -> Result<String> {
             if !expected.is_empty() {
                 let actual = sha256_hex(&archive_bytes);
                 if actual != expected {
-                    bail!(
-                        "checksum mismatch!\n  expected: {expected}\n  actual:   {actual}"
-                    );
+                    bail!("checksum mismatch!\n  expected: {expected}\n  actual:   {actual}");
                 }
                 true
             } else {
@@ -85,7 +83,8 @@ pub async fn self_update(tag: &str) -> Result<String> {
     }
 
     // Replace current binary via atomic rename
-    let current_exe = std::env::current_exe().context("cannot determine current executable path")?;
+    let current_exe =
+        std::env::current_exe().context("cannot determine current executable path")?;
     let current_exe = current_exe
         .canonicalize()
         .unwrap_or_else(|_| current_exe.clone());
@@ -96,17 +95,19 @@ pub async fn self_update(tag: &str) -> Result<String> {
     if backup.exists() {
         let _ = std::fs::remove_file(&backup);
     }
-    std::fs::rename(&current_exe, &backup)
-        .with_context(|| format!("failed to rename current binary at {}", current_exe.display()))?;
+    std::fs::rename(&current_exe, &backup).with_context(|| {
+        format!(
+            "failed to rename current binary at {}",
+            current_exe.display()
+        )
+    })?;
     match std::fs::copy(&extracted, &current_exe) {
         Ok(_) => {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ = std::fs::set_permissions(
-                    &current_exe,
-                    std::fs::Permissions::from_mode(0o755),
-                );
+                let _ =
+                    std::fs::set_permissions(&current_exe, std::fs::Permissions::from_mode(0o755));
             }
             let _ = std::fs::remove_file(&backup);
         }

--- a/crates/zedra-host/src/version_check.rs
+++ b/crates/zedra-host/src/version_check.rs
@@ -1,0 +1,208 @@
+//! Version checking and self-update for zedra-host.
+//!
+//! Resolves the latest release from GitHub and optionally downloads + replaces
+//! the running binary.
+
+use anyhow::{bail, Context, Result};
+const REPO: &str = "tanlethanh/zedra";
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Returns the latest release tag if it is newer than the current version,
+/// or `None` if already up-to-date.
+pub async fn check_latest_version() -> Result<Option<String>> {
+    let tag = resolve_latest_tag().await?;
+    let latest = tag.strip_prefix('v').unwrap_or(&tag);
+    if is_newer(latest, CURRENT_VERSION) {
+        Ok(Some(tag))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Download the specified release and replace the current binary.
+pub async fn self_update(tag: &str) -> Result<String> {
+    let tag = tag.to_string();
+
+    let platform = detect_platform()?;
+
+    let base_url = format!("https://github.com/{REPO}/releases/download/{tag}");
+    let archive_name = format!("zedra-{platform}.tar.gz");
+    let archive_url = format!("{base_url}/{archive_name}");
+    let checksum_url = format!("{base_url}/{archive_name}.sha256");
+
+    let tmp_dir = tempfile::tempdir().context("failed to create temp dir")?;
+
+    eprintln!("  Downloading {archive_url}...");
+    let client = reqwest::Client::new();
+    let archive_bytes = client
+        .get(&archive_url)
+        .send()
+        .await?
+        .error_for_status()
+        .with_context(|| format!("download failed — does release '{tag}' exist?"))?
+        .bytes()
+        .await?;
+
+    let archive_path = tmp_dir.path().join(&archive_name);
+    tokio::fs::write(&archive_path, &archive_bytes).await?;
+
+    // Verify SHA256 checksum (best-effort: skip if .sha256 file unavailable)
+    let checksum_verified = if let Ok(resp) = client.get(&checksum_url).send().await {
+        if let Ok(body) = resp.text().await {
+            let expected = body.split_whitespace().next().unwrap_or("");
+            if !expected.is_empty() {
+                let actual = sha256_hex(&archive_bytes);
+                if actual != expected {
+                    bail!(
+                        "checksum mismatch!\n  expected: {expected}\n  actual:   {actual}"
+                    );
+                }
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+    if checksum_verified {
+        eprintln!("  Checksum verified.");
+    } else {
+        eprintln!("  Warning: checksum verification skipped (unavailable).");
+    }
+
+    eprintln!("  Extracting...");
+    let archive_file = std::fs::File::open(&archive_path)?;
+    let decoder = flate2::read::GzDecoder::new(archive_file);
+    let mut archive = tar::Archive::new(decoder);
+    archive.unpack(tmp_dir.path())?;
+
+    let extracted = tmp_dir.path().join("zedra");
+    if !extracted.exists() {
+        bail!("archive did not contain 'zedra' binary");
+    }
+
+    // Replace current binary via atomic rename
+    let current_exe = std::env::current_exe().context("cannot determine current executable path")?;
+    let current_exe = current_exe
+        .canonicalize()
+        .unwrap_or_else(|_| current_exe.clone());
+
+    // On macOS/Linux: rename the old binary out of the way, move new one in,
+    // then delete old. This avoids "text file busy" on some systems.
+    let backup = current_exe.with_extension("old");
+    if backup.exists() {
+        let _ = std::fs::remove_file(&backup);
+    }
+    std::fs::rename(&current_exe, &backup)
+        .with_context(|| format!("failed to rename current binary at {}", current_exe.display()))?;
+    match std::fs::copy(&extracted, &current_exe) {
+        Ok(_) => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(
+                    &current_exe,
+                    std::fs::Permissions::from_mode(0o755),
+                );
+            }
+            let _ = std::fs::remove_file(&backup);
+        }
+        Err(e) => {
+            // Rollback
+            let _ = std::fs::rename(&backup, &current_exe);
+            bail!("failed to install new binary: {e}");
+        }
+    }
+
+    Ok(tag)
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+async fn resolve_latest_tag() -> Result<String> {
+    let url = format!("https://github.com/{REPO}/releases/latest");
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+    let resp = client.head(&url).send().await?;
+
+    // GitHub responds with 302 → Location: .../releases/tag/vX.Y.Z
+    let location = resp
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    let tag = location.rsplit('/').next().unwrap_or("");
+    if tag.is_empty() || !tag.starts_with('v') {
+        bail!("failed to resolve latest release tag from GitHub");
+    }
+    Ok(tag.to_string())
+}
+
+fn detect_platform() -> Result<String> {
+    let arch = std::env::consts::ARCH;
+    let os = std::env::consts::OS;
+
+    let arch = match arch {
+        "aarch64" => "aarch64",
+        "x86_64" => "x86_64",
+        other => bail!("unsupported architecture: {other}"),
+    };
+    let os = match os {
+        "macos" => "apple-darwin",
+        "linux" => "unknown-linux-gnu",
+        other => bail!("unsupported OS: {other}"),
+    };
+
+    Ok(format!("{arch}-{os}"))
+}
+
+/// Simple semver comparison: returns true if `a` > `b`.
+fn is_newer(a: &str, b: &str) -> bool {
+    let parse = |s: &str| -> (u64, u64, u64) {
+        let mut parts = s.splitn(3, '.');
+        let major = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        let minor = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        let patch = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        (major, minor, patch)
+    };
+    parse(a) > parse(b)
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write;
+    let hash = Sha256::digest(data);
+    let mut out = String::with_capacity(64);
+    for b in hash {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_newer() {
+        assert!(is_newer("0.2.0", "0.1.1"));
+        assert!(is_newer("1.0.0", "0.9.9"));
+        assert!(is_newer("0.1.2", "0.1.1"));
+        assert!(!is_newer("0.1.1", "0.1.1"));
+        assert!(!is_newer("0.1.0", "0.1.1"));
+    }
+
+    #[test]
+    fn test_detect_platform() {
+        // Should not fail on the current platform
+        let p = detect_platform().unwrap();
+        assert!(p.contains("apple-darwin") || p.contains("unknown-linux-gnu"));
+    }
+}

--- a/crates/zedra-telemetry/src/lib.rs
+++ b/crates/zedra-telemetry/src/lib.rs
@@ -289,6 +289,30 @@ pub enum Event {
         bytes_recv: u64,
         interval_secs: u64,
     },
+
+    // ── Self-update (server-side) ──────────────────────────────────────────
+    /// Background version check completed at daemon start.
+    UpdateChecked {
+        /// Whether a newer version is available.
+        update_available: bool,
+        /// The latest version tag (e.g. "v0.3.0"), or empty string if already up-to-date or check failed.
+        latest_version: String,
+        /// Current running version (e.g. "0.2.1").
+        current_version: &'static str,
+    },
+    /// `zedra update` ran to completion (success or failure).
+    SelfUpdate {
+        success: bool,
+        /// Target version tag (e.g. "v0.3.0").
+        target_version: String,
+        /// Current version before update (e.g. "0.2.1").
+        from_version: &'static str,
+        /// Error label on failure (e.g. "download_failed", "checksum_mismatch",
+        /// "extract_failed", "install_failed"); empty on success.
+        error: &'static str,
+        /// Wall time from update start to finish (ms).
+        elapsed_ms: u64,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -325,6 +349,8 @@ impl Event {
             Self::HostTerminalOpen { .. } => "terminal_open",
             Self::DaemonHeartbeat { .. } => "daemon_heartbeat",
             Self::BandwidthSample { .. } => "bandwidth_sample",
+            Self::UpdateChecked { .. } => "update_checked",
+            Self::SelfUpdate { .. } => "self_update",
         }
     }
 
@@ -577,6 +603,28 @@ impl Event {
                 ("bytes_sent", bytes_sent.to_string()),
                 ("bytes_recv", bytes_recv.to_string()),
                 ("interval_secs", interval_secs.to_string()),
+            ],
+            Self::UpdateChecked {
+                update_available,
+                latest_version,
+                current_version,
+            } => vec![
+                ("update_available", bool_str(*update_available)),
+                ("latest_version", latest_version.clone()),
+                ("current_version", current_version.to_string()),
+            ],
+            Self::SelfUpdate {
+                success,
+                target_version,
+                from_version,
+                error,
+                elapsed_ms,
+            } => vec![
+                ("success", bool_str(*success)),
+                ("target_version", target_version.clone()),
+                ("from_version", from_version.to_string()),
+                ("error", error.to_string()),
+                ("elapsed_ms", elapsed_ms.to_string()),
             ],
         }
     }


### PR DESCRIPTION
Self-update downloads the latest GitHub release, verifies SHA256 checksum, and atomically replaces the running binary. Warns about running daemons that need restart.

Async version check on daemon startup prints a notice if outdated.