### PR TITLE
fix(ci): checkout submodules in JS/TS job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
### Motivation
- Ensure the JS/TS CI job checks out git submodules so workspace/package resolution that depends on `vendor/zed` files succeeds during JS workflows.

### Description
- Add `with: submodules: recursive` to the `actions/checkout@v4` step in the `js-check` job of `.github/workflows/ci.yml` so submodules like `vendor/zed` are populated for the JS/TS job.

### Testing
- Ran `cargo fmt --check`, which passed.
- Ran `cargo check -p zedra-rpc -p zedra-session -p zedra-terminal -p zedra-host`, which failed locally because the `vendor/zed` submodule content was not present so `vendor/zed/crates/gpui` could not be read.
- Ran `bun install`, which failed in this environment due to repeated `403` responses from the registry preventing dependency installation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f426b22ae08326bc772aeb7c933f68)