### PR TITLE
fix: use native app build version in launch screen footer

### DIFF
--- a/android/app/src/main/java/dev/zedra/app/MainActivity.java
+++ b/android/app/src/main/java/dev/zedra/app/MainActivity.java
@@ -72,6 +72,33 @@ public class MainActivity extends AppCompatActivity {
     }
 
     /**
+     * Get the native app build version shown to users.
+     * Returns "versionName (versionCode)" when available.
+     */
+    public static String getAppVersion() {
+        if (sActivity == null) {
+            return "";
+        }
+        try {
+            String packageName = sActivity.getPackageName();
+            android.content.pm.PackageInfo info =
+                sActivity.getPackageManager().getPackageInfo(packageName, 0);
+            String versionName = info.versionName == null ? "" : info.versionName.trim();
+            long versionCode = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+                ? info.getLongVersionCode()
+                : info.versionCode;
+
+            if (versionName.isEmpty()) {
+                return String.valueOf(versionCode);
+            }
+            return versionName + " (" + versionCode + ")";
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to read app version", e);
+            return "";
+        }
+    }
+
+    /**
      * Show a native alert dialog (called from Rust via JNI)
      */
     public static void showAlert(

--- a/crates/zedra/src/android/bridge.rs
+++ b/crates/zedra/src/android/bridge.rs
@@ -40,6 +40,15 @@ impl PlatformBridge for AndroidBridge {
         jni::launch_qr_scanner()
     }
 
+    fn app_version(&self) -> Option<String> {
+        let version = jni::get_app_version();
+        if version.trim().is_empty() {
+            None
+        } else {
+            Some(version)
+        }
+    }
+
     fn data_directory(&self) -> Option<String> {
         jni::get_files_dir()
     }

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -885,6 +885,84 @@ pub fn open_url(url: &str) {
     jni_call("open_url", move || open_url_inner(url_owned));
 }
 
+/// Get the app build version from Android package metadata.
+pub fn get_app_version() -> String {
+    let out = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let out_clone = out.clone();
+    jni_call("get_app_version", move || get_app_version_inner(out_clone));
+    out.lock().map(|s| s.clone()).unwrap_or_default()
+}
+
+fn get_app_version_inner(output: std::sync::Arc<std::sync::Mutex<String>>) {
+    let jvm = match JVM.lock() {
+        Ok(guard) => match guard.as_ref() {
+            Some(jvm) => jvm.clone(),
+            None => {
+                tracing::error!("JVM not available for get_app_version");
+                return;
+            }
+        },
+        Err(e) => {
+            tracing::error!("Failed to lock JVM mutex: {:?}", e);
+            return;
+        }
+    };
+
+    let mut env = match jvm.get_env() {
+        Ok(env) => env,
+        Err(_) => match jvm.attach_current_thread_as_daemon() {
+            Ok(env) => env,
+            Err(e) => {
+                tracing::error!("Failed to attach thread for get_app_version: {:?}", e);
+                return;
+            }
+        },
+    };
+
+    let class = match env.find_class("dev/zedra/app/MainActivity") {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("Failed to find MainActivity class: {:?}", e);
+            if env.exception_check().unwrap_or(false) {
+                env.exception_describe().ok();
+                env.exception_clear().ok();
+            }
+            return;
+        }
+    };
+
+    let value = match env.call_static_method(&class, "getAppVersion", "()Ljava/lang/String;", &[]) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("Failed to call getAppVersion: {:?}", e);
+            if env.exception_check().unwrap_or(false) {
+                env.exception_describe().ok();
+                env.exception_clear().ok();
+            }
+            return;
+        }
+    };
+
+    let Ok(obj) = value.l() else {
+        return;
+    };
+    if obj.is_null() {
+        return;
+    }
+    let jstr = jni::objects::JString::from(obj);
+    match env.get_string(&jstr) {
+        Ok(v) => {
+            let s: String = v.into();
+            if let Ok(mut guard) = output.lock() {
+                *guard = s;
+            }
+        }
+        Err(e) => {
+            tracing::error!("Failed to read app version string: {:?}", e);
+        }
+    }
+}
+
 fn open_url_inner(url: String) {
     let jvm = match JVM.lock() {
         Ok(guard) => match guard.as_ref() {

--- a/crates/zedra/src/home_view.rs
+++ b/crates/zedra/src/home_view.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use gpui::*;
 
 use crate::fonts;
@@ -260,11 +262,16 @@ impl Render for HomeView {
 }
 
 fn app_version_text() -> String {
-    let version = platform_bridge::bridge()
-        .app_version()
-        .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
-    format!("zedra v{version}")
+    static APP_VERSION_TEXT: OnceLock<String> = OnceLock::new();
+    APP_VERSION_TEXT
+        .get_or_init(|| {
+            let version = platform_bridge::bridge()
+                .app_version()
+                .filter(|v| !v.trim().is_empty())
+                .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+            format!("zedra v{version}")
+        })
+        .clone()
 }
 
 fn workspace_card(

--- a/crates/zedra/src/home_view.rs
+++ b/crates/zedra/src/home_view.rs
@@ -253,10 +253,18 @@ impl Render for HomeView {
                         div()
                             .text_color(rgb(theme::TEXT_MUTED))
                             .text_size(px(theme::FONT_DETAIL))
-                            .child(concat!("zedra v", env!("CARGO_PKG_VERSION"))),
+                            .child(app_version_text()),
                     ),
             )
     }
+}
+
+fn app_version_text() -> String {
+    let version = platform_bridge::bridge()
+        .app_version()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+    format!("zedra v{version}")
 }
 
 fn workspace_card(

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -73,6 +73,8 @@ unsafe extern "C" {
     fn ios_present_qr_scanner();
     /// Returns the app's Documents directory path (from NSSearchPathForDirectoriesInDomains).
     fn ios_get_documents_directory() -> *const std::ffi::c_char;
+    /// Returns the app's user-facing version string from Info.plist metadata.
+    fn ios_get_app_version() -> *const std::ffi::c_char;
     /// Present a native UIAlertController with dynamic buttons.
     /// `labels` and `styles` are parallel arrays of length `button_count`.
     /// Style values: 0 = default, 1 = cancel, 2 = destructive.
@@ -145,6 +147,18 @@ impl PlatformBridge for IosBridge {
 
     fn launch_qr_scanner(&self) {
         unsafe { ios_present_qr_scanner() };
+    }
+
+    fn app_version(&self) -> Option<String> {
+        unsafe {
+            let ptr = ios_get_app_version();
+            if ptr.is_null() {
+                return None;
+            }
+            let cstr = std::ffi::CStr::from_ptr(ptr);
+            let s = cstr.to_str().ok()?.trim().to_string();
+            if s.is_empty() { None } else { Some(s) }
+        }
     }
 
     fn data_directory(&self) -> Option<String> {

--- a/crates/zedra/src/ios_stub.c
+++ b/crates/zedra/src/ios_stub.c
@@ -6,6 +6,7 @@
 __attribute__((weak)) void ios_present_qr_scanner(void) {}
 __attribute__((weak)) void ios_open_url(const char *url) {}
 __attribute__((weak)) const char* ios_get_documents_directory(void) { return 0; }
+__attribute__((weak)) const char* ios_get_app_version(void) { return 0; }
 __attribute__((weak)) void ios_present_alert(
     unsigned int callback_id,
     const char *title,

--- a/crates/zedra/src/platform_bridge.rs
+++ b/crates/zedra/src/platform_bridge.rs
@@ -175,6 +175,10 @@ pub trait PlatformBridge: Send + Sync + 'static {
     fn show_keyboard(&self);
     fn hide_keyboard(&self);
     fn launch_qr_scanner(&self);
+    /// Returns the native app build version displayed to users (e.g. Android versionName).
+    fn app_version(&self) -> Option<String> {
+        None
+    }
     /// Returns the app's writable data directory for persisting workspace state.
     /// On iOS: Documents directory. On Android: internal files directory.
     fn data_directory(&self) -> Option<String> {

--- a/ios/Zedra/main.m
+++ b/ios/Zedra/main.m
@@ -50,6 +50,37 @@ extern void zedra_ios_selection_result(unsigned int callback_id, int button_inde
 extern void zedra_ios_selection_dismiss(unsigned int callback_id);
 extern void zedra_deeplink_received(const char* url);
 
+// Returns the app version as "shortVersion (buildVersion)" in a static C buffer.
+// Called from Rust via FFI for the launch footer version label.
+const char* ios_get_app_version(void) {
+    static char buf[128];
+    NSString *shortVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSString *buildVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
+
+    if (![shortVersion isKindOfClass:[NSString class]]) {
+        shortVersion = @"";
+    }
+    if (![buildVersion isKindOfClass:[NSString class]]) {
+        buildVersion = @"";
+    }
+
+    NSString *value = nil;
+    if (shortVersion.length > 0 && buildVersion.length > 0) {
+        value = [NSString stringWithFormat:@"%@ (%@)", shortVersion, buildVersion];
+    } else if (shortVersion.length > 0) {
+        value = shortVersion;
+    } else if (buildVersion.length > 0) {
+        value = buildVersion;
+    } else {
+        return NULL;
+    }
+
+    const char *cstr = [value UTF8String];
+    if (!cstr) return NULL;
+    strlcpy(buf, cstr, sizeof(buf));
+    return buf;
+}
+
 @interface ZedraPresentationDismissDelegate : NSObject <UIAdaptivePresentationControllerDelegate>
 @property (nonatomic, assign) unsigned int callbackId;
 @property (nonatomic, assign) BOOL handled;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace launch-screen footer version source from Rust crate metadata to platform-native app build version.
- Add `PlatformBridge::app_version()` with both Android and iOS implementations:
  - Android: JNI call to `MainActivity.getAppVersion()` returning `versionName (versionCode)`.
  - iOS: Obj-C bridge `ios_get_app_version()` reading `CFBundleShortVersionString` and `CFBundleVersion`.
- Keep a safe fallback to `CARGO_PKG_VERSION` if native version is unavailable.
- Cache resolved footer version text to avoid repeated bridge calls during UI re-renders.

## Related issue
- Fixes #37

## Testing
- `cargo fmt`
- `cargo check -p zedra`
- `cargo check -p zedra-rpc -p zedra-session -p zedra-terminal -p zedra-host`
- `cargo check -p zedra --target aarch64-apple-ios` *(blocked: iOS Rust target not installed in this environment)*
- `./gradlew :app:compileDebugJavaWithJavac` *(blocked: Android SDK path not configured in this environment)*
- `./scripts/preflight-check.sh` *(confirms missing Android toolchain/device in this environment)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f150a08-782a-4993-a54b-7ada8acbbb7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f150a08-782a-4993-a54b-7ada8acbbb7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

