### PR TITLE
fix(telemetry): align app and host tracking

### DIFF
--- a/crates/zedra-host/src/api.rs
+++ b/crates/zedra-host/src/api.rs
@@ -29,6 +29,7 @@ use crate::rpc_daemon::{create_terminal, DaemonState};
 use crate::session_registry::SessionRegistry;
 use zedra_rpc::proto::HostEvent;
 use zedra_rpc::ZedraPairingTicket;
+use zedra_telemetry::Event;
 
 // ---------------------------------------------------------------------------
 // Shared state
@@ -260,6 +261,12 @@ async fn create_terminal_handler(
 
     match create_terminal(&session, req.cols, req.rows, opts).await {
         Ok(id) => {
+            zedra_telemetry::send(Event::HostTerminalOpen {
+                has_launch_cmd: launch_cmd
+                    .as_ref()
+                    .map(|command| !command.is_empty())
+                    .unwrap_or(false),
+            });
             // Push TerminalCreated event to the subscribed client (if any).
             session
                 .push_event(HostEvent::TerminalCreated {

--- a/crates/zedra-host/src/ga4.rs
+++ b/crates/zedra-host/src/ga4.rs
@@ -131,6 +131,17 @@ impl Ga4 {
             inner.send(name, params).await;
         });
     }
+
+    /// Send an event and wait for the HTTP request to finish.
+    ///
+    /// Short-lived CLI commands use this so completion telemetry is not dropped
+    /// when the Tokio runtime shuts down immediately after the command exits.
+    pub(crate) async fn track_raw_now(&self, name: &'static str, params: Value) {
+        let Some(inner) = self.inner.clone() else {
+            return;
+        };
+        inner.send(name, params).await;
+    }
 }
 
 impl Inner {

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -368,6 +368,33 @@ fn start_detached(_options: DetachedStartOptions) -> Result<DetachedStartResult>
     anyhow::bail!("`zedra start --detach` is only supported on Unix platforms.");
 }
 
+fn telemetry_disabled(no_telemetry: bool) -> bool {
+    no_telemetry
+        || std::env::var("ZEDRA_TELEMETRY")
+            .map(|v| v == "0" || v.eq_ignore_ascii_case("false"))
+            .unwrap_or(false)
+}
+
+fn new_ga4(
+    telemetry_id_fallback_dir: &Path,
+    no_telemetry: bool,
+    debug_telemetry: bool,
+) -> Arc<Ga4> {
+    Arc::new(if telemetry_disabled(no_telemetry) {
+        Ga4::disabled()
+    } else {
+        let ga4 = Ga4::new(
+            &identity::telemetry_id_path()
+                .unwrap_or_else(|_| telemetry_id_fallback_dir.join(".zedra-telemetry-id")),
+            debug_telemetry,
+        );
+        if debug_telemetry {
+            eprintln!("[telemetry] debug mode (GA4 validation endpoint, not recorded)");
+        }
+        ga4
+    })
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -485,23 +512,7 @@ async fn main() -> Result<()> {
             let endpoint_id = host_identity.endpoint_id();
 
             // Initialize telemetry. Disabled by --no-telemetry flag or ZEDRA_TELEMETRY=0.
-            let telemetry_disabled = no_telemetry
-                || std::env::var("ZEDRA_TELEMETRY")
-                    .map(|v| v == "0" || v.eq_ignore_ascii_case("false"))
-                    .unwrap_or(false);
-            let ga4 = Arc::new(if telemetry_disabled {
-                Ga4::disabled()
-            } else {
-                let g = Ga4::new(
-                    &identity::telemetry_id_path()
-                        .unwrap_or_else(|_| workdir.join(".zedra-telemetry-id")),
-                    debug_telemetry,
-                );
-                if debug_telemetry {
-                    eprintln!("[telemetry] debug mode (GA4 validation endpoint, not recorded)");
-                }
-                g
-            });
+            let ga4 = new_ga4(&workdir, no_telemetry, debug_telemetry);
             let is_first_run = ga4.is_first_run;
 
             // Register host GA4 backend as the global telemetry provider.
@@ -915,6 +926,8 @@ async fn main() -> Result<()> {
         }
 
         Commands::Update { version, yes } => {
+            let telemetry_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            let ga4 = new_ga4(&telemetry_dir, false, false);
             let current = env!("CARGO_PKG_VERSION");
             utils::eprintln_heading("Zedra Update");
             eprintln!();
@@ -971,13 +984,17 @@ async fn main() -> Result<()> {
             match version_check::self_update(&target_tag).await {
                 Ok(tag) => {
                     let elapsed_ms = update_start.elapsed().as_millis() as u64;
-                    zedra_telemetry::send(Event::SelfUpdate {
-                        success: true,
-                        target_version: tag.clone(),
-                        from_version: env!("CARGO_PKG_VERSION"),
-                        error: "",
-                        elapsed_ms,
-                    });
+                    zedra_host::telemetry::send_now(
+                        &ga4,
+                        Event::SelfUpdate {
+                            success: true,
+                            target_version: tag.clone(),
+                            from_version: env!("CARGO_PKG_VERSION"),
+                            error: "",
+                            elapsed_ms,
+                        },
+                    )
+                    .await;
                     eprintln!();
                     utils::eprintln_success(format!("Updated to {tag}."));
                     if !alive.is_empty() {
@@ -990,13 +1007,17 @@ async fn main() -> Result<()> {
                 Err(e) => {
                     let elapsed_ms = update_start.elapsed().as_millis() as u64;
                     let error_label = classify_update_error(&e);
-                    zedra_telemetry::send(Event::SelfUpdate {
-                        success: false,
-                        target_version: target_tag.clone(),
-                        from_version: env!("CARGO_PKG_VERSION"),
-                        error: error_label,
-                        elapsed_ms,
-                    });
+                    zedra_host::telemetry::send_now(
+                        &ga4,
+                        Event::SelfUpdate {
+                            success: false,
+                            target_version: target_tag.clone(),
+                            from_version: env!("CARGO_PKG_VERSION"),
+                            error: error_label,
+                            elapsed_ms,
+                        },
+                    )
+                    .await;
                     utils::eprintln_error(format!("Update failed: {e}"));
                     std::process::exit(1);
                 }

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -254,6 +254,43 @@ fn initial_path_type(conn: &iroh::endpoint::Connection) -> &'static str {
     result
 }
 
+fn connection_latency_sample(
+    path: &iroh::endpoint::PathInfo,
+    path_count: usize,
+    interval_secs: u64,
+) -> Event {
+    let (connection_type, network_type, relay, relay_region, nearest_relay_region) =
+        match path.remote_addr() {
+            iroh::TransportAddr::Ip(addr) => (
+                "p2p",
+                zedra_telemetry::ip_network_type(addr.ip()),
+                "none",
+                "none",
+                "unknown",
+            ),
+            iroh::TransportAddr::Relay(url) => {
+                let relay = url.host_str().unwrap_or(url.as_str());
+                let relay_id = zedra_telemetry::relay_id_label(relay);
+                let relay_region = zedra_telemetry::relay_region_label(relay);
+                ("relay", "relay", relay_id, relay_region, relay_region)
+            }
+            _ => ("unknown", "unknown", "none", "unknown", "unknown"),
+        };
+
+    Event::ConnectionLatencySample {
+        source: "host",
+        connection_type,
+        network_type,
+        rtt_ms: path.stats().rtt.as_millis() as u64,
+        relay,
+        relay_region,
+        nearest_relay_region,
+        path_count,
+        interval_secs,
+        sample_reason: "periodic",
+    }
+}
+
 /// Resolve `user_path` relative to `workdir`, then verify the canonical path
 /// stays inside `workdir`. Rejects absolute paths, `..` escapes, and symlinks
 /// that point outside the jail.
@@ -530,6 +567,7 @@ pub async fn handle_connection(
             let mut paths = conn_for_bw.paths(); // hold watcher for the lifetime of the task
             let mut prev_tx: u64 = 0;
             let mut prev_rx: u64 = 0;
+            const SAMPLE_INTERVAL_SECS: u64 = 60;
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
@@ -537,12 +575,18 @@ pub async fn handle_connection(
                         let mut cur_tx = 0u64;
                         let mut cur_rx = 0u64;
                         let mut bw_found = false;
+                        let mut latency_sample = None;
                         for p in path_list.iter() {
                             if p.is_selected() {
                                 let s = p.stats();
                                 cur_tx = s.udp_tx.bytes;
                                 cur_rx = s.udp_rx.bytes;
                                 bw_found = true;
+                                latency_sample = Some(connection_latency_sample(
+                                    p,
+                                    path_list.len(),
+                                    SAMPLE_INTERVAL_SECS,
+                                ));
                                 break;
                             }
                         }
@@ -555,8 +599,11 @@ pub async fn handle_connection(
                             zedra_telemetry::send(Event::BandwidthSample {
                                 bytes_sent: delta_tx,
                                 bytes_recv: delta_rx,
-                                interval_secs: 60,
+                                interval_secs: SAMPLE_INTERVAL_SECS,
                             });
+                        }
+                        if let Some(sample) = latency_sample {
+                            zedra_telemetry::send(sample);
                         }
                     }
                     _ = conn_for_bw.closed() => break,

--- a/crates/zedra-host/src/telemetry.rs
+++ b/crates/zedra-host/src/telemetry.rs
@@ -8,6 +8,14 @@ use std::sync::Arc;
 
 use crate::ga4::Ga4;
 
+fn params_value(event: &zedra_telemetry::Event) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    for (k, v) in event.to_params() {
+        obj.insert(k.to_string(), serde_json::Value::String(v));
+    }
+    serde_json::Value::Object(obj)
+}
+
 /// Wraps the host's `Ga4` transport as a `TelemetryBackend`.
 struct HostBackend {
     ga4: Arc<Ga4>,
@@ -16,12 +24,7 @@ struct HostBackend {
 impl zedra_telemetry::TelemetryBackend for HostBackend {
     fn send(&self, event: &zedra_telemetry::Event) {
         let name = event.name();
-        let params = event.to_params();
-        let mut obj = serde_json::Map::new();
-        for (k, v) in params {
-            obj.insert(k.to_string(), serde_json::Value::String(v));
-        }
-        self.ga4.track_raw(name, serde_json::Value::Object(obj));
+        self.ga4.track_raw(name, params_value(event));
     }
 
     fn record_panic(&self, message: &str, location: &str) {
@@ -32,4 +35,9 @@ impl zedra_telemetry::TelemetryBackend for HostBackend {
 /// Register the host's GA4 backend as the global telemetry backend.
 pub fn init(ga4: Arc<Ga4>) {
     let _ = zedra_telemetry::init(Box::new(HostBackend { ga4 }));
+}
+
+/// Send and flush one event for short-lived CLI commands.
+pub async fn send_now(ga4: &Ga4, event: zedra_telemetry::Event) {
+    ga4.track_raw_now(event.name(), params_value(&event)).await;
 }

--- a/crates/zedra-session/src/connect.rs
+++ b/crates/zedra-session/src/connect.rs
@@ -366,6 +366,12 @@ impl Connector {
             .process_sync(&client, &sync, existing_terminals)
             .await?;
         let sync_ms = t_sync.elapsed().as_millis() as u64;
+        if !terminals.is_empty() {
+            self.emit(ConnectEvent::TerminalsReattached {
+                count: terminals.len(),
+                resume_ms: sync_ms,
+            });
+        }
 
         self.emit(ConnectEvent::SyncComplete {
             sync: sync.clone(),

--- a/crates/zedra-session/src/state.rs
+++ b/crates/zedra-session/src/state.rs
@@ -254,6 +254,7 @@ pub struct ConnectSnapshot {
     pub local_node_id: Option<String>,
     pub remote_node_id: Option<String>,
     pub relay_url: Option<String>,
+    pub preferred_relay_url: Option<String>,
     pub alpn: Option<String>,
     pub relay_connected: bool,
     pub direct_addrs: Vec<String>,
@@ -367,6 +368,8 @@ impl SessionState {
                 snap.has_ipv4 = net_report.udp_v4;
                 snap.has_ipv6 = net_report.udp_v6;
                 snap.mapping_varies = net_report.mapping_varies_by_dest();
+                snap.preferred_relay_url =
+                    net_report.preferred_relay.as_ref().map(ToString::to_string);
                 snap.relay_latency_ms = net_report
                     .relay_latency
                     .iter()

--- a/crates/zedra-telemetry/src/lib.rs
+++ b/crates/zedra-telemetry/src/lib.rs
@@ -160,6 +160,28 @@ pub enum Event {
         /// Relay hostname the connection upgraded from.
         from_relay: String,
     },
+    /// Periodic selected-path latency sample.
+    ConnectionLatencySample {
+        /// "app" or "host".
+        source: &'static str,
+        /// "relay", "p2p", or "unknown".
+        connection_type: &'static str,
+        /// "LAN", "WAN", "Tailscale", "relay", or "unknown".
+        network_type: &'static str,
+        rtt_ms: u64,
+        /// Known relay id ("sg1", "vn1", "us1", "eu1"), "custom", or "none".
+        relay: &'static str,
+        /// Region for the selected relay, or "none" / "custom" / "unknown".
+        relay_region: &'static str,
+        /// Approximate client region inferred from the preferred relay, never from IP geolocation.
+        nearest_relay_region: &'static str,
+        /// Number of paths iroh currently reports.
+        path_count: usize,
+        /// Configured sampling interval, not a session average.
+        interval_secs: u64,
+        /// "initial", "periodic", or "path_changed".
+        sample_reason: &'static str,
+    },
 
     // ── Terminal (client-side) ─────────────────────────────────────────────
     /// A new terminal was created (PTY spawned on server).
@@ -339,6 +361,7 @@ impl Event {
             Self::ReconnectSuccess { .. } => "reconnect_success",
             Self::ReconnectExhausted { .. } => "reconnect_exhausted",
             Self::PathUpgraded { .. } => "path_upgraded",
+            Self::ConnectionLatencySample { .. } => "connection_latency_sample",
             Self::TerminalOpened { .. } => "terminal_opened",
             Self::TerminalClosed { .. } => "terminal_closed",
             Self::DaemonStart { .. } => "daemon_start",
@@ -499,6 +522,29 @@ impl Event {
                 ("rtt_ms", rtt_ms.to_string()),
                 ("from_relay", from_relay.clone()),
             ],
+            Self::ConnectionLatencySample {
+                source,
+                connection_type,
+                network_type,
+                rtt_ms,
+                relay,
+                relay_region,
+                nearest_relay_region,
+                path_count,
+                interval_secs,
+                sample_reason,
+            } => vec![
+                ("source", source.to_string()),
+                ("connection_type", connection_type.to_string()),
+                ("network_type", network_type.to_string()),
+                ("rtt_ms", rtt_ms.to_string()),
+                ("relay", relay.to_string()),
+                ("relay_region", relay_region.to_string()),
+                ("nearest_relay_region", nearest_relay_region.to_string()),
+                ("path_count", path_count.to_string()),
+                ("interval_secs", interval_secs.to_string()),
+                ("sample_reason", sample_reason.to_string()),
+            ],
             Self::TerminalOpened {
                 source,
                 terminal_count,
@@ -648,6 +694,71 @@ fn bool_str(v: bool) -> String {
     if v { "1" } else { "0" }.to_string()
 }
 
+pub fn relay_id_label(relay: &str) -> &'static str {
+    let host = relay_host(relay);
+    if host.is_empty() || host == "none" {
+        "none"
+    } else if host.starts_with("sg1.") || host == "sg1" {
+        "sg1"
+    } else if host.starts_with("vn1.") || host == "vn1" {
+        "vn1"
+    } else if host.starts_with("us1.") || host == "us1" {
+        "us1"
+    } else if host.starts_with("eu1.") || host == "eu1" {
+        "eu1"
+    } else {
+        "custom"
+    }
+}
+
+pub fn relay_region_label(relay: &str) -> &'static str {
+    match relay_id_label(relay) {
+        "sg1" => "ap-southeast-1",
+        "vn1" => "vietnam",
+        "us1" => "us-east-1",
+        "eu1" => "eu-central-1",
+        "custom" => "custom",
+        "none" => "none",
+        _ => "unknown",
+    }
+}
+
+pub fn ip_network_type(ip: std::net::IpAddr) -> &'static str {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            let o = v4.octets();
+            if v4.is_loopback() {
+                "LAN"
+            } else if o[0] == 100 && o[1] >= 64 && o[1] <= 127 {
+                "Tailscale"
+            } else if o[0] == 10
+                || (o[0] == 172 && o[1] >= 16 && o[1] <= 31)
+                || (o[0] == 192 && o[1] == 168)
+            {
+                "LAN"
+            } else {
+                "WAN"
+            }
+        }
+        std::net::IpAddr::V6(v6) => {
+            let s = v6.segments();
+            if v6.is_loopback() || s[0] == 0xfe80 || s[0] & 0xfe00 == 0xfc00 {
+                "LAN"
+            } else {
+                "WAN"
+            }
+        }
+    }
+}
+
+fn relay_host(relay: &str) -> &str {
+    let without_scheme = relay
+        .strip_prefix("https://")
+        .or_else(|| relay.strip_prefix("http://"))
+        .unwrap_or(relay);
+    without_scheme.split('/').next().unwrap_or(without_scheme)
+}
+
 // ---------------------------------------------------------------------------
 // Backend trait
 // ---------------------------------------------------------------------------
@@ -764,7 +875,8 @@ pub fn set_custom_key(key: &str, value: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::Event;
+    use super::{Event, ip_network_type, relay_id_label, relay_region_label};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn screen_view_serializes_firebase_screen_params() {
@@ -783,5 +895,67 @@ mod tests {
                 ("screen_class", "WorkspaceEditor".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn connection_latency_sample_serializes_periodic_path_context() {
+        let params = Event::ConnectionLatencySample {
+            source: "app",
+            connection_type: "p2p",
+            network_type: "Tailscale",
+            rtt_ms: 42,
+            relay: "none",
+            relay_region: "none",
+            nearest_relay_region: "ap-southeast-1",
+            path_count: 2,
+            interval_secs: 60,
+            sample_reason: "periodic",
+        }
+        .to_params();
+
+        assert_eq!(
+            params,
+            vec![
+                ("source", "app".to_string()),
+                ("connection_type", "p2p".to_string()),
+                ("network_type", "Tailscale".to_string()),
+                ("rtt_ms", "42".to_string()),
+                ("relay", "none".to_string()),
+                ("relay_region", "none".to_string()),
+                ("nearest_relay_region", "ap-southeast-1".to_string()),
+                ("path_count", "2".to_string()),
+                ("interval_secs", "60".to_string()),
+                ("sample_reason", "periodic".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn relay_labels_are_sanitized_to_known_ids_and_regions() {
+        assert_eq!(relay_id_label("https://sg1.relay.zedra.dev"), "sg1");
+        assert_eq!(
+            relay_region_label("https://sg1.relay.zedra.dev"),
+            "ap-southeast-1"
+        );
+        assert_eq!(relay_id_label("custom-relay.example.com"), "custom");
+        assert_eq!(relay_region_label("custom-relay.example.com"), "custom");
+        assert_eq!(relay_id_label("none"), "none");
+    }
+
+    #[test]
+    fn ip_network_type_does_not_return_ip_values() {
+        assert_eq!(
+            ip_network_type(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))),
+            "Tailscale"
+        );
+        assert_eq!(
+            ip_network_type(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10))),
+            "LAN"
+        );
+        assert_eq!(
+            ip_network_type(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))),
+            "WAN"
+        );
+        assert_eq!(ip_network_type(IpAddr::V6(Ipv6Addr::LOCALHOST)), "LAN");
     }
 }

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -8,7 +8,10 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::*;
 use zedra_rpc::ZedraPairingTicket;
 use zedra_rpc::proto::{HostEvent, SyncSessionResult};
-use zedra_session::{ConnectEvent, Session, SessionHandle, SessionState, signer::ClientSigner};
+use zedra_session::{
+    ConnectEvent, ConnectPhase, ConnectSnapshot, ReconnectReason, Session, SessionHandle,
+    SessionState, signer::ClientSigner,
+};
 
 use crate::active_terminal;
 use crate::agent;
@@ -63,6 +66,7 @@ pub struct Workspace {
     connection_request: Option<ConnectionRequest>,
     /// Becomes true once a ReconnectStarted event is seen; gates initial auto-open/create.
     seen_reconnect: bool,
+    active_reconnect_reason: Option<ReconnectReason>,
     /// Listens for connect events and syncs them into SessionState/WorkspaceState.
     _connect_listener: Option<Task<()>>,
     /// Listens for host events/actions from the remote host.
@@ -194,6 +198,205 @@ fn should_initialize_terminals_after_sync(
 
 fn should_apply_connect_event(_event: &ConnectEvent, user_disconnect: bool) -> bool {
     !user_disconnect
+}
+
+fn reconnect_reason_label(reason: &ReconnectReason) -> &'static str {
+    match reason {
+        ReconnectReason::ConnectionLost => "connection_lost",
+        ReconnectReason::AppForegrounded => "app_foregrounded",
+    }
+}
+
+fn path_label(snap: &ConnectSnapshot) -> &'static str {
+    if snap
+        .transport
+        .as_ref()
+        .map(|transport| transport.is_direct)
+        .unwrap_or(false)
+    {
+        "direct"
+    } else if snap.transport.is_some() || snap.relay_connected {
+        "relay"
+    } else {
+        "unknown"
+    }
+}
+
+fn network_label(snap: &ConnectSnapshot) -> &'static str {
+    snap.transport
+        .as_ref()
+        .and_then(|transport| transport.network_hint.as_ref())
+        .map(|network| network.label())
+        .unwrap_or("unknown")
+}
+
+fn relay_label(snap: &ConnectSnapshot) -> String {
+    snap.transport
+        .as_ref()
+        .and_then(|transport| transport.relay_url.clone())
+        .or_else(|| snap.relay_url.clone())
+        .unwrap_or_else(|| {
+            if snap.relay_connected {
+                "custom".to_string()
+            } else {
+                "none".to_string()
+            }
+        })
+}
+
+fn classify_ip_network(ip: std::net::IpAddr) -> &'static str {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            if octets[0] == 100 && octets[1] >= 64 && octets[1] <= 127 {
+                "Tailscale"
+            } else if octets[0] == 10
+                || (octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31)
+                || (octets[0] == 192 && octets[1] == 168)
+            {
+                "LAN"
+            } else {
+                "Internet"
+            }
+        }
+        std::net::IpAddr::V6(v6) => {
+            let segments = v6.segments();
+            if segments[0] == 0xfe80 || segments[0] & 0xfe00 == 0xfc00 {
+                "LAN"
+            } else {
+                "Internet"
+            }
+        }
+    }
+}
+
+fn path_network_label(path: &iroh::endpoint::PathInfo) -> &'static str {
+    match path.remote_addr() {
+        iroh::TransportAddr::Ip(addr) => classify_ip_network(addr.ip()),
+        _ => "unknown",
+    }
+}
+
+fn path_relay_label(path: &iroh::endpoint::PathInfo) -> Option<String> {
+    match path.remote_addr() {
+        iroh::TransportAddr::Relay(url) => Some(url.host_str().unwrap_or(url.as_str()).to_string()),
+        _ => None,
+    }
+}
+
+fn record_connect_telemetry(
+    event: &ConnectEvent,
+    state: &SessionState,
+    previous_phase: &ConnectPhase,
+    is_reconnect_context: bool,
+    reconnect_reason: Option<&ReconnectReason>,
+) {
+    let snap = &state.snapshot;
+    match event {
+        ConnectEvent::Connected { total_ms } if !is_reconnect_context => {
+            zedra_telemetry::send(zedra_telemetry::Event::ConnectSuccess {
+                total_ms: *total_ms,
+                binding_ms: snap.binding_ms.unwrap_or(0),
+                hole_punch_ms: snap.hole_punch_ms.unwrap_or(0),
+                auth_ms: snap.auth_ms.unwrap_or(0),
+                fetch_ms: snap.sync_ms.unwrap_or(0),
+                path: path_label(snap),
+                network: network_label(snap),
+                rtt_ms: snap
+                    .transport
+                    .as_ref()
+                    .map(|transport| transport.rtt_ms)
+                    .unwrap_or(0),
+                relay: relay_label(snap),
+                relay_latency_ms: snap.relay_latency_ms.unwrap_or(0),
+                alpn: snap.alpn.clone().unwrap_or_default(),
+                has_ipv4: snap.has_ipv4,
+                has_ipv6: snap.has_ipv6,
+                symmetric_nat: snap.mapping_varies.unwrap_or(false),
+                is_first_pairing: snap.is_first_pairing,
+            });
+        }
+        ConnectEvent::Failed { error } if !is_reconnect_context => {
+            zedra_telemetry::send(zedra_telemetry::Event::ConnectFailed {
+                phase: previous_phase.label(),
+                error: error.label(),
+                elapsed_ms: state.elapsed_ms(),
+                relay: relay_label(snap),
+                alpn: snap.alpn.clone().unwrap_or_default(),
+                has_ipv4: snap.has_ipv4,
+                has_ipv6: snap.has_ipv6,
+                relay_connected: snap.relay_connected,
+            });
+        }
+        ConnectEvent::TerminalsReattached { count, resume_ms } => {
+            zedra_telemetry::send(zedra_telemetry::Event::SessionResumed {
+                terminal_count: *count,
+                resume_ms: *resume_ms,
+            });
+        }
+        ConnectEvent::ReconnectStarted { reason } => {
+            zedra_telemetry::send(zedra_telemetry::Event::ReconnectStarted {
+                reason: reconnect_reason_label(reason),
+            });
+        }
+        ConnectEvent::ReconnectSuccess {
+            attempt,
+            elapsed_ms,
+        } => {
+            let reason = reconnect_reason
+                .map(reconnect_reason_label)
+                .unwrap_or("connection_lost");
+            zedra_telemetry::send(zedra_telemetry::Event::ReconnectSuccess {
+                attempt: *attempt,
+                elapsed_ms: *elapsed_ms,
+                reason,
+                binding_ms: snap.binding_ms.unwrap_or(0),
+                hole_punch_ms: snap.hole_punch_ms.unwrap_or(0),
+                auth_ms: snap.auth_ms.unwrap_or(0),
+                fetch_ms: snap.sync_ms.unwrap_or(0),
+                path: path_label(snap),
+                network: network_label(snap),
+                rtt_ms: snap
+                    .transport
+                    .as_ref()
+                    .map(|transport| transport.rtt_ms)
+                    .unwrap_or(0),
+                relay: relay_label(snap),
+                alpn: snap.alpn.clone().unwrap_or_default(),
+                has_ipv4: snap.has_ipv4,
+                has_ipv6: snap.has_ipv6,
+            });
+        }
+        ConnectEvent::ReconnectExhausted {
+            attempts,
+            elapsed_ms,
+            error,
+        } => {
+            let reason = reconnect_reason
+                .map(reconnect_reason_label)
+                .unwrap_or("connection_lost");
+            zedra_telemetry::send(zedra_telemetry::Event::ReconnectExhausted {
+                attempts: *attempts,
+                elapsed_ms: *elapsed_ms,
+                reason,
+                fatal_error: error.is_fatal().then_some(error.label()),
+            });
+        }
+        ConnectEvent::PathUpgraded {
+            prev_path,
+            new_path,
+        } => {
+            zedra_telemetry::send(zedra_telemetry::Event::PathUpgraded {
+                network: path_network_label(new_path),
+                rtt_ms: new_path.stats().rtt.as_millis() as u64,
+                from_relay: prev_path
+                    .as_ref()
+                    .and_then(path_relay_label)
+                    .unwrap_or_else(|| relay_label(snap)),
+            });
+        }
+        _ => {}
+    }
 }
 
 fn terminal_id_in_sync(id: &str, terminal_ids: &[String]) -> bool {
@@ -420,6 +623,7 @@ impl Workspace {
             persist_workspace_state: true,
             connection_request: None,
             seen_reconnect: false,
+            active_reconnect_reason: None,
             _connect_listener: None,
             _host_event_listener: Some(host_event_listener),
             _host_info_listener: Some(host_info_listener),
@@ -463,13 +667,33 @@ impl Workspace {
 
                         let sync_refresh_mode =
                             sync_refresh_mode_for_event(&event, &mut ws.seen_reconnect);
+                        if let ConnectEvent::ReconnectStarted { reason } = &event {
+                            ws.active_reconnect_reason = Some(reason.clone());
+                        }
+                        let is_reconnect_context = ws.seen_reconnect;
+                        let reconnect_reason = ws.active_reconnect_reason.clone();
                         ws.session_state.update(cx, |state, cx| {
+                            let previous_phase = state.phase();
                             state.apply_event(event.clone());
+                            record_connect_telemetry(
+                                &event,
+                                state,
+                                &previous_phase,
+                                is_reconnect_context,
+                                reconnect_reason.as_ref(),
+                            );
                             cx.notify();
                             ws.workspace_state.update(cx, |this, cx| {
                                 this.sync_from_session(ws.session_handle(), state, cx);
                             });
                         });
+                        if matches!(
+                            event,
+                            ConnectEvent::ReconnectSuccess { .. }
+                                | ConnectEvent::ReconnectExhausted { .. }
+                        ) {
+                            ws.active_reconnect_reason = None;
+                        }
                         if let ConnectEvent::SyncComplete { sync, .. } = &event {
                             ws.seed_terminal_meta_from_sync(sync, cx);
                         }
@@ -569,6 +793,8 @@ impl Workspace {
             session_id,
         };
         self.connection_request = Some(request.clone());
+        self.seen_reconnect = false;
+        self.active_reconnect_reason = None;
         self.start_connection(request);
 
         self.content.update(cx, |c, cx| c.show_connecting_view(cx));
@@ -598,6 +824,8 @@ impl Workspace {
         }
 
         info!("restart connection requested");
+        self.seen_reconnect = false;
+        self.active_reconnect_reason = None;
         self.start_connection(request);
         self.content.update(cx, |c, cx| c.show_connecting_view(cx));
         self.record_current_view(cx);
@@ -1052,6 +1280,15 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.create_new_terminal("user_action", window, cx);
+    }
+
+    fn create_new_terminal(
+        &mut self,
+        telemetry_source: &'static str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         info!("handle CreateNewTerminal from workspace");
         self.drawer_host
             .update(cx, |host, cx| host.close_with_window(&mut *window, cx));
@@ -1092,6 +1329,11 @@ impl Workspace {
                 });
 
                 ws.activate_terminal(terminal_id, workspace_terminal.into(), cx);
+                let terminal_count = ws.workspace_state.read(cx).terminal_ids.len();
+                zedra_telemetry::send(zedra_telemetry::Event::TerminalOpened {
+                    source: telemetry_source,
+                    terminal_count,
+                });
             });
         })
         .detach();
@@ -1215,6 +1457,9 @@ impl Workspace {
             });
             view_telemetry::record(view_telemetry::WORKSPACE_NO_ACTIVE_TERMINAL);
         }
+
+        let remaining = self.workspace_state.read(cx).terminal_ids.len();
+        zedra_telemetry::send(zedra_telemetry::Event::TerminalClosed { remaining });
 
         let handle = self.session.handle().clone();
         cx.spawn(async move |_workspace, _cx| {
@@ -1431,7 +1676,7 @@ impl Workspace {
             self.handle_open_terminal(&OpenTerminal { id: first_id }, window, cx);
         } else {
             info!("no terminals on connect, creating new terminal");
-            self.handle_create_new_terminal(&CreateNewTerminal, window, cx);
+            self.create_new_terminal("new_session", window, cx);
         }
     }
 }

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Result as AnyhowResult, anyhow};
 use gpui::{prelude::FluentBuilder as _, *};
@@ -67,6 +67,7 @@ pub struct Workspace {
     /// Becomes true once a ReconnectStarted event is seen; gates initial auto-open/create.
     seen_reconnect: bool,
     active_reconnect_reason: Option<ReconnectReason>,
+    latency_sampler: LatencySampler,
     /// Listens for connect events and syncs them into SessionState/WorkspaceState.
     _connect_listener: Option<Task<()>>,
     /// Listens for host events/actions from the remote host.
@@ -158,6 +159,47 @@ impl agent::AppCtx for WorkspaceAgentApp {
 enum SyncRefreshMode {
     InitialConnect,
     Reconnect,
+}
+
+const LATENCY_SAMPLE_INTERVAL: Duration = Duration::from_secs(60);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LatencySampleKey {
+    connection_type: &'static str,
+    network_type: &'static str,
+    relay: &'static str,
+    relay_region: &'static str,
+    nearest_relay_region: &'static str,
+}
+
+#[derive(Default)]
+struct LatencySampler {
+    last_sample_at: Option<Instant>,
+    last_key: Option<LatencySampleKey>,
+}
+
+impl LatencySampler {
+    fn next_reason(&mut self, key: LatencySampleKey, now: Instant) -> Option<&'static str> {
+        let reason = match (&self.last_sample_at, &self.last_key) {
+            (None, _) => "initial",
+            (_, Some(previous_key)) if previous_key != &key => "path_changed",
+            (Some(last_sample_at), _)
+                if now.duration_since(*last_sample_at) >= LATENCY_SAMPLE_INTERVAL =>
+            {
+                "periodic"
+            }
+            _ => return None,
+        };
+
+        self.last_sample_at = Some(now);
+        self.last_key = Some(key);
+        Some(reason)
+    }
+
+    fn reset(&mut self) {
+        self.last_sample_at = None;
+        self.last_key = None;
+    }
 }
 
 fn sync_refresh_mode_for_event(
@@ -284,12 +326,97 @@ fn path_relay_label(path: &iroh::endpoint::PathInfo) -> Option<String> {
     }
 }
 
+fn latency_network_type(snap: &ConnectSnapshot) -> &'static str {
+    let Some(transport) = &snap.transport else {
+        return "unknown";
+    };
+    if !transport.is_direct {
+        return "relay";
+    }
+
+    match transport
+        .network_hint
+        .as_ref()
+        .map(|network| network.label())
+    {
+        Some("Internet") => "WAN",
+        Some(label) => label,
+        None => "unknown",
+    }
+}
+
+fn latency_relay_label(snap: &ConnectSnapshot) -> &'static str {
+    let relay = snap
+        .transport
+        .as_ref()
+        .and_then(|transport| transport.relay_url.as_deref())
+        .or(snap.relay_url.as_deref())
+        .unwrap_or("none");
+    zedra_telemetry::relay_id_label(relay)
+}
+
+fn latency_relay_region(snap: &ConnectSnapshot) -> &'static str {
+    let relay = snap
+        .transport
+        .as_ref()
+        .and_then(|transport| transport.relay_url.as_deref())
+        .or(snap.relay_url.as_deref())
+        .unwrap_or("none");
+    zedra_telemetry::relay_region_label(relay)
+}
+
+fn latency_nearest_relay_region(snap: &ConnectSnapshot) -> &'static str {
+    snap.preferred_relay_url
+        .as_deref()
+        .map(zedra_telemetry::relay_region_label)
+        .unwrap_or_else(|| latency_relay_region(snap))
+}
+
+fn record_latency_sample(state: &SessionState, sampler: &mut LatencySampler) {
+    if !matches!(
+        state.phase,
+        ConnectPhase::Connected | ConnectPhase::Idle { .. }
+    ) {
+        return;
+    }
+
+    let Some(transport) = &state.snapshot.transport else {
+        return;
+    };
+
+    let connection_type = if transport.is_direct { "p2p" } else { "relay" };
+    let key = LatencySampleKey {
+        connection_type,
+        network_type: latency_network_type(&state.snapshot),
+        relay: latency_relay_label(&state.snapshot),
+        relay_region: latency_relay_region(&state.snapshot),
+        nearest_relay_region: latency_nearest_relay_region(&state.snapshot),
+    };
+    let Some(sample_reason) = sampler.next_reason(key.clone(), Instant::now()) else {
+        return;
+    };
+
+    zedra_telemetry::send(zedra_telemetry::Event::ConnectionLatencySample {
+        source: "app",
+        connection_type: key.connection_type,
+        network_type: key.network_type,
+        rtt_ms: transport.rtt_ms,
+        relay: key.relay,
+        relay_region: key.relay_region,
+        nearest_relay_region: key.nearest_relay_region,
+        path_count: transport.num_paths,
+        interval_secs: LATENCY_SAMPLE_INTERVAL.as_secs(),
+        sample_reason,
+    });
+}
+
 fn record_connect_telemetry(
     event: &ConnectEvent,
     state: &SessionState,
     previous_phase: &ConnectPhase,
     is_reconnect_context: bool,
     reconnect_reason: Option<&ReconnectReason>,
+    latency_sampler: &mut LatencySampler,
 ) {
     let snap = &state.snapshot;
     match event {
@@ -327,6 +454,7 @@ fn record_connect_telemetry(
                 has_ipv6: snap.has_ipv6,
                 relay_connected: snap.relay_connected,
             });
+            latency_sampler.reset();
         }
         ConnectEvent::TerminalsReattached { count, resume_ms } => {
             zedra_telemetry::send(zedra_telemetry::Event::SessionResumed {
@@ -338,6 +466,7 @@ fn record_connect_telemetry(
             zedra_telemetry::send(zedra_telemetry::Event::ReconnectStarted {
                 reason: reconnect_reason_label(reason),
             });
+            latency_sampler.reset();
         }
         ConnectEvent::ReconnectSuccess {
             attempt,
@@ -395,6 +524,8 @@ fn record_connect_telemetry(
                     .unwrap_or_else(|| relay_label(snap)),
             });
         }
+        ConnectEvent::PathReport { .. } => record_latency_sample(state, latency_sampler),
+        ConnectEvent::Failed { .. } | ConnectEvent::ConnectionClosed => latency_sampler.reset(),
         _ => {}
     }
 }
@@ -624,6 +755,7 @@ impl Workspace {
             connection_request: None,
             seen_reconnect: false,
             active_reconnect_reason: None,
+            latency_sampler: LatencySampler::default(),
             _connect_listener: None,
             _host_event_listener: Some(host_event_listener),
             _host_info_listener: Some(host_info_listener),
@@ -672,21 +804,25 @@ impl Workspace {
                         }
                         let is_reconnect_context = ws.seen_reconnect;
                         let reconnect_reason = ws.active_reconnect_reason.clone();
-                        ws.session_state.update(cx, |state, cx| {
-                            let previous_phase = state.phase();
-                            state.apply_event(event.clone());
-                            record_connect_telemetry(
-                                &event,
-                                state,
-                                &previous_phase,
-                                is_reconnect_context,
-                                reconnect_reason.as_ref(),
-                            );
-                            cx.notify();
-                            ws.workspace_state.update(cx, |this, cx| {
-                                this.sync_from_session(ws.session_handle(), state, cx);
+                        let (previous_phase, telemetry_state) =
+                            ws.session_state.update(cx, |state, cx| {
+                                let previous_phase = state.phase();
+                                state.apply_event(event.clone());
+                                let telemetry_state = state.clone();
+                                cx.notify();
+                                ws.workspace_state.update(cx, |this, cx| {
+                                    this.sync_from_session(ws.session_handle(), state, cx);
+                                });
+                                (previous_phase, telemetry_state)
                             });
-                        });
+                        record_connect_telemetry(
+                            &event,
+                            &telemetry_state,
+                            &previous_phase,
+                            is_reconnect_context,
+                            reconnect_reason.as_ref(),
+                            &mut ws.latency_sampler,
+                        );
                         if matches!(
                             event,
                             ConnectEvent::ReconnectSuccess { .. }
@@ -795,6 +931,7 @@ impl Workspace {
         self.connection_request = Some(request.clone());
         self.seen_reconnect = false;
         self.active_reconnect_reason = None;
+        self.latency_sampler.reset();
         self.start_connection(request);
 
         self.content.update(cx, |c, cx| c.show_connecting_view(cx));
@@ -826,6 +963,7 @@ impl Workspace {
         info!("restart connection requested");
         self.seen_reconnect = false;
         self.active_reconnect_reason = None;
+        self.latency_sampler.reset();
         self.start_connection(request);
         self.content.update(cx, |c, cx| c.show_connecting_view(cx));
         self.record_current_view(cx);
@@ -869,6 +1007,7 @@ impl Workspace {
     /// Programmatically disconnect this workspace.
     pub fn disconnect(&mut self, cx: &mut Context<Self>) {
         self.session.disconnect();
+        self.latency_sampler.reset();
         self.workspace_state.update(cx, |state, cx| {
             state.mark_disconnected(cx);
         });
@@ -879,6 +1018,7 @@ impl Workspace {
     pub fn prepare_for_saved_removal(&mut self) {
         self.persist_workspace_state = false;
         self.session.disconnect();
+        self.latency_sampler.reset();
     }
 
     pub fn open_terminal_from_quick_action(&mut self, id: String, cx: &mut Context<Self>) {

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -66,6 +66,7 @@ Emitted by `zedra` (app crate) and `zedra-session`.
 | `reconnect_success` | `attempt`, `elapsed_ms`, `reason`, `binding_ms`, `hole_punch_ms`, `auth_ms`, `fetch_ms`, `path`, `network`, `rtt_ms`, `relay`, `alpn`, `has_ipv4`, `has_ipv6` | `handle.rs` |
 | `reconnect_exhausted` | `attempts`, `elapsed_ms`, `reason`, `fatal_error` (optional) | `handle.rs` |
 | `path_upgraded` | `network`, `rtt_ms`, `from_relay` | `handle.rs` — path watcher |
+| `connection_latency_sample` | `source`, `connection_type`, `network_type`, `rtt_ms`, `relay`, `relay_region`, `nearest_relay_region`, `path_count`, `interval_secs`, `sample_reason` | `workspace.rs` — selected-path latency sample |
 | `terminal_opened` | `source`, `terminal_count` | `workspace_view.rs` |
 | `terminal_closed` | `remaining` | `workspace_view.rs` |
 
@@ -83,9 +84,19 @@ Emitted by `zedra-host` via the same `zedra_telemetry::send()` mechanism.
 | `session_end` | `duration_ms`, `terminal_count`, `path_type` | `rpc_daemon.rs` — client disconnect |
 | `terminal_open` | `has_launch_cmd` | `rpc_daemon.rs` — PTY spawned |
 | `bandwidth_sample` | `bytes_sent`, `bytes_recv`, `interval_secs` | `rpc_daemon.rs` — every 60s |
+| `connection_latency_sample` | `source`, `connection_type`, `network_type`, `rtt_ms`, `relay`, `relay_region`, `nearest_relay_region`, `path_count`, `interval_secs`, `sample_reason` | `rpc_daemon.rs` — every 60s while connected |
 
 Host events also carry `host_version`, `os`, and `arch` — injected automatically
 by `Ga4::build_payload()` before the GA4 HTTP POST.
+
+`connection_latency_sample` is a point-in-time selected-path sample, not a
+session average. The app emits an initial sample after connection, another when
+the selected path type changes, and then periodic samples on the configured
+interval. The host emits the same event every 60 seconds from the active RPC
+connection. Relay values are sanitized to known relay IDs (`sg1`, `vn1`, `us1`,
+`eu1`) or `custom`; no arbitrary relay hostname, IP address, or geolocation is
+sent. `nearest_relay_region` is inferred from the preferred relay reported by
+iroh, not from user IP lookup.
 
 ---
 

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -20,6 +20,8 @@
 
 #define TEXT_MUTED 5263440
 
+#define BORDER_HIGHLIGHT 13290186
+
 #define BORDER_DEFAULT 2894892
 
 #define BORDER_ACTIVE 5263440
@@ -37,6 +39,8 @@
 #define ACCENT_DIM 5263440
 
 #define DRAWER_PADDING 12.0
+
+#define SPACING_XS 4.0
 
 #define SPACING_SM 8.0
 
@@ -89,6 +93,8 @@
 #define ICON_MD 18.0
 
 #define ICON_SM 16.0
+
+#define ICON_XS 14.0
 
 #define ICON_FILE 12.0
 

--- a/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
@@ -20,6 +20,8 @@
 
 #define TEXT_MUTED 5263440
 
+#define BORDER_HIGHLIGHT 13290186
+
 #define BORDER_DEFAULT 2894892
 
 #define BORDER_ACTIVE 5263440
@@ -37,6 +39,8 @@
 #define ACCENT_DIM 5263440
 
 #define DRAWER_PADDING 12.0
+
+#define SPACING_XS 4.0
 
 #define SPACING_SM 8.0
 
@@ -89,6 +93,8 @@
 #define ICON_MD 18.0
 
 #define ICON_SM 16.0
+
+#define ICON_XS 14.0
 
 #define ICON_FILE 12.0
 


### PR DESCRIPTION
## Summary
- wire app connection, reconnect, session resume, path upgrade, and terminal telemetry to the current workspace/session flow
- emit session resume when sync reattaches existing terminals
- cover host REST terminal creation and flush self-update telemetry for short-lived update commands

## Validation
- cargo fmt
- cargo check -p zedra-session -p zedra-host -p zedra
- cargo test -p zedra-session --lib
- cargo test -p zedra-host --lib
- git diff --check