### PR TITLE
fix: keyboard helper theming in light mode

### DIFF
--- a/android/app/src/main/java/dev/zedra/app/MainActivity.java
+++ b/android/app/src/main/java/dev/zedra/app/MainActivity.java
@@ -2,6 +2,7 @@ package dev.zedra.app;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.splashscreen.SplashScreen;
 
 import android.app.Activity;
@@ -208,6 +209,8 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // Keep Android native UI (including IME helper text) aligned with Zedra's dark theme.
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
         SplashScreen.installSplashScreen(this);
         super.onCreate(savedInstanceState);
         Log.d(TAG, "onCreate");

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="splash_bg">#0e0c0c</color>
+    <color name="app_text_primary">#f5f5f5</color>
+    <color name="app_text_secondary">#bdbdbd</color>
 </resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTheme" parent="@style/Theme.AppCompat.NoActionBar">
+    <style name="AppTheme" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowBackground">@color/splash_bg</item>
+        <item name="android:colorBackground">@color/splash_bg</item>
+        <item name="colorBackground">@color/splash_bg</item>
+        <item name="android:textColorPrimary">@color/app_text_primary</item>
+        <item name="textColorPrimary">@color/app_text_primary</item>
+        <item name="android:textColorSecondary">@color/app_text_secondary</item>
+        <item name="textColorSecondary">@color/app_text_secondary</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
     </style>
 
     <style name="SplashTheme" parent="Theme.SplashScreen">

--- a/ios/Zedra/main.m
+++ b/ios/Zedra/main.m
@@ -377,7 +377,10 @@ static const char *kAccessoryKeyNames[] = {"escape", "tab", "left", "down", "up"
     CGFloat height = 44.0;
 
     UIView *bar = [[UIView alloc] initWithFrame:CGRectMake(0, 0, width, height)];
-    bar.backgroundColor = [UIColor clearColor];
+    bar.backgroundColor = [UIColor colorWithRed:0.055 green:0.047 blue:0.047 alpha:0.96];
+    if (@available(iOS 13.0, *)) {
+        bar.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+    }
 
     // Hairline top border as a subtle separator above the keyboard.
     UIView *border = [[UIView alloc] initWithFrame:CGRectMake(0, 0, width, 0.33)];
@@ -393,7 +396,12 @@ static const char *kAccessoryKeyNames[] = {"escape", "tab", "left", "down", "up"
         btn.frame = CGRectMake(btnWidth * i, 0, btnWidth, height);
         [btn setTitle:labels[i] forState:UIControlStateNormal];
         btn.titleLabel.font = [UIFont systemFontOfSize:16.0];
-        [btn setTitleColor:[UIColor labelColor] forState:UIControlStateNormal];
+        UIColor *buttonColor = [UIColor colorWithRed:0.96 green:0.96 blue:0.96 alpha:1.0];
+        [btn setTitleColor:buttonColor forState:UIControlStateNormal];
+        btn.tintColor = buttonColor;
+        if (@available(iOS 13.0, *)) {
+            btn.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+        }
         btn.tag = i;
         [btn addTarget:self action:@selector(keyboardShortcutTapped:)
       forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Force native keyboard helper/accessory UI to stay readable against Zedra’s dark app surfaces, regardless of system light mode.
- Apply fix on both Android and iOS paths.

## Changes
- `android/app/src/main/java/dev/zedra/app/MainActivity.java`
  - Force dark mode at startup via `AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)`.
- `android/app/src/main/res/values/themes.xml`
  - Switch to `Theme.AppCompat.DayNight.NoActionBar`.
  - Define explicit dark background + primary/secondary text colors.
  - Keep status/navigation bars configured for dark appearance.
- `android/app/src/main/res/values/colors.xml`
  - Add `app_text_primary` and `app_text_secondary`.
- `ios/Zedra/main.m`
  - Style keyboard accessory bar with app-aligned dark background.
  - Replace dynamic `labelColor` with fixed light button text color.
  - Force accessory bar/button `overrideUserInterfaceStyle = UIUserInterfaceStyleDark` (iOS 13+).

## Testing
- `cargo fmt --check` ✅
- `cargo check -p zedra-rpc -p zedra-session -p zedra-terminal -p zedra-host` ✅
- `bun run check` ✅
- `./gradlew :app:compileDebugJavaWithJavac` ⚠️ (cloud VM missing Android SDK/`ANDROID_HOME`)
- `clang -fsyntax-only -x objective-c -fobjc-arc -D__IPHONE_OS_VERSION_MIN_REQUIRED=130000 -isysroot /usr/include ios/Zedra/main.m` ⚠️ (Linux toolchain/runtime cannot validate iOS Objective-C ARC syntax)

## Issue
- Closes #41
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9032fa74-06b0-4daf-9fbb-de7fedbeff66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9032fa74-06b0-4daf-9fbb-de7fedbeff66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

