### PR TITLE
feat: TCP proxy for mobile dev-server preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9575,6 +9575,14 @@ dependencies = [
  "tokio",
  "tracing",
  "zedra-rpc",
+ "zedra-telemetry",
+]
+
+[[package]]
+name = "zedra-telemetry"
+version = "0.1.1"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/crates/zedra-host/src/lib.rs
+++ b/crates/zedra-host/src/lib.rs
@@ -12,4 +12,5 @@ pub mod pty;
 pub mod qr;
 pub mod rpc_daemon;
 pub mod session_registry;
+pub mod tcp_proxy;
 pub mod workspace_lock;

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -1415,6 +1415,19 @@ async fn dispatch(
                 })
                 .await;
         }
+
+        // -- TCP Proxy --
+        ZedraMessage::TcpTunnel(msg) => {
+            session.touch().await;
+            let port = msg.port;
+            let rx = msg.rx;
+            let tx = msg.tx;
+            tokio::spawn(async move {
+                if let Err(e) = crate::tcp_proxy::handle_tcp_tunnel(port, rx, tx).await {
+                    tracing::debug!("TcpTunnel error (port {}): {}", port, e);
+                }
+            });
+        }
     }
 
     Ok(())

--- a/crates/zedra-host/src/tcp_proxy.rs
+++ b/crates/zedra-host/src/tcp_proxy.rs
@@ -1,0 +1,119 @@
+// TCP proxy handler: connects to a local port on the host and pipes data
+// bidirectionally with an irpc TcpTunnel stream.
+//
+// One call to `handle_tcp_tunnel` corresponds to one TCP connection accepted
+// by the mobile proxy server. Multiple concurrent tunnels to the same port are
+// supported (each is an independent stream).
+
+use anyhow::Result;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use zedra_rpc::proto::TcpData;
+
+/// Handle a single TcpTunnel RPC stream.
+///
+/// Connects to `127.0.0.1:port` on the host, then pipes data bidirectionally:
+///   - TCP read → `TcpData` chunks sent to client via `tx`
+///   - `TcpData` from client via `rx` → TCP write
+///
+/// If the TCP connection is refused, sends `TcpData { data: [], closed: true }`
+/// and returns immediately.
+pub async fn handle_tcp_tunnel(
+    port: u16,
+    mut rx: irpc::channel::mpsc::Receiver<TcpData>,
+    tx: irpc::channel::mpsc::Sender<TcpData>,
+) -> Result<()> {
+    let stream = match TcpStream::connect(("127.0.0.1", port)).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("TcpTunnel: connection refused to 127.0.0.1:{}: {}", port, e);
+            let _ = tx
+                .send(TcpData {
+                    data: vec![],
+                    closed: true,
+                })
+                .await;
+            return Ok(());
+        }
+    };
+
+    tracing::info!("TcpTunnel: connected to 127.0.0.1:{}", port);
+    let (mut tcp_read, mut tcp_write) = stream.into_split();
+
+    // Bridge channel: TCP reader task → output task → irpc tx.
+    // Keeps the read task and output task decoupled so slow relay sends don't
+    // block the TCP reader (same pattern as TermAttach output coalescing).
+    let (bridge_tx, mut bridge_rx) = tokio::sync::mpsc::channel::<TcpData>(64);
+
+    let read_task = tokio::spawn(async move {
+        let mut buf = vec![0u8; 65536];
+        loop {
+            match tcp_read.read(&mut buf).await {
+                Ok(0) => {
+                    let _ = bridge_tx
+                        .send(TcpData {
+                            data: vec![],
+                            closed: true,
+                        })
+                        .await;
+                    break;
+                }
+                Ok(n) => {
+                    if bridge_tx
+                        .send(TcpData {
+                            data: buf[..n].to_vec(),
+                            closed: false,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("TcpTunnel: TCP read error: {}", e);
+                    let _ = bridge_tx
+                        .send(TcpData {
+                            data: vec![],
+                            closed: true,
+                        })
+                        .await;
+                    break;
+                }
+            }
+        }
+    });
+
+    let output_task = tokio::spawn(async move {
+        while let Some(chunk) = bridge_rx.recv().await {
+            let done = chunk.closed;
+            if tx.send(chunk).await.is_err() {
+                break;
+            }
+            if done {
+                break;
+            }
+        }
+    });
+
+    // Write loop: irpc rx → TCP
+    loop {
+        match rx.recv().await {
+            Ok(Some(chunk)) => {
+                if chunk.closed {
+                    break;
+                }
+                if !chunk.data.is_empty() {
+                    if tcp_write.write_all(&chunk.data).await.is_err() {
+                        break;
+                    }
+                }
+            }
+            Ok(None) | Err(_) => break,
+        }
+    }
+
+    read_task.abort();
+    output_task.abort();
+    Ok(())
+}

--- a/crates/zedra-rpc/src/proto.rs
+++ b/crates/zedra-rpc/src/proto.rs
@@ -133,6 +133,13 @@ pub enum ZedraProto {
 
     #[rpc(tx = oneshot::Sender<FsUnwatchResult>)]
     FsUnwatch(FsUnwatchReq),
+
+    // -- TCP Proxy --
+    /// Open a raw TCP tunnel to a port on the host's loopback interface.
+    /// One stream instance per accepted TCP connection on the mobile proxy server.
+    /// Host sends TcpData { data: [], closed: true } immediately if the port is unreachable.
+    #[rpc(rx = mpsc::Receiver<TcpData>, tx = mpsc::Sender<TcpData>)]
+    TcpTunnel(TcpTunnelReq),
 }
 
 // ---------------------------------------------------------------------------
@@ -695,6 +702,30 @@ pub struct LspHoverReq {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LspHoverResult {
     pub contents: String,
+}
+
+// ---------------------------------------------------------------------------
+// TCP Proxy types
+// ---------------------------------------------------------------------------
+
+/// Request to open a raw TCP tunnel to a port on the host's loopback.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TcpTunnelReq {
+    /// Target port on the host's loopback (e.g. 3000 for a local dev server).
+    pub port: u16,
+}
+
+/// A chunk of raw TCP data, flowing in either direction through a TcpTunnel stream.
+///
+/// When `closed` is true and `data` is empty, signals connection end (FIN) or
+/// refused (host sends this immediately on the first message if the target port
+/// is unreachable).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TcpData {
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
+    /// True on the final message — signals TCP half-close (FIN) or connection refused.
+    pub closed: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/zedra-session/Cargo.toml
+++ b/crates/zedra-session/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 zedra-rpc = { path = "../zedra-rpc" }
+zedra-telemetry = { path = "../zedra-telemetry" }
 iroh.workspace = true
 iroh-relay.workspace = true
 irpc.workspace = true

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -1321,7 +1321,7 @@ impl SessionHandle {
         self.notify_state_change();
     }
 
-    fn client(&self) -> Result<irpc::Client<ZedraProto>> {
+    pub(crate) fn client(&self) -> Result<irpc::Client<ZedraProto>> {
         self.0
             .client
             .lock()
@@ -1625,5 +1625,19 @@ impl SessionHandle {
     pub async fn terminal_list(&self) -> Result<Vec<String>> {
         let result: TermListResult = self.client()?.rpc(TermListReq {}).await?;
         Ok(result.terminals.into_iter().map(|e| e.id).collect())
+    }
+
+    // -----------------------------------------------------------------------
+    // TCP Proxy
+    // -----------------------------------------------------------------------
+
+    /// Start a local TCP proxy server that tunnels connections to `target_port`
+    /// on the host's loopback through the active iroh session.
+    ///
+    /// The returned `TcpProxyServer` binds to `127.0.0.1:0`; call
+    /// `server.local_port()` to get the port to open in the WebView.
+    /// Dropping the server shuts down the listener and all active tunnels.
+    pub async fn open_proxy(&self, target_port: u16) -> Result<crate::proxy::TcpProxyServer> {
+        crate::proxy::TcpProxyServer::start(self.clone(), target_port).await
     }
 }

--- a/crates/zedra-session/src/lib.rs
+++ b/crates/zedra-session/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod connect_state;
 pub mod handle;
+pub mod proxy;
 pub mod signer;
 pub mod terminal;
 
@@ -61,4 +62,5 @@ pub use connect_state::{
     STEPPER_STEP_NAMES, TransportSnapshot,
 };
 pub use handle::SessionHandle;
+pub use proxy::TcpProxyServer;
 pub use terminal::{OscEvent, RemoteTerminal, ShellState, TerminalMeta};

--- a/crates/zedra-session/src/proxy.rs
+++ b/crates/zedra-session/src/proxy.rs
@@ -1,0 +1,207 @@
+// Local TCP proxy server for dev-server preview.
+//
+// TcpProxyServer listens on 127.0.0.1:0 (OS-assigned port). For each accepted
+// TCP connection it opens a TcpTunnel RPC stream on the active session, then
+// pipes data bidirectionally:
+//
+//   WebView → TcpProxyServer loopback → iroh QUIC → host 127.0.0.1:<target_port>
+//
+// One TcpProxyServer instance per target port. Multiple concurrent connections
+// to the same port are supported (each gets its own TcpTunnel stream).
+//
+// The server runs until the returned `TcpProxyServer` is dropped.
+
+use anyhow::{Context as _, Result};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+
+use zedra_rpc::proto::{TcpData, TcpTunnelReq};
+
+use crate::handle::SessionHandle;
+
+/// A running local TCP proxy server.
+///
+/// Dropping this value shuts down the listener and cancels all active tunnel tasks.
+pub struct TcpProxyServer {
+    local_port: u16,
+    _shutdown_tx: watch::Sender<()>,
+}
+
+impl TcpProxyServer {
+    /// Start a proxy server that forwards TCP connections to `target_port` on the host.
+    ///
+    /// Returns immediately once the listener is bound. Returns `Err` if the
+    /// listener cannot bind (very rare on loopback with port 0).
+    pub async fn start(handle: SessionHandle, target_port: u16) -> Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("failed to bind local proxy listener")?;
+        let local_port = listener.local_addr()?.port();
+
+        tracing::info!(
+            "TcpProxyServer: listening on 127.0.0.1:{} → host:{}",
+            local_port,
+            target_port,
+        );
+
+        zedra_telemetry::send(zedra_telemetry::Event::TcpTunnelOpened(
+            zedra_telemetry::TcpTunnelOpened { port: target_port },
+        ));
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(());
+
+        tokio::spawn(accept_loop(listener, handle, target_port, shutdown_rx));
+
+        Ok(Self {
+            local_port,
+            _shutdown_tx: shutdown_tx,
+        })
+    }
+
+    /// The loopback port the WebView should connect to.
+    pub fn local_port(&self) -> u16 {
+        self.local_port
+    }
+}
+
+async fn accept_loop(
+    listener: TcpListener,
+    handle: SessionHandle,
+    target_port: u16,
+    mut shutdown_rx: watch::Receiver<()>,
+) {
+    loop {
+        tokio::select! {
+            res = listener.accept() => {
+                match res {
+                    Ok((stream, peer)) => {
+                        tracing::debug!("TcpProxyServer: accepted connection from {}", peer);
+                        tokio::spawn(handle_connection(stream, handle.clone(), target_port));
+                    }
+                    Err(e) => {
+                        tracing::warn!("TcpProxyServer: accept error: {}", e);
+                        break;
+                    }
+                }
+            }
+            _ = shutdown_rx.changed() => {
+                tracing::info!("TcpProxyServer: shutdown signal received");
+                break;
+            }
+        }
+    }
+}
+
+async fn handle_connection(stream: TcpStream, handle: SessionHandle, target_port: u16) {
+    let started = Instant::now();
+    let client = match handle.client() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("TcpProxyServer: no active session for tunnel: {}", e);
+            return;
+        }
+    };
+
+    let (irpc_write_tx, mut irpc_read_rx) = match client
+        .bidi_streaming::<TcpTunnelReq, TcpData, TcpData>(
+            TcpTunnelReq { port: target_port },
+            64,
+            64,
+        )
+        .await
+    {
+        Ok(channels) => channels,
+        Err(e) => {
+            tracing::warn!("TcpProxyServer: TcpTunnel RPC failed: {}", e);
+            return;
+        }
+    };
+
+    let (mut tcp_read, mut tcp_write) = stream.into_split();
+
+    // Read first message from host — if closed=true, connection was refused.
+    let first = match irpc_read_rx.recv().await {
+        Ok(Some(msg)) => msg,
+        Ok(None) | Err(_) => {
+            tracing::debug!("TcpProxyServer: irpc stream closed before first message");
+            return;
+        }
+    };
+    if first.closed {
+        tracing::warn!(
+            "TcpProxyServer: host refused connection to port {}",
+            target_port
+        );
+        return;
+    }
+    if !first.data.is_empty() {
+        if tcp_write.write_all(&first.data).await.is_err() {
+            return;
+        }
+    }
+
+    let bytes_out = Arc::new(AtomicU64::new(0));
+    let bytes_out_write = bytes_out.clone();
+
+    // WebView → irpc: read TCP bytes and forward to host.
+    let tcp_to_irpc = tokio::spawn(async move {
+        let mut buf = vec![0u8; 65536];
+        loop {
+            match tcp_read.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    bytes_out_write.fetch_add(n as u64, Ordering::Relaxed);
+                    if irpc_write_tx
+                        .send(TcpData {
+                            data: buf[..n].to_vec(),
+                            closed: false,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = irpc_write_tx
+            .send(TcpData {
+                data: vec![],
+                closed: true,
+            })
+            .await;
+    });
+
+    let mut bytes_in: u64 = first.data.len() as u64;
+
+    // irpc → WebView: forward host chunks to TCP.
+    loop {
+        match irpc_read_rx.recv().await {
+            Ok(Some(chunk)) => {
+                if chunk.closed {
+                    break;
+                }
+                bytes_in += chunk.data.len() as u64;
+                if tcp_write.write_all(&chunk.data).await.is_err() {
+                    break;
+                }
+            }
+            Ok(None) | Err(_) => break,
+        }
+    }
+
+    tcp_to_irpc.abort();
+
+    zedra_telemetry::send(zedra_telemetry::Event::TcpTunnelClosed(
+        zedra_telemetry::TcpTunnelClosed {
+            bytes_proxied_in: bytes_in,
+            bytes_proxied_out: bytes_out.load(Ordering::Relaxed),
+            duration_ms: started.elapsed().as_millis() as u64,
+        },
+    ));
+}

--- a/crates/zedra-telemetry/Cargo.toml
+++ b/crates/zedra-telemetry/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "zedra-telemetry"
+version.workspace = true
+edition.workspace = true
+description = "Pure telemetry trait + global dispatch for Zedra"
+
+[dependencies]
+log.workspace = true

--- a/crates/zedra-telemetry/src/lib.rs
+++ b/crates/zedra-telemetry/src/lib.rs
@@ -1,0 +1,424 @@
+// zedra-telemetry: typed telemetry events with runtime dependency injection.
+//
+// Each runtime (app, host, client) calls `init()` once at startup to register
+// its concrete backend (Firebase, GA4, no-op). All other crates call `send()`
+// with a typed `Event` variant that carries relevant context.
+//
+// If no backend is registered, all calls are silent no-ops.
+//
+// Privacy: no personal data (usernames, file paths, IP addresses) is ever
+// included in events. Only opaque IDs, durations, counts, and enum labels.
+
+use std::sync::{
+    OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
+
+static BACKEND: OnceLock<Box<dyn TelemetryBackend>> = OnceLock::new();
+static ENABLED: AtomicBool = AtomicBool::new(true);
+
+// ---------------------------------------------------------------------------
+// Event enum — every telemetry event is a typed variant
+// ---------------------------------------------------------------------------
+
+/// All telemetry events. Each variant carries the context relevant to that event.
+#[derive(Clone, Debug)]
+pub enum Event {
+    // ═══════════════════════════════════════════════════════════════════════
+    // APP EVENTS — mobile app + shared crates (zedra-session)
+    // ═══════════════════════════════════════════════════════════════════════
+    AppOpen(AppOpen),
+    ScreenView(ScreenView),
+    QrScanInitiated,
+    ConnectSuccess(ConnectSuccess),
+    ConnectFailed(ConnectFailed),
+    SessionResumed(SessionResumed),
+    Disconnect,
+    ReconnectStarted(ReconnectStarted),
+    ReconnectSuccess(ReconnectSuccess),
+    ReconnectExhausted(ReconnectExhausted),
+    PathUpgraded(PathUpgraded),
+    TerminalOpened(TerminalOpened),
+    TerminalClosed(TerminalClosed),
+
+    // ── TCP Proxy (client-side) ────────────────────────────────────────────
+    /// User opened a local-port tunnel to preview a dev server.
+    TcpTunnelOpened(TcpTunnelOpened),
+    /// A TCP tunnel session ended.
+    TcpTunnelClosed(TcpTunnelClosed),
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // HOST EVENTS — desktop daemon (zedra-host)
+    // ═══════════════════════════════════════════════════════════════════════
+    DaemonStart(DaemonStart),
+    NetReport(NetReport),
+    ClientPaired,
+    AuthSuccess(AuthSuccess),
+    AuthFailed(AuthFailed),
+    SessionEnd(SessionEnd),
+    HostTerminalOpen(HostTerminalOpen),
+    BandwidthSample(BandwidthSample),
+}
+
+// ---------------------------------------------------------------------------
+// Event context structs
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub struct AppOpen {
+    pub saved_workspaces: usize,
+    pub app_version: &'static str,
+    pub platform: &'static str,
+    pub arch: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct ScreenView {
+    pub screen: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct ConnectSuccess {
+    pub total_ms: u64,
+    pub binding_ms: u64,
+    pub hole_punch_ms: u64,
+    pub auth_ms: u64,
+    pub fetch_ms: u64,
+    pub path: &'static str,
+    pub network: &'static str,
+    pub rtt_ms: u64,
+    pub relay: String,
+    pub relay_latency_ms: u64,
+    pub alpn: String,
+    pub has_ipv4: bool,
+    pub has_ipv6: bool,
+    pub symmetric_nat: bool,
+    pub is_first_pairing: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct ConnectFailed {
+    pub phase: &'static str,
+    pub error: &'static str,
+    pub relay: String,
+    pub alpn: String,
+    pub has_ipv4: bool,
+    pub has_ipv6: bool,
+    pub relay_connected: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct SessionResumed {
+    pub terminal_count: usize,
+    pub resume_ms: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReconnectStarted {
+    pub reason: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReconnectSuccess {
+    pub attempt: u32,
+    pub elapsed_ms: u64,
+    pub reason: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReconnectExhausted {
+    pub attempts: u32,
+    pub elapsed_ms: u64,
+    pub reason: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct PathUpgraded {
+    pub network: &'static str,
+    pub rtt_ms: u64,
+    pub from_relay: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct TerminalOpened {
+    pub source: &'static str,
+    pub terminal_count: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct TerminalClosed {
+    pub remaining: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct TcpTunnelOpened {
+    /// Target port on the host's loopback (e.g. 3000).
+    pub port: u16,
+}
+
+#[derive(Clone, Debug)]
+pub struct TcpTunnelClosed {
+    /// Bytes received from the host dev server and forwarded to the WebView.
+    pub bytes_proxied_in: u64,
+    /// Bytes received from the WebView and forwarded to the host dev server.
+    pub bytes_proxied_out: u64,
+    /// Wall time the tunnel was open.
+    pub duration_ms: u64,
+}
+
+// ── Host event context structs ─────────────────────────────────────────────
+
+#[derive(Clone, Debug)]
+pub struct DaemonStart {
+    pub relay_type: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct NetReport {
+    pub has_ipv4: bool,
+    pub has_ipv6: bool,
+    pub symmetric_nat: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct AuthSuccess {
+    pub is_new_client: bool,
+    pub duration_ms: u64,
+    pub path_type: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct AuthFailed {
+    pub reason: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct SessionEnd {
+    pub duration_ms: u64,
+    pub terminal_count: u64,
+    pub path_type: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub struct HostTerminalOpen {
+    pub has_launch_cmd: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct BandwidthSample {
+    pub bytes_sent: u64,
+    pub bytes_recv: u64,
+    pub interval_secs: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Event → (name, params) serialization
+// ---------------------------------------------------------------------------
+
+impl Event {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::AppOpen(_) => "app_open",
+            Self::ScreenView(_) => "screen_view",
+            Self::QrScanInitiated => "qr_scan_initiated",
+            Self::ConnectSuccess(_) => "connect_success",
+            Self::ConnectFailed(_) => "connect_failed",
+            Self::SessionResumed(_) => "session_resumed",
+            Self::Disconnect => "disconnect",
+            Self::ReconnectStarted(_) => "reconnect_started",
+            Self::ReconnectSuccess(_) => "reconnect_success",
+            Self::ReconnectExhausted(_) => "reconnect_exhausted",
+            Self::PathUpgraded(_) => "path_upgraded",
+            Self::TerminalOpened(_) => "terminal_opened",
+            Self::TerminalClosed(_) => "terminal_closed",
+            Self::TcpTunnelOpened(_) => "tcp_tunnel_opened",
+            Self::TcpTunnelClosed(_) => "tcp_tunnel_closed",
+            // Host events
+            Self::DaemonStart(_) => "daemon_start",
+            Self::NetReport(_) => "net_report",
+            Self::ClientPaired => "client_paired",
+            Self::AuthSuccess(_) => "auth_success",
+            Self::AuthFailed(_) => "auth_failed",
+            Self::SessionEnd(_) => "session_end",
+            Self::HostTerminalOpen(_) => "terminal_open",
+            Self::BandwidthSample(_) => "bandwidth_sample",
+        }
+    }
+
+    pub fn to_params(&self) -> Vec<(&str, String)> {
+        match self {
+            Self::AppOpen(e) => vec![
+                ("saved_workspaces", e.saved_workspaces.to_string()),
+                ("app_version", e.app_version.to_string()),
+                ("platform", e.platform.to_string()),
+                ("arch", e.arch.to_string()),
+            ],
+            Self::ScreenView(e) => vec![("screen", e.screen.to_string())],
+            Self::QrScanInitiated | Self::Disconnect | Self::ClientPaired => vec![],
+            Self::ConnectSuccess(e) => vec![
+                ("total_ms", e.total_ms.to_string()),
+                ("binding_ms", e.binding_ms.to_string()),
+                ("hole_punch_ms", e.hole_punch_ms.to_string()),
+                ("auth_ms", e.auth_ms.to_string()),
+                ("fetch_ms", e.fetch_ms.to_string()),
+                ("path", e.path.to_string()),
+                ("network", e.network.to_string()),
+                ("rtt_ms", e.rtt_ms.to_string()),
+                ("relay", e.relay.clone()),
+                ("relay_latency_ms", e.relay_latency_ms.to_string()),
+                ("alpn", e.alpn.clone()),
+                ("has_ipv4", bool_str(e.has_ipv4)),
+                ("has_ipv6", bool_str(e.has_ipv6)),
+                ("symmetric_nat", bool_str(e.symmetric_nat)),
+                ("is_first_pairing", bool_str(e.is_first_pairing)),
+            ],
+            Self::ConnectFailed(e) => vec![
+                ("phase", e.phase.to_string()),
+                ("error", e.error.to_string()),
+                ("relay", e.relay.clone()),
+                ("alpn", e.alpn.clone()),
+                ("has_ipv4", bool_str(e.has_ipv4)),
+                ("has_ipv6", bool_str(e.has_ipv6)),
+                ("relay_connected", bool_str(e.relay_connected)),
+            ],
+            Self::SessionResumed(e) => vec![
+                ("terminal_count", e.terminal_count.to_string()),
+                ("resume_ms", e.resume_ms.to_string()),
+            ],
+            Self::ReconnectStarted(e) => vec![("reason", e.reason.to_string())],
+            Self::ReconnectSuccess(e) => vec![
+                ("attempt", e.attempt.to_string()),
+                ("elapsed_ms", e.elapsed_ms.to_string()),
+                ("reason", e.reason.to_string()),
+            ],
+            Self::ReconnectExhausted(e) => vec![
+                ("attempts", e.attempts.to_string()),
+                ("elapsed_ms", e.elapsed_ms.to_string()),
+                ("reason", e.reason.to_string()),
+            ],
+            Self::PathUpgraded(e) => vec![
+                ("network", e.network.to_string()),
+                ("rtt_ms", e.rtt_ms.to_string()),
+                ("from_relay", e.from_relay.clone()),
+            ],
+            Self::TerminalOpened(e) => vec![
+                ("source", e.source.to_string()),
+                ("terminal_count", e.terminal_count.to_string()),
+            ],
+            Self::TerminalClosed(e) => vec![("remaining", e.remaining.to_string())],
+            Self::TcpTunnelOpened(e) => vec![("port", e.port.to_string())],
+            Self::TcpTunnelClosed(e) => vec![
+                ("bytes_proxied_in", e.bytes_proxied_in.to_string()),
+                ("bytes_proxied_out", e.bytes_proxied_out.to_string()),
+                ("duration_ms", e.duration_ms.to_string()),
+            ],
+            // Host events
+            Self::DaemonStart(e) => vec![("relay_type", e.relay_type.to_string())],
+            Self::NetReport(e) => vec![
+                ("has_ipv4", bool_str(e.has_ipv4)),
+                ("has_ipv6", bool_str(e.has_ipv6)),
+                ("symmetric_nat", bool_str(e.symmetric_nat)),
+            ],
+            Self::AuthSuccess(e) => vec![
+                ("is_new_client", bool_str(e.is_new_client)),
+                ("duration_ms", e.duration_ms.to_string()),
+                ("path_type", e.path_type.to_string()),
+            ],
+            Self::AuthFailed(e) => vec![("reason", e.reason.to_string())],
+            Self::SessionEnd(e) => vec![
+                ("duration_ms", e.duration_ms.to_string()),
+                ("terminal_count", e.terminal_count.to_string()),
+                ("path_type", e.path_type.to_string()),
+            ],
+            Self::HostTerminalOpen(e) => {
+                vec![("has_launch_cmd", bool_str(e.has_launch_cmd))]
+            }
+            Self::BandwidthSample(e) => vec![
+                ("bytes_sent", e.bytes_sent.to_string()),
+                ("bytes_recv", e.bytes_recv.to_string()),
+                ("interval_secs", e.interval_secs.to_string()),
+            ],
+        }
+    }
+}
+
+fn bool_str(v: bool) -> String {
+    if v { "1" } else { "0" }.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Backend trait
+// ---------------------------------------------------------------------------
+
+pub trait TelemetryBackend: Send + Sync + 'static {
+    fn send(&self, event: &Event);
+    fn record_error(&self, _message: &str, _file: &str, _line: u32) {}
+    fn record_panic(&self, _message: &str, _location: &str) {}
+    fn set_user_id(&self, _id: &str) {}
+    fn set_custom_key(&self, _key: &str, _value: &str) {}
+    fn set_collection_enabled(&self, _enabled: bool) {}
+}
+
+// ---------------------------------------------------------------------------
+// Public API — free functions
+// ---------------------------------------------------------------------------
+
+pub fn init(backend: Box<dyn TelemetryBackend>) -> Result<(), Box<dyn TelemetryBackend>> {
+    BACKEND.set(backend)
+}
+
+pub fn set_enabled(enabled: bool) {
+    ENABLED.store(enabled, Ordering::Relaxed);
+    if let Some(b) = BACKEND.get() {
+        b.set_collection_enabled(enabled);
+    }
+}
+
+pub fn is_enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+pub fn send(event: Event) {
+    if !ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+    if let Some(b) = BACKEND.get() {
+        b.send(&event);
+    }
+}
+
+pub fn record_error(message: &str) {
+    if !ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+    if let Some(b) = BACKEND.get() {
+        b.record_error(message, "", 0);
+    }
+}
+
+pub fn record_error_at(message: &str, file: &str, line: u32) {
+    if !ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+    if let Some(b) = BACKEND.get() {
+        b.record_error(message, file, line);
+    }
+}
+
+pub fn record_panic(message: &str, location: &str) {
+    if let Some(b) = BACKEND.get() {
+        b.record_panic(message, location);
+    }
+}
+
+pub fn set_user_id(id: &str) {
+    if let Some(b) = BACKEND.get() {
+        b.set_user_id(id);
+    }
+}
+
+pub fn set_custom_key(key: &str, value: &str) {
+    if let Some(b) = BACKEND.get() {
+        b.set_custom_key(key, value);
+    }
+}

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -32,6 +32,7 @@ pub mod workspace_drawer;
 pub mod session_panel;
 pub mod terminal_card;
 pub mod terminal_panel;
+pub mod web_preview_panel;
 
 // Per-session workspace view (DrawerHost + WorkspaceContent + WorkspaceDrawer)
 pub mod workspace_view;

--- a/crates/zedra/src/web_preview_panel.rs
+++ b/crates/zedra/src/web_preview_panel.rs
@@ -1,0 +1,266 @@
+/// Web preview panel for the workspace drawer.
+///
+/// Lets the developer tap a port preset and tap "Open Preview" to tunnel
+/// that port through the active iroh session and open it in the device browser.
+///
+/// Flow:
+///   1. User selects port (e.g. 3000) or keeps the default
+///   2. Taps "Open Preview"
+///   3. We start a `TcpProxyServer` on a random loopback port
+///   4. We call `platform_bridge::bridge().open_url("http://127.0.0.1:<proxy_port>/")` which
+///      hands the URL to the system browser / in-app WebView on the platform
+///   5. The proxy server stays alive (held in panel state) until the user changes
+///      the port or taps "Stop Proxy"
+use gpui::prelude::FluentBuilder as _;
+use gpui::*;
+
+use crate::platform_bridge;
+use crate::theme;
+use crate::workspace_drawer::WorkspaceDrawer;
+use zedra_session::{SessionHandle, TcpProxyServer};
+
+pub struct WebPreviewState {
+    /// The port text the user selected.
+    pub port_input: String,
+    /// Running proxy server, if one was started for the current port.
+    pub proxy: Option<TcpProxyServer>,
+    /// Error message to display if the proxy failed to start.
+    pub error: Option<String>,
+}
+
+impl Default for WebPreviewState {
+    fn default() -> Self {
+        Self {
+            port_input: "3000".to_string(),
+            proxy: None,
+            error: None,
+        }
+    }
+}
+
+/// Render the Web Preview tab content for the workspace drawer.
+pub fn render_web_preview_tab(
+    state: &mut WebPreviewState,
+    handle: Option<&SessionHandle>,
+    cx: &mut Context<WorkspaceDrawer>,
+) -> impl IntoElement {
+    let is_connected = handle.map(|h| h.is_connected()).unwrap_or(false);
+
+    let proxy_port = state.proxy.as_ref().map(|p| p.local_port());
+    let error_text = state.error.clone();
+    let port_label = state.port_input.clone();
+    let has_proxy = proxy_port.is_some();
+
+    div()
+        .size_full()
+        .flex()
+        .flex_col()
+        .px(px(theme::DRAWER_PADDING))
+        .gap(px(12.0))
+        .child(
+            div()
+                .pt(px(8.0))
+                .text_size(px(theme::FONT_DETAIL))
+                .text_color(rgb(theme::TEXT_MUTED))
+                .child("Preview a local dev server running on your host machine."),
+        )
+        .child(
+            // ── Port row ─────────────────────────────────────────────────
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(8.0))
+                .child(
+                    div()
+                        .text_size(px(theme::FONT_BODY))
+                        .text_color(rgb(theme::TEXT_SECONDARY))
+                        .flex_shrink_0()
+                        .child("Port"),
+                )
+                .child(
+                    div()
+                        .flex_1()
+                        .rounded(px(6.0))
+                        .bg(rgb(theme::BG_CARD))
+                        .border_1()
+                        .border_color(rgb(theme::BORDER_DEFAULT))
+                        .px(px(10.0))
+                        .py(px(6.0))
+                        .text_size(px(theme::FONT_BODY))
+                        .text_color(rgb(theme::TEXT_PRIMARY))
+                        .child(port_label),
+                ),
+        )
+        .child(
+            // ── Port presets ──────────────────────────────────────────────
+            div()
+                .flex()
+                .flex_row()
+                .gap(px(8.0))
+                .child(port_preset_button("3000", cx))
+                .child(port_preset_button("5173", cx))
+                .child(port_preset_button("8080", cx))
+                .child(port_preset_button("4321", cx)),
+        )
+        .child(
+            // ── Open / status button ──────────────────────────────────────
+            if !is_connected {
+                div()
+                    .rounded(px(8.0))
+                    .bg(rgb(theme::BG_CARD))
+                    .border_1()
+                    .border_color(rgb(theme::BORDER_DEFAULT))
+                    .px(px(16.0))
+                    .py(px(10.0))
+                    .text_size(px(theme::FONT_BODY))
+                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_align(TextAlign::Center)
+                    .child("Connect to a session first")
+            } else if has_proxy {
+                let local_port = proxy_port.unwrap();
+                let url = format!("http://127.0.0.1:{}/", local_port);
+                div()
+                    .rounded(px(8.0))
+                    .bg(rgb(0x1a4d2e))
+                    .border_1()
+                    .border_color(rgb(0x2d7a4a))
+                    .px(px(16.0))
+                    .py(px(10.0))
+                    .cursor_pointer()
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |_this, _event, _window, _cx| {
+                            platform_bridge::bridge().open_url(&url);
+                        }),
+                    )
+                    .flex()
+                    .flex_col()
+                    .gap(px(2.0))
+                    .child(
+                        div()
+                            .text_size(px(theme::FONT_BODY))
+                            .text_color(rgb(0x4ade80))
+                            .child("Proxy active — tap to open"),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(theme::FONT_DETAIL))
+                            .text_color(rgb(theme::TEXT_MUTED))
+                            .child(format!("127.0.0.1:{}", local_port)),
+                    )
+            } else {
+                let handle_weak = handle.cloned();
+                let port_str = state.port_input.clone();
+                div()
+                    .rounded(px(8.0))
+                    .bg(rgb(theme::ACCENT_BLUE))
+                    .px(px(16.0))
+                    .py(px(10.0))
+                    .cursor_pointer()
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |_this, _event, _window, cx| {
+                            let Ok(port) = port_str.trim().parse::<u16>() else {
+                                return;
+                            };
+                            if let Some(handle) = handle_weak.clone() {
+                                let rt = zedra_session::session_runtime();
+                                cx.spawn(async move |this, cx| {
+                                    match rt
+                                        .spawn(async move { handle.open_proxy(port).await })
+                                        .await
+                                    {
+                                        Ok(Ok(proxy)) => {
+                                            let local_port = proxy.local_port();
+                                            let url =
+                                                format!("http://127.0.0.1:{}/", local_port);
+                                            let _ = this.update(
+                                                cx,
+                                                |drawer: &mut WorkspaceDrawer, cx| {
+                                                    drawer.web_preview.proxy = Some(proxy);
+                                                    drawer.web_preview.error = None;
+                                                    cx.notify();
+                                                },
+                                            );
+                                            platform_bridge::bridge().open_url(&url);
+                                        }
+                                        Ok(Err(e)) => {
+                                            let _ = this.update(
+                                                cx,
+                                                |drawer: &mut WorkspaceDrawer, cx| {
+                                                    drawer.web_preview.error =
+                                                        Some(format!("Failed: {}", e));
+                                                    cx.notify();
+                                                },
+                                            );
+                                        }
+                                        Err(_) => {}
+                                    }
+                                })
+                                .detach();
+                            }
+                        }),
+                    )
+                    .text_size(px(theme::FONT_BODY))
+                    .text_color(rgb(0xffffff))
+                    .text_align(TextAlign::Center)
+                    .child("Open Preview")
+            },
+        )
+        .when_some(error_text, |el, err| {
+            el.child(
+                div()
+                    .text_size(px(theme::FONT_DETAIL))
+                    .text_color(rgb(0xff6b6b))
+                    .child(err),
+            )
+        })
+        .when(has_proxy, |el| {
+            el.child(
+                div()
+                    .rounded(px(8.0))
+                    .bg(rgb(theme::BG_CARD))
+                    .border_1()
+                    .border_color(rgb(theme::BORDER_DEFAULT))
+                    .px(px(16.0))
+                    .py(px(8.0))
+                    .cursor_pointer()
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, _event, _window, cx| {
+                            this.web_preview.proxy = None;
+                            this.web_preview.error = None;
+                            cx.notify();
+                        }),
+                    )
+                    .text_size(px(theme::FONT_BODY))
+                    .text_color(rgb(theme::TEXT_SECONDARY))
+                    .text_align(TextAlign::Center)
+                    .child("Stop Proxy"),
+            )
+        })
+}
+
+fn port_preset_button(port: &'static str, cx: &mut Context<WorkspaceDrawer>) -> impl IntoElement {
+    div()
+        .rounded(px(6.0))
+        .bg(rgb(theme::BG_CARD))
+        .border_1()
+        .border_color(rgb(theme::BORDER_DEFAULT))
+        .px(px(10.0))
+        .py(px(4.0))
+        .cursor_pointer()
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _event, _window, cx| {
+                this.web_preview.port_input = port.to_string();
+                this.web_preview.proxy = None;
+                this.web_preview.error = None;
+                cx.notify();
+            }),
+        )
+        .text_size(px(theme::FONT_DETAIL))
+        .text_color(rgb(theme::TEXT_SECONDARY))
+        .child(port)
+}

--- a/crates/zedra/src/workspace_drawer.rs
+++ b/crates/zedra/src/workspace_drawer.rs
@@ -8,7 +8,8 @@ use crate::file_explorer::{FileExplorer, FileSelected};
 use crate::pending::{SharedPendingSlot, shared_pending_slot};
 use crate::platform_bridge;
 use crate::theme;
-use crate::{session_panel, terminal_panel};
+use crate::web_preview_panel::WebPreviewState;
+use crate::{session_panel, terminal_panel, web_preview_panel};
 use zedra_session::ConnectPhase;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -17,6 +18,7 @@ pub enum DrawerSection {
     Git,
     Terminal,
     Session,
+    Preview,
 }
 
 #[derive(Clone, Debug)]
@@ -56,6 +58,8 @@ pub struct WorkspaceDrawer {
     terminal_order: Vec<String>,
     session_handle: Option<zedra_session::SessionHandle>,
     workspace_state: crate::workspace_state::WorkspaceState,
+    /// Web preview panel state: port input, running proxy server, error message.
+    pub web_preview: WebPreviewState,
     /// Kept alive to poll session state every 2 s and re-render the session tab.
     /// Dropped (and cancelled) when replaced by a new session.
     _session_refresh_task: Option<Task<()>>,
@@ -122,6 +126,7 @@ impl WorkspaceDrawer {
             terminal_order: Vec::new(),
             session_handle: None,
             workspace_state: crate::workspace_state::WorkspaceState::default(),
+            web_preview: WebPreviewState::default(),
             _session_refresh_task: None,
             _subscriptions: subscriptions,
         }
@@ -319,6 +324,15 @@ impl WorkspaceDrawer {
                 }
             }
             DrawerSection::Terminal => "terminals".into(),
+            DrawerSection::Preview => {
+                let port = &self.web_preview.port_input;
+                let active = self.web_preview.proxy.is_some();
+                if active {
+                    format!(":{} — active", port)
+                } else {
+                    format!(":{}", port)
+                }
+            }
             DrawerSection::Session => {
                 let cs = self.session_handle.as_ref().map(|h| h.connect_state());
                 let phase = cs.as_ref().map(|s| &s.phase);
@@ -413,6 +427,14 @@ impl WorkspaceDrawer {
     fn render_session_tab(&self, cx: &mut Context<Self>) -> Div {
         session_panel::render_session_tab(self.session_handle.as_ref(), cx)
     }
+
+    fn render_web_preview_tab(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+        web_preview_panel::render_web_preview_tab(
+            &mut self.web_preview,
+            self.session_handle.as_ref(),
+            cx,
+        )
+    }
 }
 
 impl Focusable for WorkspaceDrawer {
@@ -467,6 +489,12 @@ impl Render for WorkspaceDrawer {
                 .flex_1()
                 .overflow_y_scroll()
                 .child(self.render_session_tab(cx))
+                .into_any_element(),
+            DrawerSection::Preview => div()
+                .id("preview-scroll")
+                .flex_1()
+                .overflow_y_scroll()
+                .child(self.render_web_preview_tab(cx))
                 .into_any_element(),
         };
 
@@ -576,7 +604,8 @@ impl Render for WorkspaceDrawer {
                     .child(self.nav_icon("icons/folder.svg", DrawerSection::Files, cx))
                     .child(self.nav_icon("icons/git-branch.svg", DrawerSection::Git, cx))
                     .child(self.nav_icon("icons/terminal.svg", DrawerSection::Terminal, cx))
-                    .child(self.nav_icon("icons/server.svg", DrawerSection::Session, cx)),
+                    .child(self.nav_icon("icons/server.svg", DrawerSection::Session, cx))
+                    .child(self.nav_icon("icons/cube.svg", DrawerSection::Preview, cx)),
             )
     }
 }

--- a/docs/PROTOCOL_SPECS.md
+++ b/docs/PROTOCOL_SPECS.md
@@ -191,6 +191,47 @@ The protocol layer includes:
 - `LspDiagnostics(LspDiagnosticsReq) -> LspDiagnosticsResult`
 - `LspHover(LspHoverReq) -> LspHoverResult`
 
+## 5.8 TCP Proxy
+
+- `TcpTunnel(TcpTunnelReq) <-> TcpData/TcpData` (bidirectional stream)
+
+### Purpose
+
+Tunnels raw TCP connections from the mobile device to a port on the host's loopback interface, enabling the mobile WebView to preview a local dev server (Vite, Next.js, etc.) running on the desktop.
+
+### TcpTunnelReq
+
+```
+port: u16   // Target port on host's 127.0.0.1 (e.g. 3000)
+```
+
+### TcpData (both directions)
+
+```
+data:   Vec<u8>   // Raw TCP bytes (may be empty on FIN)
+closed: bool      // true = connection end signal (FIN or refused)
+```
+
+### Stream lifecycle
+
+1. Client opens a `TcpTunnel` stream with `TcpTunnelReq { port }`.
+2. Host attempts `TcpStream::connect("127.0.0.1:<port>")`.
+   - **Refused**: Host immediately sends `TcpData { data: [], closed: true }` and closes the stream.
+   - **Connected**: Host starts forwarding TCP data as `TcpData` chunks.
+3. Both sides forward raw bytes as `TcpData { data: <bytes>, closed: false }`.
+4. When either TCP side closes, the closer sends `TcpData { data: [], closed: true }` and stops.
+5. The other side tears down its TCP half and closes the stream.
+
+### Mobile-side proxy architecture
+
+`TcpProxyServer` (`zedra-session/src/proxy.rs`) binds `127.0.0.1:0` and accepts local TCP connections from the WebView. For each accepted connection it opens a new `TcpTunnel` stream. Multiple concurrent connections to the same target port are supported.
+
+### Notes
+
+- One iroh QUIC stream per TCP connection (cheap — multiplexed over existing transport).
+- No content inspection — the tunnel is protocol-transparent (HTTP/1.1, HTTP/2, WebSockets, SSE, HMR all work).
+- The proxy server is tied to the `SessionHandle` lifecycle. It shuts down on disconnect and must be restarted after reconnect.
+
 ---
 
 ## 6) Host Events
@@ -293,6 +334,18 @@ Any protocol-layer change must include all applicable steps:
 ---
 
 ## 11) Protocol Changelog
+
+### 2026-03-24
+
+- Added TCP proxy RPC:
+  - `TcpTunnel(TcpTunnelReq) <-> TcpData/TcpData` (bidirectional stream)
+  - `TcpTunnelReq { port: u16 }` — target port on host loopback
+  - `TcpData { data: Vec<u8>, closed: bool }` — raw byte framing with FIN signal
+- Host handler: `crates/zedra-host/src/tcp_proxy.rs` — connects to `127.0.0.1:<port>`, pipes bidirectionally
+- Client proxy server: `crates/zedra-session/src/proxy.rs` — `TcpProxyServer` binds loopback, one stream per connection
+- Mobile API: `SessionHandle::open_proxy(port)` starts a `TcpProxyServer`
+- UI: Web Preview panel (`zedra/src/web_preview_panel.rs`) in workspace drawer (cube icon)
+- Telemetry: `TcpTunnelOpened { port }`, `TcpTunnelClosed { bytes_proxied_in, bytes_proxied_out, duration_ms }`
 
 ### 2026-03-19
 


### PR DESCRIPTION
## Summary

- **New `ZedraProto::TcpTunnel` bidi stream** — tunnels raw TCP from mobile loopback → host `127.0.0.1:<port>` over the existing iroh QUIC connection, one stream per accepted TCP connection
- **Host handler** (`zedra-host/src/tcp_proxy.rs`) — connects to the target port, bridges TCP↔irpc with decoupled read/write tasks (same pattern as TermAttach)
- **Client proxy server** (`zedra-session/src/proxy.rs`) — `TcpProxyServer` binds `127.0.0.1:0`, spawns a `TcpTunnel` stream per accepted connection, shuts down on drop
- **`zedra-telemetry` crate** — typed `Event` enum with runtime DI backend; `TcpTunnelOpened` / `TcpTunnelClosed` events included
- **Web Preview drawer tab** (`zedra/src/web_preview_panel.rs`) — port presets (3000/5173/8080/4321), Open Preview / Stop Proxy buttons, active state opens URL via `platform_bridge`
- **Protocol docs** updated — `PROTOCOL_SPECS.md` §5.8 + 2026-03-24 changelog

## Protocol change

```
ZedraProto::TcpTunnel(TcpTunnelReq)   // append-only, ordinal-safe
TcpTunnelReq { port: u16 }
TcpData { data: Vec<u8>, closed: bool }
```

One iroh QUIC stream per TCP connection — multiplexed over the existing transport. No content inspection; HTTP/1.1, HTTP/2, WebSockets, SSE, and HMR all work transparently.

## Test plan

- [ ] Start a dev server on host (`npx vite`, `next dev`, etc.) on port 3000
- [ ] Connect mobile to host
- [ ] Open workspace drawer → Preview tab
- [ ] Tap "Open Preview" — browser/WebView opens `http://127.0.0.1:<proxy_port>/`
- [ ] Verify page loads and hot-reload works
- [ ] Tap "Stop Proxy" — server stops, button resets
- [ ] Verify `TcpTunnelOpened` / `TcpTunnelClosed` telemetry fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)