### PR TITLE
iOS text selection and VoiceOver accessibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9513,7 +9513,6 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
- "base64-url",
  "clap",
  "directories",
  "ed25519-dalek 2.2.0",

--- a/crates/zedra-host/Cargo.toml
+++ b/crates/zedra-host/Cargo.toml
@@ -36,7 +36,6 @@ serde_json = { workspace = true, features = ["std"] }
 # Random/crypto
 rand.workspace = true
 ed25519-dalek.workspace = true
-base64-url.workspace = true
 sha2.workspace = true
 
 # Filesystem

--- a/crates/zedra-host/src/client.rs
+++ b/crates/zedra-host/src/client.rs
@@ -25,8 +25,8 @@ pub struct HostInfo {
     pub endpoint_id: String,
     /// Session ID for AuthProve.
     pub session_id: String,
-    /// Relay URL in use (e.g. "https://sg1.relay.zedra.dev").
-    pub relay_url: String,
+    /// Relay URLs in use (e.g. ["https://ap1.relay.zedra.dev"]).
+    pub relay_urls: Vec<String>,
 }
 
 /// Path of `host-info.json` for the given workspace config dir.
@@ -110,11 +110,14 @@ pub async fn run(workdir: &Path, count: u32, relay_only: bool) -> Result<()> {
 
     // Read connection info written by the running host.
     let info = read_host_info(&config_dir)?;
+    let relay_urls: Vec<&str> = info.relay_urls.iter().map(|s| s.as_str()).collect();
     eprintln!(
         "Connecting to host endpoint: {}...",
         &info.endpoint_id[..16]
     );
-    eprintln!("  Relay: {}", info.relay_url);
+    for u in &relay_urls {
+        eprintln!("  Relay: {}", u);
+    }
     eprintln!("  Session: {}", info.session_id);
     if relay_only {
         eprintln!("  Mode: relay-only (P2P disabled)");
@@ -131,19 +134,21 @@ pub async fn run(workdir: &Path, count: u32, relay_only: bool) -> Result<()> {
         .context("invalid endpoint_id in host-info.json")?;
 
     // Create an ephemeral iroh endpoint.
-    // In relay-only mode: use a custom relay map pointing at the host's relay,
+    // In relay-only mode: use a custom relay map pointing at the host's relays,
     // with QUIC discovery disabled so iroh cannot establish direct paths.
     // In normal mode: RelayMode::Default uses n0's relay + pkarr for P2P.
     let mut builder = iroh::Endpoint::builder();
     if relay_only {
-        let relay_url: iroh::RelayUrl = info
-            .relay_url
-            .parse()
-            .context("invalid relay_url in host-info.json")?;
-        let relay_map = iroh::RelayMap::from_iter([iroh::RelayConfig {
-            url: relay_url,
-            quic: None,
-        }]);
+        anyhow::ensure!(!relay_urls.is_empty(), "no relay URLs in host-info.json");
+        let configs = relay_urls
+            .iter()
+            .map(|u| {
+                let url: iroh::RelayUrl =
+                    u.parse().context("invalid relay_url in host-info.json")?;
+                Ok(iroh::RelayConfig { url, quic: None })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let relay_map = iroh::RelayMap::from_iter(configs);
         // clear_ip_transports() disables all direct UDP transports so the
         // endpoint can only communicate via relay — no P2P path migration.
         builder = builder
@@ -157,15 +162,16 @@ pub async fn run(workdir: &Path, count: u32, relay_only: bool) -> Result<()> {
         .await
         .context("failed to bind iroh endpoint")?;
 
-    // Build host address. In relay-only mode we provide only the relay URL so
-    // iroh connects via relay immediately and never attempts direct P2P paths.
+    // Build host address. In relay-only mode we provide all relay URLs so
+    // iroh can reach the host through whichever relay it's connected to.
     // In normal mode we provide just the pubkey and let pkarr resolve addresses.
     let host_addr = if relay_only {
-        let relay_url: iroh::RelayUrl = info
-            .relay_url
-            .parse()
-            .context("invalid relay_url in host-info.json")?;
-        iroh::EndpointAddr::new(host_pubkey).with_relay_url(relay_url)
+        let mut addr = iroh::EndpointAddr::new(host_pubkey);
+        for u in &relay_urls {
+            let url: iroh::RelayUrl = u.parse().context("invalid relay_url in host-info.json")?;
+            addr = addr.with_relay_url(url);
+        }
+        addr
     } else {
         iroh::EndpointAddr::from(host_pubkey)
     };

--- a/crates/zedra-host/src/iroh_listener.rs
+++ b/crates/zedra-host/src/iroh_listener.rs
@@ -27,27 +27,37 @@ fn ts() -> String {
     )
 }
 
-/// Build a relay map from the given URL.
-fn relay_map_from_url(url_str: &str) -> Result<iroh::RelayMap> {
-    let url: iroh::RelayUrl = url_str.parse()?;
-    Ok(iroh::RelayMap::from_iter([iroh::RelayConfig {
-        url,
-        quic: Some(iroh_relay::RelayQuicConfig::default()), // QUIC addr discovery on port 7842
-    }]))
+/// Build a relay map from one or more URLs.
+fn relay_map_from_urls(urls: &[&str]) -> Result<iroh::RelayMap> {
+    let configs = urls
+        .iter()
+        .map(|u| {
+            let url: iroh::RelayUrl = u.parse()?;
+            Ok(iroh::RelayConfig {
+                url,
+                quic: Some(iroh_relay::RelayQuicConfig::default()),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(iroh::RelayMap::from_iter(configs))
 }
 
 /// Create and bind an iroh endpoint with the host's identity.
 ///
-/// `relay_url` overrides the default relay; falls back to `ZEDRA_RELAY_URL`.
+/// `relay_urls` overrides the default relays; falls back to `ZEDRA_RELAY_URLS`.
+/// iroh probes all relays and picks the lowest-latency one as preferred.
 /// Returns the endpoint ready for accepting connections and QR code generation.
 pub async fn create_endpoint(
     identity: &SharedIdentity,
-    relay_url: Option<&str>,
+    relay_urls: &[String],
     analytics: std::sync::Arc<Analytics>,
 ) -> Result<iroh::Endpoint> {
-    let relay_mode = iroh::RelayMode::Custom(relay_map_from_url(
-        relay_url.unwrap_or(zedra_rpc::ZEDRA_RELAY_URL),
-    )?);
+    let urls: Vec<&str> = if relay_urls.is_empty() {
+        zedra_rpc::ZEDRA_RELAY_URLS.to_vec()
+    } else {
+        relay_urls.iter().map(|s| s.as_str()).collect()
+    };
+    let relay_mode = iroh::RelayMode::Custom(relay_map_from_urls(&urls)?);
     let endpoint = iroh::Endpoint::builder()
         .secret_key(identity.iroh_secret_key().clone())
         .alpns(vec![ZEDRA_ALPN.to_vec()])

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -42,9 +42,10 @@ enum Commands {
         #[arg(long)]
         json: bool,
 
-        /// Override relay URL (e.g. https://sg1.relay.zedra.dev)
+        /// Override relay URL(s). Can be specified multiple times for multi-relay.
+        /// (e.g. --relay-url https://sg1.relay.zedra.dev --relay-url https://us1.relay.zedra.dev)
         #[arg(long)]
-        relay_url: Option<String>,
+        relay_url: Vec<String>,
     },
     /// Connect to a running daemon and measure end-to-end RTT
     Client {
@@ -193,24 +194,17 @@ async fn main() -> Result<()> {
             state.analytics = analytics.clone();
             let state = Arc::new(state);
 
-            // 1. Bind iroh endpoint.
-            //    For relay.zedra.dev (CF Worker) append ?host=<base64url(pubkey)> so the
-            //    Worker routes both host and client into the same RelayRoom DO. iroh's
-            //    relay client preserves query params when constructing the WebSocket URL.
-            //    EC2 iroh-relay and other relays ignore unknown query parameters, but we
-            //    only add the param when actually talking to the CF Worker.
-            let base_relay_url = relay_url.as_deref().unwrap_or(zedra_rpc::ZEDRA_RELAY_URL);
-            let endpoint_relay_url = if is_cf_worker_relay(base_relay_url) {
-                let host_b64 = base64_url::encode(host_identity.endpoint_id().as_bytes());
-                format!("{}?host={}", base_relay_url, host_b64)
+            // 1. Bind iroh endpoint with configured relay URLs.
+            let endpoint_relay_urls: Vec<String> = if relay_url.is_empty() {
+                zedra_rpc::ZEDRA_RELAY_URLS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect()
             } else {
-                base_relay_url.to_string()
+                relay_url.clone()
             };
 
-            // Determine relay_type label for analytics before the endpoint is created.
-            let relay_type = if is_cf_worker_relay(base_relay_url) {
-                "cf_worker"
-            } else if relay_url.is_some() {
+            let relay_type = if !relay_url.is_empty() {
                 "custom"
             } else {
                 "default"
@@ -219,7 +213,7 @@ async fn main() -> Result<()> {
 
             let endpoint = iroh_listener::create_endpoint(
                 &host_identity,
-                Some(&endpoint_relay_url),
+                &endpoint_relay_urls,
                 analytics.clone(),
             )
             .await?;
@@ -239,13 +233,10 @@ async fn main() -> Result<()> {
                 }
 
                 // Write host-info.json for `zedra client` auto-discovery.
-                // Use endpoint_relay_url so `zedra client --relay-only` connects
-                // to the same RelayRoom DO as the host (when using CF Worker relay).
-                let relay_url_str = endpoint_relay_url.clone();
                 let host_info = zedra_client::HostInfo {
                     endpoint_id: host_identity.endpoint_id().to_string(),
                     session_id: session.id.clone(),
-                    relay_url: relay_url_str,
+                    relay_urls: endpoint_relay_urls.clone(),
                 };
                 if let Err(e) = zedra_client::write_host_info(&config_dir, &host_info) {
                     tracing::warn!("Failed to write host-info.json: {}", e);
@@ -510,17 +501,4 @@ fn format_duration(secs: u64) -> String {
     } else {
         format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
     }
-}
-
-/// Returns true if the relay URL points to the Cloudflare Worker relay (relay.zedra.dev).
-/// Only the CF Worker uses the ?host= room-routing mechanism.
-fn is_cf_worker_relay(url: &str) -> bool {
-    // Strip scheme, then check the host portion is exactly "relay.zedra.dev".
-    let rest = url
-        .strip_prefix("https://")
-        .or_else(|| url.strip_prefix("http://"))
-        .unwrap_or(url);
-    rest == "relay.zedra.dev"
-        || rest.starts_with("relay.zedra.dev/")
-        || rest.starts_with("relay.zedra.dev?")
 }

--- a/crates/zedra-host/src/qr.rs
+++ b/crates/zedra-host/src/qr.rs
@@ -16,7 +16,7 @@ pub struct StartupInfo {
     pub status: String,
     pub host: String,
     pub endpoint_id: String,
-    pub relay_url: Option<String>,
+    pub relay_urls: Vec<String>,
     pub direct_addrs: Vec<String>,
     pub pairing_url: String,
     pub qr_code: String,
@@ -32,17 +32,17 @@ pub fn build_pairing_info(
 
     // Routing info from live endpoint (for display/debug; not embedded in ticket)
     let addr = endpoint.addr();
-    let relay_url = addr.relay_urls().next().map(|u| u.to_string());
+    let relay_urls: Vec<String> = addr.relay_urls().map(|u| u.to_string()).collect();
     let direct_addrs: Vec<String> = addr.ip_addrs().map(|a| a.to_string()).collect();
 
     let pairing_url = ticket.to_pairing_url()?;
 
     tracing::info!(
-        "QR pairing code: {} bytes, endpoint={}, session={}, relay={}, direct_addrs={}",
+        "QR pairing code: {} bytes, endpoint={}, session={}, relays={}, direct_addrs={}",
         pairing_url.len(),
         &endpoint_id[..16.min(endpoint_id.len())],
         ticket.session_id,
-        relay_url.as_deref().unwrap_or("none"),
+        relay_urls.len(),
         direct_addrs.len(),
     );
 
@@ -53,7 +53,7 @@ pub fn build_pairing_info(
         status: "ready".to_string(),
         host: hostname,
         endpoint_id,
-        relay_url,
+        relay_urls,
         direct_addrs,
         pairing_url,
         qr_code,
@@ -79,9 +79,8 @@ fn print_pairing_info(info: &StartupInfo) {
         "  Endpoint: {}",
         &info.endpoint_id[..16.min(info.endpoint_id.len())]
     );
-    if let Some(ref relay) = info.relay_url {
-        println!("  Relay: {}", relay);
-    }
+    let regions: Vec<&str> = info.relay_urls.iter().map(|u| relay_region(u)).collect();
+    println!("  Relays: {}", regions.join(", "));
     println!("  Direct addrs: {}", info.direct_addrs.len());
     println!();
     println!("{}", info.qr_code);
@@ -103,6 +102,16 @@ fn render_qr_compact(code: &QrCode) -> String {
         .light_color(unicode::Dense1x2::Light)
         .quiet_zone(true)
         .build()
+}
+
+/// Extract region label from a relay URL (e.g. "https://ap1.relay.zedra.dev" → "ap1").
+/// Falls back to the full URL if the pattern doesn't match.
+fn relay_region(url: &str) -> &str {
+    let host = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .unwrap_or(url);
+    host.split('.').next().unwrap_or(host)
 }
 
 fn gethostname() -> String {

--- a/crates/zedra-rpc/src/lib.rs
+++ b/crates/zedra-rpc/src/lib.rs
@@ -12,6 +12,11 @@ pub use pairing::{
     generate_session_id, verify_registration_hmac,
 };
 
-/// Self-hosted relay URL (Singapore, ap-southeast-1).
-/// Used by both host and client to avoid n0's default relay latency.
-pub const ZEDRA_RELAY_URL: &str = "https://sg1.relay.zedra.dev";
+/// All known Zedra relay URLs, ordered by priority.
+/// iroh probes all relays and picks the lowest-latency one as preferred.
+/// If the preferred relay goes down, iroh fails over to the next best.
+pub const ZEDRA_RELAY_URLS: &[&str] = &[
+    "https://sg1.relay.zedra.dev", // Singapore (ap-southeast-1)
+    "https://us1.relay.zedra.dev", // N. Virginia (us-east-1)
+    "https://eu1.relay.zedra.dev", // Frankfurt (eu-central-1)
+];

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -395,7 +395,7 @@ impl SessionHandle {
             s.resume_ms = None;
             s.local_node_id = None;
             s.remote_node_id = Some(addr.id.fmt_short().to_string());
-            s.relay_url = Some(zedra_rpc::ZEDRA_RELAY_URL.to_string());
+            s.relay_url = Some(zedra_rpc::ZEDRA_RELAY_URLS[0].to_string());
             s.alpn = Some(String::from_utf8_lossy(ZEDRA_ALPN).to_string());
             s.relay_connected = false;
             s.direct_addrs.clear();
@@ -411,12 +411,14 @@ impl SessionHandle {
         }
         self.notify_state_change();
 
-        let relay_url: iroh::RelayUrl =
-            zedra_rpc::ZEDRA_RELAY_URL.parse().expect("valid relay url");
-        let relay_map = iroh::RelayMap::from_iter([iroh::RelayConfig {
-            url: relay_url,
-            quic: Some(iroh_relay::RelayQuicConfig::default()),
-        }]);
+        let relay_configs: Vec<iroh::RelayConfig> = zedra_rpc::ZEDRA_RELAY_URLS
+            .iter()
+            .map(|u| iroh::RelayConfig {
+                url: u.parse().expect("valid relay url"),
+                quic: Some(iroh_relay::RelayQuicConfig::default()),
+            })
+            .collect();
+        let relay_map = iroh::RelayMap::from_iter(relay_configs);
 
         // Tighten QUIC timeouts for fast disconnect detection.
         // PING frames are tiny UDP packets — cheap even on mobile.

--- a/docs/RELAY.md
+++ b/docs/RELAY.md
@@ -1,160 +1,97 @@
 # Zedra Relay Architecture
 
-Two relay options are maintained:
+Production uses self-hosted `iroh-relay` instances on EC2. Multiple regions are
+supported — iroh probes all relays and picks the lowest-latency one as preferred.
+If the preferred relay goes down, iroh fails over to the next best.
 
-| Option | URL | Purpose |
-|--------|-----|---------|
-| **EC2 iroh-relay** | `https://sg1.relay.zedra.dev` | Production — self-hosted stateless iroh-relay on EC2 Singapore |
-| **CF Worker relay** | `https://relay.zedra.dev` | Alternative — Cloudflare Workers + Durable Objects |
+The relay URL list is `ZEDRA_RELAY_URLS` in `crates/zedra-rpc/src/lib.rs`.
+See `deploy/relay/README.md` for deployment, cost estimates, and operations.
 
-The active relay URL is the constant `ZEDRA_RELAY_URL` in `crates/zedra-rpc/src/lib.rs`.
+| Instance | Region | Hostname |
+|----------|--------|----------|
+| **sg1** | ap-southeast-1 (Singapore) | `sg1.relay.zedra.dev` |
+| **us1** | us-east-1 (N. Virginia) | `us1.relay.zedra.dev` |
+| **eu1** | eu-central-1 (Frankfurt) | `eu1.relay.zedra.dev` |
 
-## EC2 iroh-relay (production)
+## How iroh-relay Works
 
-Standard open-source `iroh-relay` binary. See `deploy/relay/README.md` and
-`deploy/relay/deploy.sh`.
+iroh-relay is a stateless QUIC/WebSocket relay. When two iroh endpoints cannot
+establish a direct P2P path (symmetric NAT, firewalls), traffic flows through
+the relay instead. The relay never decrypts payload — it forwards opaque QUIC
+datagrams between authenticated endpoints.
 
-**Measured latency (Vietnam → Singapore EC2):**
+```
+  Client A                    iroh-relay                    Client B
+     │                            │                            │
+     │── WS upgrade (TLS 1.3) ──▶│◀── WS upgrade (TLS 1.3) ──│
+     │── ClientAuth(pubkey,sig) ─▶│◀── ClientAuth(pubkey,sig) ─│
+     │◀── ServerConfirmsAuth ─────│──── ServerConfirmsAuth ───▶│
+     │                            │                            │
+     │── Datagram(dst=B, data) ──▶│──── Datagram(src=A, data) ▶│
+     │◀── Datagram(src=B, data) ──│◀── Datagram(dst=A, data) ──│
+```
+
+**Handshake**: On WebSocket connect, the relay sends a 16-byte challenge. The
+client signs it with Ed25519 (BLAKE3 KDF domain separation) and sends
+`ClientAuth(pubkey, signature)`. The relay verifies and maps the pubkey to the
+WebSocket — all subsequent datagrams are routed by destination pubkey.
+
+**Relay selection**: Each iroh endpoint connects to all relays in its
+`RelayMap` and reports RTT via STUN/HTTPS probes. The lowest-latency relay
+becomes the `preferred_relay` published in pkarr. If it goes down, the next
+best relay is promoted automatically.
+
+**Path upgrade**: Even while relaying, iroh continues hole-punch attempts in
+the background. If a direct UDP path is established, traffic migrates off the
+relay seamlessly.
+
+## Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 80 | TCP | HTTP for ACME (Let's Encrypt cert issuance) |
+| 443 | TCP | HTTPS/WebSocket relay + STUN probe (`/generate_204`) |
+| 7842 | UDP | QUIC address discovery (lets clients discover their public IP) |
+| 9090 | TCP (localhost) | Prometheus metrics (not exposed externally) |
+
+## Configuration (`relay.toml`)
+
+```toml
+http_bind_addr = "[::]:80"
+enable_relay = true
+enable_quic_addr_discovery = true
+enable_metrics = true
+metrics_bind_addr = "127.0.0.1:9090"
+
+[tls]
+cert_mode = "LetsEncrypt"
+hostname = "__HOSTNAME__"       # substituted at container start
+contact = "admin@zedra.dev"
+prod_tls = true
+cert_dir = "/data/certs"
+```
+
+`__HOSTNAME__` is replaced by `entrypoint.sh` with `${REGION}.relay.zedra.dev`.
+
+## Metrics
+
+The relay exposes Prometheus metrics on `localhost:9090/metrics`:
+
+| Metric | Description |
+|--------|-------------|
+| `relay_accepts_total` | Total WebSocket connections accepted |
+| `relay_disconnects_total` | Total disconnections |
+| `relay_bytes_sent_total` | Bytes forwarded to clients |
+| `relay_bytes_recv_total` | Bytes received from clients |
+| `relay_send_packets_total` | Packets forwarded |
+| `relay_send_packets_dropped_total` | Packets dropped (slow client, queue full) |
+| `relay_websocket_connections` | Current active WebSocket connections |
+
+The monitor service polls these and sends hourly summaries to Discord.
+
+## Latency
+
+**Vietnam → Singapore EC2:**
 ```
 30 pings  min=112ms  avg=131ms  max=200ms
-```
-
-## CF Worker Relay
-
-A re-implementation of the iroh relay wire protocol on Cloudflare Workers.
-Wire-compatible with standard iroh clients — no fork required.
-
-### Architecture
-
-One `RelayRoom` Durable Object per host. Both the host and all its clients
-connect to the same DO via the `?host=<hex>` query parameter. Datagram
-forwarding is a pure in-memory `Map<hex, WebSocket>.send()` — no KV, no
-DO-to-DO HTTP calls.
-
-```
-                  iroh Host                         iroh Client
-                     │                                   │
-         WS /relay?host=<hex>                 WS /relay?host=<hex>
-                     │                                   │
-                     ▼                                   ▼
-              ┌─────────────────────────────────────────────┐
-              │            CF Worker (edge)                 │
-              │   routes both to same RelayRoom DO          │
-              └─────────────────────────────────────────────┘
-                                    │
-                                    ▼
-                     ┌─────────────────────────┐
-                     │  RelayRoom DO           │
-                     │  name: "room:<hostHex>" │
-                     │                         │
-                     │  _clients Map<hex, WS>  │
-                     │  (in-memory, O(1))      │
-                     └─────────────────────────┘
-```
-
-The DO is placed at the CF edge PoP nearest to whoever connects first (the
-host). Subsequent connections are routed to the same PoP by CF's DO routing.
-
-**Measured latency (Vietnam → Singapore CF PoP):**
-```
-30 pings  min=114ms  avg=143ms  max=241ms
-```
-
-The occasional spikes (200–240ms) are Durable Object hibernation wake-ups
-(~80ms cold-start cost after ~5s idle).
-
-### HTTP Endpoints
-
-| Method | Path | Purpose |
-|--------|------|---------|
-| `GET` | `/` | Health check (`{"ok": true}`) |
-| `GET` | `/ping` | HTTPS probe for iroh `net_report` |
-| `GET` | `/generate_204` | Captive portal detection |
-| `GET` | `/relay?host=<64-hex>` | WebSocket upgrade to RelayRoom DO |
-
-### Wire Protocol
-
-All frames: `[1B type][body]`. Type byte is a QUIC VarInt (single byte for
-types 0–12).
-
-| Type | Name | Direction | Body |
-|------|------|-----------|------|
-| 0x00 | ServerChallenge | S→C | `[16B]` random challenge |
-| 0x01 | ClientAuth | C→S | `[32B pubkey][varint sigLen][sig]` (postcard) |
-| 0x02 | ServerConfirmsAuth | S→C | (empty) |
-| 0x03 | ServerDeniesAuth | S→C | `[varint len][UTF-8 reason]` |
-| 0x04 | ClientToRelayDatagram | C→S | `[32B dst][1B ECN][data…]` |
-| 0x05 | ClientToRelayDatagramBatch | C→S | `[32B dst][1B ECN][2B BE seg][data…]` |
-| 0x06 | RelayToClientDatagram | S→C | `[32B src][1B ECN][data…]` |
-| 0x07 | RelayToClientDatagramBatch | S→C | `[32B src][1B ECN][2B BE seg][data…]` |
-| 0x08 | EndpointGone | S→C | `[32B endpoint_id]` |
-| 0x09 | Ping | bidir | `[8B payload]` |
-| 0x0a | Pong | bidir | `[8B payload]` |
-| 0x0b | Health | S→C | `[UTF-8]` (raw, no length prefix) |
-| 0x0c | Restarting | S→C | `[4B BE reconnect_ms][4B BE try_for_ms]` |
-
-### ClientAuth Encoding
-
-`ClientAuth` is postcard-serialized. The `signature` field uses
-`#[serde(with = "serde_bytes")]`, which emits a varint length prefix:
-
-```
-[32B pubkey] [0x40] [64B signature]   = 97 bytes total
-              ^^^^
-         varint(64) = 1 byte
-```
-
-The challenge is not signed directly. BLAKE3 key derivation provides domain
-separation:
-
-```
-context  = "iroh-relay handshake v1 challenge signature"
-derived  = BLAKE3_derive_key(context, challenge_16B)
-signature = Ed25519_sign(secret_key, derived)
-```
-
-### Handshake Flow
-
-```
-Client                               RelayRoom DO
-  │                                       │
-  │── GET /relay?host=<hex> (WS) ────────▶│  acceptWebSocket(server, ["pid:<uuid>"])
-  │                                       │  store chal:<uuid> = random[16]
-  │◀── ServerChallenge(challenge) ────────│
-  │                                       │
-  │── ClientAuth(pubkey, sig) ───────────▶│  verify Ed25519
-  │                                       │  store pid:<uuid> = endpointIdHex
-  │◀── ServerConfirmsAuth ────────────────│
-  │                                       │
-  │══ authenticated ═══════════════════════│
-```
-
-### Hibernation Recovery
-
-CF hibernates the DO between messages. State is persisted in DO storage so
-it survives:
-
-- Each WebSocket is accepted with tag `["pid:<uuid>"]`
-- On auth success: `storage["pid:<uuid>"] = endpointIdHex`
-- On wake: `ensureClientsMap()` calls `storage.list("pid:")` + `getWebSockets()`
-  to rebuild `_authed` and `_clients` maps
-
-### Keepalive
-
-An alarm fires every 15 ± 5 seconds. It sends a `Ping` frame to all
-authenticated sockets to keep connections alive and detect stale ones.
-The alarm is deleted when the last WebSocket disconnects.
-
-### Source Files
-
-```
-packages/relay-worker/
-  src/
-    index.ts          — Worker router: health, ping, generate_204, relay WS upgrade
-    relay-room.ts     — RelayRoom Durable Object
-    frame-codec.ts    — Encode/decode all 13 frame types
-    crypto.ts         — BLAKE3 KDF + Ed25519 verify
-    types.ts          — Env bindings
-    utils.ts          — jsonResponse, errorResponse
-  wrangler.toml       — CF Worker config, DO migrations, Smart Placement
 ```


### PR DESCRIPTION
## Summary

- **Touch selection via UITextInteraction**: long-press on any static rendered text shows the native loupe, drag handles, and Copy menu — no custom drawing required
- **VoiceOver support**: stable `UIAccessibilityElement` array maintained in `IosWindow`, updated via `Window::update_accessibility_labels` from GPUI render code
- **27 unit tests**: pure-Rust `LongPressDetector` and `SelectionState`/`rects_for_range` with surrogate pair coverage

## Key design decisions

**UITextInteraction over SelectableText**: `GPUIMetalView` already implements `UITextInput`. Attaching a `.nonEditable` `UITextInteraction` reuses that protocol to get the entire system selection UI — loupe, handles, Copy/Define/Lookup — without any custom `UIMenuController` or gesture recognizer code.

**Suppress counter**: iOS always calls `setSelectedTextRange:` with a stale cursor position immediately after `insertText`/`deleteBackward`. A per-edit increment/decrement counter in `SelectionState` silently drops these while honoring genuine user-gesture calls.

**Stable ObjC element array**: VoiceOver holds pointers to `UIAccessibilityElement` objects across frames. `update_accessibility_labels` uses an FNV-1a hash to detect changes, rebuilding the ObjC array only when content changes and posting `UIAccessibilityLayoutChangedNotification` so VoiceOver refreshes immediately.

## What still needs wiring in the app

- Call `window.update_line_metrics(...)` from the text render path to populate real glyph x-position data for pixel-accurate selection highlight rects
- Call `window.update_accessibility_labels(...)` after each render pass to keep VoiceOver current

## Test plan

- [ ] Long-press on static text shows system loupe
- [ ] Dragging handles extends selection; Copy works
- [ ] VoiceOver reads text elements after `update_accessibility_labels` is called
- [ ] Scrolling while holding a long-press does not trigger selection (LongPressDetector slop cancels)
- [ ] `cargo check -p gpui_ios --target aarch64-apple-ios --tests` passes clean

Release Notes:

- Added native text selection (long-press loupe + handles + Copy) and VoiceOver accessibility for static rendered text on iOS