### PR TITLE
feat: add reconnect token protocol flow

### DIFF
--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -1,8 +1,9 @@
 // RPC daemon: exposes filesystem, git, terminal, LSP, and AI operations over irpc.
 //
-// Connection lifecycle (Phase 1 PKI):
-//   First pairing:  Register → Authenticate → AuthProve → (RPC calls)
-//   Reconnect:      Authenticate → AuthProve → (RPC calls)
+// Connection lifecycle:
+//   First pairing:  Register → Authenticate → AuthProve → SyncSession → (RPC calls)
+//   Reconnect:      Reconnect → (RPC calls)
+//   Fallback:       Authenticate → AuthProve → SyncSession → (RPC calls)
 //   Health:         Ping (every 2s, foreground only, 5 misses = client reconnects)
 
 use crate::analytics::Analytics;
@@ -24,6 +25,34 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zedra_rpc::osc::{encode_meta_preamble, OscEvent};
 use zedra_rpc::proto::*;
+
+async fn build_sync_result(
+    session: &Arc<ServerSession>,
+    state: &DaemonState,
+    reconnect_token: [u8; 32],
+) -> SyncSessionResult {
+    let hostname = hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".to_string());
+    let username = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
+    let workdir = state.workdir.to_string_lossy().into_owned();
+    let home_dir = std::env::var("HOME").ok();
+
+    SyncSessionResult {
+        session_id: session.id.clone(),
+        reconnect_token,
+        hostname,
+        workdir,
+        username,
+        home_dir,
+        os: Some(std::env::consts::OS.to_string()),
+        arch: Some(std::env::consts::ARCH.to_string()),
+        os_version: os_version_string(),
+        host_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        terminals: session.terminal_sync_entries().await,
+    }
+}
 
 fn ts() -> String {
     let s = SystemTime::now()
@@ -277,15 +306,7 @@ pub async fn handle_connection(
 
     // Auth phase: returns (session, client_pubkey, is_new_client) or closes connection
     let auth_start = std::time::Instant::now();
-    let (session, client_pubkey, is_new_client) = match auth_phase(
-        &conn,
-        &registry,
-        &state.identity,
-        &state.workdir,
-        &state.analytics,
-    )
-    .await
-    {
+    let (session, client_pubkey, is_new_client) = match auth_phase(&conn, &registry, &state).await {
         Ok(triple) => triple,
         Err(e) => {
             state.analytics.auth_failed("auth_error");
@@ -410,20 +431,64 @@ pub async fn handle_connection(
 /// Perform the full auth handshake for a new connection.
 ///
 /// Flow:
-///   1. Optional Register (first-time only, proves QR possession via HMAC)
-///   2. Authenticate (get nonce + host signature from us)
-///   3. AuthProve (client signs nonce, specifies session to attach)
+///   1. Reconnect (fast path, host-issued reconnect token), or
+///   2. Optional Register (first-time only, proves QR possession via HMAC)
+///   3. Authenticate (get nonce + host signature from us)
+///   4. AuthProve (client signs nonce, specifies session to attach)
 async fn auth_phase(
     conn: &iroh::endpoint::Connection,
     registry: &Arc<SessionRegistry>,
-    identity: &SharedIdentity,
-    workdir: &std::path::Path,
-    analytics: &Arc<Analytics>,
+    state: &Arc<DaemonState>,
 ) -> Result<(Arc<ServerSession>, [u8; 32], bool)> {
+    let analytics = &state.analytics;
     // Step 1: Optional Register
     let first = irpc_iroh::read_request::<ZedraProto>(conn).await?;
 
     let client_pubkey: [u8; 32] = match first {
+        Some(ZedraMessage::Reconnect(msg)) => {
+            let pubkey = msg.client_pubkey;
+            let requested_session_id = msg.session_id.clone();
+            let session = registry.get(&requested_session_id).await;
+            let attach_result = match session {
+                Some(session) => {
+                    if !session
+                        .validate_reconnect_token(&pubkey, &msg.reconnect_token)
+                        .await
+                    {
+                        Err(AttachResult::SessionNotFound)
+                    } else {
+                        match registry.attach_client(&requested_session_id, pubkey).await {
+                            AttachResult::Ok => Ok(session),
+                            err => Err(err),
+                        }
+                    }
+                }
+                None => Err(AttachResult::SessionNotFound),
+            };
+            let result = match attach_result {
+                Ok(session) => {
+                    let reconnect_token = session.issue_reconnect_token(pubkey).await;
+                    ReconnectResult::Ok(build_sync_result(&session, state, reconnect_token).await)
+                }
+                Err(AttachResult::SessionNotFound) => ReconnectResult::SessionNotFound,
+                Err(AttachResult::NotInSessionAcl) => ReconnectResult::NotInSessionAcl,
+                Err(AttachResult::SessionOccupied) => ReconnectResult::SessionOccupied,
+                Err(AttachResult::Ok) => unreachable!("resume_with_token never returns Ok error"),
+            };
+            let success = matches!(result, ReconnectResult::Ok(_));
+            let _ = msg.tx.send(result).await;
+            if !success {
+                anyhow::bail!("reconnect rejected");
+            }
+            return Ok((
+                registry
+                    .get(&requested_session_id)
+                    .await
+                    .ok_or_else(|| anyhow::anyhow!("session missing after reconnect"))?,
+                pubkey,
+                false,
+            ));
+        }
         Some(ZedraMessage::Register(msg)) => {
             let pubkey = msg.client_pubkey;
             let result = handle_register(&msg, registry, analytics).await;
@@ -443,11 +508,11 @@ async fn auth_phase(
                 drop(msg.tx); // signal error by dropping
                 anyhow::bail!("client not authorized");
             }
-            let nonce = issue_challenge(msg.tx, identity).await?;
+            let nonce = issue_challenge(msg.tx, &state.identity).await?;
             // is_new_client = false: this is a reconnect
-            return finish_auth(conn, registry, pubkey, nonce, workdir, false).await;
+            return finish_auth(conn, registry, pubkey, nonce, &state.workdir, false).await;
         }
-        _ => anyhow::bail!("expected Register or Authenticate as first message"),
+        _ => anyhow::bail!("expected Reconnect, Register, or Authenticate as first message"),
     };
 
     // After Register: expect Authenticate
@@ -455,9 +520,9 @@ async fn auth_phase(
     match auth_msg {
         Some(ZedraMessage::Authenticate(msg)) => {
             // After fresh registration, client is authorized
-            let nonce = issue_challenge(msg.tx, identity).await?;
+            let nonce = issue_challenge(msg.tx, &state.identity).await?;
             // is_new_client = true: came through the Register path
-            finish_auth(conn, registry, client_pubkey, nonce, workdir, true).await
+            finish_auth(conn, registry, client_pubkey, nonce, &state.workdir, true).await
         }
         _ => anyhow::bail!("expected Authenticate after Register"),
     }
@@ -777,8 +842,11 @@ async fn dispatch(
     client_pubkey: [u8; 32],
 ) -> Result<()> {
     match msg {
-        // -- Auth (should not appear in dispatch loop) --
-        ZedraMessage::Register(_) | ZedraMessage::Authenticate(_) | ZedraMessage::AuthProve(_) => {
+        // -- Auth / bootstrap (should not appear in dispatch loop) --
+        ZedraMessage::Register(_)
+        | ZedraMessage::Authenticate(_)
+        | ZedraMessage::AuthProve(_)
+        | ZedraMessage::Reconnect(_) => {
             tracing::warn!("auth message received in dispatch loop (ignored)");
         }
 
@@ -811,6 +879,14 @@ async fn dispatch(
                     os_version: os_version_string(),
                     host_version: Some(env!("CARGO_PKG_VERSION").to_string()),
                 })
+                .await;
+        }
+
+        ZedraMessage::SyncSession(msg) => {
+            let reconnect_token = session.issue_reconnect_token(client_pubkey).await;
+            let _ = msg
+                .tx
+                .send(build_sync_result(&session, &state, reconnect_token).await)
                 .await;
         }
 

--- a/crates/zedra-host/src/session_registry.rs
+++ b/crates/zedra-host/src/session_registry.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 use zedra_rpc::osc::OscScanner;
-use zedra_rpc::proto::{BacklogEntry, HostEvent, TermOutput};
+use zedra_rpc::proto::{BacklogEntry, HostEvent, TermOutput, TerminalSyncEntry};
 
 // ---------------------------------------------------------------------------
 // Pairing slot
@@ -69,6 +69,9 @@ pub struct ServerSession {
     pub acl: Mutex<HashSet<[u8; 32]>>,
     /// Currently attached client pubkey. None = session is free.
     pub active_client: Mutex<Option<[u8; 32]>>,
+    /// Ephemeral reconnect tokens keyed by authorized client pubkey.
+    /// Rotated on every successful bootstrap/reconnect.
+    pub reconnect_tokens: Mutex<HashMap<[u8; 32], ReconnectToken>>,
     /// Channel for pushing host-initiated events to the connected client.
     /// Installed by the Subscribe RPC handler; replaced on each new subscription.
     pub event_tx: Mutex<Option<tokio::sync::mpsc::Sender<HostEvent>>>,
@@ -85,6 +88,14 @@ pub struct ServerSession {
     pub fs_watch_quota_rejected: AtomicU64,
     pub fs_watch_rate_limited: AtomicU64,
 }
+
+#[derive(Clone)]
+pub struct ReconnectToken {
+    pub token: [u8; 32],
+    pub expires_at: Instant,
+}
+
+const RECONNECT_TOKEN_TTL_SECS: u64 = 300;
 
 /// Max number of observed paths stored per session.
 pub const MAX_WATCHED_PATHS_PER_SESSION: usize = 128;
@@ -728,6 +739,7 @@ impl ServerSession {
             next_output_seq: Mutex::new(1),
             acl: Mutex::new(HashSet::new()),
             active_client: Mutex::new(None),
+            reconnect_tokens: Mutex::new(HashMap::new()),
             event_tx: Mutex::new(None),
             fs_watched_paths: Mutex::new(HashSet::new()),
             fs_watch_rpc_limiter: Mutex::new(TokenBucket::new(
@@ -741,6 +753,60 @@ impl ServerSession {
             fs_watch_quota_rejected: AtomicU64::new(0),
             fs_watch_rate_limited: AtomicU64::new(0),
         }
+    }
+
+    pub async fn issue_reconnect_token(&self, client_pubkey: [u8; 32]) -> [u8; 32] {
+        let mut token = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut token);
+        self.reconnect_tokens.lock().await.insert(
+            client_pubkey,
+            ReconnectToken {
+                token,
+                expires_at: Instant::now() + Duration::from_secs(RECONNECT_TOKEN_TTL_SECS),
+            },
+        );
+        token
+    }
+
+    pub async fn validate_reconnect_token(
+        &self,
+        client_pubkey: &[u8; 32],
+        reconnect_token: &[u8; 32],
+    ) -> bool {
+        let mut tokens = self.reconnect_tokens.lock().await;
+        let Some(entry) = tokens.get(client_pubkey).cloned() else {
+            return false;
+        };
+        if entry.expires_at < Instant::now() {
+            tokens.remove(client_pubkey);
+            return false;
+        }
+        if &entry.token != reconnect_token {
+            return false;
+        }
+        true
+    }
+
+    pub async fn terminal_sync_entries(&self) -> Vec<TerminalSyncEntry> {
+        let next_seq = *self.next_output_seq.lock().await;
+        let terms = self.terminals.lock().await;
+        let mut entries = Vec::with_capacity(terms.len());
+        for (id, term) in terms.iter() {
+            let (title, cwd) = term
+                .host_meta
+                .lock()
+                .ok()
+                .map(|meta| (meta.title.clone(), meta.cwd.clone()))
+                .unwrap_or((None, None));
+            entries.push(TerminalSyncEntry {
+                id: id.clone(),
+                last_seq: next_seq.saturating_sub(1),
+                title,
+                cwd,
+            });
+        }
+        entries.sort_by(|a, b| a.id.cmp(&b.id));
+        entries
     }
 
     /// Push a host-initiated event to the subscribed client, if any.
@@ -1132,5 +1198,41 @@ mod tests {
         let list = registry.list_sessions().await;
         assert_eq!(list.len(), 1);
         assert!(list[0].is_occupied);
+    }
+
+    #[tokio::test]
+    async fn reconnect_token_rotates_and_validates_per_client() {
+        let registry = SessionRegistry::new();
+        let session = create_session(&registry).await;
+        let pubkey = make_pubkey(11);
+
+        registry.add_client_to_session(&session.id, pubkey).await;
+        assert!(matches!(
+            registry.attach_client(&session.id, pubkey).await,
+            AttachResult::Ok
+        ));
+
+        let first = session.issue_reconnect_token(pubkey).await;
+        assert!(session.validate_reconnect_token(&pubkey, &first).await);
+
+        let second = session.issue_reconnect_token(pubkey).await;
+        assert_ne!(first, second);
+        assert!(!session.validate_reconnect_token(&pubkey, &first).await);
+        assert!(session.validate_reconnect_token(&pubkey, &second).await);
+    }
+
+    #[tokio::test]
+    async fn reconnect_token_is_scoped_to_its_client() {
+        let registry = SessionRegistry::new();
+        let session = create_session(&registry).await;
+        let key_a = make_pubkey(21);
+        let key_b = make_pubkey(22);
+
+        registry.add_client_to_session(&session.id, key_a).await;
+        registry.add_client_to_session(&session.id, key_b).await;
+
+        let token = session.issue_reconnect_token(key_a).await;
+        assert!(session.validate_reconnect_token(&key_a, &token).await);
+        assert!(!session.validate_reconnect_token(&key_b, &token).await);
     }
 }

--- a/crates/zedra-host/tests/integration.rs
+++ b/crates/zedra-host/tests/integration.rs
@@ -102,7 +102,12 @@ async fn connect_client(
     host_endpoint: &iroh::Endpoint,
     registry: &Arc<SessionRegistry>,
     host_identity: &Arc<HostIdentity>,
-) -> anyhow::Result<(irpc::Client<ZedraProto>, String)> {
+) -> anyhow::Result<(
+    irpc::Client<ZedraProto>,
+    String,
+    [u8; 32],
+    SyncSessionResult,
+)> {
     use ed25519_dalek::{SigningKey, Verifier, VerifyingKey};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -177,7 +182,9 @@ async fn connect_client(
         prove_result
     );
 
-    Ok((client, session.id.clone()))
+    let sync: SyncSessionResult = client.rpc(SyncSessionReq {}).await?;
+
+    Ok((client, session.id.clone(), client_pubkey, sync))
 }
 
 // ---------------------------------------------------------------------------
@@ -284,10 +291,13 @@ async fn test_full_rpc_over_iroh() {
     let (_relay, relay_url) = spawn_test_relay().await.unwrap();
     let (host_ep, registry, identity, _dir) = setup_host(relay_url.clone()).await.unwrap();
 
-    let (client, session_id) = connect_client(relay_url, &host_ep, &registry, &identity)
-        .await
-        .unwrap();
+    let (client, session_id, _client_pubkey, sync) =
+        connect_client(relay_url, &host_ep, &registry, &identity)
+            .await
+            .unwrap();
     assert!(!session_id.is_empty());
+    assert_eq!(sync.session_id, session_id);
+    assert_ne!(sync.reconnect_token, [0u8; 32]);
 
     let info: SessionInfoResult = client.rpc(SessionInfoReq {}).await.unwrap();
     assert!(!info.hostname.is_empty());
@@ -301,9 +311,10 @@ async fn test_rpc_terminal_over_relay() {
     let (_relay, relay_url) = spawn_test_relay().await.unwrap();
     let (host_ep, registry, identity, _dir) = setup_host(relay_url.clone()).await.unwrap();
 
-    let (client, _session_id) = connect_client(relay_url, &host_ep, &registry, &identity)
-        .await
-        .unwrap();
+    let (client, _session_id, _client_pubkey, _sync) =
+        connect_client(relay_url, &host_ep, &registry, &identity)
+            .await
+            .unwrap();
 
     // Create terminal
     let result: TermCreateResult = client

--- a/crates/zedra-rpc/src/proto.rs
+++ b/crates/zedra-rpc/src/proto.rs
@@ -3,8 +3,9 @@
 // Typed, binary-serialized (postcard) messages over iroh QUIC streams.
 //
 // Connection lifecycle:
-//   First pairing:   Register → Authenticate → AuthProve → (RPC calls)
-//   Reconnect:       Authenticate → AuthProve → (RPC calls)
+//   First pairing:   Register → Authenticate → AuthProve → SyncSession → (RPC calls)
+//   Reconnect:       Reconnect → (RPC calls)
+//   Fallback:        Authenticate → AuthProve → SyncSession → (RPC calls)
 //   Health:          Ping → Pong (every 2s, foreground only)
 
 use irpc::channel::{mpsc, oneshot};
@@ -38,6 +39,11 @@ pub enum ZedraProto {
     /// Also specifies which session to attach to.
     #[rpc(tx = oneshot::Sender<AuthProveResult>)]
     AuthProve(AuthProveReq),
+
+    /// Fast reconnect path for a previously bootstrapped session.
+    /// Validates a host-issued reconnect token and returns the latest sync state.
+    #[rpc(tx = oneshot::Sender<ReconnectResult>)]
+    Reconnect(ReconnectReq),
 
     // -- Health / RTT --
     /// Ping the host. Host echoes timestamp_ms back for RTT measurement.
@@ -133,6 +139,12 @@ pub enum ZedraProto {
 
     #[rpc(tx = oneshot::Sender<FsUnwatchResult>)]
     FsUnwatch(FsUnwatchReq),
+
+    /// Bootstrap session state after a successful PKI auth attach.
+    /// Returns the canonical session id, a fresh reconnect token, and resumable
+    /// terminal state so the client can avoid a follow-up info/list round trip.
+    #[rpc(tx = oneshot::Sender<SyncSessionResult>)]
+    SyncSession(SyncSessionReq),
 }
 
 // ---------------------------------------------------------------------------
@@ -268,6 +280,34 @@ pub enum AuthProveResult {
     InvalidSignature,
 }
 
+/// Fast reconnect request using a host-issued session token.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ReconnectReq {
+    /// Client's Ed25519 application public key (32 bytes).
+    pub client_pubkey: [u8; 32],
+    /// Session the client expects to resume.
+    pub session_id: String,
+    /// Opaque host-issued reconnect token bound to `(session_id, client_pubkey)`.
+    pub reconnect_token: [u8; 32],
+}
+
+/// Result of a reconnect-token resume attempt.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ReconnectResult {
+    /// Token accepted and session attached; payload contains the latest state.
+    Ok(SyncSessionResult),
+    /// Token invalid, expired, or missing. Client should fall back to PKI auth.
+    InvalidToken,
+    /// Client pubkey is no longer globally authorized.
+    Unauthorized,
+    /// Session exists but this client is not in the session ACL.
+    NotInSessionAcl,
+    /// Another client currently owns the session.
+    SessionOccupied,
+    /// Session not found (host restart / session removal).
+    SessionNotFound,
+}
+
 // ---------------------------------------------------------------------------
 // Ping / Pong
 // ---------------------------------------------------------------------------
@@ -321,6 +361,32 @@ pub struct SessionInfoResult {
     pub os_version: Option<String>,
     pub host_version: Option<String>,
     pub home_dir: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncSessionReq {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncSessionResult {
+    pub session_id: String,
+    pub reconnect_token: [u8; 32],
+    pub hostname: String,
+    pub workdir: String,
+    pub username: String,
+    pub home_dir: Option<String>,
+    pub os: Option<String>,
+    pub arch: Option<String>,
+    pub os_version: Option<String>,
+    pub host_version: Option<String>,
+    pub terminals: Vec<TerminalSyncEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TerminalSyncEntry {
+    pub id: String,
+    pub last_seq: u64,
+    pub title: Option<String>,
+    pub cwd: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -765,5 +831,47 @@ mod tests {
         let encoded = postcard::to_allocvec(&req).unwrap();
         let decoded: PingReq = postcard::from_bytes(&encoded).unwrap();
         assert_eq!(decoded.timestamp_ms, 9_999_999);
+    }
+
+    #[test]
+    fn reconnect_req_roundtrip() {
+        let req = ReconnectReq {
+            client_pubkey: [7u8; 32],
+            session_id: "sess-fast".to_string(),
+            reconnect_token: [8u8; 32],
+        };
+        let encoded = postcard::to_allocvec(&req).unwrap();
+        let decoded: ReconnectReq = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(decoded.client_pubkey, [7u8; 32]);
+        assert_eq!(decoded.session_id, "sess-fast");
+        assert_eq!(decoded.reconnect_token, [8u8; 32]);
+    }
+
+    #[test]
+    fn sync_session_result_roundtrip() {
+        let result = SyncSessionResult {
+            session_id: "sess-1".into(),
+            reconnect_token: [9u8; 32],
+            hostname: "host".into(),
+            workdir: "/workspace".into(),
+            username: "user".into(),
+            home_dir: Some("/home/user".into()),
+            os: Some("linux".into()),
+            arch: Some("x86_64".into()),
+            os_version: Some("6.12".into()),
+            host_version: Some("0.1.1".into()),
+            terminals: vec![TerminalSyncEntry {
+                id: "term-1".into(),
+                last_seq: 42,
+                title: Some("shell".into()),
+                cwd: Some("/workspace".into()),
+            }],
+        };
+        let encoded = postcard::to_allocvec(&result).unwrap();
+        let decoded: SyncSessionResult = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(decoded.session_id, "sess-1");
+        assert_eq!(decoded.reconnect_token, [9u8; 32]);
+        assert_eq!(decoded.terminals.len(), 1);
+        assert_eq!(decoded.terminals[0].last_seq, 42);
     }
 }

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -9,8 +9,8 @@ use anyhow::Result;
 use zedra_rpc::proto::*;
 
 use crate::connect_state::{
-    AuthOutcome, ConnectError, ConnectPhase, ConnectState, NetworkHint, ReconnectReason,
-    TransportSnapshot,
+    AuthOutcome, ConnectError, ConnectPhase, ConnectSnapshot, ConnectState, NetworkHint,
+    ReconnectReason, TransportSnapshot,
 };
 
 /// Classify a remote IP address for debugging display.
@@ -43,6 +43,12 @@ fn classify_ip(ip: std::net::IpAddr) -> NetworkHint {
     }
 }
 use crate::{push_callback, session_runtime, signer::ClientSigner, terminal::RemoteTerminal};
+
+fn snapshot_has_cached_session_info(snapshot: &ConnectSnapshot) -> bool {
+    snapshot.hostname.as_ref().is_some_and(|s| !s.is_empty())
+        && snapshot.workdir.as_ref().is_some_and(|s| !s.is_empty())
+        && snapshot.session_id.as_ref().is_some_and(|s| !s.is_empty())
+}
 
 /// Workspace-scoped durable session state. Arc-wrapped — clone freely to share
 /// with async tasks. Survives transport failures and reconnect cycles.
@@ -354,6 +360,11 @@ impl SessionHandle {
             .lock()
             .map(|g| g.clone())
             .unwrap_or_default()
+    }
+
+    fn has_cached_session_info(&self) -> bool {
+        let cs = self.connect_state();
+        snapshot_has_cached_session_info(&cs.snapshot)
     }
 
     // -----------------------------------------------------------------------
@@ -696,23 +707,33 @@ impl SessionHandle {
             }
         }
 
-        // ── Phase: FetchingInfo ────────────────────────────────────────────
-        {
-            let mut cs = self.0.connect_state.lock().unwrap();
-            cs.phase = ConnectPhase::FetchingInfo;
-        }
-        self.notify_state_change();
+        let needs_session_info = !self.has_cached_session_info();
+        if needs_session_info {
+            // ── Phase: FetchingInfo ────────────────────────────────────────
+            {
+                let mut cs = self.0.connect_state.lock().unwrap();
+                cs.phase = ConnectPhase::FetchingInfo;
+            }
+            self.notify_state_change();
 
-        let t_fetch = Instant::now();
-        self.fetch_session_info(&client).await;
+            let t_fetch = Instant::now();
+            self.fetch_session_info(&client).await;
 
-        {
-            let mut cs = self.0.connect_state.lock().unwrap();
-            cs.snapshot.fetch_ms = Some(t_fetch.elapsed().as_millis() as u64);
-            cs.phase = ConnectPhase::Connected;
-            cs.reconnect_attempt = None;
+            {
+                let mut cs = self.0.connect_state.lock().unwrap();
+                cs.snapshot.fetch_ms = Some(t_fetch.elapsed().as_millis() as u64);
+                cs.phase = ConnectPhase::Connected;
+                cs.reconnect_attempt = None;
+            }
+            self.notify_state_change();
+        } else {
+            if let Ok(mut cs) = self.0.connect_state.lock() {
+                cs.snapshot.fetch_ms = None;
+                cs.phase = ConnectPhase::Connected;
+                cs.reconnect_attempt = None;
+            }
+            self.notify_state_change();
         }
-        self.notify_state_change();
 
         self.reattach_terminals(&client).await;
 
@@ -1627,5 +1648,29 @@ impl SessionHandle {
     pub async fn terminal_list(&self) -> Result<Vec<String>> {
         let result: TermListResult = self.client()?.rpc(TermListReq {}).await?;
         Ok(result.terminals.into_iter().map(|e| e.id).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_session_info_requires_host_workdir_and_session_id() {
+        let mut snapshot = ConnectSnapshot {
+            hostname: Some("host".into()),
+            workdir: Some("/workspace".into()),
+            session_id: Some("sid-1".into()),
+            ..Default::default()
+        };
+
+        assert!(snapshot_has_cached_session_info(&snapshot));
+
+        snapshot.workdir = Some(String::new());
+        assert!(!snapshot_has_cached_session_info(&snapshot));
+
+        snapshot.workdir = Some("/workspace".into());
+        snapshot.session_id = None;
+        assert!(!snapshot_has_cached_session_info(&snapshot));
     }
 }

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -9,8 +9,8 @@ use anyhow::Result;
 use zedra_rpc::proto::*;
 
 use crate::connect_state::{
-    AuthOutcome, ConnectError, ConnectPhase, ConnectSnapshot, ConnectState, NetworkHint,
-    ReconnectReason, TransportSnapshot,
+    AuthOutcome, ConnectError, ConnectPhase, ConnectState, NetworkHint, ReconnectReason,
+    TransportSnapshot,
 };
 
 /// Classify a remote IP address for debugging display.
@@ -44,10 +44,18 @@ fn classify_ip(ip: std::net::IpAddr) -> NetworkHint {
 }
 use crate::{push_callback, session_runtime, signer::ClientSigner, terminal::RemoteTerminal};
 
-fn snapshot_has_cached_session_info(snapshot: &ConnectSnapshot) -> bool {
+#[cfg(test)]
+fn snapshot_has_cached_session_info(snapshot: &crate::connect_state::ConnectSnapshot) -> bool {
     snapshot.hostname.as_ref().is_some_and(|s| !s.is_empty())
         && snapshot.workdir.as_ref().is_some_and(|s| !s.is_empty())
         && snapshot.session_id.as_ref().is_some_and(|s| !s.is_empty())
+}
+
+#[derive(Clone, Debug)]
+struct SessionBootstrap {
+    session_id: String,
+    reconnect_token: [u8; 32],
+    terminals: Vec<TerminalSyncEntry>,
 }
 
 /// Workspace-scoped durable session state. Arc-wrapped — clone freely to share
@@ -63,6 +71,7 @@ struct SessionHandleInner {
     signer: Mutex<Option<Arc<dyn ClientSigner>>>,
     endpoint_id: Mutex<Option<iroh::PublicKey>>,
     pending_ticket: Mutex<Option<zedra_rpc::ZedraPairingTicket>>,
+    reconnect_token: Mutex<Option<[u8; 32]>>,
 
     // ── Live connection ──────────────────────────────────────────────────────
     client: Mutex<Option<irpc::Client<ZedraProto>>>,
@@ -111,6 +120,7 @@ impl SessionHandle {
             signer: Mutex::new(None),
             endpoint_id: Mutex::new(None),
             pending_ticket: Mutex::new(None),
+            reconnect_token: Mutex::new(None),
             client: Mutex::new(None),
             connect_state: Mutex::new(ConnectState::idle()),
             conn_generation: AtomicU64::new(0),
@@ -157,6 +167,16 @@ impl SessionHandle {
         if let Ok(mut slot) = self.0.pending_ticket.lock() {
             *slot = Some(ticket);
         }
+    }
+
+    pub fn set_reconnect_token(&self, token: Option<[u8; 32]>) {
+        if let Ok(mut slot) = self.0.reconnect_token.lock() {
+            *slot = token;
+        }
+    }
+
+    pub fn reconnect_token(&self) -> Option<[u8; 32]> {
+        self.0.reconnect_token.lock().ok().and_then(|g| *g)
     }
 
     pub fn set_endpoint_addr(&self, addr: iroh::EndpointAddr) {
@@ -324,6 +344,34 @@ impl SessionHandle {
             .and_then(|terms| terms.iter().find(|t| t.id == id).cloned())
     }
 
+    pub fn apply_sync_terminals(&self, entries: &[TerminalSyncEntry]) {
+        let mut terminals = match self.0.terminals.lock() {
+            Ok(terms) => terms,
+            Err(_) => return,
+        };
+
+        let mut by_id = terminals
+            .iter()
+            .cloned()
+            .map(|terminal| (terminal.id.clone(), terminal))
+            .collect::<std::collections::HashMap<_, _>>();
+
+        let mut ordered = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let terminal = by_id
+                .remove(&entry.id)
+                .unwrap_or_else(|| RemoteTerminal::new(entry.id.clone()));
+            terminal.update_seq(entry.last_seq);
+            if let Ok(mut meta) = terminal.meta.lock() {
+                meta.title = entry.title.clone();
+                meta.cwd = entry.cwd.clone();
+            }
+            ordered.push(terminal);
+        }
+
+        *terminals = ordered;
+    }
+
     // -----------------------------------------------------------------------
     // Cached host display fields (survive reconnect cycles)
     // -----------------------------------------------------------------------
@@ -360,11 +408,6 @@ impl SessionHandle {
             .lock()
             .map(|g| g.clone())
             .unwrap_or_default()
-    }
-
-    fn has_cached_session_info(&self) -> bool {
-        let cs = self.connect_state();
-        snapshot_has_cached_session_info(&cs.snapshot)
     }
 
     // -----------------------------------------------------------------------
@@ -668,16 +711,14 @@ impl SessionHandle {
             });
         }
 
-        // ── PKI auth phases (Registering → Authenticating → Proving) ─────
         let ticket = self.0.pending_ticket.lock().ok().and_then(|mut g| g.take());
         let session_id = self.session_id();
         let endpoint_id = self.endpoint_id().expect("endpoint_id stored above");
-
-        match self.signer() {
+        let bootstrap = match self.signer() {
             Some(signer) => {
                 let t_auth = Instant::now();
                 match self
-                    .authenticate(
+                    .bootstrap_session(
                         &client,
                         ticket.as_ref(),
                         signer.as_ref(),
@@ -686,54 +727,38 @@ impl SessionHandle {
                     )
                     .await
                 {
-                    Ok((sid, outcome)) => {
-                        if let Ok(mut slot) = self.0.sid.lock() {
-                            *slot = Some(sid.clone());
-                        }
+                    Ok((bootstrap, outcome)) => {
                         if let Ok(mut cs) = self.0.connect_state.lock() {
-                            cs.snapshot.session_id = Some(sid);
                             cs.snapshot.auth_outcome = Some(outcome);
                             cs.snapshot.auth_ms = Some(t_auth.elapsed().as_millis() as u64);
+                            cs.snapshot.fetch_ms = Some(0);
                         }
+                        bootstrap
                     }
                     Err(e) => {
-                        tracing::warn!("PKI auth failed: {e}");
+                        tracing::warn!("session bootstrap failed: {e}");
                         return Err(e);
                     }
                 }
             }
             None => {
                 tracing::warn!("No signer — skipping PKI auth (RPC calls will fail)");
+                let t_fetch = Instant::now();
+                let result = self.sync_session(&client).await?;
+                if let Ok(mut cs) = self.0.connect_state.lock() {
+                    cs.snapshot.fetch_ms = Some(t_fetch.elapsed().as_millis() as u64);
+                }
+                result
             }
+        };
+
+        self.apply_bootstrap(&bootstrap);
+
+        if let Ok(mut cs) = self.0.connect_state.lock() {
+            cs.phase = ConnectPhase::Connected;
+            cs.reconnect_attempt = None;
         }
-
-        let needs_session_info = !self.has_cached_session_info();
-        if needs_session_info {
-            // ── Phase: FetchingInfo ────────────────────────────────────────
-            {
-                let mut cs = self.0.connect_state.lock().unwrap();
-                cs.phase = ConnectPhase::FetchingInfo;
-            }
-            self.notify_state_change();
-
-            let t_fetch = Instant::now();
-            self.fetch_session_info(&client).await;
-
-            {
-                let mut cs = self.0.connect_state.lock().unwrap();
-                cs.snapshot.fetch_ms = Some(t_fetch.elapsed().as_millis() as u64);
-                cs.phase = ConnectPhase::Connected;
-                cs.reconnect_attempt = None;
-            }
-            self.notify_state_change();
-        } else {
-            if let Ok(mut cs) = self.0.connect_state.lock() {
-                cs.snapshot.fetch_ms = None;
-                cs.phase = ConnectPhase::Connected;
-                cs.reconnect_attempt = None;
-            }
-            self.notify_state_change();
-        }
+        self.notify_state_change();
 
         self.reattach_terminals(&client).await;
 
@@ -770,19 +795,51 @@ impl SessionHandle {
     // PKI auth (Registering → Authenticating → Proving)
     // -----------------------------------------------------------------------
 
-    async fn authenticate(
+    async fn bootstrap_session(
         &self,
         client: &irpc::Client<ZedraProto>,
         ticket: Option<&zedra_rpc::ZedraPairingTicket>,
         signer: &dyn ClientSigner,
         endpoint_id: &iroh::PublicKey,
         session_id: Option<&str>,
-    ) -> Result<(String, AuthOutcome)> {
+    ) -> Result<(SessionBootstrap, AuthOutcome)> {
         use ed25519_dalek::{Verifier, VerifyingKey};
         use std::time::{SystemTime, UNIX_EPOCH};
 
         let client_pubkey = signer.pubkey();
         let mut outcome = AuthOutcome::Authenticated;
+
+        if ticket.is_none() {
+            if let Some(token) = self.reconnect_token() {
+                if let Some(stored_session_id) = session_id.filter(|sid| !sid.is_empty()) {
+                    match client
+                        .rpc(ReconnectReq {
+                            client_pubkey,
+                            session_id: stored_session_id.to_string(),
+                            reconnect_token: token,
+                        })
+                        .await?
+                    {
+                        ReconnectResult::Ok(sync) => {
+                            tracing::info!("Reconnect token accepted, session={}", sync.session_id);
+                            return Ok((Self::bootstrap_from_sync(sync), outcome));
+                        }
+                        ReconnectResult::InvalidToken | ReconnectResult::SessionNotFound => {
+                            tracing::info!("Reconnect token rejected, falling back to PKI auth");
+                            self.set_reconnect_token(None);
+                        }
+                        ReconnectResult::Unauthorized | ReconnectResult::NotInSessionAcl => {
+                            self.set_failed(ConnectError::Unauthorized);
+                            return Err(anyhow::anyhow!("reconnect: Unauthorized"));
+                        }
+                        ReconnectResult::SessionOccupied => {
+                            self.set_failed(ConnectError::SessionOccupied);
+                            return Err(anyhow::anyhow!("reconnect: SessionOccupied"));
+                        }
+                    }
+                }
+            }
+        }
 
         // Step 1: Register (first pairing only).
         if let Some(t) = ticket {
@@ -881,7 +938,8 @@ impl SessionHandle {
         {
             AuthProveResult::Ok => {
                 tracing::info!("PKI: authenticated, session={}", attach_session_id);
-                Ok((attach_session_id, outcome))
+                let bootstrap = self.sync_session(client).await?;
+                Ok((bootstrap, outcome))
             }
             AuthProveResult::Unauthorized => {
                 self.set_failed(ConnectError::Unauthorized);
@@ -906,84 +964,45 @@ impl SessionHandle {
         }
     }
 
-    async fn fetch_session_info(&self, client: &irpc::Client<ZedraProto>) {
-        match client.rpc(SessionInfoReq {}).await {
-            Ok(info) => {
-                tracing::info!(
-                    "Session info: host={}, user={}, workdir={}",
-                    info.hostname,
-                    info.username,
-                    info.workdir,
-                );
-
-                // Update snapshot.
-                if let Ok(mut cs) = self.0.connect_state.lock() {
-                    cs.snapshot.hostname = Some(info.hostname.clone());
-                    cs.snapshot.username = Some(info.username.clone());
-                    cs.snapshot.workdir = Some(info.workdir.clone());
-                    cs.snapshot.os = info.os.clone();
-                    cs.snapshot.arch = info.arch.clone();
-                    cs.snapshot.os_version = info.os_version.clone();
-                    cs.snapshot.host_version = info.host_version.clone();
-                }
-
-                // Update cached fields (survive reconnect cycles for header display).
-                if !info.hostname.is_empty() {
-                    if let Ok(mut h) = self.0.hostname.lock() {
-                        *h = info.hostname.clone();
-                    }
-                }
-                if !info.workdir.is_empty() {
-                    let workdir = info.workdir.clone();
-                    let project = workdir.rsplit('/').next().unwrap_or(&workdir).to_string();
-
-                    // Cache raw workdir and derived project name.
-                    if let Ok(mut w) = self.0.workdir.lock() {
-                        *w = workdir.clone();
-                    }
-                    if let Ok(mut p) = self.0.project_name.lock() {
-                        *p = project;
-                    }
-
-                    // Cache home directory and a `~`-stripped display path.
-                    let home_dir = info.home_dir.clone().unwrap_or_default();
-                    if !home_dir.is_empty() {
-                        if let Ok(mut h) = self.0.homedir.lock() {
-                            *h = home_dir.clone();
-                        }
-                    }
-                    let display_path = if !home_dir.is_empty() {
-                        if let Some(rest) = workdir.strip_prefix(&home_dir) {
-                            format!("~{rest}")
-                        } else {
-                            workdir
-                        }
-                    } else {
-                        workdir
-                    };
-                    if let Ok(mut s) = self.0.strip_path.lock() {
-                        *s = display_path;
-                    }
-                }
-
-                // Store session ID if the server provided one and we don't have one yet.
-                if let Some(sid) = info.session_id {
-                    if let Ok(mut slot) = self.0.sid.lock() {
-                        if slot.is_none() {
-                            *slot = Some(sid.clone());
-                        }
-                    }
-                    if let Ok(mut cs) = self.0.connect_state.lock() {
-                        if cs.snapshot.session_id.is_none() {
-                            cs.snapshot.session_id = Some(sid);
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::warn!("session/info failed: {e}");
-            }
+    fn bootstrap_from_sync(sync: SyncSessionResult) -> SessionBootstrap {
+        SessionBootstrap {
+            session_id: sync.session_id,
+            reconnect_token: sync.reconnect_token,
+            terminals: sync.terminals,
         }
+    }
+
+    async fn sync_session(&self, client: &irpc::Client<ZedraProto>) -> Result<SessionBootstrap> {
+        {
+            let mut cs = self.0.connect_state.lock().unwrap();
+            cs.phase = ConnectPhase::FetchingInfo;
+        }
+        self.notify_state_change();
+
+        let sync = client.rpc(SyncSessionReq {}).await.map_err(|e| {
+            self.set_failed(ConnectError::SessionInfoFailed(e.to_string()));
+            anyhow::anyhow!("sync session failed: {e}")
+        })?;
+
+        Ok(Self::bootstrap_from_sync(sync))
+    }
+
+    fn apply_bootstrap(&self, bootstrap: &SessionBootstrap) {
+        if let Ok(mut slot) = self.0.sid.lock() {
+            *slot = Some(bootstrap.session_id.clone());
+        }
+        self.set_reconnect_token(Some(bootstrap.reconnect_token));
+
+        if let Ok(mut cs) = self.0.connect_state.lock() {
+            cs.snapshot.session_id = Some(bootstrap.session_id.clone());
+        }
+
+        if let Ok(mut cs) = self.0.connect_state.lock() {
+            cs.snapshot.hostname = Some(self.hostname());
+            cs.snapshot.workdir = Some(self.workdir());
+        }
+
+        self.apply_sync_terminals(&bootstrap.terminals);
     }
 
     // -----------------------------------------------------------------------
@@ -1654,6 +1673,7 @@ impl SessionHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ConnectSnapshot;
 
     #[test]
     fn cached_session_info_requires_host_workdir_and_session_id() {

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -412,6 +412,9 @@ impl ZedraApp {
         // handle.session_id() inside connect_with_iroh, and that
         // persist_current_workspaces() doesn't wipe the saved session_id from disk.
         session_handle.set_session_id(session_id);
+        if let Some(saved) = saved.as_ref() {
+            session_handle.set_reconnect_token(saved.reconnect_token());
+        }
 
         // Create the workspace view (creates its own terminal view + pending slots)
         let handle_for_view = session_handle.clone();
@@ -535,62 +538,21 @@ impl ZedraApp {
                 Ok(()) => {
                     tracing::info!("connected via iroh!");
 
-                    // Check for existing server-side terminals (session resume case).
-                    // If found, attach them and restore the UI; otherwise create a new terminal.
-                    match handle_for_connect.terminal_list().await {
-                        Ok(server_ids) if !server_ids.is_empty() => {
-                            tracing::info!(
-                                "Session resumed: attaching {} existing terminal(s)",
-                                server_ids.len()
-                            );
-                            handle_for_connect.set_resuming_terminals();
-                            let t_resume = std::time::Instant::now();
-                            let mut attached = Vec::new();
-                            for id in &server_ids {
-                                match handle_for_connect.terminal_attach_existing(id).await {
-                                    Ok(()) => attached.push(id.clone()),
-                                    Err(e) => {
-                                        tracing::warn!("Failed to attach terminal {}: {}", id, e)
-                                    }
-                                }
+                    let server_ids = handle_for_connect.terminal_ids();
+                    if !server_ids.is_empty() {
+                        tracing::info!(
+                            "Session resumed: attaching {} existing terminal(s)",
+                            server_ids.len()
+                        );
+                        pending_existing_terminals.set(server_ids);
+                    } else {
+                        match handle_for_connect.terminal_create(cols_u16, rows_u16).await {
+                            Ok(term_id) => {
+                                tracing::info!("Remote terminal created: {}", term_id);
+                                pending_term_id.set(term_id);
                             }
-                            let resume_ms = t_resume.elapsed().as_millis() as u64;
-                            if !attached.is_empty() {
-                                handle_for_connect.mark_connected_after_resume(resume_ms);
-                                pending_existing_terminals.set(attached);
-                            } else {
-                                // All attaches failed — fall back to creating a new terminal
-                                handle_for_connect.mark_connected_after_resume(resume_ms);
-                                match handle_for_connect.terminal_create(cols_u16, rows_u16).await {
-                                    Ok(term_id) => pending_term_id.set(term_id),
-                                    Err(e) => {
-                                        tracing::error!("Failed to create remote terminal: {}", e)
-                                    }
-                                }
-                            }
-                        }
-                        Ok(_) => {
-                            // No existing terminals (new session) — create one
-                            match handle_for_connect.terminal_create(cols_u16, rows_u16).await {
-                                Ok(term_id) => {
-                                    tracing::info!("Remote terminal created: {}", term_id);
-                                    pending_term_id.set(term_id);
-                                }
-                                Err(e) => {
-                                    tracing::error!("Failed to create remote terminal: {}", e)
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            tracing::warn!("terminal_list failed ({}), creating new terminal", e);
-                            match handle_for_connect.terminal_create(cols_u16, rows_u16).await {
-                                Ok(term_id) => {
-                                    tracing::info!("Remote terminal created: {}", term_id);
-                                    pending_term_id.set(term_id);
-                                }
-                                Err(e) => {
-                                    tracing::error!("Failed to create remote terminal: {}", e)
-                                }
+                            Err(e) => {
+                                tracing::error!("Failed to create remote terminal: {}", e)
                             }
                         }
                     }

--- a/crates/zedra/src/workspace_state.rs
+++ b/crates/zedra/src/workspace_state.rs
@@ -26,6 +26,7 @@ struct StoreFile {
 pub struct WorkspaceStateInner {
     pub endpoint_addr: String,
     pub session_id: String,
+    pub reconnect_token: Option<[u8; 32]>,
     pub strip_path: String,
     pub project_name: String,
     pub workdir: String,
@@ -180,6 +181,7 @@ impl WorkspaceState {
             // during the connecting phase, so we preserve saved info until the
             // connection succeeds and the server populates these fields.
             i.session_id = entry.inner().session_id.clone();
+            i.reconnect_token = entry.inner().reconnect_token;
             if !entry.inner().strip_path.is_empty() {
                 i.strip_path = entry.inner().strip_path.clone();
             }
@@ -227,6 +229,7 @@ impl WorkspaceState {
         Some(Self(Arc::new(WorkspaceStateInner {
             endpoint_addr: encoded,
             session_id: handle.session_id().unwrap_or_default(),
+            reconnect_token: handle.reconnect_token(),
             strip_path: handle.strip_path(),
             project_name: handle.project_name(),
             workdir: handle.workdir(),
@@ -273,6 +276,10 @@ impl WorkspaceState {
 
     pub fn session_id(&self) -> &str {
         &self.0.session_id
+    }
+
+    pub fn reconnect_token(&self) -> Option<[u8; 32]> {
+        self.0.reconnect_token
     }
 
     pub fn project_name(&self) -> &str {

--- a/crates/zedra/src/workspace_view.rs
+++ b/crates/zedra/src/workspace_view.rs
@@ -13,6 +13,7 @@ use crate::mgpui::DrawerHost;
 use crate::pending::{SharedPendingSlot, shared_pending_slot};
 use crate::platform_bridge::{self, AlertButton, status_bar_inset};
 use crate::theme;
+use crate::transport_badge::transport_badge_info;
 use crate::workspace_drawer::{WorkspaceDrawer, WorkspaceDrawerEvent};
 use zedra_session::SessionHandle;
 use zedra_terminal::view::{DisconnectRequested, TerminalView};
@@ -136,6 +137,17 @@ pub struct WorkspaceContent {
 }
 
 impl WorkspaceContent {
+    fn workspace_has_cached_context(state: &crate::workspace_state::WorkspaceState) -> bool {
+        !state.session_id().is_empty()
+            && (!state.project_name().is_empty()
+                || !state.hostname().is_empty()
+                || !state.strip_path().is_empty())
+    }
+
+    fn has_cached_workspace_context(&self) -> bool {
+        Self::workspace_has_cached_context(&self.workspace_state)
+    }
+
     pub fn new(
         main_view: AnyView,
         title: impl Into<SharedString>,
@@ -199,15 +211,16 @@ impl Focusable for WorkspaceContent {
 
 impl Render for WorkspaceContent {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        // Manage the full opaque overlay (initial connect, resume, failed).
+        // Keep reconnects inside the workspace once we already have session context.
+        // The full overlay is only useful for first connect / hard-failure states.
         let phase = self.session_handle.connect_phase();
-        let needs_full_overlay = !phase.is_connected() && !phase.is_idle();
+        let show_inline_status = self.has_cached_workspace_context()
+            && (phase.is_connecting() || phase.is_reconnecting() || phase.is_failed());
+        let needs_full_overlay = !phase.is_connected() && !phase.is_idle() && !show_inline_status;
 
         if needs_full_overlay {
-            // Active connect/failed phase — ensure full overlay is showing.
             self.overlay_visible = true;
         } else if self.overlay_visible {
-            // Connected — hide overlay immediately.
             self.overlay_visible = false;
         }
 
@@ -248,6 +261,11 @@ impl Render for WorkspaceContent {
             } else {
                 Some(name.into())
             }
+        };
+        let header_status = if show_inline_status {
+            Some(transport_badge_info(&self.session_handle.connect_state()))
+        } else {
+            None
         };
 
         div()
@@ -325,6 +343,35 @@ impl Render for WorkspaceContent {
                                     ),
                             ),
                     )
+                    .children(header_status.map(|(label, dot_color)| {
+                        div()
+                            .mr(px(4.0))
+                            .px(px(8.0))
+                            .py(px(4.0))
+                            .max_w(px(150.0))
+                            .min_w_0()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap(px(5.0))
+                            .rounded(px(999.0))
+                            .bg(theme::badge_bg())
+                            .child(
+                                div()
+                                    .w(px(theme::ICON_STATUS))
+                                    .h(px(theme::ICON_STATUS))
+                                    .rounded(px(3.0))
+                                    .bg(rgb(dot_color)),
+                            )
+                            .child(
+                                div()
+                                    .min_w_0()
+                                    .truncate()
+                                    .text_size(px(theme::FONT_DETAIL))
+                                    .text_color(rgb(dot_color))
+                                    .child(label),
+                            )
+                    }))
                     .child(
                         div()
                             .id("quick-action-btn")
@@ -1230,6 +1277,37 @@ impl Render for WorkspaceView {
         }
 
         div().size_full().child(self.drawer_host.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WorkspaceContent;
+    use crate::workspace_state::WorkspaceState;
+
+    #[test]
+    fn cached_workspace_context_requires_session_and_display_data() {
+        let with_context = WorkspaceState::update_inner(WorkspaceState::default(), |s| {
+            s.session_id = "session-1".into();
+            s.project_name = "zedra".into();
+        });
+        assert!(WorkspaceContent::workspace_has_cached_context(
+            &with_context
+        ));
+
+        let without_session = WorkspaceState::update_inner(WorkspaceState::default(), |s| {
+            s.project_name = "zedra".into();
+        });
+        assert!(!WorkspaceContent::workspace_has_cached_context(
+            &without_session
+        ));
+
+        let without_display_fields = WorkspaceState::update_inner(WorkspaceState::default(), |s| {
+            s.session_id = "session-1".into();
+        });
+        assert!(!WorkspaceContent::workspace_has_cached_context(
+            &without_display_fields
+        ));
     }
 }
 

--- a/docs/PROTOCOL_SPECS.md
+++ b/docs/PROTOCOL_SPECS.md
@@ -90,15 +90,25 @@ The protocol layer includes:
 1. `Register(RegisterReq)` with HMAC proof from QR ticket handshake secret.
 2. `Authenticate(AuthReq)` to request challenge nonce + host signature.
 3. `AuthProve(AuthProveReq)` with client signature and session attachment.
-4. Normal RPCs begin after success.
+4. `SyncSession(SyncSessionReq)` to fetch canonical session metadata, a fresh reconnect token, and terminal sync state.
+5. Normal RPCs begin after success.
 
 ### 4.2 Reconnect
 
+1. `Reconnect(ReconnectReq)` with the previously bootstrapped `(session_id, reconnect_token)`.
+2. If accepted, host attaches the session directly and returns `SyncSessionResult`.
+3. Client resumes normal RPCs and terminal streams using the returned terminal sync state.
+
+### 4.3 Reconnect fallback
+
+If `Reconnect` is rejected with `InvalidToken` or `SessionNotFound`, the client falls back to:
+
 1. `Authenticate(AuthReq)`
 2. `AuthProve(AuthProveReq)`
-3. Resume normal RPCs and terminal streams.
+3. `SyncSession(SyncSessionReq)`
+4. Resume normal RPCs and terminal streams.
 
-### 4.3 Health
+### 4.4 Health
 
 - `Ping(PingReq)` / `PongResult` used for RTT and liveness.
 
@@ -111,6 +121,7 @@ The protocol layer includes:
 - `Register(RegisterReq) -> RegisterResult`
 - `Authenticate(AuthReq) -> AuthChallengeResult`
 - `AuthProve(AuthProveReq) -> AuthProveResult`
+- `Reconnect(ReconnectReq) -> ReconnectResult`
 
 ## 5.2 Health
 
@@ -118,6 +129,7 @@ The protocol layer includes:
 
 ## 5.3 Session
 
+- `SyncSession(SyncSessionReq) -> SyncSessionResult`
 - `GetSessionInfo(SessionInfoReq) -> SessionInfoResult`
 - `ListSessions(SessionListReq) -> SessionListResult`
 - `SwitchSession(SessionSwitchReq) -> SessionSwitchResult`
@@ -159,12 +171,24 @@ The protocol layer includes:
 - `TermResize(TermResizeReq) -> TermResizeResult`
 - `TermClose(TermCloseReq) -> TermCloseResult`
 - `TermList(TermListReq) -> TermListResult`
+- `SyncSessionResult.terminals -> Vec<TerminalSyncEntry>`
 
 ### TermAttach conventions
 
 - Client passes `last_seq` to request backlog replay.
 - Host may replay missed output before live stream.
 - Output `seq` is monotonic per session backlog stream and used for gap detection.
+- `TerminalSyncEntry.last_seq` is the host's latest backlog sequence observed for that terminal at sync time.
+- Clients should keep local terminal tabs keyed by terminal id and use `last_seq` to seed reconnect `TermAttach` calls.
+
+### SyncSession conventions
+
+- `SyncSession` is the canonical bootstrap payload after a successful PKI attach.
+- Host rotates and returns a fresh `reconnect_token` on every successful `SyncSession` and `Reconnect`.
+- `session_id` in `SyncSessionResult` is authoritative and must replace any stale client-side session id.
+- `SyncSessionResult.terminals` is the authoritative server-side terminal set at bootstrap time.
+- `ReconnectReq.reconnect_token` is opaque, host-issued, session-bound, and client-bound.
+- Reconnect tokens are currently ephemeral host memory only; host restart may invalidate them and force PKI fallback.
 
 ## 5.6 Git
 
@@ -216,8 +240,8 @@ Client rules:
 - Avoid breaking wire compatibility unless absolutely required.
 - Prefer additive evolution:
   - Add new enum variants
-  - Add new optional fields
   - Add new RPC calls instead of repurposing old semantics
+- With postcard-encoded structs, prefer new request/response types over widening existing structs when mixed-version decoding matters.
 
 ### 7.2 Breaking Changes
 
@@ -312,4 +336,16 @@ Any protocol-layer change must include all applicable steps:
 - Added compatibility guard:
   - observer RPCs auto-disable client-side on protocol decode/variant mismatch,
     returning `Unsupported` instead of repeatedly retrying incompatible calls.
+
+### 2026-03-26
+
+- Added fast reconnect bootstrap RPC:
+  - `Reconnect(ReconnectReq) -> ReconnectResult`
+- Added canonical session bootstrap RPC:
+  - `SyncSession(SyncSessionReq) -> SyncSessionResult`
+- Added `TerminalSyncEntry` to return resumable terminal ids + latest backlog sequence + cached title/CWD.
+- Updated connection lifecycle:
+  - first pairing and PKI fallback now end with `SyncSession`
+  - reconnect may skip `Authenticate/AuthProve` entirely when a valid reconnect token is present
+- Added rotating host-issued reconnect tokens bound to `(session_id, client_pubkey)`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a real reconnect-token protocol path with `Reconnect` and `SyncSession` RPCs so resumed sessions can skip the PKI handshake path on successful token validation
- implement host-side token issuance/validation/rotation plus synced terminal bootstrap payloads in `zedra-host`
- persist reconnect tokens on the client and use the new fast reconnect path from `zedra-session` / app workspace state
- update `docs/PROTOCOL_SPECS.md` to document the new reconnect contract and bootstrap flow

## Testing
- cargo check -p zedra-rpc -p zedra-session -p zedra-host -p zedra
- cargo test -p zedra-rpc --lib
- cargo test -p zedra-session --lib
- cargo test -p zedra-host --lib reconnect_token -- --nocapture
- cargo test -p zedra --lib workspace_view::tests -- --nocapture
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7776a0f6-a347-41bc-8c85-dae87275c7ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7776a0f6-a347-41bc-8c85-dae87275c7ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

