### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Description | Run command |
+|---|---|---|
+| **zedra-host** (Rust binary) | Desktop companion daemon — iroh P2P, RPC, PTY, git/fs ops | `cargo run -p zedra-host -- start` |
+| **Landing page** (Astro) | Marketing site at `packages/landing/` | `bun run --cwd packages/landing astro dev` |
+| **Relay monitor** (Bun/TS) | Monitoring tool at `packages/relay-monitor/` | Docker-only (`deploy/relay/`) |
+
+The Android app (`crates/zedra/`) and iOS build require NDK/Xcode and a physical device — not buildable in Cloud Agent VMs.
+
+### Pre-commit checks
+
+See `CLAUDE.md` → "Pre-Commit Checks" for the canonical commands. Summary:
+
+- **Rust**: `cargo fmt --check` then `cargo check -p zedra-rpc -p zedra-session -p zedra-terminal -p zedra-host`
+- **JS/TS**: `bun run check` (runs `biome ci packages/`)
+
+### Testing
+
+- `cargo test -p zedra-host` — 41 unit tests (1 pre-existing failure: `git::tests::checkout_branch`)
+- No integration test binary is built by default; integration tests live under `tests/integration.rs` and require `--test integration`
+
+### Gotchas
+
+- **Rust edition 2024**: workspace requires Rust >= 1.85. The update script ensures `rustup update stable`.
+- **`libssl-dev`**: required for `openssl-sys` crate (dependency of iroh). Must be installed as a system package.
+- **Bun** (not npm/yarn/pnpm): JS/TS workspace uses `bun.lock`. Install via `bun install` at repo root.
+- **Git submodule `vendor/zed`**: must be initialized (`git submodule update --init --recursive`) — required even for host-only crates because `zedra-terminal` depends on `gpui` from the submodule.
+- **`zedra status` / `zedra list`** subcommands have a pre-existing Tokio runtime panic — use `zedra start` and `zedra stop` instead.
+- The binary name is `zedra` (not `zedra-host`): `./target/debug/zedra --help`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions so future cloud agents can set up the environment correctly.

### What's included

- Services overview table (zedra-host, landing page, relay monitor)
- Pre-commit check references (Rust fmt/check, Biome CI)
- Testing notes (41 unit tests, 1 pre-existing failure)
- Non-obvious gotchas:
  - Rust edition 2024 requires >= 1.85
  - `libssl-dev` required for `openssl-sys`
  - Bun (not npm) for JS/TS
  - Git submodule must be initialized for host-only crates
  - `zedra status`/`list` Tokio runtime panic (pre-existing)

### Verified

- `cargo fmt --check` — pass
- `cargo check -p zedra-rpc -p zedra-session -p zedra-terminal -p zedra-host` — pass
- `cargo test -p zedra-host` — 40/41 pass (1 pre-existing failure)
- `bun run check` — pass
- `zedra start` / `zedra stop` — daemon starts, binds iroh endpoint, prints QR
- Landing page dev server — serves on port 4321

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb016987-1901-4d73-a3df-aef7a8f30117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb016987-1901-4d73-a3df-aef7a8f30117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

