### PR TITLE
feat: expand OSC parsing for agent terminal metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10127,6 +10127,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "tree-sitter-yaml",
+ "zedra-osc",
  "zedra-rpc",
  "zedra-session",
  "zedra-telemetry",

--- a/crates/zedra-osc/src/lib.rs
+++ b/crates/zedra-osc/src/lib.rs
@@ -1,11 +1,16 @@
 /// State machine that scans raw PTY bytes for OSC sequences across chunk
 /// boundaries (split packets). Handles both BEL (0x07) and ST (ESC `\`)
-/// terminators. Only OSC 0, 2, 7, and 133 are decoded; all others are
-/// silently ignored.
+/// terminators. Only a known subset of OSC numbers are decoded; unknown
+/// sequences are silently dropped.
 #[derive(Default)]
 pub struct OscScanner {
     state: ScanState,
 }
+
+/// Guard against pathological producers that emit huge OSC bodies
+/// (e.g. inline image payloads we don't handle). Once the in-progress
+/// buffer exceeds this, the scanner drops the sequence and resets.
+const MAX_OSC_BODY: usize = 64 * 1024;
 
 #[derive(Default)]
 enum ScanState {
@@ -19,15 +24,77 @@ enum ScanState {
     },
 }
 
-/// An event decoded from an OSC escape sequence.
+/// Source terminal that emitted a notification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotificationSource {
+    /// OSC 9 — iTerm-style simple notification.
+    Osc9,
+    /// OSC 99 — Kitty rich notification.
+    Osc99,
+    /// OSC 777;notify — rxvt/urxvt style.
+    Osc777,
+}
+
+/// ConEmu/Ghostty OSC 9;4 progress state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProgressState {
+    /// State 0 — no progress, clear any existing indicator.
+    Inactive,
+    /// State 1 — normal progress.
+    Normal,
+    /// State 2 — error state.
+    Error,
+    /// State 3 — indeterminate ("spinner").
+    Indeterminate,
+    /// State 4 — warning / paused.
+    Warning,
+}
+
+/// A progress report emitted by OSC 9;4.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProgressReport {
+    pub state: ProgressState,
+    /// Percentage 0..=100 when applicable; `None` for Inactive/Indeterminate.
+    pub value: Option<u8>,
+}
+
+/// An event decoded from an OSC escape sequence in the PTY byte stream.
 #[derive(Debug, Clone)]
 pub enum OscEvent {
+    /// OSC 0 / OSC 2 — window / tab title set by the shell.
     Title(String),
+    /// OSC 0 / OSC 2 with empty argument — reset to default title.
     ResetTitle,
+    /// OSC 1 — icon name (some shells treat this as a secondary label).
+    IconName(String),
+    /// OSC 7 / OSC 633;P;Cwd / OSC 1337;CurrentDir — current working directory.
     Cwd(String),
+    /// OSC 133;A or 133;B / OSC 633;A or 633;B — shell at a prompt.
     PromptReady,
+    /// OSC 133;C / OSC 633;C — a command has started executing.
     CommandStart,
+    /// OSC 133;D / OSC 633;D — a command finished; carries its exit code.
     CommandEnd { exit_code: i32 },
+    /// OSC 633;E — VS Code shell integration escaped command line.
+    CommandLine(String),
+    /// OSC 633;P;<key>=<value> — VS Code shell integration property.
+    ShellProperty { key: String, value: String },
+    /// OSC 9 / OSC 99 / OSC 777;notify — desktop notification.
+    Notification {
+        title: Option<String>,
+        body: String,
+        source: NotificationSource,
+    },
+    /// OSC 9;4 — progress indicator.
+    Progress(ProgressReport),
+    /// OSC 1337;RemoteHost=... — iTerm2 shell integration remote host.
+    RemoteHost(String),
+    /// OSC 1337;ShellIntegrationVersion=... — iTerm2 shell integration version.
+    ShellIntegrationVersion(String),
+    /// OSC 1337;shell=... — shell name paired with ShellIntegrationVersion.
+    ShellName(String),
+    /// OSC 1337;SetUserVar=<name>=<base64> — user variable (raw, base64-encoded).
+    UserVar { key: String, value_b64: String },
 }
 
 impl OscScanner {
@@ -69,27 +136,27 @@ impl OscScanner {
                     if esc_pending {
                         match b {
                             b'\\' => {
-                                if let Some(ev) = parse_osc(&buf) {
-                                    events.push(ev);
-                                }
+                                parse_osc_into(&buf, &mut events);
                                 ScanState::Idle
                             }
                             b']' => ScanState::SawBracket,
                             _ => {
                                 buf.push(0x1B);
                                 buf.push(b);
-                                ScanState::CollectingOsc {
-                                    buf,
-                                    esc_pending: false,
+                                if buf.len() > MAX_OSC_BODY {
+                                    ScanState::Idle
+                                } else {
+                                    ScanState::CollectingOsc {
+                                        buf,
+                                        esc_pending: false,
+                                    }
                                 }
                             }
                         }
                     } else {
                         match b {
                             0x07 => {
-                                if let Some(ev) = parse_osc(&buf) {
-                                    events.push(ev);
-                                }
+                                parse_osc_into(&buf, &mut events);
                                 ScanState::Idle
                             }
                             0x1B => ScanState::CollectingOsc {
@@ -98,9 +165,13 @@ impl OscScanner {
                             },
                             _ => {
                                 buf.push(b);
-                                ScanState::CollectingOsc {
-                                    buf,
-                                    esc_pending: false,
+                                if buf.len() > MAX_OSC_BODY {
+                                    ScanState::Idle
+                                } else {
+                                    ScanState::CollectingOsc {
+                                        buf,
+                                        esc_pending: false,
+                                    }
                                 }
                             }
                         }
@@ -116,30 +187,137 @@ impl OscScanner {
     }
 }
 
-fn parse_osc(buf: &[u8]) -> Option<OscEvent> {
-    let sep = buf.iter().position(|&b| b == b';')?;
+/// Parse a completed OSC body (bytes between `]` and the terminator).
+/// The body has the form `<num>;<rest>` where `<rest>` is sequence-specific.
+/// Some sequences (633, 1337) can emit multiple logical events from one
+/// body, so this takes an output vec instead of returning `Option`.
+fn parse_osc_into(buf: &[u8], out: &mut Vec<OscEvent>) {
+    let Some(sep) = buf.iter().position(|&b| b == b';') else {
+        return;
+    };
     let num = &buf[..sep];
     let body = &buf[sep + 1..];
+
     match num {
         b"0" | b"2" => {
-            let title = std::str::from_utf8(body).ok()?.trim().to_owned();
-            if title.is_empty() {
-                Some(OscEvent::ResetTitle)
-            } else {
-                Some(OscEvent::Title(title))
+            if let Ok(s) = std::str::from_utf8(body) {
+                let title = s.trim_end_matches('\0').to_owned();
+                if title.is_empty() {
+                    out.push(OscEvent::ResetTitle);
+                } else {
+                    out.push(OscEvent::Title(title));
+                }
+            }
+        }
+        b"1" => {
+            if let Ok(s) = std::str::from_utf8(body) {
+                let name = s.trim_end_matches('\0').to_owned();
+                if !name.is_empty() {
+                    out.push(OscEvent::IconName(name));
+                }
             }
         }
         b"7" => {
-            let url = std::str::from_utf8(body).ok()?;
-            let path = parse_cwd_url(url.trim())?;
-            Some(OscEvent::Cwd(path))
+            if let Ok(url) = std::str::from_utf8(body) {
+                if let Some(path) = parse_cwd_url(url.trim()) {
+                    out.push(OscEvent::Cwd(path));
+                }
+            }
         }
-        b"133" => parse_osc_133(body),
-        _ => None,
+        b"9" => parse_osc_9(body, out),
+        b"99" => parse_osc_99(body, out),
+        b"133" => {
+            if let Some(ev) = parse_osc_133_or_633(body) {
+                out.push(ev);
+            }
+        }
+        b"633" => parse_osc_633(body, out),
+        b"777" => parse_osc_777(body, out),
+        b"1337" => parse_osc_1337(body, out),
+        _ => {}
     }
 }
 
-fn parse_osc_133(body: &[u8]) -> Option<OscEvent> {
+/// OSC 9 — either a simple notification (`9;<body>`) or a ConEmu progress
+/// report (`9;4;<state>[;<value>]`).
+fn parse_osc_9(body: &[u8], out: &mut Vec<OscEvent>) {
+    // Progress form: `4;<state>[;<value>]`. Strip the leading `4` and an
+    // optional `;`, then delegate.
+    if let Some(rest) = body.strip_prefix(b"4") {
+        let rest = rest.strip_prefix(b";").unwrap_or(rest);
+        parse_osc_9_4(rest, out);
+        return;
+    }
+    if let Ok(s) = std::str::from_utf8(body) {
+        let text = s.to_owned();
+        if !text.is_empty() {
+            out.push(OscEvent::Notification {
+                title: None,
+                body: text,
+                source: NotificationSource::Osc9,
+            });
+        }
+    }
+}
+
+fn parse_osc_9_4(body: &[u8], out: &mut Vec<OscEvent>) {
+    let Ok(s) = std::str::from_utf8(body) else {
+        return;
+    };
+    let mut parts = s.split(';');
+    let Some(state_s) = parts.next() else {
+        return;
+    };
+    let value = parts
+        .next()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .map(|v| v.min(100) as u8);
+    let state = match state_s.trim() {
+        "0" | "" => ProgressState::Inactive,
+        "1" => ProgressState::Normal,
+        "2" => ProgressState::Error,
+        "3" => ProgressState::Indeterminate,
+        "4" => ProgressState::Warning,
+        _ => return,
+    };
+    let report = ProgressReport {
+        state,
+        value: match state {
+            ProgressState::Inactive | ProgressState::Indeterminate => None,
+            _ => value,
+        },
+    };
+    out.push(OscEvent::Progress(report));
+}
+
+/// OSC 99 — Kitty rich notification. Body form: `<params>:<payload>`.
+/// We only surface title (`d=`) and body (the payload), ignoring IDs,
+/// actions, and close events for now.
+fn parse_osc_99(body: &[u8], out: &mut Vec<OscEvent>) {
+    let Ok(s) = std::str::from_utf8(body) else {
+        return;
+    };
+    let (params, payload) = match s.split_once(':') {
+        Some((p, r)) => (p, r),
+        None => ("", s),
+    };
+    if payload.is_empty() {
+        return;
+    }
+    let title = params
+        .split(':')
+        .find_map(|kv| kv.strip_prefix("d="))
+        .map(|t| t.to_owned());
+    out.push(OscEvent::Notification {
+        title,
+        body: payload.to_owned(),
+        source: NotificationSource::Osc99,
+    });
+}
+
+/// Parse the body of an OSC 133 / 633 semantic prompt sequence.
+/// Body format: `<mark>[;<params>]` where mark is A / B / C / D.
+fn parse_osc_133_or_633(body: &[u8]) -> Option<OscEvent> {
     match *body.first()? {
         b'A' | b'B' => Some(OscEvent::PromptReady),
         b'C' => Some(OscEvent::CommandStart),
@@ -155,6 +333,186 @@ fn parse_osc_133(body: &[u8]) -> Option<OscEvent> {
             Some(OscEvent::CommandEnd { exit_code })
         }
         _ => None,
+    }
+}
+
+/// OSC 633 — VS Code shell integration. Marks A..D share semantics with
+/// 133; E carries the escaped command line; P carries a `key=value`
+/// property.
+fn parse_osc_633(body: &[u8], out: &mut Vec<OscEvent>) {
+    let Some(&mark) = body.first() else {
+        return;
+    };
+    match mark {
+        b'A' | b'B' | b'C' | b'D' => {
+            if let Some(ev) = parse_osc_133_or_633(body) {
+                out.push(ev);
+            }
+        }
+        b'E' => {
+            // `E;<escaped-cmd>[;<nonce>]`. VS Code escapes `\` and `;`
+            // inside the command with a backslash prefix.
+            if body.len() < 2 || body[1] != b';' {
+                return;
+            }
+            let rest = &body[2..];
+            let (cmd_raw, _nonce) = split_unescaped_semi(rest);
+            if let Ok(cmd_s) = std::str::from_utf8(cmd_raw) {
+                let cmd = unescape_osc633(cmd_s);
+                if !cmd.is_empty() {
+                    out.push(OscEvent::CommandLine(cmd));
+                }
+            }
+        }
+        b'P' => {
+            // `P;<key>=<value>`.
+            if body.len() < 2 || body[1] != b';' {
+                return;
+            }
+            let kv = &body[2..];
+            if let Ok(s) = std::str::from_utf8(kv) {
+                if let Some((k, v)) = s.split_once('=') {
+                    // Cwd key is surfaced as a strongly-typed Cwd event too.
+                    if k.eq_ignore_ascii_case("Cwd") {
+                        out.push(OscEvent::Cwd(unescape_osc633(v)));
+                    }
+                    out.push(OscEvent::ShellProperty {
+                        key: k.to_owned(),
+                        value: unescape_osc633(v),
+                    });
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Split a 633;E payload on the first *unescaped* `;`. Returns
+/// `(command_bytes, nonce_bytes)`.
+fn split_unescaped_semi(body: &[u8]) -> (&[u8], &[u8]) {
+    let mut i = 0;
+    while i < body.len() {
+        if body[i] == b'\\' && i + 1 < body.len() {
+            i += 2;
+            continue;
+        }
+        if body[i] == b';' {
+            return (&body[..i], &body[i + 1..]);
+        }
+        i += 1;
+    }
+    (body, &[])
+}
+
+/// Undo the `\xNN` / `\\` / `\;` style escaping used by OSC 633 payloads.
+/// Also decodes `\x20`-style sequences that VS Code emits for control chars.
+///
+/// Preserves multi-byte UTF-8: non-`\`-prefixed runs are copied as string
+/// slices; only bytes produced from `\xNN` escapes go through per-byte
+/// decoding (legal, since they always encode ASCII-range control chars).
+fn unescape_osc633(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(bytes.len());
+    let mut i = 0;
+    let mut run_start = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'\\' || i + 1 >= bytes.len() {
+            i += 1;
+            continue;
+        }
+        let next = bytes[i + 1];
+        let (consumed, replacement): (usize, Option<char>) = match next {
+            b'x' if i + 3 < bytes.len() => {
+                let hi = (bytes[i + 2] as char).to_digit(16);
+                let lo = (bytes[i + 3] as char).to_digit(16);
+                match (hi, lo) {
+                    (Some(h), Some(l)) => (4, Some(((h * 16 + l) as u8) as char)),
+                    _ => (0, None),
+                }
+            }
+            b'\\' => (2, Some('\\')),
+            b';' => (2, Some(';')),
+            _ => (0, None),
+        };
+        if consumed == 0 {
+            i += 1;
+            continue;
+        }
+        if run_start < i {
+            out.push_str(std::str::from_utf8(&bytes[run_start..i]).unwrap_or(""));
+        }
+        if let Some(ch) = replacement {
+            out.push(ch);
+        }
+        i += consumed;
+        run_start = i;
+    }
+    if run_start < bytes.len() {
+        out.push_str(std::str::from_utf8(&bytes[run_start..]).unwrap_or(""));
+    }
+    out
+}
+
+/// OSC 777;<subcmd>[;<args>]. We only handle `notify;<title>;<body>`.
+fn parse_osc_777(body: &[u8], out: &mut Vec<OscEvent>) {
+    let Ok(s) = std::str::from_utf8(body) else {
+        return;
+    };
+    let mut parts = s.splitn(3, ';');
+    let Some(sub) = parts.next() else {
+        return;
+    };
+    if !sub.eq_ignore_ascii_case("notify") {
+        return;
+    }
+    let title = parts.next().map(|t| t.to_owned()).filter(|t| !t.is_empty());
+    let body_s = parts.next().unwrap_or("").to_owned();
+    if title.is_none() && body_s.is_empty() {
+        return;
+    }
+    out.push(OscEvent::Notification {
+        title,
+        body: body_s,
+        source: NotificationSource::Osc777,
+    });
+}
+
+/// OSC 1337 — iTerm2 family. Body is typically `<key>=<value>`, optionally
+/// with additional `;key=value` pairs. We decode a small allowlist.
+fn parse_osc_1337(body: &[u8], out: &mut Vec<OscEvent>) {
+    let Ok(s) = std::str::from_utf8(body) else {
+        return;
+    };
+    let (head, rest) = match s.split_once(';') {
+        Some((h, r)) => (h, r),
+        None => (s, ""),
+    };
+    dispatch_1337_pair(head, out);
+    for pair in rest.split(';').filter(|p| !p.is_empty()) {
+        dispatch_1337_pair(pair, out);
+    }
+}
+
+fn dispatch_1337_pair(pair: &str, out: &mut Vec<OscEvent>) {
+    let Some((key, value)) = pair.split_once('=') else {
+        return;
+    };
+    let key_trim = key.trim();
+    if key_trim.eq_ignore_ascii_case("CurrentDir") {
+        out.push(OscEvent::Cwd(value.to_owned()));
+    } else if key_trim.eq_ignore_ascii_case("RemoteHost") {
+        out.push(OscEvent::RemoteHost(value.to_owned()));
+    } else if key_trim.eq_ignore_ascii_case("ShellIntegrationVersion") {
+        out.push(OscEvent::ShellIntegrationVersion(value.to_owned()));
+    } else if key_trim.eq_ignore_ascii_case("shell") {
+        out.push(OscEvent::ShellName(value.to_owned()));
+    } else if key_trim.eq_ignore_ascii_case("SetUserVar") {
+        if let Some((var_key, var_val)) = value.split_once('=') {
+            out.push(OscEvent::UserVar {
+                key: var_key.to_owned(),
+                value_b64: var_val.to_owned(),
+            });
+        }
     }
 }
 
@@ -189,4 +547,209 @@ fn percent_decode(s: &str) -> String {
         i += 1;
     }
     out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn feed_all(bytes: &[u8]) -> Vec<OscEvent> {
+        let mut s = OscScanner::new();
+        s.feed(bytes)
+    }
+
+    fn feed_chunks(chunks: &[&[u8]]) -> Vec<OscEvent> {
+        let mut s = OscScanner::new();
+        let mut all = Vec::new();
+        for c in chunks {
+            all.extend(s.feed(c));
+        }
+        all
+    }
+
+    #[test]
+    fn parses_title_bel() {
+        let ev = feed_all(b"\x1b]2;hello\x07");
+        assert!(matches!(&ev[..], [OscEvent::Title(t)] if t == "hello"));
+    }
+
+    #[test]
+    fn parses_title_st() {
+        let ev = feed_all(b"\x1b]0;hi\x1b\\");
+        assert!(matches!(&ev[..], [OscEvent::Title(t)] if t == "hi"));
+    }
+
+    #[test]
+    fn parses_icon_name() {
+        let ev = feed_all(b"\x1b]1;bash\x07");
+        assert!(matches!(&ev[..], [OscEvent::IconName(n)] if n == "bash"));
+    }
+
+    #[test]
+    fn parses_cwd() {
+        let ev = feed_all(b"\x1b]7;file:///home/user\x07");
+        assert!(matches!(&ev[..], [OscEvent::Cwd(p)] if p == "/home/user"));
+    }
+
+    #[test]
+    fn parses_osc_133() {
+        let ev = feed_all(b"\x1b]133;A\x07\x1b]133;C\x07\x1b]133;D;17\x07");
+        assert_eq!(ev.len(), 3);
+        assert!(matches!(ev[0], OscEvent::PromptReady));
+        assert!(matches!(ev[1], OscEvent::CommandStart));
+        assert!(matches!(ev[2], OscEvent::CommandEnd { exit_code: 17 }));
+    }
+
+    #[test]
+    fn parses_osc_633_chain() {
+        let ev = feed_all(b"\x1b]633;A\x07\x1b]633;E;ls -la\x07\x1b]633;C\x07\x1b]633;D;0\x07");
+        assert!(matches!(ev[0], OscEvent::PromptReady));
+        assert!(matches!(&ev[1], OscEvent::CommandLine(c) if c == "ls -la"));
+        assert!(matches!(ev[2], OscEvent::CommandStart));
+        assert!(matches!(ev[3], OscEvent::CommandEnd { exit_code: 0 }));
+    }
+
+    #[test]
+    fn parses_osc_633_property_cwd() {
+        let ev = feed_all(b"\x1b]633;P;Cwd=/tmp\x07");
+        assert_eq!(ev.len(), 2);
+        assert!(matches!(&ev[0], OscEvent::Cwd(p) if p == "/tmp"));
+        assert!(matches!(
+            &ev[1],
+            OscEvent::ShellProperty { key, value } if key == "Cwd" && value == "/tmp"
+        ));
+    }
+
+    #[test]
+    fn decodes_633_e_escapes() {
+        // `\;` becomes `;`, `\\` becomes `\`, `\x20` becomes space.
+        let ev = feed_all(b"\x1b]633;E;echo hi\\x20bye\\;ls\x07");
+        assert!(matches!(&ev[0], OscEvent::CommandLine(c) if c == "echo hi bye;ls"));
+    }
+
+    #[test]
+    fn preserves_utf8_in_633_e() {
+        // Multi-byte UTF-8 (café, 日本語) must round-trip unharmed.
+        let mut bytes = b"\x1b]633;E;echo caf\xc3\xa9 ".to_vec();
+        bytes.extend_from_slice("日本語".as_bytes());
+        bytes.push(0x07);
+        let ev = feed_all(&bytes);
+        assert!(matches!(&ev[0], OscEvent::CommandLine(c) if c == "echo café 日本語"));
+    }
+
+    #[test]
+    fn parses_osc_9_notification() {
+        let ev = feed_all(b"\x1b]9;done\x07");
+        assert!(matches!(
+            &ev[0],
+            OscEvent::Notification { title: None, body, source: NotificationSource::Osc9 }
+                if body == "done"
+        ));
+    }
+
+    #[test]
+    fn parses_osc_9_4_progress_normal() {
+        let ev = feed_all(b"\x1b]9;4;1;42\x07");
+        assert!(matches!(
+            ev[0],
+            OscEvent::Progress(ProgressReport {
+                state: ProgressState::Normal,
+                value: Some(42)
+            })
+        ));
+    }
+
+    #[test]
+    fn parses_osc_9_4_progress_clear() {
+        let ev = feed_all(b"\x1b]9;4;0\x07");
+        assert!(matches!(
+            ev[0],
+            OscEvent::Progress(ProgressReport {
+                state: ProgressState::Inactive,
+                value: None
+            })
+        ));
+    }
+
+    #[test]
+    fn parses_osc_99_with_title() {
+        let ev = feed_all(b"\x1b]99;d=Build:completed\x1b\\");
+        assert!(matches!(
+            &ev[0],
+            OscEvent::Notification {
+                title: Some(t),
+                body,
+                source: NotificationSource::Osc99,
+            } if t == "Build" && body == "completed"
+        ));
+    }
+
+    #[test]
+    fn parses_osc_777() {
+        let ev = feed_all(b"\x1b]777;notify;Alert;Body text\x07");
+        assert!(matches!(
+            &ev[0],
+            OscEvent::Notification {
+                title: Some(t),
+                body,
+                source: NotificationSource::Osc777,
+            } if t == "Alert" && body == "Body text"
+        ));
+    }
+
+    #[test]
+    fn parses_osc_1337_remote_host() {
+        let ev = feed_all(b"\x1b]1337;RemoteHost=user@box\x07");
+        assert!(matches!(&ev[0], OscEvent::RemoteHost(h) if h == "user@box"));
+    }
+
+    #[test]
+    fn parses_osc_1337_current_dir() {
+        let ev = feed_all(b"\x1b]1337;CurrentDir=/tmp\x07");
+        assert!(matches!(&ev[0], OscEvent::Cwd(p) if p == "/tmp"));
+    }
+
+    #[test]
+    fn parses_osc_1337_shell_integration_version() {
+        let ev = feed_all(b"\x1b]1337;ShellIntegrationVersion=5;shell=bash\x07");
+        let mut saw_ver = false;
+        let mut saw_shell = false;
+        for e in &ev {
+            match e {
+                OscEvent::ShellIntegrationVersion(v) if v == "5" => saw_ver = true,
+                OscEvent::ShellName(n) if n == "bash" => saw_shell = true,
+                _ => {}
+            }
+        }
+        assert!(saw_ver && saw_shell, "events: {ev:?}");
+    }
+
+    #[test]
+    fn parses_osc_1337_set_user_var() {
+        let ev = feed_all(b"\x1b]1337;SetUserVar=myKey=aGVsbG8=\x07");
+        assert!(matches!(
+            &ev[0],
+            OscEvent::UserVar { key, value_b64 } if key == "myKey" && value_b64 == "aGVsbG8="
+        ));
+    }
+
+    #[test]
+    fn handles_chunked_osc_across_feeds() {
+        let ev = feed_chunks(&[b"\x1b]2;par", b"tial\x07rest"]);
+        assert!(matches!(&ev[..], [OscEvent::Title(t)] if t == "partial"));
+    }
+
+    #[test]
+    fn drops_oversized_body() {
+        let mut bytes = Vec::with_capacity(MAX_OSC_BODY + 64);
+        bytes.extend_from_slice(b"\x1b]2;");
+        bytes.extend(std::iter::repeat(b'A').take(MAX_OSC_BODY + 32));
+        bytes.push(0x07);
+        let ev = feed_all(&bytes);
+        assert!(ev.is_empty(), "oversized OSC should be dropped");
+    }
 }

--- a/crates/zedra/Cargo.toml
+++ b/crates/zedra/Cargo.toml
@@ -49,6 +49,7 @@ tree-sitter-php = "0.24"
 # Workspace crates
 zedra-session = { path = "../zedra-session" }
 zedra-terminal = { path = "../zedra-terminal" }
+zedra-osc = { path = "../zedra-osc" }
 zedra-rpc = { path = "../zedra-rpc" }
 zedra-telemetry.workspace = true
 iroh.workspace = true

--- a/crates/zedra/src/terminal_card.rs
+++ b/crates/zedra/src/terminal_card.rs
@@ -47,30 +47,32 @@ fn cwd_last(cwd: &str) -> &str {
         .unwrap_or(cwd)
 }
 
-/// Detect a known AI agent from the raw OSC 2 title and return its brand icon path.
-/// Returns `None` when the title doesn't match any known agent.
-fn agent_icon(title: Option<&str>) -> Option<&'static str> {
-    let title = title.as_deref().unwrap_or("");
-    let t = title.to_ascii_lowercase();
-    if t.contains("claude") {
-        Some("icons/claude.svg")
-    } else if t.contains("opencode") || title.contains("OC |") {
-        Some("icons/opencode.svg")
-    } else if t.contains("codex") || t.contains("openai") {
-        Some("icons/openai.svg")
-    } else if t.contains("gemini") {
-        Some("icons/gemini.svg")
-    } else if t.contains("copilot") {
-        Some("icons/copilot.svg")
-    } else {
-        None
+/// Detect a known AI agent from the OSC 2 title or the running command line
+/// and return its brand icon path. Title takes precedence — agents like Claude
+/// Code set a descriptive title, but some CLIs only surface the command name.
+/// Returns `None` when neither source matches a known agent.
+pub fn agent_icon(title: Option<&str>, command: Option<&str>) -> Option<&'static str> {
+    for raw in [title, command].into_iter().flatten() {
+        let low = raw.to_ascii_lowercase();
+        if low.contains("claude") {
+            return Some("icons/claude.svg");
+        } else if low.contains("opencode") || raw.contains("OC |") {
+            return Some("icons/opencode.svg");
+        } else if low.contains("codex") || low.contains("openai") {
+            return Some("icons/openai.svg");
+        } else if low.contains("gemini") {
+            return Some("icons/gemini.svg");
+        } else if low.contains("copilot") {
+            return Some("icons/copilot.svg");
+        }
     }
+    None
 }
 
 /// Strip the `user@host:` prefix that default PS1 configs embed in OSC 2 titles.
 /// `alice@mybox:~/projects/zedra` → `~/projects/zedra`
 /// Returns the original string unchanged if no such prefix is found.
-fn strip_ps1_prefix(title: &str) -> &str {
+pub fn strip_ps1_prefix(title: &str) -> &str {
     if let Some(at) = title.find('@') {
         if let Some(colon_offset) = title[at..].find(':') {
             let path = &title[at + colon_offset + 1..];
@@ -117,7 +119,7 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
     let card_id = SharedString::from(format!("term-card-{}", props.id));
     let close_btn_id = SharedString::from(format!("term-close-{}", props.id));
     let is_active = props.is_active;
-    let icon_path = agent_icon(props.title.as_deref()).unwrap_or("icons/terminal.svg");
+    let icon_path = agent_icon(props.title.as_deref(), None).unwrap_or("icons/terminal.svg");
 
     // Build the right-side indicator up front so we can move on_close without borrow issues.
     let right_element: AnyElement = if let Some(close_fn) = props.on_close {

--- a/crates/zedra/src/terminal_state.rs
+++ b/crates/zedra/src/terminal_state.rs
@@ -14,6 +14,8 @@ pub struct TerminalMeta {
     pub cwd: Option<String>,
     pub last_exit_code: Option<i32>,
     pub shell_state: ShellState,
+    /// Last command line reported by OSC 633;E. Cleared when the shell returns to prompt.
+    pub current_command: Option<String>,
 }
 
 /// App-level entity that holds live terminal metadata (title, cwd, shell state)
@@ -56,6 +58,11 @@ impl TerminalState {
         if let Some(code) = exit_code {
             e.last_exit_code = Some(code);
         }
+        e.current_command = None;
+    }
+
+    pub fn set_current_command(&mut self, id: &str, command: String) {
+        self.entry(id).current_command = Some(command);
     }
 
     fn entry(&mut self, id: &str) -> &mut TerminalMeta {

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -10,6 +10,7 @@ use zedra_session::{ConnectEvent, Session, SessionHandle, SessionState, signer::
 use crate::active_terminal;
 use crate::editor::git_sidebar::GitFileSection;
 use crate::platform_bridge::{self, AlertButton, HapticFeedback, status_bar_inset};
+use crate::terminal_card::{agent_icon, strip_ps1_prefix};
 use crate::terminal_state::TerminalState;
 use crate::theme;
 use crate::transport_badge::phase_indicator_color;
@@ -75,6 +76,7 @@ impl Workspace {
         let content = cx.new(|cx| {
             WorkspaceContent::new(
                 workspace_state.clone(),
+                terminal_state.clone(),
                 session_state.clone(),
                 session.handle().clone(),
                 cx,
@@ -733,6 +735,7 @@ pub fn section_to_u8(section: GitFileSection) -> u8 {
 
 pub struct WorkspaceContent {
     workspace_state: Entity<WorkspaceState>,
+    terminal_state: Entity<TerminalState>,
     #[allow(dead_code)]
     session_handle: SessionHandle,
     subtitle: SharedString,
@@ -741,11 +744,13 @@ pub struct WorkspaceContent {
     show_connecting: bool,
     connecting_view: Entity<WorkspaceConnecting>,
     mainview_bounds: Option<Bounds<Pixels>>,
+    _subscriptions: Vec<Subscription>,
 }
 
 impl WorkspaceContent {
     pub fn new(
         workspace_state: Entity<WorkspaceState>,
+        terminal_state: Entity<TerminalState>,
         session_state: Entity<SessionState>,
         session_handle: SessionHandle,
         cx: &mut Context<Self>,
@@ -753,15 +758,20 @@ impl WorkspaceContent {
         let empty_view = cx.new(|_cx| Empty);
         let connecting = cx.new(|_cx| WorkspaceConnecting::new(session_state));
 
+        let terminal_state_sub = cx.observe(&terminal_state, |_, _, cx| cx.notify());
+        let workspace_state_sub = cx.observe(&workspace_state, |_, _, cx| cx.notify());
+
         Self {
             main_view: empty_view.into(),
             subtitle: SharedString::default(),
             focus_handle: cx.focus_handle(),
             session_handle,
             workspace_state,
+            terminal_state,
             show_connecting: false,
             connecting_view: connecting,
             mainview_bounds: None,
+            _subscriptions: vec![terminal_state_sub, workspace_state_sub],
         }
     }
 
@@ -814,13 +824,24 @@ impl Render for WorkspaceContent {
         let this = cx.weak_entity();
         let workspace_state = self.workspace_state.read(cx);
         let title = workspace_state.project_name.to_string();
-        let subtitle = {
-            if !self.subtitle.is_empty() {
-                self.subtitle.to_string()
-            } else {
+        let active_terminal_id = workspace_state.active_terminal_id.clone();
+        let meta = active_terminal_id
+            .as_deref()
+            .map(|id| self.terminal_state.read(cx).meta(id))
+            .unwrap_or_default();
+        let subtitle = if let Some(t) = meta.title.as_deref() {
+            let s = strip_ps1_prefix(t);
+            if s.is_empty() {
                 workspace_state.strip_path.to_string()
+            } else {
+                s.to_owned()
             }
+        } else if !self.subtitle.is_empty() {
+            self.subtitle.to_string()
+        } else {
+            workspace_state.strip_path.to_string()
         };
+        let agent_icon_path = agent_icon(meta.title.as_deref(), meta.current_command.as_deref());
         let net_dot_color = match workspace_state.connect_phase.clone() {
             Some(phase) => phase_indicator_color(&phase),
             None => theme::ACCENT_DIM,
@@ -921,12 +942,29 @@ impl Render for WorkspaceContent {
                                 div()
                                     .w_full()
                                     .min_w_0()
-                                    .truncate()
-                                    .text_center()
-                                    .text_color(rgb(theme::TEXT_SECONDARY))
-                                    .text_size(px(theme::FONT_BODY))
-                                    .font_weight(FontWeight::MEDIUM)
-                                    .child(subtitle),
+                                    .flex()
+                                    .flex_row()
+                                    .items_center()
+                                    .justify_center()
+                                    .gap(px(6.0))
+                                    .when_some(agent_icon_path, |d, path| {
+                                        d.child(
+                                            svg()
+                                                .path(path)
+                                                .size(px(14.0))
+                                                .flex_shrink_0()
+                                                .text_color(rgb(theme::TEXT_SECONDARY)),
+                                        )
+                                    })
+                                    .child(
+                                        div()
+                                            .min_w_0()
+                                            .truncate()
+                                            .text_color(rgb(theme::TEXT_SECONDARY))
+                                            .text_size(px(theme::FONT_BODY))
+                                            .font_weight(FontWeight::MEDIUM)
+                                            .child(subtitle),
+                                    ),
                             ),
                     )
                     .child(

--- a/crates/zedra/src/workspace_terminal.rs
+++ b/crates/zedra/src/workspace_terminal.rs
@@ -1,5 +1,6 @@
 use gpui::{prelude::FluentBuilder as _, *};
 use tracing::*;
+use zedra_osc::OscEvent;
 use zedra_session::SessionHandle;
 use zedra_terminal::terminal::{TerminalEvent, TerminalHyperlinkTarget};
 use zedra_terminal::view::TerminalView;
@@ -114,8 +115,23 @@ impl WorkspaceTerminal {
                         cx.notify();
                     });
                 }
-                TerminalEvent::OscEvent(_event) => {
-                    // TODO: handle OSC events to update Title, progress
+                TerminalEvent::OscEvent(event) => {
+                    let id = this.terminal_id.clone();
+                    this.terminal_state.update(cx, |ts, cx| {
+                        match event {
+                            OscEvent::Title(title) => ts.set_title(&id, Some(title.clone())),
+                            OscEvent::ResetTitle => ts.set_title(&id, None),
+                            OscEvent::Cwd(cwd) => ts.set_cwd(&id, cwd.clone()),
+                            OscEvent::CommandLine(cmd) => ts.set_current_command(&id, cmd.clone()),
+                            OscEvent::CommandStart => ts.set_shell_running(&id),
+                            OscEvent::CommandEnd { exit_code } => {
+                                ts.set_shell_idle(&id, Some(*exit_code))
+                            }
+                            OscEvent::PromptReady => ts.set_shell_idle(&id, None),
+                            _ => return,
+                        }
+                        cx.notify();
+                    });
                 }
                 TerminalEvent::OpenHyperlink(hyperlink) => match &hyperlink.target {
                     TerminalHyperlinkTarget::Url { url } => {

--- a/docs/AI_AGENTS_CLI_INTEGRATION.md
+++ b/docs/AI_AGENTS_CLI_INTEGRATION.md
@@ -199,19 +199,54 @@ Claude Code has open feature requests for Sixel/Kitty rendering (#2266, #29254).
 
 ---
 
-## OSC sequences relevant to AI agents
+## Common OSC sequences and terminal metadata
 
-| Sequence | Purpose | Status in zedra-osc |
-|---|---|---|
-| OSC 0/2 | Terminal title | ✅ parsed |
-| OSC 7 | CWD | ✅ parsed |
-| OSC 133 A/B/C/D | Semantic zones (prompt/command boundaries) | ✅ parsed |
-| **OSC 633 A/B/C/D/E/P** | VS Code shell integration; `633;E` = command text | ❌ missing |
-| **OSC 8** | Hyperlinks | ❌ missing |
-| **OSC 9** | Desktop notifications (agent turn end) | ❌ missing |
-| OSC 1337 | iTerm2 inline images | ❌ missing (future) |
+OSC sequences are terminal control strings, usually shaped as `ESC ] <id> ; <payload> ST` or `ESC ] <id> ; <payload> BEL`.
+For Zedra, OSC should feed generic terminal metadata first. Agent identity, icons, notifications, command progress, and adapter routing should be downstream classifiers over that metadata, not special cases inside the OSC parser.
 
-OSC 633;E is particularly useful — captures the exact command line before execution, so we know when `claude` or `opencode` was invoked.
+Sources: [xterm control sequences](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html), [Ghostty VT reference](https://ghostty.org/docs/vt/reference), [VS Code shell integration](https://code.visualstudio.com/docs/terminal/shell-integration#_supported-escape-sequences), [iTerm2 escape codes](https://iterm2.com/documentation-escape-codes.html), [iTerm2 inline images](https://iterm2.com/documentation-images.html), and [Kitty desktop notifications](https://sw.kovidgoyal.net/kitty/desktop-notifications/).
+
+| Sequence | Function | Zedra metadata use | Current Zedra status |
+|---|---|---|---|
+Status legend: ✅ parsed = `zedra-osc` decodes it into a typed `OscEvent`. ✅ wired = `WorkspaceTerminal` handler routes the event into `TerminalState`. ➖ parsed but unwired = decoded but ignored by the app (no consumer yet).
+
+| Sequence | Function | Zedra metadata use | Current Zedra status |
+|---|---|---|---|
+| `OSC 0 ; <text>` | Set icon name and window title. Many shells use this as the broad "title" update. | Store latest title text; optionally remember source as `osc0`. | ✅ parsed + wired — `OscEvent::Title` updates `TerminalMeta.title` and feeds workspace header subtitle |
+| `OSC 1 ; <text>` | Set icon name only. Less useful on mobile, but can preserve a program-provided label separate from title. | Optional `icon_name` / `app_label` metadata. | ➖ parsed (`OscEvent::IconName`) — no consumer yet |
+| `OSC 2 ; <text>` | Set window title. This is the common title signal used by shells and TUIs. | Store latest title text; source should be separate from derived agent identity. | ✅ parsed + wired — same path as OSC 0 |
+| `OSC 3 ; <prop=value>` | xterm top-level window property. Rare outside X11-style terminals. | Usually ignore; do not sync unless a concrete use case appears. | ❌ missing |
+| `OSC 4 ; <index> ; <color>` | Query/change ANSI palette entries. | Renderer/theme state, not app metadata. Avoid syncing as terminal identity. | ❌ missing |
+| `OSC 5 ; <index> ; <color>` | Query/change special colors. | Renderer/theme state only. | ❌ missing |
+| `OSC 7 ; <file-uri>` | Report terminal current working directory, usually from shell integration. | Store normalized cwd plus original URI/source. | ✅ parsed + wired — `OscEvent::Cwd` updates `TerminalMeta.cwd` |
+| `OSC 8 ; <params> ; <uri>` | Begin/end explicit hyperlinks. Empty params/URI ends the current hyperlink. | Store in terminal grid/link spans, not global terminal metadata. Useful for file/URL preview and tap handling. | ✅ handled by terminal grid via alacritty hyperlink state; not emitted as `zedra-osc` metadata |
+| `OSC 9 ; <message>` | Desktop notification, originally iTerm-style and now supported by several terminals. | Store bounded notification event with terminal id, timestamp, body, and source. | ➖ parsed (`OscEvent::Notification` with `NotificationSource::Osc9`) — no consumer yet |
+| `OSC 9 ; 4 ; <state> ; <value>` | ConEmu/Ghostty progress report. States commonly map to inactive, in-progress, error, indeterminate, paused. | Store transient progress metadata with timeout/expiry; treat as advisory because programs may exit without clearing it. | ➖ parsed (`OscEvent::Progress`) — no consumer yet |
+| `OSC 10..19 ; <color>` | Query/change dynamic colors: foreground, background, cursor, pointer, highlight variants. | Renderer/theme state only. | ❌ missing |
+| `OSC 22 ; <shape>` | Pointer shape in terminals that support it. | Renderer/input affordance only, low priority for mobile. | ❌ missing |
+| `OSC 52 ; <clipboard> ; <base64>` | Query/change clipboard or selection data. Security-sensitive and may contain private data. | Do not store raw payload. If supported later, gate behind explicit policy and only keep minimal audit metadata. | ❌ missing |
+| `OSC 99 ; <params> : <payload>` | Kitty rich notification protocol with IDs, title/body payloads, close events, actions, and support queries. | Store typed notification fields and IDs; do not expose action execution without policy. | ➖ parsed (`OscEvent::Notification` with `NotificationSource::Osc99`) — no consumer yet |
+| `OSC 104 ; <indexes>` | Reset ANSI palette entries. | Renderer/theme state only. | ❌ missing |
+| `OSC 105 ; <indexes>` | Reset special colors. | Renderer/theme state only. | ❌ missing |
+| `OSC 110..119` | Reset dynamic colors such as foreground, background, and cursor color. | Renderer/theme state only. | ❌ missing |
+| `OSC 133 ; A/B/C/D` | FinalTerm/iTerm2 shell integration semantic zones: prompt start, command start, command executed, command finished with optional exit code. | Store shell state, command lifecycle timestamps, last exit code. Command text can be inferred from screen range but is less reliable than OSC 633 E. | ✅ parsed + wired — `PromptReady`/`CommandStart`/`CommandEnd { exit_code }` drive `TerminalMeta.shell_state` and `last_exit_code` |
+| `OSC 633 ; A/B/C/D/E/P` | VS Code shell integration. `A/B/C/D` mark prompt and command lifecycle, `E` provides escaped command line, `P` sets properties such as cwd. | Store command lifecycle, exact command line, cwd, nonce/provenance, and rich-detection capability. Strong generic source for "what is running". | ✅ parsed; A–D + E wired (`E` populates `TerminalMeta.current_command`, cleared on idle); `P` (`OscEvent::ShellProperty`) parsed but unwired |
+| `OSC 777 ; notify ; <title> ; <body>` | rxvt/urxvt-style simple notification, also used by some modern terminal tools. | Store notification title/body with source. | ➖ parsed (`OscEvent::Notification` with `NotificationSource::Osc777`) — no consumer yet |
+| `OSC 1337 ; File=...` | iTerm2 inline image/file-transfer protocol. | Renderer/media state; may be useful for future inline previews, but payload can be large. Do not put raw file data in app metadata. | ❌ missing |
+| `OSC 1337 ; RemoteHost=...` | iTerm2 shell integration remote user/host. | Optional remote host metadata; likely privacy-sensitive, avoid syncing unless needed. | ➖ parsed (`OscEvent::RemoteHost`) — no consumer yet |
+| `OSC 1337 ; CurrentDir=...` | iTerm2 shell integration cwd report; OSC 7 is the preferred generic equivalent. | Store cwd if OSC 7 is absent. | ✅ parsed + wired — emits `OscEvent::Cwd`, same path as OSC 7 |
+| `OSC 1337 ; SetUserVar=...` | iTerm2 user variable, base64-encoded. | Store only allowlisted keys if a feature needs them; otherwise ignore. | ➖ parsed (`OscEvent::UserVar`, raw base64) — no consumer yet |
+| `OSC 1337 ; ShellIntegrationVersion=...` | iTerm2 shell integration version and shell name. | Store shell integration capability/version metadata. | ➖ parsed (`OscEvent::ShellIntegrationVersion` + `OscEvent::ShellName`) — no consumer yet |
+| `OSC 1337 ; Block/UpdateBlock/Button/...` | iTerm2 blocks, folding, copy/custom buttons, and other UI extensions. | Future renderer/UI features; not core terminal identity. Buttons/actions need policy before execution. | ❌ missing |
+
+Implementation rule of thumb:
+
+- Parse known OSC sequences into typed events in `zedra-osc`.
+- Store normalized terminal facts in `TerminalMeta`, with source/provenance such as `osc2`, `osc7`, `osc133`, or `osc633`.
+- Keep payloads bounded. Do not persist arbitrary unknown OSC strings, clipboard contents, inline image data, or untrusted action commands.
+- Let AI-agent detection read terminal metadata as a classifier. For example, `OSC 633;E` can say the command line is `claude`, while the agent classifier decides that this maps to the Claude icon and adapter.
+
+OSC 633;E is particularly useful for command identity because it captures the exact shell-interpreted command line before execution. That makes it useful for any program, not just AI agents.
 
 ---
 
@@ -224,6 +259,17 @@ OSC 633;E is particularly useful — captures the exact command line before exec
 - MCP tool support alongside built-in tools
 
 ---
+
+## Current implementation status
+
+Wired through `zedra-osc` → `zedra-terminal` (`TerminalEvent::OscEvent`) → `WorkspaceTerminal` → `TerminalState`:
+
+- **TerminalMeta** carries `title`, `cwd`, `shell_state` (Unknown/Idle/Running), `last_exit_code`, and `current_command`. Keyed by terminal id, owned by the workspace-level `TerminalState` entity.
+- **Workspace header** (`crates/zedra/src/workspace.rs`) reads the active terminal's `TerminalMeta` and renders the title (PS1 prefix stripped) below the project name. When `agent_icon(title, current_command)` matches a known agent, the icon is drawn next to the subtitle.
+- **Agent classifier** (`crates/zedra/src/terminal_card.rs::agent_icon`) recognises claude / opencode / codex+openai / gemini / copilot from either the OSC 2 title or the OSC 633;E command line, so it works for agents that do *and* don't set a descriptive title.
+- **Shell lifecycle**: OSC 133/633 `A/B` set shell idle, `C` sets running, `D` sets idle and stores exit code. `current_command` is cleared on idle.
+
+Not yet wired (parsed only, no consumer): notifications (OSC 9/99/777), progress (OSC 9;4), shell integration version, remote host, user vars, OSC 633;P key/value properties, OSC 1 icon name. These will be plumbed when the corresponding UI surfaces are built.
 
 ## Integration options for zedra-host
 
@@ -238,8 +284,8 @@ zedra-host implements ACP server. Spawns coding agent as subprocess, wires stdin
 **Option C — PTY JSON stream scanning (Claude Code, no setup)**
 Scan PTY bytes for `--output-format stream-json` JSON lines alongside OSC scanning. Extract tool_use edits client-side. Fragile (ANSI interleaved) but requires zero user setup.
 
-**Option D — OSC 633 + semantic blocks**
-Add 633 parsing to zedra-osc. Capture command text (`633;E`) and output byte range (`633;C` → `633;D`). Agent-agnostic. Lets Zedra build "command blocks" like Warp. Doesn't give diff content directly but works for any tool.
+**Option D — OSC 633 + semantic blocks** *(parser landed; semantic blocks pending)*
+633 parsing is live in `zedra-osc`: command text (`633;E`) and prompt/command/exit lifecycle (`633;A/B/C/D`) are decoded and the lifecycle is wired into `TerminalMeta`. Capturing the per-command output byte range (between `C` and `D`) so Zedra can render Warp-style command blocks is the next step — agent-agnostic, works for any tool.
 
-**Option E — OSC 9 notification capture**
-Add OSC 9 parsing. Surface agent turn-end notifications as mobile push or in-app toast. Zero-friction — works for any agent that emits OSC 9, no server needed.
+**Option E — OSC 9 notification capture** *(parser landed; surface pending)*
+OSC 9 / 99 / 777 are decoded into `OscEvent::Notification { title, body, source }`. Surfacing them as mobile push or in-app toast still needs a notification consumer + platform bridge wiring.

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -75,3 +75,20 @@ zedra start --workdir . --relay-url https://sg1.relay.zedra.dev
 
 Expected: host connects to the specified relay; QR shows that relay URL in
 `relay` field of JSON output (`--json` flag).
+
+## 9. Workspace Header Terminal Title + Agent Icon
+
+Requires shell integration emitting OSC 133/633/1337 (zsh + iTerm2 integration,
+or VS Code shell integration).
+
+1. Open a workspace, open a terminal.
+2. Type `claude` (or `opencode`, `codex`, `gemini`) — wait for prompt.
+
+Expected:
+- Header subtitle (below project name) updates from cwd to the terminal title.
+- Agent icon appears to the left of the subtitle matching the running CLI
+  (claude/opencode/openai/gemini/copilot).
+- After the agent exits and shell returns to prompt, icon disappears;
+  subtitle shows the last title (or falls back to cwd).
+- Switching to a different terminal in the drawer updates header to the
+  active terminal's title + icon.


### PR DESCRIPTION
## Summary

Phase 1 of AI agents CLI integration (see `docs/AI_AGENTS_CLI_INTEGRATION.md`). Extends `zedra-osc` so AI-agent activity, shell integration, and command lifecycle surface as typed events instead of being silently dropped.

## New sequences parsed

| Sequence | Event(s) |
|---|---|
| `OSC 1` | `IconName` |
| `OSC 9` | `Notification { source: Osc9 }` |
| `OSC 9;4` | `Progress(ProgressReport)` |
| `OSC 99` | `Notification { source: Osc99 }` (Kitty rich) |
| `OSC 633;A..D` | `PromptReady` / `CommandStart` / `CommandEnd` |
| `OSC 633;E` | `CommandLine` (escaped command text from VS Code integration) |
| `OSC 633;P;k=v` | `ShellProperty` + `Cwd` when key is Cwd |
| `OSC 777;notify` | `Notification { source: Osc777 }` |
| `OSC 1337;CurrentDir` | `Cwd` |
| `OSC 1337;RemoteHost` | `RemoteHost` |
| `OSC 1337;ShellIntegrationVersion` / `;shell=` | `ShellIntegrationVersion` / `ShellName` |
| `OSC 1337;SetUserVar=k=v` | `UserVar { key, value_b64 }` (raw base64) |

## Safety

- `MAX_OSC_BODY` (64KB) scanner guard drops pathological producers emitting huge inline-image / file-transfer bodies.
- `unescape_osc633` preserves multi-byte UTF-8 by copying non-escape runs as `&str` slices and only byte-decoding inside `\xNN` escapes — fixes a latent bug where non-ASCII command lines (e.g. `echo café`) would be mangled.

## Deferred

`TerminalMeta` / `TerminalState` wiring to expose new fields to UI is out of scope here; will be a follow-up PR that touches `zedra/src/terminal_state.rs` and `workspace_terminal.rs`. Host `rpc_daemon.rs` catch-all absorbs the new variants; `OSC 633;P;Cwd` already feeds the existing `Cwd` cache as a bonus.

## Test plan

- [x] `cargo test -p zedra-osc` — 20/20 pass, incl. multi-byte UTF-8 round-trip, chunked OSC across feed boundaries, oversized body drop
- [x] `cargo check -p zedra-osc -p zedra-rpc -p zedra-session -p zedra-host`
- [ ] Manual: run agent that emits OSC 633 (VS Code integration script) in a session terminal; confirm `tracing::debug!` logs or downstream consumer sees `CommandLine` events
- [ ] Manual: run `printf '\e]9;hello\a'` in a remote session and confirm no regression in the existing title/cwd path

🤖 Generated with [Claude Code](https://claude.com/claude-code)