### PR TITLE
fix: hide keyboard when reconnect overlay appears

### DIFF
--- a/crates/zedra/src/workspace_view.rs
+++ b/crates/zedra/src/workspace_view.rs
@@ -204,6 +204,11 @@ impl Render for WorkspaceContent {
         let needs_full_overlay = !phase.is_connected() && !phase.is_idle();
 
         if needs_full_overlay {
+            // Reconnecting/failed overlay should always dismiss IME so it doesn't
+            // remain floating above the blocked terminal surface.
+            if !self.overlay_visible {
+                platform_bridge::bridge().hide_keyboard();
+            }
             // Active connect/failed phase — ensure full overlay is showing.
             self.overlay_visible = true;
         } else if self.overlay_visible {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- hide the soft keyboard when workspace reconnect/failed overlay becomes visible
- trigger dismissal only on transition into overlay to avoid repeated calls every frame

## Why
When the reconnect screen appears, the Android/iOS keyboard could remain visible over blocked content.

## Testing
- cargo fmt --check
- cargo check -p zedra
<!-- CURSOR_AGENT_PR_BODY_END -->

Resolves #42 

<div><a href="https://cursor.com/agents/bc-ae0b6e12-b739-45ac-8521-1e62ab8494bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae0b6e12-b739-45ac-8521-1e62ab8494bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

