### PR TITLE
feat(host): add local workspace metrics

### DIFF
--- a/crates/zedra-host/src/api.rs
+++ b/crates/zedra-host/src/api.rs
@@ -23,6 +23,7 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 
+use crate::metrics;
 use crate::pty::SpawnOptions;
 use crate::qr;
 use crate::rpc_daemon::{create_terminal, DaemonState};
@@ -185,6 +186,9 @@ async fn create_pairing_qr_handler(
             s.registry
                 .add_pairing_slot(&session.id, ticket.handshake_secret)
                 .await;
+            if let Err(e) = metrics::record_qr_created(&s.daemon_state.workdir) {
+                tracing::warn!("Failed to record QR metrics: {}", e);
+            }
             (StatusCode::OK, Json(serde_json::json!(info))).into_response()
         }
         Err(e) => (
@@ -260,6 +264,12 @@ async fn create_terminal_handler(
 
     match create_terminal(&session, req.cols, req.rows, opts).await {
         Ok(id) => {
+            let terminal_count = session.terminals.lock().await.len();
+            if let Err(e) =
+                metrics::record_terminal_created(&s.daemon_state.workdir, terminal_count)
+            {
+                tracing::warn!("Failed to record terminal metrics: {}", e);
+            }
             // Push TerminalCreated event to the subscribed client (if any).
             session
                 .push_event(HostEvent::TerminalCreated {

--- a/crates/zedra-host/src/lib.rs
+++ b/crates/zedra-host/src/lib.rs
@@ -9,6 +9,7 @@ pub mod git;
 pub mod host_info;
 pub mod identity;
 pub mod iroh_listener;
+pub mod metrics;
 pub mod net_monitor;
 pub mod pty;
 pub mod qr;

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use zedra_host::client as zedra_client;
 use zedra_host::ga4::Ga4;
 use zedra_host::{
-    api, identity, iroh_listener, net_monitor, qr, rpc_daemon, session_registry, utils,
+    api, identity, iroh_listener, metrics, net_monitor, qr, rpc_daemon, session_registry, utils,
     version_check, workspace_lock,
 };
 use zedra_rpc::ZedraPairingTicket;
@@ -109,6 +109,13 @@ enum Commands {
     /// Show daemon status, sessions, and terminals
     Status {
         /// Working directory of the running daemon
+        #[arg(short, long, default_value = ".")]
+        workdir: String,
+    },
+
+    /// Show local usage metrics for a workspace
+    Metrics {
+        /// Working directory to inspect
         #[arg(short, long, default_value = ".")]
         workdir: String,
     },
@@ -323,6 +330,7 @@ fn start_detached(options: DetachedStartOptions) -> Result<DetachedStartResult> 
     command
         .args(detached_start_child_args(&options))
         .current_dir(&options.workdir)
+        .env("ZEDRA_DETACHED", "1")
         .stdin(Stdio::null())
         .stdout(Stdio::from(log.try_clone()?))
         .stderr(Stdio::from(log));
@@ -454,6 +462,14 @@ async fn main() -> Result<()> {
 
             let _lock = workspace_lock::acquire(&workdir)?;
             tracing::info!("Acquired workspace lock for {}", workdir.display());
+            let start_mode = if std::env::var_os("ZEDRA_DETACHED").is_some() {
+                metrics::DaemonStartMode::Detached
+            } else {
+                metrics::DaemonStartMode::Foreground
+            };
+            if let Err(e) = metrics::record_daemon_start(&workdir, start_mode) {
+                tracing::warn!("Failed to record daemon start metrics: {}", e);
+            }
 
             let host_identity = match identity::HostIdentity::load_or_generate_for_workdir(&workdir)
             {
@@ -474,8 +490,17 @@ async fn main() -> Result<()> {
                 .and_then(|n| n.to_str())
                 .unwrap_or("default")
                 .to_string();
+            let session_was_existing = registry.get_by_name(&session_name).await.is_some();
             let session = registry.create_named(&session_name, workdir.clone()).await;
             let session_id = session.id.clone();
+            let session_count = registry.session_count().await;
+            if !session_was_existing {
+                if let Err(e) = metrics::record_session_created(&workdir, session_count) {
+                    tracing::warn!("Failed to record session metrics: {}", e);
+                }
+            } else if let Err(e) = metrics::record_daemon_heartbeat(&workdir, session_count, 0) {
+                tracing::warn!("Failed to record session metrics: {}", e);
+            }
             tracing::info!(
                 "Created session '{}' (id={}) for {}",
                 session_name,
@@ -629,6 +654,7 @@ async fn main() -> Result<()> {
                 &endpoint_relay_urls,
                 json,
                 Some(&workdir),
+                Some(&workdir),
             )
             .await
             {
@@ -643,6 +669,7 @@ async fn main() -> Result<()> {
                 let registry = registry.clone();
                 let session_id = session_id.clone();
                 let relay_urls_for_listener = endpoint_relay_urls.clone();
+                let qr_workdir = workdir.clone();
                 tokio::spawn(async move {
                     if let Err(e) = run_qr_key_listener(
                         registry,
@@ -650,6 +677,7 @@ async fn main() -> Result<()> {
                         endpoint_id,
                         endpoint,
                         relay_urls_for_listener,
+                        qr_workdir,
                     )
                     .await
                     {
@@ -704,6 +732,7 @@ async fn main() -> Result<()> {
             {
                 let registry = registry.clone();
                 let started_at = state.started_at;
+                let metrics_workdir = workdir.clone();
                 tokio::spawn(async move {
                     let mut interval =
                         tokio::time::interval(std::time::Duration::from_secs(10 * 60));
@@ -714,6 +743,13 @@ async fn main() -> Result<()> {
                         let sessions = registry.list_sessions().await;
                         let session_count = sessions.len();
                         let terminal_count: usize = sessions.iter().map(|s| s.terminal_count).sum();
+                        if let Err(e) = metrics::record_daemon_heartbeat(
+                            &metrics_workdir,
+                            session_count,
+                            terminal_count,
+                        ) {
+                            tracing::warn!("Failed to record daemon heartbeat metrics: {}", e);
+                        }
                         zedra_telemetry::send(Event::DaemonHeartbeat {
                             uptime_secs,
                             session_count,
@@ -762,6 +798,22 @@ async fn main() -> Result<()> {
                     std::process::exit(1);
                 }
             }
+        }
+
+        Commands::Metrics { workdir } => {
+            let workdir = std::path::PathBuf::from(workdir)
+                .canonicalize()
+                .unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let snapshot = metrics::snapshot(&workdir)?;
+            let http = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(2))
+                .build()
+                .unwrap_or_default();
+            let status = fetch_instance_status(&http, &workdir).await;
+            println!(
+                "{}",
+                render_metrics_output(&workdir, &snapshot, status.as_ref())
+            );
         }
 
         Commands::Qr { workdir, json } => {
@@ -1179,6 +1231,152 @@ fn render_status_output(status: &serde_json::Value) -> String {
     sections.join("\n")
 }
 
+fn render_metrics_output(
+    workdir: &Path,
+    snapshot: &metrics::MetricsSnapshot,
+    status: Option<&serde_json::Value>,
+) -> String {
+    let metrics = &snapshot.metrics;
+    let daemon_running = status.is_some();
+    let daemon = status
+        .and_then(|status| status["uptime_secs"].as_u64())
+        .map(|uptime| format!("running ({})", utils::format_duration(uptime)))
+        .unwrap_or_else(|| "not running".to_string());
+    let current_sessions = status
+        .and_then(|status| status["sessions"].as_array())
+        .map(|sessions| sessions.len() as u64);
+    let current_terminals = status
+        .and_then(|status| status["terminals"].as_array())
+        .map(|terminals| terminals.len() as u64);
+    let active_connections = if daemon_running {
+        metrics.active_connection_count
+    } else {
+        0
+    };
+    let active_secs = display_active_secs(snapshot, daemon_running);
+
+    let mut rows = vec![
+        ("Workdir", workdir.display().to_string()),
+        ("Daemon", daemon),
+        ("Active Time", utils::format_duration(active_secs)),
+        ("Active Now", format_count(active_connections, "connection")),
+        ("Connections", metrics.successful_connections.to_string()),
+        ("Pairings", metrics.new_pairings.to_string()),
+        ("QR Codes", metrics.qr_codes_created.to_string()),
+        (
+            "Sessions",
+            render_current_and_total(
+                current_sessions,
+                metrics.sessions_created,
+                metrics.max_sessions_seen,
+                "created",
+            ),
+        ),
+        (
+            "Terminals",
+            render_current_and_total(
+                current_terminals,
+                metrics.terminals_created,
+                metrics.max_terminals_seen,
+                "created",
+            ),
+        ),
+        (
+            "Starts",
+            format!(
+                "{} total ({} detached)",
+                metrics.daemon_starts, metrics.detached_starts
+            ),
+        ),
+        (
+            "Last Start",
+            format_since_unix_secs(
+                metrics.last_started_at_unix_secs,
+                snapshot.generated_at_unix_secs,
+            ),
+        ),
+        (
+            "Last Connect",
+            format_since_unix_secs(
+                metrics.last_connected_at_unix_secs,
+                snapshot.generated_at_unix_secs,
+            ),
+        ),
+    ];
+
+    if metrics.new_pairings > 0 {
+        rows.push((
+            "Last Pairing",
+            format_since_unix_secs(
+                metrics.last_pairing_at_unix_secs,
+                snapshot.generated_at_unix_secs,
+            ),
+        ));
+    }
+
+    format!(
+        "{}\n\n{}",
+        utils::heading_text("Zedra Metrics"),
+        utils::render_key_values(&rows)
+    )
+}
+
+fn display_active_secs(snapshot: &metrics::MetricsSnapshot, daemon_running: bool) -> u64 {
+    if daemon_running {
+        return snapshot.active_secs;
+    }
+
+    let metrics = &snapshot.metrics;
+    let stale_active_secs = if metrics.active_connection_count > 0 {
+        metrics
+            .active_started_at_unix_secs
+            .zip(metrics.last_seen_at_unix_secs)
+            .map(|(started, seen)| seen.saturating_sub(started))
+            .unwrap_or_default()
+    } else {
+        0
+    };
+    metrics.total_active_secs.saturating_add(stale_active_secs)
+}
+
+fn render_current_and_total(
+    current: Option<u64>,
+    total: u64,
+    max_seen: u64,
+    total_label: &str,
+) -> String {
+    match current {
+        Some(current) if total > 0 => format!("{current} current / {total} {total_label}"),
+        Some(current) if max_seen > 0 => format!("{current} current / {max_seen} max"),
+        Some(current) => format!("{current} current"),
+        None if total > 0 && max_seen > 0 => format!("{total} {total_label} / {max_seen} max"),
+        None if total > 0 => format!("{total} {total_label}"),
+        None if max_seen > 0 => format!("{max_seen} max"),
+        None => format!("0 {total_label}"),
+    }
+}
+
+fn format_count(count: u64, singular: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{count} {singular}s")
+    }
+}
+
+fn format_since_unix_secs(timestamp: Option<u64>, now: u64) -> String {
+    match timestamp {
+        Some(timestamp) if timestamp <= now => {
+            format!(
+                "{} ago",
+                utils::format_duration(now.saturating_sub(timestamp))
+            )
+        }
+        Some(_) => "just now".to_string(),
+        None => "-".to_string(),
+    }
+}
+
 fn session_status_row(session: &serde_json::Value) -> Vec<String> {
     let id = session["id"]
         .as_str()
@@ -1422,21 +1620,26 @@ async fn generate_pairing_qr(
     relay_urls: &[String],
     json: bool,
     started_workdir: Option<&Path>,
+    metrics_workdir: Option<&Path>,
 ) -> Result<()> {
     let ticket = ZedraPairingTicket {
         endpoint_id,
         handshake_secret: rand::random(),
         session_id: session_id.to_string(),
     };
+    let info = qr::build_pairing_info(&ticket, endpoint, relay_urls)?;
     registry
         .add_pairing_slot(session_id, ticket.handshake_secret)
         .await;
+    if let Some(workdir) = metrics_workdir {
+        if let Err(e) = metrics::record_qr_created(workdir) {
+            tracing::warn!("Failed to record QR metrics: {}", e);
+        }
+    }
 
     if json {
-        let info = qr::build_pairing_info(&ticket, endpoint, relay_urls)?;
         qr::print_pairing_json(&info);
     } else {
-        let info = qr::build_pairing_info(&ticket, endpoint, relay_urls)?;
         if let Some(workdir) = started_workdir {
             qr::print_started_pairing_info(&info, workdir);
         } else {
@@ -1454,6 +1657,7 @@ async fn run_qr_key_listener(
     endpoint_id: iroh::PublicKey,
     endpoint: iroh::Endpoint,
     relay_urls: Vec<String>,
+    workdir: PathBuf,
 ) -> Result<()> {
     use std::io::Read;
     use std::os::fd::AsRawFd;
@@ -1482,7 +1686,7 @@ async fn run_qr_key_listener(
                     break;
                 };
                 if matches!(key, b'r' | b'R') {
-                    if let Err(e) = generate_pairing_qr(&registry, &session_id, endpoint_id, &endpoint, &relay_urls, false, None).await {
+                    if let Err(e) = generate_pairing_qr(&registry, &session_id, endpoint_id, &endpoint, &relay_urls, false, None, Some(&workdir)).await {
                         tracing::warn!("Failed to regenerate QR code: {}", e);
                     } else {
                         utils::eprintln_success("Regenerated pairing QR. Press 'r' again to refresh.");
@@ -1681,6 +1885,69 @@ mod tests {
         assert!(output.contains("connected"));
         assert!(output.contains("Terminals"));
         assert!(output.contains("zsh"));
+    }
+
+    #[test]
+    fn metrics_output_includes_local_and_live_counts() {
+        let snapshot = metrics::MetricsSnapshot {
+            metrics: metrics::WorkspaceMetrics {
+                daemon_starts: 3,
+                detached_starts: 2,
+                successful_connections: 9,
+                new_pairings: 1,
+                qr_codes_created: 4,
+                sessions_created: 1,
+                terminals_created: 7,
+                active_connection_count: 1,
+                last_started_at_unix_secs: Some(90),
+                last_connected_at_unix_secs: Some(95),
+                ..metrics::WorkspaceMetrics::default()
+            },
+            generated_at_unix_secs: 100,
+            active_secs: 3605,
+        };
+        let status = serde_json::json!({
+            "uptime_secs": 120,
+            "sessions": [{ "id": "session" }],
+            "terminals": [{ "id": "terminal" }, { "id": "terminal-2" }]
+        });
+
+        let output = render_metrics_output(Path::new("/repo"), &snapshot, Some(&status));
+
+        assert!(output.contains("Zedra Metrics"));
+        assert!(output.contains("  Workdir       /repo"));
+        assert!(output.contains("  Daemon        running (2m0s)"));
+        assert!(output.contains("  Active Time   1h0m"));
+        assert!(output.contains("  Active Now    1 connection"));
+        assert!(output.contains("  Connections   9"));
+        assert!(output.contains("  Pairings      1"));
+        assert!(output.contains("  QR Codes      4"));
+        assert!(output.contains("  Sessions      1 current / 1 created"));
+        assert!(output.contains("  Terminals     2 current / 7 created"));
+        assert!(output.contains("  Starts        3 total (2 detached)"));
+        assert!(output.contains("  Last Start    10s ago"));
+        assert!(output.contains("  Last Connect  5s ago"));
+    }
+
+    #[test]
+    fn metrics_output_caps_stale_active_time_when_daemon_is_not_running() {
+        let snapshot = metrics::MetricsSnapshot {
+            metrics: metrics::WorkspaceMetrics {
+                total_active_secs: 10,
+                active_connection_count: 1,
+                active_started_at_unix_secs: Some(100),
+                last_seen_at_unix_secs: Some(130),
+                ..metrics::WorkspaceMetrics::default()
+            },
+            generated_at_unix_secs: 500,
+            active_secs: 410,
+        };
+
+        let output = render_metrics_output(Path::new("/repo"), &snapshot, None);
+
+        assert!(output.contains("  Daemon        not running"));
+        assert!(output.contains("  Active Time   40s"));
+        assert!(output.contains("  Active Now    0 connections"));
     }
 
     #[test]

--- a/crates/zedra-host/src/metrics.rs
+++ b/crates/zedra-host/src/metrics.rs
@@ -1,0 +1,372 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::identity;
+
+const METRICS_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DaemonStartMode {
+    Foreground,
+    Detached,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WorkspaceMetrics {
+    pub version: u32,
+    pub daemon_starts: u64,
+    pub foreground_starts: u64,
+    pub detached_starts: u64,
+    pub successful_connections: u64,
+    pub new_pairings: u64,
+    pub qr_codes_created: u64,
+    pub sessions_created: u64,
+    pub terminals_created: u64,
+    pub max_sessions_seen: u64,
+    pub max_terminals_seen: u64,
+    pub total_active_secs: u64,
+    pub active_connection_count: u64,
+    pub active_started_at_unix_secs: Option<u64>,
+    pub first_started_at_unix_secs: Option<u64>,
+    pub last_started_at_unix_secs: Option<u64>,
+    pub last_connected_at_unix_secs: Option<u64>,
+    pub last_pairing_at_unix_secs: Option<u64>,
+    pub last_qr_created_at_unix_secs: Option<u64>,
+    pub last_terminal_created_at_unix_secs: Option<u64>,
+    pub last_seen_at_unix_secs: Option<u64>,
+}
+
+impl Default for WorkspaceMetrics {
+    fn default() -> Self {
+        Self {
+            version: METRICS_VERSION,
+            daemon_starts: 0,
+            foreground_starts: 0,
+            detached_starts: 0,
+            successful_connections: 0,
+            new_pairings: 0,
+            qr_codes_created: 0,
+            sessions_created: 0,
+            terminals_created: 0,
+            max_sessions_seen: 0,
+            max_terminals_seen: 0,
+            total_active_secs: 0,
+            active_connection_count: 0,
+            active_started_at_unix_secs: None,
+            first_started_at_unix_secs: None,
+            last_started_at_unix_secs: None,
+            last_connected_at_unix_secs: None,
+            last_pairing_at_unix_secs: None,
+            last_qr_created_at_unix_secs: None,
+            last_terminal_created_at_unix_secs: None,
+            last_seen_at_unix_secs: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetricsSnapshot {
+    pub metrics: WorkspaceMetrics,
+    pub generated_at_unix_secs: u64,
+    pub active_secs: u64,
+}
+
+impl WorkspaceMetrics {
+    fn active_secs_at(&self, now: u64) -> u64 {
+        let live_secs = if self.active_connection_count > 0 {
+            self.active_started_at_unix_secs
+                .map(|started| now.saturating_sub(started))
+                .unwrap_or_default()
+        } else {
+            0
+        };
+        self.total_active_secs.saturating_add(live_secs)
+    }
+
+    fn close_stale_active_window(&mut self, now: u64) {
+        if self.active_connection_count == 0 {
+            self.active_started_at_unix_secs = None;
+            return;
+        }
+
+        let end = self.last_seen_at_unix_secs.unwrap_or(now).min(now);
+        if let Some(started) = self.active_started_at_unix_secs.take() {
+            self.total_active_secs = self
+                .total_active_secs
+                .saturating_add(end.saturating_sub(started));
+        }
+        self.active_connection_count = 0;
+    }
+
+    fn snapshot_at(&self, now: u64) -> MetricsSnapshot {
+        MetricsSnapshot {
+            metrics: self.clone(),
+            generated_at_unix_secs: now,
+            active_secs: self.active_secs_at(now),
+        }
+    }
+}
+
+pub fn metrics_path(workdir: &Path) -> Result<PathBuf> {
+    Ok(identity::workspace_config_dir(workdir)?.join("metrics.json"))
+}
+
+pub fn load(workdir: &Path) -> Result<WorkspaceMetrics> {
+    read_metrics_file(&metrics_path(workdir)?)
+}
+
+pub fn snapshot(workdir: &Path) -> Result<MetricsSnapshot> {
+    let now = unix_now_secs();
+    let metrics = load(workdir)?;
+    Ok(metrics.snapshot_at(now))
+}
+
+pub fn record_daemon_start(workdir: &Path, mode: DaemonStartMode) -> Result<()> {
+    update(workdir, |metrics, now| {
+        metrics.close_stale_active_window(now);
+        metrics.daemon_starts = metrics.daemon_starts.saturating_add(1);
+        match mode {
+            DaemonStartMode::Foreground => {
+                metrics.foreground_starts = metrics.foreground_starts.saturating_add(1);
+            }
+            DaemonStartMode::Detached => {
+                metrics.detached_starts = metrics.detached_starts.saturating_add(1);
+            }
+        }
+        if metrics.first_started_at_unix_secs.is_none() {
+            metrics.first_started_at_unix_secs = Some(now);
+        }
+        metrics.last_started_at_unix_secs = Some(now);
+    })
+}
+
+pub fn record_daemon_heartbeat(
+    workdir: &Path,
+    session_count: usize,
+    terminal_count: usize,
+) -> Result<()> {
+    update(workdir, |metrics, _now| {
+        metrics.max_sessions_seen = metrics.max_sessions_seen.max(session_count as u64);
+        metrics.max_terminals_seen = metrics.max_terminals_seen.max(terminal_count as u64);
+    })
+}
+
+pub fn record_session_created(workdir: &Path, session_count: usize) -> Result<()> {
+    update(workdir, |metrics, _now| {
+        metrics.sessions_created = metrics.sessions_created.saturating_add(1);
+        metrics.max_sessions_seen = metrics.max_sessions_seen.max(session_count as u64);
+    })
+}
+
+pub fn record_connection_opened(workdir: &Path) -> Result<()> {
+    update(workdir, |metrics, now| {
+        if metrics.active_connection_count == 0 {
+            metrics.active_started_at_unix_secs = Some(now);
+        }
+        metrics.active_connection_count = metrics.active_connection_count.saturating_add(1);
+        metrics.successful_connections = metrics.successful_connections.saturating_add(1);
+        metrics.last_connected_at_unix_secs = Some(now);
+    })
+}
+
+pub fn record_connection_closed(workdir: &Path) -> Result<()> {
+    update(workdir, |metrics, now| {
+        if metrics.active_connection_count == 0 {
+            metrics.active_started_at_unix_secs = None;
+            return;
+        }
+
+        metrics.active_connection_count = metrics.active_connection_count.saturating_sub(1);
+        if metrics.active_connection_count == 0 {
+            if let Some(started) = metrics.active_started_at_unix_secs.take() {
+                metrics.total_active_secs = metrics
+                    .total_active_secs
+                    .saturating_add(now.saturating_sub(started));
+            }
+        }
+    })
+}
+
+pub fn record_pairing_completed(workdir: &Path) -> Result<()> {
+    update(workdir, |metrics, now| {
+        metrics.new_pairings = metrics.new_pairings.saturating_add(1);
+        metrics.last_pairing_at_unix_secs = Some(now);
+    })
+}
+
+pub fn record_qr_created(workdir: &Path) -> Result<()> {
+    update(workdir, |metrics, now| {
+        metrics.qr_codes_created = metrics.qr_codes_created.saturating_add(1);
+        metrics.last_qr_created_at_unix_secs = Some(now);
+    })
+}
+
+pub fn record_terminal_created(workdir: &Path, terminal_count: usize) -> Result<()> {
+    update(workdir, |metrics, now| {
+        metrics.terminals_created = metrics.terminals_created.saturating_add(1);
+        metrics.max_terminals_seen = metrics.max_terminals_seen.max(terminal_count as u64);
+        metrics.last_terminal_created_at_unix_secs = Some(now);
+    })
+}
+
+fn update(workdir: &Path, apply: impl FnOnce(&mut WorkspaceMetrics, u64)) -> Result<()> {
+    let _guard = metrics_lock().lock().unwrap_or_else(|err| err.into_inner());
+    let path = metrics_path(workdir)?;
+    let now = unix_now_secs();
+    let mut metrics = read_metrics_file(&path)?;
+    metrics.version = METRICS_VERSION;
+    apply(&mut metrics, now);
+    metrics.last_seen_at_unix_secs = Some(now);
+    write_metrics_file(&path, &metrics)
+}
+
+fn read_metrics_file(path: &Path) -> Result<WorkspaceMetrics> {
+    let data = match std::fs::read_to_string(path) {
+        Ok(data) => data,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(WorkspaceMetrics::default());
+        }
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to read metrics at {}", path.display()));
+        }
+    };
+
+    serde_json::from_str(&data)
+        .with_context(|| format!("failed to parse metrics at {}", path.display()))
+}
+
+fn write_metrics_file(path: &Path, metrics: &WorkspaceMetrics) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("metrics path has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+
+    let json = serde_json::to_string_pretty(metrics)?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("metrics.json");
+    let tmp_path = parent.join(format!(
+        ".{}.{}.{}.tmp",
+        file_name,
+        std::process::id(),
+        rand::random::<u64>()
+    ));
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options
+        .open(&tmp_path)
+        .with_context(|| format!("failed to create metrics temp file {}", tmp_path.display()))?;
+    file.write_all(json.as_bytes())?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    drop(file);
+
+    std::fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "failed to replace metrics file {} with {}",
+            path.display(),
+            tmp_path.display()
+        )
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    Ok(())
+}
+
+fn metrics_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn unix_now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_seconds_accumulate_after_last_connection_closes() {
+        let mut metrics = WorkspaceMetrics::default();
+
+        metrics.active_connection_count = 1;
+        metrics.active_started_at_unix_secs = Some(100);
+        assert_eq!(metrics.active_secs_at(150), 50);
+
+        metrics.close_stale_active_window(160);
+        assert_eq!(metrics.active_connection_count, 0);
+        assert_eq!(metrics.total_active_secs, 60);
+        assert_eq!(metrics.active_secs_at(200), 60);
+    }
+
+    #[test]
+    fn stale_active_window_uses_last_seen_instead_of_restart_time() {
+        let mut metrics = WorkspaceMetrics {
+            active_connection_count: 1,
+            active_started_at_unix_secs: Some(100),
+            last_seen_at_unix_secs: Some(140),
+            ..WorkspaceMetrics::default()
+        };
+
+        metrics.close_stale_active_window(200);
+
+        assert_eq!(metrics.total_active_secs, 40);
+        assert_eq!(metrics.active_connection_count, 0);
+        assert_eq!(metrics.active_started_at_unix_secs, None);
+    }
+
+    #[test]
+    fn missing_metrics_file_loads_empty_metrics() {
+        let dir = tempfile::tempdir().unwrap();
+        let metrics = read_metrics_file(&dir.path().join("missing.json")).unwrap();
+
+        assert_eq!(metrics.version, METRICS_VERSION);
+        assert_eq!(metrics.daemon_starts, 0);
+        assert_eq!(metrics.successful_connections, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn metrics_file_is_private_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metrics.json");
+        let metrics = WorkspaceMetrics {
+            daemon_starts: 1,
+            ..WorkspaceMetrics::default()
+        };
+
+        write_metrics_file(&path, &metrics).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(read_metrics_file(&path).unwrap().daemon_starts, 1);
+    }
+}

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -14,6 +14,7 @@ use crate::fs::{Filesystem, LocalFs};
 use crate::git::GitRepo;
 use crate::host_info;
 use crate::identity::SharedIdentity;
+use crate::metrics;
 use crate::pty::{ShellSession, SpawnOptions};
 use crate::session_registry::{
     AttachResult, ConsumeSlotResult, HostShellState, HostTermMeta, OutputSenderSlot, ServerSession,
@@ -517,6 +518,18 @@ pub async fn handle_connection(
         &client_pubkey[..4],
         session.id,
     );
+    let metrics_connection_open = match metrics::record_connection_opened(&state.workdir) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!("Failed to record connection metrics: {}", e);
+            false
+        }
+    };
+    if is_new_client {
+        if let Err(e) = metrics::record_pairing_completed(&state.workdir) {
+            tracing::warn!("Failed to record pairing metrics: {}", e);
+        }
+    }
 
     let session_start = std::time::Instant::now();
 
@@ -607,6 +620,11 @@ pub async fn handle_connection(
     });
 
     registry.detach_client(&session.id, client_pubkey).await;
+    if metrics_connection_open {
+        if let Err(e) = metrics::record_connection_closed(&state.workdir) {
+            tracing::warn!("Failed to record connection metrics: {}", e);
+        }
+    }
 
     tracing::info!(
         "Connection closed: session={} (session stays alive in registry)",
@@ -915,41 +933,49 @@ async fn finish_auth(
 
     // Attach to the requested session, with fallback for stale session IDs
     // (e.g. after a daemon restart the client's stored session_id is gone).
-    let (attach_result, resolved_session_id) =
-        match registry.attach_client(&session_id, client_pubkey).await {
-            AttachResult::SessionNotFound => {
-                // Client is globally authorized but their session was lost.
-                // Try to find another session they have ACL for, or create one.
-                let fallback =
-                    if let Some(s) = registry.find_session_for_client(&client_pubkey).await {
-                        tracing::info!(
-                            "finish_auth: session {} gone, falling back to session {}",
-                            session_id,
-                            s.id,
-                        );
-                        s
-                    } else {
-                        // No existing session — create a fresh default one.
-                        let workdir = &state.workdir;
-                        let name = workdir
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .unwrap_or("default");
-                        let s = registry.create_named(name, workdir.to_path_buf()).await;
-                        registry.add_client_to_session(&s.id, client_pubkey).await;
-                        tracing::info!(
-                            "finish_auth: session {} gone, created new session {} ({})",
-                            session_id,
-                            s.id,
-                            name,
-                        );
-                        s
-                    };
-                let new_id = fallback.id.clone();
-                (registry.attach_client(&new_id, client_pubkey).await, new_id)
-            }
-            other => (other, session_id.clone()),
-        };
+    let (attach_result, resolved_session_id) = match registry
+        .attach_client(&session_id, client_pubkey)
+        .await
+    {
+        AttachResult::SessionNotFound => {
+            // Client is globally authorized but their session was lost.
+            // Try to find another session they have ACL for, or create one.
+            let fallback = if let Some(s) = registry.find_session_for_client(&client_pubkey).await {
+                tracing::info!(
+                    "finish_auth: session {} gone, falling back to session {}",
+                    session_id,
+                    s.id,
+                );
+                s
+            } else {
+                // No existing session — create a fresh default one.
+                let workdir = &state.workdir;
+                let name = workdir
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("default");
+                let session_was_existing = registry.get_by_name(name).await.is_some();
+                let s = registry.create_named(name, workdir.to_path_buf()).await;
+                if !session_was_existing {
+                    let session_count = registry.session_count().await;
+                    if let Err(e) = metrics::record_session_created(workdir, session_count) {
+                        tracing::warn!("Failed to record session metrics: {}", e);
+                    }
+                }
+                registry.add_client_to_session(&s.id, client_pubkey).await;
+                tracing::info!(
+                    "finish_auth: session {} gone, created new session {} ({})",
+                    session_id,
+                    s.id,
+                    name,
+                );
+                s
+            };
+            let new_id = fallback.id.clone();
+            (registry.attach_client(&new_id, client_pubkey).await, new_id)
+        }
+        other => (other, session_id.clone()),
+    };
 
     match attach_result {
         AttachResult::Ok => {
@@ -1756,6 +1782,11 @@ async fn dispatch(
             {
                 Ok(id) => {
                     zedra_telemetry::send(Event::HostTerminalOpen { has_launch_cmd });
+                    let terminal_count = session.terminals.lock().await.len();
+                    if let Err(e) = metrics::record_terminal_created(&state.workdir, terminal_count)
+                    {
+                        tracing::warn!("Failed to record terminal metrics: {}", e);
+                    }
                     let _ = msg.tx.send(TermCreateResult { id, error: None }).await;
                 }
                 Err(e) => {


### PR DESCRIPTION
## Summary
- add local per-workspace metrics persisted under the Zedra workspace config directory
- add `zedra metrics` to show usage, active time, starts, connections, pairings, QR creations, sessions, and terminals
- record metrics from daemon start, QR creation, auth connection lifecycle, session fallback, and terminal creation

## Tests
- cargo check -p zedra-host
- cargo test -p zedra-host