### PR TITLE
fix(ios): repeat held accessory arrow keys

### DIFF
--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -405,6 +405,16 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:1:1\033\\/tmp/zedra-long-code.rs:
 17. Commit message input, dictation: tap the microphone, dictate a short phrase, then stop dictation
 18. Expected: the dictated phrase remains in the input after UIKit commits, the final cleanup delete does not clear the field, and any late `insertDictationResult` does not duplicate the phrase
 
+## 11e. Terminal Keyboard Accessory Arrow Repeat On iOS
+
+1. Connect to a session on iPhone or iOS simulator and open the terminal view
+2. Tap each arrow button in the keyboard accessory once
+3. Expected: each tap sends exactly one corresponding arrow keystroke
+4. Press and hold each arrow button, then release it
+5. Expected: the corresponding arrow input repeats continuously while held and stops immediately on release
+6. Start holding an arrow button, then dismiss the keyboard or background the app
+7. Expected: repeat stops and does not resume when the keyboard or app returns
+
 ## 12. Quick Action Terminal Navigation
 
 1. Connect to a session with at least two open terminals

--- a/ios/Zedra/GPUIRuntimeController.swift
+++ b/ios/Zedra/GPUIRuntimeController.swift
@@ -82,16 +82,19 @@ final class GPUIRuntimeController: NSObject {
     }
 
     func applicationWillResignActive() {
+        keyboardAccessoryController.stopRepeating()
         gpui_ios_will_resign_active(gpuiApp)
     }
 
     func applicationDidEnterBackground() {
+        keyboardAccessoryController.stopRepeating()
         gpui_ios_did_enter_background(gpuiApp)
         zedra_ios_app_did_enter_background()
         stopDisplayLink()
     }
 
     func applicationWillTerminate() {
+        keyboardAccessoryController.stopRepeating()
         stopDisplayLink()
         gpui_ios_will_terminate(gpuiApp)
     }
