### PR TITLE
fix: refresh terminal accessory input after reconnect

### DIFF
--- a/crates/zedra/src/active_terminal.rs
+++ b/crates/zedra/src/active_terminal.rs
@@ -2,34 +2,42 @@
 ///
 /// The iOS keyboard accessory bar sends key input via a C FFI callback
 /// (`zedra_ios_send_key_input`) without any GPUI context. This module
-/// holds a single process-scoped callback that is updated by `WorkspaceView`
-/// whenever the active terminal changes, pointing directly at the right
-/// `SessionHandle::send_terminal_input` call.
+/// holds a single process-scoped sender for the active terminal. Terminal
+/// activation and reconnect attach both refresh this slot, so native input
+/// reads the current channel instead of a callback that captured an older one.
 ///
 /// Nothing in `zedra-session` is involved — the routing is entirely
 /// within the `zedra` crate.
 use std::sync::{Mutex, OnceLock};
 
-type InputFn = Box<dyn Fn(Vec<u8>) + Send + 'static>;
+use tokio::sync::mpsc;
+use tracing::warn;
 
-static ACTIVE_INPUT: OnceLock<Mutex<Option<InputFn>>> = OnceLock::new();
+#[derive(Clone)]
+struct ActiveInput {
+    terminal_id: String,
+    sender: mpsc::Sender<Vec<u8>>,
+}
 
-fn slot() -> &'static Mutex<Option<InputFn>> {
+static ACTIVE_INPUT: OnceLock<Mutex<Option<ActiveInput>>> = OnceLock::new();
+
+fn slot() -> &'static Mutex<Option<ActiveInput>> {
     ACTIVE_INPUT.get_or_init(|| Mutex::new(None))
 }
 
-/// Register a callback for the currently-active terminal.
+/// Register the input channel for the currently-active terminal.
 ///
 /// Called by `WorkspaceView` whenever `active_terminal_id` changes.
