### PR TITLE
fix: truncate git panel filenames

### DIFF
--- a/crates/zedra/src/editor/git_sidebar.rs
+++ b/crates/zedra/src/editor/git_sidebar.rs
@@ -386,10 +386,12 @@ impl GitSidebar {
 
         let mut row = div()
             .id(SharedString::from(path.clone()))
+            .w_full()
             .flex()
             .flex_row()
             .items_center()
             .justify_between()
+            .gap(px(6.0))
             .h(px(theme::PANEL_ITEM_HEIGHT))
             .px(px(theme::DRAWER_PADDING))
             .cursor_pointer()
@@ -414,6 +416,8 @@ impl GitSidebar {
             .child(
                 div()
                     .flex()
+                    .flex_1()
+                    .min_w_0()
                     .flex_row()
                     .items_center()
                     .gap_1()
@@ -421,22 +425,26 @@ impl GitSidebar {
                     .child(
                         div()
                             .w(px(ICON_SIZE))
+                            .flex_shrink_0()
                             .text_color(rgb(status_color))
                             .text_size(px(theme::FONT_BODY))
                             .child(status.icon()),
                     )
                     .child(
                         div()
+                            .flex_1()
+                            .min_w_0()
                             .text_size(px(theme::FONT_BODY))
                             .when(is_active, |el| el.font_weight(FontWeight::MEDIUM))
                             .text_color(rgb(filename_color))
-                            .overflow_hidden()
+                            .truncate()
                             .child(filename),
                     ),
             )
             .child(
                 div()
                     .flex()
+                    .flex_shrink_0()
                     .flex_row()
                     .items_center()
                     .gap_1()

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -464,12 +464,13 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:1:1\033\\/tmp/zedra-long-code.rs:
 9. Expected: added and removed lines are indicated by full-width background color only; the diff text does not render a leading `+` or `-`
 10. Expected: added and removed backgrounds stay continuous across rows without thin gaps, including after horizontal scrolling long lines
 11. Expected: the workspace header subtitle shows the git filename plus added and removed totals, and long filenames truncate instead of overflowing
-12. Tap the untracked file entry
-13. Expected: the diff view shows the untracked file content as added lines
-14. Long-press a file entry
-15. Expected: the file action sheet opens for that entry instead of doing nothing
-16. Tap the dimmed backdrop outside the action sheet
-17. Expected: the native action sheet dismisses without staging or unstaging the file
+12. Expected: long filenames in the git panel file list truncate with an ellipsis, while status marks and change counts remain visible
+13. Tap the untracked file entry
+14. Expected: the diff view shows the untracked file content as added lines
+15. Long-press a file entry
+16. Expected: the file action sheet opens for that entry instead of doing nothing
+17. Tap the dimmed backdrop outside the action sheet
+18. Expected: the native action sheet dismisses without staging or unstaging the file
 
 ## 15. Markdown List Item Wrap In Preview
 


### PR DESCRIPTION
## Summary

- Bound Git panel file rows to the drawer width and truncate long filenames with an ellipsis.
- Keep status marks and change counts visible beside long filenames.
- Add manual coverage for the Git panel long-filename case.

## Notes

- This fixes long Git filenames clipping or crowding the status/count controls because the label did not have a bounded truncating flex slot.
- CI owns full validation.