@@ -132,6 +135,7 @@ final class GPUIRuntimeController: NSObject {
 
     @objc
     func keyboardWillHide(_ notification: Notification) {
+        keyboardAccessoryController.stopRepeating()
         zedra_ios_set_keyboard_height(0)
         gpui_ios_set_software_keyboard_visible(false)
     }
@@ -142,21 +146,7 @@ final class GPUIRuntimeController: NSObject {
         pushWindowSize()
     }
 
-    @objc
-    func keyboardShortcutTapped(_ sender: UIButton) {
-        let idx = sender.tag
-        let key: String?
-        switch idx {
-        case 0: key = "escape"
-        case 1: key = "tab"
-        case 2: key = "left"
-        case 3: key = "down"
-        case 4: key = "up"
-        case 5: key = "right"
-        case 6: key = "enter"
-        default: key = nil
-        }
-        guard let key else { return }
+    private func sendKeyboardAccessoryKey(_ key: String) {
         key.withCString { zedra_ios_send_key_input($0) }
     }
 
@@ -180,10 +170,10 @@ final class GPUIRuntimeController: NSObject {
     private func setupKeyboardAccessoryView() {
         let width = UIScreen.main.bounds.width
         let bar = keyboardAccessoryController.makeAccessoryView(
-            width: width,
-            target: self,
-            action: #selector(keyboardShortcutTapped(_:))
-        )
+            width: width
+        ) { [weak self] key in
+            self?.sendKeyboardAccessoryKey(key)
+        }
         gpui_ios_set_keyboard_accessory_view(Unmanaged.passUnretained(bar).toOpaque())
     }
 

--- a/ios/Zedra/KeyboardSupporter.swift
+++ b/ios/Zedra/KeyboardSupporter.swift
@@ -2,9 +2,34 @@ import UIKit
 
 @objcMembers
 final class KeyboardSupporter: NSObject {
-    private(set) var accessoryView: UIView?
+    private struct KeySpec {
+        let label: String
+        let key: String
+        let repeats: Bool
+    }
 
-    func makeAccessoryView(width: CGFloat, target: Any, action: Selector) -> UIView {
+    private let keySpecs = [
+        KeySpec(label: "Esc", key: "escape", repeats: false),
+        KeySpec(label: "Tab", key: "tab", repeats: false),
+        KeySpec(label: "←", key: "left", repeats: true),
+        KeySpec(label: "↓", key: "down", repeats: true),
+        KeySpec(label: "↑", key: "up", repeats: true),
+        KeySpec(label: "→", key: "right", repeats: true),
+        KeySpec(label: "⏎", key: "enter", repeats: false),
+    ]
+
+    private let repeatInitialDelay: TimeInterval = 0.35
+    private let repeatInterval: TimeInterval = 0.06
+
+    private(set) var accessoryView: UIView?
+    private var sendKey: ((String) -> Void)?
+    private var repeatTimer: Timer?
+    private var repeatingKey: String?
+
+    func makeAccessoryView(width: CGFloat, sendKey: @escaping (String) -> Void) -> UIView {
+        stopRepeating()
+        self.sendKey = sendKey
+
         let height: CGFloat = 44.0
         let bar = UIView(frame: CGRect(x: 0, y: 0, width: width, height: height))
         bar.backgroundColor = UIColor(red: 0.055, green: 0.047, blue: 0.047, alpha: 0.96)
@@ -16,13 +41,12 @@ final class KeyboardSupporter: NSObject {
         border.backgroundColor = UIColor(white: 1.0, alpha: 0.12)
         bar.addSubview(border)
 
-        let labels = ["Esc", "Tab", "←", "↓", "↑", "→", "⏎"]
-        let buttonWidth = width / CGFloat(labels.count)
+        let buttonWidth = width / CGFloat(keySpecs.count)
 
-        for (index, label) in labels.enumerated() {
+        for (index, spec) in keySpecs.enumerated() {
             let button = UIButton(type: .system)
             button.frame = CGRect(x: buttonWidth * CGFloat(index), y: 0, width: buttonWidth, height: height)
-            button.setTitle(label, for: .normal)
+            button.setTitle(spec.label, for: .normal)
             button.titleLabel?.font = .systemFont(ofSize: 16.0)
             let color = UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.0)
             button.setTitleColor(color, for: .normal)
@@ -31,11 +55,68 @@ final class KeyboardSupporter: NSObject {
                 button.overrideUserInterfaceStyle = .dark
             }
             button.tag = index
-            button.addTarget(target, action: action, for: .touchUpInside)
+            button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
+            button.addTarget(self, action: #selector(buttonTouchUpInside(_:)), for: .touchUpInside)
+            button.addTarget(self, action: #selector(stopRepeating), for: .touchUpOutside)
+            button.addTarget(self, action: #selector(stopRepeating), for: .touchCancel)
+            button.addTarget(self, action: #selector(stopRepeating), for: .touchDragExit)
             bar.addSubview(button)
         }
 
         accessoryView = bar
         return bar
+    }
+
+    func stopRepeating() {
+        repeatTimer?.invalidate()
+        repeatTimer = nil
+        repeatingKey = nil
+    }
+
+    private func keySpec(for sender: UIButton) -> KeySpec? {
+        guard keySpecs.indices.contains(sender.tag) else {
+            return nil
+        }
+        return keySpecs[sender.tag]
+    }
+
+    @objc
+    private func buttonTouchDown(_ sender: UIButton) {
+        guard let spec = keySpec(for: sender), spec.repeats else {
+            return
+        }
+        sendKey?(spec.key)
+        startRepeating(spec.key)
+    }
+
+    @objc
+    private func buttonTouchUpInside(_ sender: UIButton) {
+        guard let spec = keySpec(for: sender) else {
+            stopRepeating()
+            return
+        }
+
+        if spec.repeats {
+            stopRepeating()
+        } else {
+            sendKey?(spec.key)
+        }
+    }
+
+    private func startRepeating(_ key: String) {
+        stopRepeating()
+        repeatingKey = key
+
+        // Accessory arrow keys should behave like held hardware keys: one immediate
+        // keystroke, then repeat until UIKit reports any release or cancellation.
+        let timer = Timer(timeInterval: repeatInterval, repeats: true) { [weak self] _ in
+            guard let self, self.repeatingKey == key else {
+                return
+            }
+            self.sendKey?(key)
+        }
+        timer.fireDate = Date(timeIntervalSinceNow: repeatInitialDelay)
+        repeatTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
     }
 }


### PR DESCRIPTION
## Summary
- Add native repeat handling for held iOS keyboard accessory arrow buttons while keeping Esc, Tab, and Enter single-tap.
- Stop arrow repeat on release, cancellation, keyboard dismissal, and app lifecycle exits.
- Add manual coverage for accessory arrow tap and hold behavior.

## Validation
- `git diff --check`
- `pod install`
- `xcodebuild -workspace ios/Zedra.xcworkspace -scheme Zedra -configuration Debug -destination generic/platform=iOS -derivedDataPath /private/tmp/zedra-ios-accessory-key-repeat-dd CODE_SIGNING_ALLOWED=NO ZEDRA_SKIP_RUST_XCODE_BUILD=1 build`

Note: the Xcode validation skipped the Rust build phase and used local ignored FFI artifacts copied from the main checkout because this new worktree could not fetch the pinned `vendor/zed` submodule commit from the remote.