-/// The callback captures the `SessionHandle` and terminal ID, so the
-/// caller doesn't need to pass them separately.
-pub fn set_active_input(f: InputFn) {
+pub fn set_active_input(terminal_id: String, sender: mpsc::Sender<Vec<u8>>) {
     if let Ok(mut slot) = slot().lock() {
-        *slot = Some(f);
+        *slot = Some(ActiveInput {
+            terminal_id,
+            sender,
+        });
     }
 }
 
-/// Clear the callback (e.g. when all terminals are closed).
+/// Clear the active input channel (e.g. when all terminals are closed).
 pub fn clear_active_input() {
     if let Ok(mut slot) = slot().lock() {
         *slot = None;
@@ -38,13 +46,46 @@ pub fn clear_active_input() {
 
 /// Send bytes to the currently-active terminal.
 ///
-/// Returns `true` if a callback was registered and invoked.
+/// Returns `true` if the data was accepted by the active channel.
 pub fn send_to_active(data: Vec<u8>) -> bool {
-    if let Ok(slot) = slot().lock() {
-        if let Some(ref f) = *slot {
-            f(data);
-            return true;
+    let active = slot().lock().ok().and_then(|slot| slot.clone());
+    let Some(active) = active else {
+        return false;
+    };
+
+    match active.sender.try_send(data) {
+        Ok(()) => true,
+        Err(error) => {
+            warn!(
+                terminal_id = active.terminal_id,
+                "failed to send input: {}", error
+            );
+            false
         }
     }
-    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc::error::TryRecvError;
+
+    #[test]
+    fn send_to_active_reads_latest_registered_channel() {
+        clear_active_input();
+
+        let (first_tx, mut first_rx) = mpsc::channel(1);
+        let (second_tx, mut second_rx) = mpsc::channel(1);
+        set_active_input("first".to_string(), first_tx);
+        set_active_input("second".to_string(), second_tx);
+
+        assert!(send_to_active(b"\t".to_vec()));
+        assert!(matches!(
+            first_rx.try_recv(),
+            Err(TryRecvError::Empty | TryRecvError::Disconnected)
+        ));
+        assert_eq!(second_rx.try_recv(), Ok(b"\t".to_vec()));
+
+        clear_active_input();
+    }
 }

--- a/crates/zedra/src/workspace_terminal.rs
+++ b/crates/zedra/src/workspace_terminal.rs
@@ -157,22 +157,26 @@ impl WorkspaceTerminal {
         let attach_sub = cx.subscribe(&workspace_state, |this, _ws, event, cx| match event {
             WorkspaceStateEvent::SyncComplete => {
                 info!("received SyncComplete event, attempt to attach input/output channel");
-                Self::attach_channel_to_terminal_view(
+                if Self::attach_channel_to_terminal_view(
                     this.session_handle.clone(),
                     this.terminal_id.clone(),
                     this.terminal_view.clone(),
                     cx,
-                );
+                ) {
+                    this.refresh_active_input_if_current(cx);
+                }
             }
             WorkspaceStateEvent::TerminalCreated { id } => {
                 if this.terminal_id == *id {
                     info!("received TerminalCreated event, attempt to attach input/output channel");
-                    Self::attach_channel_to_terminal_view(
+                    if Self::attach_channel_to_terminal_view(
                         this.session_handle.clone(),
                         this.terminal_id.clone(),
                         this.terminal_view.clone(),
                         cx,
-                    );
+                    ) {
+                        this.refresh_active_input_if_current(cx);
+                    }
                 }
             }
             WorkspaceStateEvent::TerminalOpened { id } => {
@@ -358,11 +362,7 @@ impl WorkspaceTerminal {
         match self.terminal_view.read(cx).input_sender(cx) {
             Some(sender) => {
                 let terminal_id = self.terminal_id.clone();
-                active_terminal::set_active_input(Box::new(move |bytes| {
-                    if let Err(e) = sender.try_send(bytes) {
-                        warn!(terminal_id, "failed to send input: {}", e);
-                    }
-                }));
+                active_terminal::set_active_input(terminal_id, sender);
             }
             None => {
                 warn!(terminal_id = %self.terminal_id, "no input sender, skipping active input registration");
@@ -375,6 +375,15 @@ impl WorkspaceTerminal {
 
     pub fn input_sender(&self, cx: &App) -> Option<tokio::sync::mpsc::Sender<Vec<u8>>> {
         self.terminal_view.read(cx).input_sender(cx)
+    }
+
+    fn refresh_active_input_if_current(&mut self, cx: &mut Context<Self>) {
+        let is_active = self.workspace_state.read(cx).active_terminal_id.as_deref()
+            == Some(self.terminal_id.as_str());
+        if is_active {
+            // Reconnect reuses the active terminal entity but replaces its channel sender.
+            self.register_as_active_input(cx);
+        }
     }
 
     pub fn set_terminal_id(&mut self, terminal_id: String, cx: &mut Context<Self>) {
@@ -399,10 +408,10 @@ impl WorkspaceTerminal {
         terminal_id: String,
         terminal_view: Entity<TerminalView>,
         cx: &mut Context<Self>,
-    ) {
+    ) -> bool {
         let Some(remote_terminal) = session_handle.terminal(&terminal_id) else {
             warn!("no remote terminal found with id: {}", terminal_id);
-            return;
+            return false;
         };
         match remote_terminal.take_chanel() {
             Ok((input_tx, output_rx)) => {
@@ -411,9 +420,11 @@ impl WorkspaceTerminal {
                     terminal_view.sync_remote_size_after_attach(cx);
                     info!("attached channel to terminal");
                 });
+                true
             }
             Err(e) => {
                 warn!("failed to attach input/output channel: {}", e);
+                false
             }
         }
     }

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -415,6 +415,16 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:1:1\033\\/tmp/zedra-long-code.rs:
 6. Start holding an arrow button, then dismiss the keyboard or background the app
 7. Expected: repeat stops and does not resume when the keyboard or app returns
 
+## 11f. Terminal Keyboard Accessory After Reconnect On iOS
+
+1. Connect to a session on iPhone or iOS simulator and open a terminal
+2. Tap the terminal so the software keyboard and accessory bar are visible
+3. Press `Tab`, `Enter`, and an arrow key in the accessory bar
+4. Expected: each key reaches the PTY
+5. Put the workspace through an idle/reconnect recovery by backgrounding the app, sleeping/waking the host, or briefly interrupting network until the badge returns to `Connected`
+6. Keep the same terminal active, show the software keyboard again, then press `Tab`, `Enter`, and an arrow key in the accessory bar
+7. Expected: each key still reaches the PTY after reconnect; the accessory bar does not keep sending to a stale terminal channel
+
 ## 12. Quick Action Terminal Navigation
 
 1. Connect to a session with at least two open terminals


### PR DESCRIPTION
## Summary

- Refresh the active terminal input route when a reconnect replaces the terminal channel.
- Route iOS keyboard accessory input through the current active sender instead of a callback that captured an older channel.
- Add manual coverage for accessory input after idle/reconnect recovery.

## Notes

- This fixes accessory keys going to a stale terminal channel after the same active terminal reattaches.
- CI owns full validation.
