### PR TITLE
fix(host): allow stale client takeover

### DIFF
--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -17,8 +17,9 @@ use crate::identity::SharedIdentity;
 use crate::metrics;
 use crate::pty::{ShellSession, SpawnOptions};
 use crate::session_registry::{
-    AttachResult, ConsumeSlotResult, HostShellState, HostTermMeta, OutputSenderSlot, ServerSession,
-    SessionRegistry, TermBacklog, TermSession, MAX_WATCHED_PATHS_PER_SESSION,
+    ActiveClientConnection, AttachResult, ConsumeSlotResult, HostShellState, HostTermMeta,
+    OutputSenderSlot, ServerSession, SessionRegistry, TermBacklog, TermSession,
+    MAX_WATCHED_PATHS_PER_SESSION,
 };
 use crate::utils;
 use anyhow::Result;
@@ -515,7 +516,7 @@ pub async fn handle_connection(
     let path_type = initial_path_type(&conn);
     let mut failure_reason: &'static str = "io_error";
     let mut failure_is_new_client = false;
-    let (session, client_pubkey, is_new_client, auth_timing) = match auth_phase(
+    let (session, client_pubkey, active_connection, is_new_client, auth_timing) = match auth_phase(
         &conn,
         &registry,
         &state,
@@ -555,6 +556,7 @@ pub async fn handle_connection(
         &client_pubkey[..4],
         session.id,
     );
+    active_connection.spawn_monitor();
     let metrics_connection_open = match metrics::record_connection_opened(&state.workdir) {
         Ok(()) => true,
         Err(e) => {
@@ -633,8 +635,9 @@ pub async fn handle_connection(
                 let st = state.clone();
                 let r = registry.clone();
                 let cpk = client_pubkey;
+                let active_connection_id = active_connection.id();
                 tokio::spawn(async move {
-                    if let Err(e) = dispatch(msg, s, st, r, cpk).await {
+                    if let Err(e) = dispatch(msg, s, st, r, cpk, active_connection_id).await {
                         tracing::warn!("dispatch error: {}", e);
                     }
                 });
@@ -666,7 +669,9 @@ pub async fn handle_connection(
         ai_prompts: session.rpc_ai_prompts.load(Ordering::Relaxed),
     });
 
-    registry.detach_client(&session.id, client_pubkey).await;
+    registry
+        .detach_client(&session.id, client_pubkey, active_connection.id())
+        .await;
     if metrics_connection_open {
         if let Err(e) = metrics::record_connection_closed(&state.workdir) {
             tracing::warn!("Failed to record connection metrics: {}", e);
@@ -706,7 +711,13 @@ async fn auth_phase(
     state: &Arc<DaemonState>,
     failure_reason: &mut &'static str,
     failure_is_new_client: &mut bool,
-) -> Result<(Arc<ServerSession>, [u8; 32], bool, AuthTiming)> {
+) -> Result<(
+    Arc<ServerSession>,
+    [u8; 32],
+    ActiveClientConnection,
+    bool,
+    AuthTiming,
+)> {
     let first = irpc_iroh::read_request::<ZedraProto>(conn).await?;
 
     match first {
@@ -735,11 +746,12 @@ async fn auth_phase(
                 Some(ZedraMessage::Connect(msg)) => {
                     // is_new_client = true: came through the Register path
                     let t_connect = std::time::Instant::now();
-                    let (session, pubkey, is_new, prove_ms) =
+                    let (session, pubkey, active_connection, is_new, prove_ms) =
                         handle_connect(msg, conn, registry, state, true, failure_reason).await?;
                     Ok((
                         session,
                         pubkey,
+                        active_connection,
                         is_new,
                         AuthTiming {
                             register_ms,
@@ -757,11 +769,12 @@ async fn auth_phase(
         Some(ZedraMessage::Connect(msg)) => {
             // PKI reconnect or token resume — is_new_client = false
             let t = std::time::Instant::now();
-            let (session, pubkey, is_new, prove_ms) =
+            let (session, pubkey, active_connection, is_new, prove_ms) =
                 handle_connect(msg, conn, registry, state, false, failure_reason).await?;
             Ok((
                 session,
                 pubkey,
+                active_connection,
                 is_new,
                 AuthTiming {
                     register_ms: 0,
@@ -780,7 +793,7 @@ async fn auth_phase(
 /// Process a `Connect` message. If the client presents a valid session_token,
 /// attach immediately and return Ok with SyncSessionResult. Otherwise, issue a
 /// Challenge (nonce + host_signature) and wait for AuthProve.
-/// Returns (session, pubkey, is_new_client, prove_ms).
+/// Returns (session, pubkey, active connection, is_new_client, prove_ms).
 async fn handle_connect(
     msg: irpc::WithChannels<ConnectReq, ZedraProto>,
     conn: &iroh::endpoint::Connection,
@@ -788,7 +801,13 @@ async fn handle_connect(
     state: &Arc<DaemonState>,
     is_new_client: bool,
     failure_reason: &mut &'static str,
-) -> Result<(Arc<ServerSession>, [u8; 32], bool, u64)> {
+) -> Result<(
+    Arc<ServerSession>,
+    [u8; 32],
+    ActiveClientConnection,
+    bool,
+    u64,
+)> {
     let pubkey = msg.client_pubkey;
     let session_id = msg.session_id.clone();
 
@@ -797,13 +816,20 @@ async fn handle_connect(
         let session = registry.get(&session_id).await;
         if let Some(ref session) = session {
             if session.validate_session_token(&pubkey, &token).await {
-                match registry.attach_client(&session_id, pubkey).await {
-                    AttachResult::Ok => {
+                let active_connection = ActiveClientConnection::new(pubkey, conn.clone());
+                match registry
+                    .attach_client(&session_id, active_connection.clone())
+                    .await
+                {
+                    AttachResult::Ok { previous } => {
+                        if let Some(previous) = previous {
+                            previous.close_for_takeover();
+                        }
                         let new_token = session.issue_session_token(pubkey).await;
                         let sync = build_sync_result(session, state, new_token).await;
                         let _ = msg.tx.send(ConnectResult::Ok(sync)).await;
                         // Token fast-path: no challenge/prove round trip, prove_ms=0
-                        return Ok((session.clone(), pubkey, false, 0));
+                        return Ok((session.clone(), pubkey, active_connection, false, 0));
                     }
                     AttachResult::NotInSessionAcl => {
                         *failure_reason = "not_in_session_acl";
@@ -929,7 +955,7 @@ async fn handle_register(
 }
 
 /// Read AuthProve, verify client signature, attach to session.
-/// Returns (session, pubkey, is_new_client, prove_ms).
+/// Returns (session, pubkey, active connection, is_new_client, prove_ms).
 /// On success, sends `AuthProveResult::Ok(SyncSessionResult)` so the client
 /// has everything it needs without a separate SyncSession round trip.
 async fn finish_auth(
@@ -940,7 +966,13 @@ async fn finish_auth(
     state: &Arc<DaemonState>,
     is_new_client: bool,
     failure_reason: &mut &'static str,
-) -> Result<(Arc<ServerSession>, [u8; 32], bool, u64)> {
+) -> Result<(
+    Arc<ServerSession>,
+    [u8; 32],
+    ActiveClientConnection,
+    bool,
+    u64,
+)> {
     let prove_start = std::time::Instant::now();
     let prove_msg = irpc_iroh::read_request::<ZedraProto>(conn).await?;
 
@@ -980,8 +1012,9 @@ async fn finish_auth(
 
     // Attach to the requested session, with fallback for stale session IDs
     // (e.g. after a daemon restart the client's stored session_id is gone).
+    let active_connection = ActiveClientConnection::new(client_pubkey, conn.clone());
     let (attach_result, resolved_session_id) = match registry
-        .attach_client(&session_id, client_pubkey)
+        .attach_client(&session_id, active_connection.clone())
         .await
     {
         AttachResult::SessionNotFound => {
@@ -1019,13 +1052,21 @@ async fn finish_auth(
                 s
             };
             let new_id = fallback.id.clone();
-            (registry.attach_client(&new_id, client_pubkey).await, new_id)
+            (
+                registry
+                    .attach_client(&new_id, active_connection.clone())
+                    .await,
+                new_id,
+            )
         }
         other => (other, session_id.clone()),
     };
 
     match attach_result {
-        AttachResult::Ok => {
+        AttachResult::Ok { previous } => {
+            if let Some(previous) = previous {
+                previous.close_for_takeover();
+            }
             let Some(session) = registry.get(&resolved_session_id).await else {
                 let _ = tx.send(AuthProveResult::SessionNotFound).await;
                 anyhow::bail!("session {} vanished after attach", resolved_session_id);
@@ -1036,6 +1077,7 @@ async fn finish_auth(
             Ok((
                 session,
                 client_pubkey,
+                active_connection,
                 is_new_client,
                 prove_start.elapsed().as_millis() as u64,
             ))
@@ -1370,7 +1412,20 @@ async fn dispatch(
     state: Arc<DaemonState>,
     registry: Arc<SessionRegistry>,
     client_pubkey: [u8; 32],
+    active_connection_id: u64,
 ) -> Result<()> {
+    if !registry
+        .is_active_client(&session.id, client_pubkey, active_connection_id)
+        .await
+    {
+        tracing::debug!(
+            "ignoring request from stale client {:?}... for session {}",
+            &client_pubkey[..4],
+            session.id,
+        );
+        return Ok(());
+    }
+
     match msg {
         // -- Auth / bootstrap (should not appear in dispatch loop) --
         ZedraMessage::Register(_)

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -2120,8 +2120,22 @@ async fn dispatch(
                         }
                     }
                     Ok(None) => break,
+                    Err(irpc::channel::mpsc::RecvError::Io { source, .. }) => {
+                        tracing::info!(
+                            "TermAttach: input stream closed id={} session={} error={:?}",
+                            term_id,
+                            session.id,
+                            source
+                        );
+                        break;
+                    }
                     Err(e) => {
-                        tracing::error!("TermAttach: input receiver error: {}", e);
+                        tracing::warn!(
+                            "TermAttach: input receiver failed id={} session={} error={}",
+                            term_id,
+                            session.id,
+                            e
+                        );
                         break;
                     }
                 }

--- a/crates/zedra-host/src/session_registry.rs
+++ b/crates/zedra-host/src/session_registry.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -53,6 +53,114 @@ pub enum ConsumeSlotResult {
     NotFound,
 }
 
+const ACTIVE_CLIENT_STALE_AFTER: Duration = Duration::from_secs(4);
+const ACTIVE_CLIENT_PROBE_INTERVAL: Duration = Duration::from_secs(1);
+
+static NEXT_ACTIVE_CONNECTION_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Host-side lease for the active client connection.
+#[derive(Clone)]
+pub struct ActiveClientConnection {
+    id: u64,
+    client_pubkey: [u8; 32],
+    conn: Option<iroh::endpoint::Connection>,
+    last_rx_bytes: Arc<AtomicU64>,
+    last_rx_at: Arc<StdMutex<Instant>>,
+    closed: Arc<AtomicBool>,
+}
+
+impl ActiveClientConnection {
+    pub fn new(client_pubkey: [u8; 32], conn: iroh::endpoint::Connection) -> Self {
+        let stats = conn.stats();
+        Self {
+            id: NEXT_ACTIVE_CONNECTION_ID.fetch_add(1, Ordering::Relaxed),
+            client_pubkey,
+            conn: Some(conn),
+            last_rx_bytes: Arc::new(AtomicU64::new(stats.udp_rx.bytes)),
+            last_rx_at: Arc::new(StdMutex::new(Instant::now())),
+            closed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    #[cfg(test)]
+    fn for_test(client_pubkey: [u8; 32], last_rx_at: Instant, closed: bool) -> Self {
+        Self {
+            id: NEXT_ACTIVE_CONNECTION_ID.fetch_add(1, Ordering::Relaxed),
+            client_pubkey,
+            conn: None,
+            last_rx_bytes: Arc::new(AtomicU64::new(0)),
+            last_rx_at: Arc::new(StdMutex::new(last_rx_at)),
+            closed: Arc::new(AtomicBool::new(closed)),
+        }
+    }
+
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    pub fn client_pubkey(&self) -> [u8; 32] {
+        self.client_pubkey
+    }
+
+    pub fn spawn_monitor(&self) {
+        let Some(conn) = self.conn.clone() else {
+            return;
+        };
+        let last_rx_bytes = self.last_rx_bytes.clone();
+        let last_rx_at = self.last_rx_at.clone();
+        let closed = self.closed.clone();
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(ACTIVE_CLIENT_PROBE_INTERVAL);
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        if conn.close_reason().is_some() {
+                            closed.store(true, Ordering::Release);
+                            break;
+                        }
+
+                        let rx_bytes = conn.stats().udp_rx.bytes;
+                        let previous = last_rx_bytes.swap(rx_bytes, Ordering::AcqRel);
+                        if rx_bytes > previous {
+                            if let Ok(mut last_rx_at) = last_rx_at.lock() {
+                                *last_rx_at = Instant::now();
+                            }
+                        }
+                    }
+                    _ = conn.closed() => {
+                        closed.store(true, Ordering::Release);
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    pub fn is_stale(&self, now: Instant) -> bool {
+        if self.closed.load(Ordering::Acquire)
+            || self
+                .conn
+                .as_ref()
+                .is_some_and(|conn| conn.close_reason().is_some())
+        {
+            return true;
+        }
+
+        self.last_rx_at
+            .lock()
+            .map(|last_rx_at| now.duration_since(*last_rx_at) > ACTIVE_CLIENT_STALE_AFTER)
+            .unwrap_or(true)
+    }
+
+    pub fn close_for_takeover(&self) {
+        if let Some(conn) = &self.conn {
+            conn.close(0u32.into(), b"replaced by new client");
+        }
+        self.closed.store(true, Ordering::Release);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // ServerSession
 // ---------------------------------------------------------------------------
@@ -70,8 +178,8 @@ pub struct ServerSession {
     pub terminal_order: Mutex<Vec<String>>,
     /// Client pubkeys authorized to attach to this session (per-session ACL).
     pub acl: Mutex<HashSet<[u8; 32]>>,
-    /// Currently attached client pubkey. None = session is free.
-    pub active_client: Mutex<Option<[u8; 32]>>,
+    /// Currently attached client connection. None = session is free.
+    pub active_client: Mutex<Option<ActiveClientConnection>>,
     /// Ephemeral in-memory session token for the currently attached client.
     /// At most one token exists per session at a time (bound to the active
     /// client pubkey). Rotated on every successful connect. Consumed atomically
@@ -715,7 +823,7 @@ impl SessionRegistry {
         for session in sessions.values() {
             let terminal_count = session.terminals.lock().await.len();
             let last_activity = *session.last_activity.lock().await;
-            let is_occupied = session.active_client.lock().await.is_some();
+            let is_occupied = session.is_occupied().await;
             result.push(SessionInfo {
                 id: session.id.clone(),
                 name: session.name.clone(),
@@ -819,14 +927,19 @@ impl SessionRegistry {
         added
     }
 
-    /// Try to attach a client to a session (set as active_client).
+    /// Try to attach a client connection to a session.
     ///
-    /// Returns `true` if the client was attached successfully.
-    /// Returns `false` if:
+    /// Returns `AttachResult::Ok` if the client was attached successfully.
+    /// Returns another `AttachResult` if:
     /// - Session not found
     /// - Client not in session ACL
     /// - Another client is already active
-    pub async fn attach_client(&self, session_id: &str, client_pubkey: [u8; 32]) -> AttachResult {
+    pub async fn attach_client(
+        &self,
+        session_id: &str,
+        connection: ActiveClientConnection,
+    ) -> AttachResult {
+        let client_pubkey = connection.client_pubkey();
         let sessions = self.sessions.lock().await;
         let session = match sessions.get(session_id) {
             Some(s) => s,
@@ -838,27 +951,64 @@ impl SessionRegistry {
             return AttachResult::NotInSessionAcl;
         }
 
-        // Check if occupied
         let mut active = session.active_client.lock().await;
-        if active.is_some() && *active != Some(client_pubkey) {
-            return AttachResult::SessionOccupied;
+        let previous = match active.as_ref() {
+            Some(current) if current.client_pubkey() == client_pubkey => Some(current.clone()),
+            Some(current) if current.is_stale(Instant::now()) => Some(current.clone()),
+            Some(_) => return AttachResult::SessionOccupied,
+            None => None,
+        };
+
+        if let Some(previous) = &previous {
+            if previous.client_pubkey() != client_pubkey {
+                tracing::info!(
+                    "Replacing stale active client in session {} with {:?}...",
+                    session_id,
+                    &client_pubkey[..4],
+                );
+            }
         }
 
-        *active = Some(client_pubkey);
+        *active = Some(connection);
         session.touch().await;
-        AttachResult::Ok
+        AttachResult::Ok { previous }
     }
 
     /// Clear the active client for a session (on disconnect or detach).
-    pub async fn detach_client(&self, session_id: &str, client_pubkey: [u8; 32]) {
+    pub async fn detach_client(
+        &self,
+        session_id: &str,
+        client_pubkey: [u8; 32],
+        connection_id: u64,
+    ) {
         let sessions = self.sessions.lock().await;
         if let Some(session) = sessions.get(session_id) {
             let mut active = session.active_client.lock().await;
-            if *active == Some(client_pubkey) {
+            if active.as_ref().is_some_and(|active| {
+                active.client_pubkey() == client_pubkey && active.id() == connection_id
+            }) {
                 *active = None;
                 tracing::info!("Detached client from session {}", session_id);
             }
         }
+    }
+
+    pub async fn is_active_client(
+        &self,
+        session_id: &str,
+        client_pubkey: [u8; 32],
+        connection_id: u64,
+    ) -> bool {
+        let sessions = self.sessions.lock().await;
+        let session = sessions.get(session_id).cloned();
+        drop(sessions);
+        let Some(session) = session else {
+            return false;
+        };
+        let active = session.active_client.lock().await;
+        active.as_ref().is_some_and(|active| {
+            active.client_pubkey() == client_pubkey && active.id() == connection_id
+        })
     }
 
     /// Find the first session that has `client_pubkey` in its ACL.
@@ -948,7 +1098,9 @@ impl SessionRegistry {
 
 /// Outcome of an `attach_client` attempt.
 pub enum AttachResult {
-    Ok,
+    Ok {
+        previous: Option<ActiveClientConnection>,
+    },
     SessionNotFound,
     NotInSessionAcl,
     SessionOccupied,
@@ -1218,7 +1370,11 @@ impl ServerSession {
 
     /// Whether a client is currently attached.
     pub async fn is_occupied(&self) -> bool {
-        self.active_client.lock().await.is_some()
+        self.active_client
+            .lock()
+            .await
+            .as_ref()
+            .is_some_and(|active| !active.is_stale(Instant::now()))
     }
 
     /// Allocate the next terminal ID for this session.
@@ -1274,6 +1430,26 @@ mod tests {
         [seed; 32]
     }
 
+    fn active_connection(pubkey: [u8; 32]) -> ActiveClientConnection {
+        ActiveClientConnection::for_test(pubkey, Instant::now(), false)
+    }
+
+    fn connection_last_seen(
+        pubkey: [u8; 32],
+        last_rx_at: Instant,
+        closed: bool,
+    ) -> ActiveClientConnection {
+        ActiveClientConnection::for_test(pubkey, last_rx_at, closed)
+    }
+
+    fn stale_connection(pubkey: [u8; 32]) -> ActiveClientConnection {
+        ActiveClientConnection::for_test(
+            pubkey,
+            Instant::now() - ACTIVE_CLIENT_STALE_AFTER - Duration::from_secs(1),
+            false,
+        )
+    }
+
     async fn create_session(registry: &SessionRegistry) -> Arc<ServerSession> {
         registry.create_named("test", PathBuf::from("/tmp")).await
     }
@@ -1287,6 +1463,37 @@ mod tests {
             truncated: false,
             created_at: Instant::now(),
         }
+    }
+
+    #[test]
+    fn active_connection_stale_state_uses_close_and_rx_deadline() {
+        let pubkey = make_pubkey(1);
+        let now = Instant::now();
+
+        let fresh = connection_last_seen(pubkey, now - Duration::from_secs(1), false);
+        assert!(!fresh.is_stale(now));
+
+        let at_deadline = connection_last_seen(pubkey, now - ACTIVE_CLIENT_STALE_AFTER, false);
+        assert!(!at_deadline.is_stale(now));
+
+        let past_deadline = connection_last_seen(
+            pubkey,
+            now - ACTIVE_CLIENT_STALE_AFTER - Duration::from_millis(1),
+            false,
+        );
+        assert!(past_deadline.is_stale(now));
+
+        let closed = connection_last_seen(pubkey, now, true);
+        assert!(closed.is_stale(now));
+    }
+
+    #[test]
+    fn close_for_takeover_marks_connection_stale() {
+        let connection = active_connection(make_pubkey(1));
+
+        assert!(!connection.is_stale(Instant::now()));
+        connection.close_for_takeover();
+        assert!(connection.is_stale(Instant::now()));
     }
 
     #[test]
@@ -1518,12 +1725,21 @@ mod tests {
         assert!(registry.is_globally_authorized(&pubkey).await);
 
         // Attach
-        match registry.attach_client(&session.id, pubkey).await {
-            AttachResult::Ok => {}
+        let connection = active_connection(pubkey);
+        match registry
+            .attach_client(&session.id, connection.clone())
+            .await
+        {
+            AttachResult::Ok { previous: None } => {}
             _ => panic!("expected Ok"),
         }
 
         assert!(session.is_occupied().await);
+        assert!(
+            registry
+                .is_active_client(&session.id, pubkey, connection.id())
+                .await
+        );
     }
 
     #[tokio::test]
@@ -1537,16 +1753,206 @@ mod tests {
         registry.add_client_to_session(&session.id, key_b).await;
 
         // A attaches first
+        let connection_a = active_connection(key_a);
         assert!(matches!(
-            registry.attach_client(&session.id, key_a).await,
-            AttachResult::Ok
+            registry
+                .attach_client(&session.id, connection_a.clone())
+                .await,
+            AttachResult::Ok { previous: None }
         ));
 
         // B is blocked
         assert!(matches!(
-            registry.attach_client(&session.id, key_b).await,
+            registry
+                .attach_client(&session.id, active_connection(key_b))
+                .await,
             AttachResult::SessionOccupied
         ));
+
+        assert!(
+            registry
+                .is_active_client(&session.id, key_a, connection_a.id())
+                .await
+        );
+        assert!(
+            !registry
+                .is_active_client(&session.id, key_b, connection_a.id())
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_replaces_stale_active_client() {
+        let registry = SessionRegistry::new();
+        let session = registry.create_named("s1", PathBuf::from("/s1")).await;
+        let key_a = make_pubkey(1);
+        let key_b = make_pubkey(2);
+
+        registry.add_client_to_session(&session.id, key_a).await;
+        registry.add_client_to_session(&session.id, key_b).await;
+
+        let stale_a = stale_connection(key_a);
+        let connection_b = active_connection(key_b);
+        let _ = registry.attach_client(&session.id, stale_a.clone()).await;
+
+        match registry
+            .attach_client(&session.id, connection_b.clone())
+            .await
+        {
+            AttachResult::Ok {
+                previous: Some(previous),
+            } => assert_eq!(previous.id(), stale_a.id()),
+            _ => panic!("expected stale client replacement"),
+        }
+
+        assert!(
+            registry
+                .is_active_client(&session.id, key_b, connection_b.id())
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_replaces_closed_active_client_before_stale_deadline() {
+        let registry = SessionRegistry::new();
+        let session = registry.create_named("s1", PathBuf::from("/s1")).await;
+        let key_a = make_pubkey(1);
+        let key_b = make_pubkey(2);
+
+        registry.add_client_to_session(&session.id, key_a).await;
+        registry.add_client_to_session(&session.id, key_b).await;
+
+        let closed_a = connection_last_seen(key_a, Instant::now(), true);
+        let connection_b = active_connection(key_b);
+        let _ = registry.attach_client(&session.id, closed_a.clone()).await;
+
+        match registry
+            .attach_client(&session.id, connection_b.clone())
+            .await
+        {
+            AttachResult::Ok {
+                previous: Some(previous),
+            } => assert_eq!(previous.id(), closed_a.id()),
+            _ => panic!("expected closed client replacement"),
+        }
+
+        assert!(
+            registry
+                .is_active_client(&session.id, key_b, connection_b.id())
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_same_client_replaces_live_connection() {
+        let registry = SessionRegistry::new();
+        let session = registry.create_named("s1", PathBuf::from("/s1")).await;
+        let pubkey = make_pubkey(1);
+
+        registry.add_client_to_session(&session.id, pubkey).await;
+
+        let first = active_connection(pubkey);
+        let second = active_connection(pubkey);
+        let _ = registry.attach_client(&session.id, first.clone()).await;
+
+        match registry.attach_client(&session.id, second.clone()).await {
+            AttachResult::Ok {
+                previous: Some(previous),
+            } => assert_eq!(previous.id(), first.id()),
+            _ => panic!("expected same-client replacement"),
+        }
+
+        assert!(
+            registry
+                .is_active_client(&session.id, pubkey, second.id())
+                .await
+        );
+        assert!(
+            !registry
+                .is_active_client(&session.id, pubkey, first.id())
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_active_client_does_not_report_session_occupied() {
+        let registry = SessionRegistry::new();
+        let session = registry.create_named("s1", PathBuf::from("/s1")).await;
+        let pubkey = make_pubkey(1);
+
+        registry.add_client_to_session(&session.id, pubkey).await;
+        let _ = registry
+            .attach_client(&session.id, stale_connection(pubkey))
+            .await;
+
+        assert!(!session.is_occupied().await);
+        let sessions = registry.list_sessions().await;
+        assert_eq!(sessions.len(), 1);
+        assert!(!sessions[0].is_occupied);
+    }
+
+    #[tokio::test]
+    async fn old_connection_detach_does_not_clear_replacement() {
+        let registry = SessionRegistry::new();
+        let session = registry.create_named("s1", PathBuf::from("/s1")).await;
+        let key_a = make_pubkey(1);
+        let key_b = make_pubkey(2);
+
+        registry.add_client_to_session(&session.id, key_a).await;
+        registry.add_client_to_session(&session.id, key_b).await;
+
+        let stale_a = stale_connection(key_a);
+        let connection_b = active_connection(key_b);
+        let _ = registry.attach_client(&session.id, stale_a.clone()).await;
+        let _ = registry
+            .attach_client(&session.id, connection_b.clone())
+            .await;
+
+        registry
+            .detach_client(&session.id, key_a, stale_a.id())
+            .await;
+
+        assert!(
+            registry
+                .is_active_client(&session.id, key_b, connection_b.id())
+                .await
+        );
+        assert!(session.is_occupied().await);
+    }
+
+    #[tokio::test]
+    async fn detach_ignores_wrong_connection_id_or_pubkey() {
+        let registry = SessionRegistry::new();
+        let session = registry.create_named("s1", PathBuf::from("/s1")).await;
+        let key_a = make_pubkey(1);
+        let key_b = make_pubkey(2);
+
+        registry.add_client_to_session(&session.id, key_a).await;
+        registry.add_client_to_session(&session.id, key_b).await;
+
+        let connection = active_connection(key_a);
+        let _ = registry
+            .attach_client(&session.id, connection.clone())
+            .await;
+
+        registry
+            .detach_client(&session.id, key_a, connection.id() + 1)
+            .await;
+        assert!(
+            registry
+                .is_active_client(&session.id, key_a, connection.id())
+                .await
+        );
+
+        registry
+            .detach_client(&session.id, key_b, connection.id())
+            .await;
+        assert!(
+            registry
+                .is_active_client(&session.id, key_a, connection.id())
+                .await
+        );
+        assert!(session.is_occupied().await);
     }
 
     #[tokio::test]
@@ -1556,10 +1962,15 @@ mod tests {
         let pubkey = make_pubkey(1);
 
         registry.add_client_to_session(&session.id, pubkey).await;
-        let _ = registry.attach_client(&session.id, pubkey).await;
+        let connection = active_connection(pubkey);
+        let _ = registry
+            .attach_client(&session.id, connection.clone())
+            .await;
         assert!(session.is_occupied().await);
 
-        registry.detach_client(&session.id, pubkey).await;
+        registry
+            .detach_client(&session.id, pubkey, connection.id())
+            .await;
         assert!(!session.is_occupied().await);
     }
 
@@ -1569,7 +1980,10 @@ mod tests {
         let session = registry.create_named("s1", PathBuf::from("/s1")).await;
         let pubkey = make_pubkey(99);
 
-        match registry.attach_client(&session.id, pubkey).await {
+        match registry
+            .attach_client(&session.id, active_connection(pubkey))
+            .await
+        {
             AttachResult::NotInSessionAcl => {}
             _ => panic!("expected NotInSessionAcl"),
         }
@@ -1674,7 +2088,9 @@ mod tests {
         let s = registry.create_named("s", PathBuf::from("/s")).await;
         let pubkey = make_pubkey(7);
         registry.add_client_to_session(&s.id, pubkey).await;
-        let _ = registry.attach_client(&s.id, pubkey).await;
+        let _ = registry
+            .attach_client(&s.id, active_connection(pubkey))
+            .await;
 
         let list = registry.list_sessions().await;
         assert_eq!(list.len(), 1);
@@ -1689,8 +2105,10 @@ mod tests {
 
         registry.add_client_to_session(&session.id, pubkey).await;
         assert!(matches!(
-            registry.attach_client(&session.id, pubkey).await,
-            AttachResult::Ok
+            registry
+                .attach_client(&session.id, active_connection(pubkey))
+                .await,
+            AttachResult::Ok { previous: None }
         ));
 
         let first = session.issue_session_token(pubkey).await;

--- a/crates/zedra-host/tests/integration.rs
+++ b/crates/zedra-host/tests/integration.rs
@@ -112,6 +112,23 @@ async fn register_client_for_session(
     ed25519_dalek::SigningKey,
     [u8; 32],
 )> {
+    let (client, signing_key, pubkey, _conn) =
+        register_client_for_session_with_connection(relay_url, host_endpoint, registry, session_id)
+            .await?;
+    Ok((client, signing_key, pubkey))
+}
+
+async fn register_client_for_session_with_connection(
+    relay_url: iroh::RelayUrl,
+    host_endpoint: &iroh::Endpoint,
+    registry: &Arc<SessionRegistry>,
+    session_id: &str,
+) -> anyhow::Result<(
+    irpc::Client<ZedraProto>,
+    ed25519_dalek::SigningKey,
+    [u8; 32],
+    iroh::endpoint::Connection,
+)> {
     use ed25519_dalek::SigningKey;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -127,7 +144,7 @@ async fn register_client_for_session(
     let conn = client_endpoint
         .connect(host_endpoint.addr(), proto::ZEDRA_ALPN)
         .await?;
-    let remote = irpc_iroh::IrohRemoteConnection::new(conn);
+    let remote = irpc_iroh::IrohRemoteConnection::new(conn.clone());
     let client = irpc::Client::<ZedraProto>::boxed(remote);
 
     let timestamp = SystemTime::now()
@@ -147,7 +164,7 @@ async fn register_client_for_session(
         anyhow::bail!("register failed: {:?}", reg_result);
     }
 
-    Ok((client, client_signing_key, client_pubkey))
+    Ok((client, client_signing_key, client_pubkey, conn))
 }
 
 async fn prove_registered_client(
@@ -202,12 +219,35 @@ async fn connect_client(
     [u8; 32],
     SyncSessionResult,
 )> {
+    let (client, session_id, pubkey, sync, _conn) =
+        connect_client_with_connection(relay_url, host_endpoint, registry, host_identity).await?;
+    Ok((client, session_id, pubkey, sync))
+}
+
+async fn connect_client_with_connection(
+    relay_url: iroh::RelayUrl,
+    host_endpoint: &iroh::Endpoint,
+    registry: &Arc<SessionRegistry>,
+    host_identity: &Arc<HostIdentity>,
+) -> anyhow::Result<(
+    irpc::Client<ZedraProto>,
+    String,
+    [u8; 32],
+    SyncSessionResult,
+    iroh::endpoint::Connection,
+)> {
     let session = registry
         .create_named("test", std::path::PathBuf::from("/tmp/test"))
         .await;
 
-    let (client, client_signing_key, client_pubkey) =
-        register_client_for_session(relay_url, host_endpoint, registry, &session.id).await?;
+    let (client, client_signing_key, client_pubkey, conn) =
+        register_client_for_session_with_connection(
+            relay_url,
+            host_endpoint,
+            registry,
+            &session.id,
+        )
+        .await?;
 
     let prove_result = prove_registered_client(
         &client,
@@ -223,7 +263,7 @@ async fn connect_client(
         other => anyhow::bail!("auth prove failed: {:?}", other),
     };
 
-    Ok((client, session.id.clone(), client_pubkey, sync))
+    Ok((client, session.id.clone(), client_pubkey, sync, conn))
 }
 
 // ---------------------------------------------------------------------------
@@ -372,6 +412,43 @@ async fn test_live_second_client_auth_returns_host_occupied() {
 
     let info: SessionInfoResult = client_a.rpc(SessionInfoReq {}).await.unwrap();
     assert_eq!(info.session_id.as_deref(), Some(session_id.as_str()));
+}
+
+/// A client-side close should release the host slot before the stale timer.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_second_client_auth_succeeds_after_first_client_close() {
+    let (_relay, relay_url) = spawn_test_relay().await.unwrap();
+    let (host_ep, registry, identity, _dir) = setup_host(relay_url.clone()).await.unwrap();
+
+    let (_client_a, session_id, _client_a_pubkey, _sync, conn_a) =
+        connect_client_with_connection(relay_url.clone(), &host_ep, &registry, &identity)
+            .await
+            .unwrap();
+    conn_a.close(0u32.into(), b"test client disconnect");
+
+    let session = registry.get(&session_id).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while session.is_occupied().await {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("host did not observe client close");
+
+    let (client_b, signing_key_b, pubkey_b) =
+        register_client_for_session(relay_url, &host_ep, &registry, &session_id)
+            .await
+            .unwrap();
+    let result =
+        prove_registered_client(&client_b, &signing_key_b, pubkey_b, &session_id, &identity)
+            .await
+            .unwrap();
+
+    assert!(
+        matches!(result, AuthProveResult::Ok(_)),
+        "expected client B to attach after client A close, got {:?}",
+        result
+    );
 }
 
 /// SwitchSession is kept in the protocol, but the host cannot change the

--- a/crates/zedra-host/tests/integration.rs
+++ b/crates/zedra-host/tests/integration.rs
@@ -102,6 +102,95 @@ async fn setup_host(
 ///
 /// Generates an ephemeral client keypair, adds a pairing slot to the
 /// registry, and runs Register → Connect → Challenge → AuthProve.
+async fn register_client_for_session(
+    relay_url: iroh::RelayUrl,
+    host_endpoint: &iroh::Endpoint,
+    registry: &Arc<SessionRegistry>,
+    session_id: &str,
+) -> anyhow::Result<(
+    irpc::Client<ZedraProto>,
+    ed25519_dalek::SigningKey,
+    [u8; 32],
+)> {
+    use ed25519_dalek::SigningKey;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let client_signing_key = SigningKey::generate(&mut rand::thread_rng());
+    let client_pubkey = client_signing_key.verifying_key().to_bytes();
+
+    let handshake_key: [u8; 16] = rand::random();
+    registry.add_pairing_slot(session_id, handshake_key).await;
+
+    let client_endpoint = make_endpoint(relay_url).await?;
+    wait_online(&client_endpoint).await;
+
+    let conn = client_endpoint
+        .connect(host_endpoint.addr(), proto::ZEDRA_ALPN)
+        .await?;
+    let remote = irpc_iroh::IrohRemoteConnection::new(conn);
+    let client = irpc::Client::<ZedraProto>::boxed(remote);
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let hmac = zedra_rpc::compute_registration_hmac(&handshake_key, &client_pubkey, timestamp);
+    let reg_result: RegisterResult = client
+        .rpc(RegisterReq {
+            client_pubkey,
+            timestamp,
+            hmac,
+            session_id: session_id.to_string(),
+        })
+        .await?;
+    if !matches!(reg_result, RegisterResult::Ok) {
+        anyhow::bail!("register failed: {:?}", reg_result);
+    }
+
+    Ok((client, client_signing_key, client_pubkey))
+}
+
+async fn prove_registered_client(
+    client: &irpc::Client<ZedraProto>,
+    client_signing_key: &ed25519_dalek::SigningKey,
+    client_pubkey: [u8; 32],
+    session_id: &str,
+    host_identity: &Arc<HostIdentity>,
+) -> anyhow::Result<AuthProveResult> {
+    use ed25519_dalek::{Verifier, VerifyingKey};
+
+    let connect_result: ConnectResult = client
+        .rpc(ConnectReq {
+            client_pubkey,
+            session_id: session_id.to_string(),
+            session_token: None,
+        })
+        .await?;
+
+    let nonce = match connect_result {
+        ConnectResult::Challenge {
+            nonce,
+            host_signature,
+        } => {
+            let host_pk_bytes = *host_identity.endpoint_id().as_bytes();
+            let host_vk = VerifyingKey::from_bytes(&host_pk_bytes)?;
+            let host_sig = ed25519_dalek::Signature::from_bytes(&host_signature);
+            host_vk.verify(&nonce, &host_sig)?;
+            nonce
+        }
+        other => anyhow::bail!("expected Challenge, got {:?}", other),
+    };
+
+    let client_signature = client_signing_key.sign(&nonce).to_bytes();
+    Ok(client
+        .rpc(AuthProveReq {
+            nonce,
+            client_signature,
+            session_id: session_id.to_string(),
+        })
+        .await?)
+}
+
 async fn connect_client(
     relay_url: iroh::RelayUrl,
     host_endpoint: &iroh::Endpoint,
@@ -113,84 +202,21 @@ async fn connect_client(
     [u8; 32],
     SyncSessionResult,
 )> {
-    use ed25519_dalek::{SigningKey, Verifier, VerifyingKey};
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    // Generate ephemeral client keypair
-    let client_signing_key = SigningKey::generate(&mut rand::thread_rng());
-    let client_pubkey = client_signing_key.verifying_key().to_bytes();
-
-    // Create a session with a pairing slot
     let session = registry
         .create_named("test", std::path::PathBuf::from("/tmp/test"))
         .await;
-    let handshake_key: [u8; 16] = rand::random();
-    registry.add_pairing_slot(&session.id, handshake_key).await;
 
-    // Connect
-    let client_endpoint = make_endpoint(relay_url).await?;
-    wait_online(&client_endpoint).await;
+    let (client, client_signing_key, client_pubkey) =
+        register_client_for_session(relay_url, host_endpoint, registry, &session.id).await?;
 
-    let host_addr = host_endpoint.addr();
-    let conn = client_endpoint
-        .connect(host_addr, proto::ZEDRA_ALPN)
-        .await?;
-    let remote = irpc_iroh::IrohRemoteConnection::new(conn);
-    let client = irpc::Client::<ZedraProto>::boxed(remote);
-
-    // Step 1: Register
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    let hmac = zedra_rpc::compute_registration_hmac(&handshake_key, &client_pubkey, timestamp);
-    let reg_result: RegisterResult = client
-        .rpc(RegisterReq {
-            client_pubkey,
-            timestamp,
-            hmac,
-            session_id: session.id.clone(),
-        })
-        .await?;
-    assert!(
-        matches!(reg_result, RegisterResult::Ok),
-        "register failed: {:?}",
-        reg_result
-    );
-
-    // Step 2: Connect — no session_token yet (first pairing), server issues a Challenge
-    let connect_result: ConnectResult = client
-        .rpc(ConnectReq {
-            client_pubkey,
-            session_id: session.id.clone(),
-            session_token: None,
-        })
-        .await?;
-
-    let nonce = match connect_result {
-        ConnectResult::Challenge {
-            nonce,
-            host_signature,
-        } => {
-            // Verify host signature
-            let host_pk_bytes = *host_identity.endpoint_id().as_bytes();
-            let host_vk = VerifyingKey::from_bytes(&host_pk_bytes)?;
-            let host_sig = ed25519_dalek::Signature::from_bytes(&host_signature);
-            host_vk.verify(&nonce, &host_sig)?;
-            nonce
-        }
-        other => anyhow::bail!("expected Challenge, got {:?}", other),
-    };
-
-    // Step 3: AuthProve — sign the nonce
-    let client_signature = client_signing_key.sign(&nonce).to_bytes();
-    let prove_result: AuthProveResult = client
-        .rpc(AuthProveReq {
-            nonce,
-            client_signature,
-            session_id: session.id.clone(),
-        })
-        .await?;
+    let prove_result = prove_registered_client(
+        &client,
+        &client_signing_key,
+        client_pubkey,
+        &session.id,
+        host_identity,
+    )
+    .await?;
 
     let sync = match prove_result {
         AuthProveResult::Ok(sync) => sync,
@@ -315,6 +341,36 @@ async fn test_full_rpc_over_iroh() {
     let info: SessionInfoResult = client.rpc(SessionInfoReq {}).await.unwrap();
     assert!(!info.hostname.is_empty());
     assert!(!info.workdir.is_empty());
+    assert_eq!(info.session_id.as_deref(), Some(session_id.as_str()));
+}
+
+/// A new authorized client is still blocked while the current active client is live.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_live_second_client_auth_returns_host_occupied() {
+    let (_relay, relay_url) = spawn_test_relay().await.unwrap();
+    let (host_ep, registry, identity, _dir) = setup_host(relay_url.clone()).await.unwrap();
+
+    let (client_a, session_id, _client_a_pubkey, _sync) =
+        connect_client(relay_url.clone(), &host_ep, &registry, &identity)
+            .await
+            .unwrap();
+
+    let (client_b, signing_key_b, pubkey_b) =
+        register_client_for_session(relay_url, &host_ep, &registry, &session_id)
+            .await
+            .unwrap();
+    let result =
+        prove_registered_client(&client_b, &signing_key_b, pubkey_b, &session_id, &identity)
+            .await
+            .unwrap();
+
+    assert!(
+        matches!(result, AuthProveResult::SessionOccupied),
+        "expected SessionOccupied, got {:?}",
+        result
+    );
+
+    let info: SessionInfoResult = client_a.rpc(SessionInfoReq {}).await.unwrap();
     assert_eq!(info.session_id.as_deref(), Some(session_id.as_str()));
 }
 

--- a/crates/zedra-session/src/connect.rs
+++ b/crates/zedra-session/src/connect.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use ed25519_dalek::VerifyingKey;
@@ -45,6 +45,7 @@ pub type ConnectedResult = (
     irpc::Client<ZedraProto>,
     SyncSessionResult,
     Vec<RemoteTerminal>,
+    Connection,
 );
 
 const IDLE_STALE_INTERVAL_MULTIPLIER: u32 = 2;
@@ -141,6 +142,7 @@ pub struct Connector {
     config: ConnectConfig,
     abort_signal: CancellationToken,
     started_at: Option<Instant>,
+    active_connection: Arc<Mutex<Option<Connection>>>,
 }
 
 fn reconcile_synced_terminals(
@@ -188,6 +190,7 @@ impl Connector {
             config: ConnectConfig::default(),
             abort_signal: CancellationToken::new(),
             started_at: None,
+            active_connection: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -197,22 +200,42 @@ impl Connector {
             config,
             abort_signal: CancellationToken::new(),
             started_at: None,
+            active_connection: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Cancel all active watcher tasks (call before starting a new connection).
     pub fn abort(&self) {
+        self.close_active_connection(b"client abort");
         self.abort_signal.cancel();
     }
 
     /// Reset for a new connection attempt.
     pub fn reset(&mut self) {
+        self.close_active_connection(b"client reconnect");
         self.abort_signal = CancellationToken::new();
         self.started_at = Some(Instant::now());
     }
 
     fn emit(&self, event: ConnectEvent) {
         let _ = self.tx.try_send(event);
+    }
+
+    fn set_active_connection(&self, conn: Connection) {
+        if let Ok(mut active) = self.active_connection.lock() {
+            if let Some(previous) = active.take() {
+                previous.close(0u32.into(), b"client reconnect");
+            }
+            *active = Some(conn);
+        }
+    }
+
+    fn close_active_connection(&self, reason: &'static [u8]) {
+        if let Ok(mut active) = self.active_connection.lock() {
+            if let Some(conn) = active.take() {
+                conn.close(0u32.into(), reason);
+            }
+        }
     }
 }
 
@@ -325,6 +348,8 @@ impl Connector {
 
         // Phase: HolePunching
         let conn = self.proceed_hole_punching(endpoint, remote_addr).await?;
+        let active_connection = conn.clone();
+        self.set_active_connection(active_connection.clone());
         self.spawn_remote_paths_watcher(conn.clone());
         self.spawn_connection_closed_watcher(conn.clone());
 
@@ -385,7 +410,7 @@ impl Connector {
             .unwrap_or(0);
         self.emit(ConnectEvent::Connected { total_ms });
 
-        Ok((client, sync, terminals))
+        Ok((client, sync, terminals, active_connection))
     }
 
     pub async fn proceed_binding_endpoint(&mut self) -> Result<Endpoint, ConnectError> {
@@ -1008,6 +1033,40 @@ mod tests {
         assert!(!is_no_application_protocol_error_code(
             TransportErrorCode::crypto(0x2f)
         ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn abort_closes_active_connection() {
+        let (tx, _rx) = mpsc::channel(8);
+        let connector = Connector::new(tx);
+        let client = Endpoint::empty_builder(RelayMode::Disabled)
+            .bind()
+            .await
+            .unwrap();
+        let server = Endpoint::empty_builder(RelayMode::Disabled)
+            .alpns(vec![ZEDRA_ALPN.to_vec()])
+            .bind()
+            .await
+            .unwrap();
+        let server_addr = server.addr();
+        let server_task = tokio::spawn(async move {
+            let incoming = server.accept().await.expect("incoming connection");
+            let conn = incoming.await.expect("accepted connection");
+            conn.closed().await
+        });
+
+        let conn = client.connect(server_addr, ZEDRA_ALPN).await.unwrap();
+        connector.set_active_connection(conn);
+        connector.abort();
+
+        let close_reason = tokio::time::timeout(Duration::from_secs(5), server_task)
+            .await
+            .expect("timed out waiting for remote close")
+            .unwrap();
+        assert!(
+            matches!(close_reason, IrohConnectionError::ApplicationClosed(_)),
+            "expected application close, got {close_reason:?}",
+        );
     }
 
     #[test]

--- a/crates/zedra-session/src/connect.rs
+++ b/crates/zedra-session/src/connect.rs
@@ -25,9 +25,10 @@ use zedra_rpc::{
     },
 };
 
-use crate::RemoteTerminal;
-use crate::signer::ClientSigner;
 use crate::state::{AuthOutcome, ConnectError, ReconnectReason};
+use crate::{
+    RemoteTerminal, register_active_connection, signer::ClientSigner, unregister_active_connection,
+};
 
 pub struct ConnectConfig {
     alpn: Vec<u8>,
@@ -224,8 +225,10 @@ impl Connector {
     fn set_active_connection(&self, conn: Connection) {
         if let Ok(mut active) = self.active_connection.lock() {
             if let Some(previous) = active.take() {
+                unregister_active_connection(&previous);
                 previous.close(0u32.into(), b"client reconnect");
             }
+            register_active_connection(&conn);
             *active = Some(conn);
         }
     }
@@ -233,6 +236,7 @@ impl Connector {
     fn close_active_connection(&self, reason: &'static [u8]) {
         if let Ok(mut active) = self.active_connection.lock() {
             if let Some(conn) = active.take() {
+                unregister_active_connection(&conn);
                 conn.close(0u32.into(), reason);
             }
         }

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -6,7 +6,10 @@ use std::sync::{
 use anyhow::Result;
 use zedra_rpc::proto::*;
 
-use crate::{signer::ClientSigner, terminal::RemoteTerminal};
+use crate::{
+    register_active_connection, signer::ClientSigner, terminal::RemoteTerminal,
+    unregister_active_connection,
+};
 
 #[derive(Clone)]
 pub struct SessionHandle(Arc<SessionHandleInner>);
@@ -30,6 +33,7 @@ impl Drop for SessionHandleInner {
     fn drop(&mut self) {
         if let Ok(mut active) = self.active_connection.lock() {
             if let Some(conn) = active.take() {
+                unregister_active_connection(&conn);
                 conn.close(0u32.into(), b"client handle dropped");
             }
         }
@@ -117,21 +121,26 @@ impl SessionHandle {
     pub fn set_active_connection(&self, conn: iroh::endpoint::Connection) {
         if let Ok(mut active) = self.0.active_connection.lock() {
             if let Some(previous) = active.take() {
+                unregister_active_connection(&previous);
                 previous.close(0u32.into(), b"client reconnect");
             }
+            register_active_connection(&conn);
             *active = Some(conn);
         }
     }
 
     pub fn clear_active_connection(&self) {
         if let Ok(mut active) = self.0.active_connection.lock() {
-            *active = None;
+            if let Some(conn) = active.take() {
+                unregister_active_connection(&conn);
+            }
         }
     }
 
     pub fn close_active_connection(&self, reason: &'static [u8]) {
         if let Ok(mut active) = self.0.active_connection.lock() {
             if let Some(conn) = active.take() {
+                unregister_active_connection(&conn);
                 conn.close(0u32.into(), reason);
             }
         }
@@ -691,6 +700,42 @@ mod tests {
         let handle = SessionHandle::new();
         handle.set_active_connection(conn);
         drop(handle);
+
+        let close_reason = tokio::time::timeout(std::time::Duration::from_secs(5), server_task)
+            .await
+            .expect("timed out waiting for remote close")
+            .unwrap();
+        assert!(
+            matches!(
+                close_reason,
+                iroh::endpoint::ConnectionError::ApplicationClosed(_)
+            ),
+            "expected application close, got {close_reason:?}",
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn lifecycle_close_all_closes_active_connection_without_handle_borrow() {
+        let client = iroh::Endpoint::empty_builder(iroh::RelayMode::Disabled)
+            .bind()
+            .await
+            .unwrap();
+        let server = iroh::Endpoint::empty_builder(iroh::RelayMode::Disabled)
+            .alpns(vec![ZEDRA_ALPN.to_vec()])
+            .bind()
+            .await
+            .unwrap();
+        let server_addr = server.addr();
+        let server_task = tokio::spawn(async move {
+            let incoming = server.accept().await.expect("incoming connection");
+            let conn = incoming.await.expect("accepted connection");
+            conn.closed().await
+        });
+
+        let conn = client.connect(server_addr, ZEDRA_ALPN).await.unwrap();
+        let handle = SessionHandle::new();
+        handle.set_active_connection(conn);
+        crate::close_all_active_connections_for_lifecycle(b"client lifecycle close");
 
         let close_reason = tokio::time::timeout(std::time::Duration::from_secs(5), server_task)
             .await

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -19,10 +19,21 @@ struct SessionHandleInner {
     session_token: Mutex<Option<[u8; 32]>>,
     pending_ticket: Mutex<Option<zedra_rpc::ZedraPairingTicket>>,
     rpc_client: Mutex<Option<irpc::Client<ZedraProto>>>,
+    active_connection: Mutex<Option<iroh::endpoint::Connection>>,
     terminals: Mutex<Vec<RemoteTerminal>>,
     user_disconnect: AtomicBool,
     observer_rpc_supported: AtomicBool,
     docs_tree_rpc_supported: AtomicBool,
+}
+
+impl Drop for SessionHandleInner {
+    fn drop(&mut self) {
+        if let Ok(mut active) = self.active_connection.lock() {
+            if let Some(conn) = active.take() {
+                conn.close(0u32.into(), b"client handle dropped");
+            }
+        }
+    }
 }
 
 impl Default for SessionHandle {
@@ -41,6 +52,7 @@ impl SessionHandle {
             session_token: Mutex::new(None),
             pending_ticket: Mutex::new(None),
             rpc_client: Mutex::new(None),
+            active_connection: Mutex::new(None),
             terminals: Mutex::new(Vec::new()),
             user_disconnect: AtomicBool::new(false),
             observer_rpc_supported: AtomicBool::new(true),
@@ -102,6 +114,29 @@ impl SessionHandle {
         *self.0.rpc_client.lock().unwrap() = Some(client);
     }
 
+    pub fn set_active_connection(&self, conn: iroh::endpoint::Connection) {
+        if let Ok(mut active) = self.0.active_connection.lock() {
+            if let Some(previous) = active.take() {
+                previous.close(0u32.into(), b"client reconnect");
+            }
+            *active = Some(conn);
+        }
+    }
+
+    pub fn clear_active_connection(&self) {
+        if let Ok(mut active) = self.0.active_connection.lock() {
+            *active = None;
+        }
+    }
+
+    pub fn close_active_connection(&self, reason: &'static [u8]) {
+        if let Ok(mut active) = self.0.active_connection.lock() {
+            if let Some(conn) = active.take() {
+                conn.close(0u32.into(), reason);
+            }
+        }
+    }
+
     pub fn clear_rpc_client(&self) {
         *self.0.rpc_client.lock().unwrap() = None;
     }
@@ -129,6 +164,9 @@ impl SessionHandle {
 
     pub fn clear_session(&self) {
         self.set_user_disconnect(true);
+        // Send CONNECTION_CLOSE before dropping RPC handles so the host can
+        // release this client's active slot without waiting for QUIC idle expiry.
+        self.close_active_connection(b"client disconnect");
         self.clear_rpc_client();
         *self.0.terminals.lock().unwrap() = Vec::new();
         tracing::info!("SessionHandle: session cleared");
@@ -166,6 +204,12 @@ impl SessionHandle {
     pub fn set_terminals(&self, new_terminals: Vec<RemoteTerminal>) {
         if let Ok(mut terminals_slot) = self.0.terminals.lock() {
             *terminals_slot = new_terminals;
+        }
+    }
+
+    pub fn detach_terminals(&self) {
+        for terminal in self.terminals() {
+            terminal.detach_remote();
         }
     }
 
@@ -623,5 +667,41 @@ mod tests {
 
         let err = git_checkout_result(GitCheckoutResult { ok: false }, "missing").unwrap_err();
         assert!(err.to_string().contains("missing"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dropping_last_handle_closes_active_connection() {
+        let client = iroh::Endpoint::empty_builder(iroh::RelayMode::Disabled)
+            .bind()
+            .await
+            .unwrap();
+        let server = iroh::Endpoint::empty_builder(iroh::RelayMode::Disabled)
+            .alpns(vec![ZEDRA_ALPN.to_vec()])
+            .bind()
+            .await
+            .unwrap();
+        let server_addr = server.addr();
+        let server_task = tokio::spawn(async move {
+            let incoming = server.accept().await.expect("incoming connection");
+            let conn = incoming.await.expect("accepted connection");
+            conn.closed().await
+        });
+
+        let conn = client.connect(server_addr, ZEDRA_ALPN).await.unwrap();
+        let handle = SessionHandle::new();
+        handle.set_active_connection(conn);
+        drop(handle);
+
+        let close_reason = tokio::time::timeout(std::time::Duration::from_secs(5), server_task)
+            .await
+            .expect("timed out waiting for remote close")
+            .unwrap();
+        assert!(
+            matches!(
+                close_reason,
+                iroh::endpoint::ConnectionError::ApplicationClosed(_)
+            ),
+            "expected application close, got {close_reason:?}",
+        );
     }
 }

--- a/crates/zedra-session/src/lib.rs
+++ b/crates/zedra-session/src/lib.rs
@@ -11,9 +11,40 @@ pub use session::*;
 pub use state::*;
 pub use terminal::*;
 
-use std::sync::OnceLock;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 
 static SESSION_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+static ACTIVE_CONNECTIONS: OnceLock<Mutex<HashMap<usize, iroh::endpoint::Connection>>> =
+    OnceLock::new();
+
+fn active_connections() -> &'static Mutex<HashMap<usize, iroh::endpoint::Connection>> {
+    ACTIVE_CONNECTIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub(crate) fn register_active_connection(conn: &iroh::endpoint::Connection) {
+    if let Ok(mut active) = active_connections().lock() {
+        active.insert(conn.stable_id(), conn.clone());
+    }
+}
+
+pub(crate) fn unregister_active_connection(conn: &iroh::endpoint::Connection) {
+    if let Ok(mut active) = active_connections().lock() {
+        active.remove(&conn.stable_id());
+    }
+}
+
+pub fn close_all_active_connections_for_lifecycle(reason: &'static [u8]) {
+    // Lifecycle callbacks may run after GPUI state is unavailable; keep transport
+    // release independent so the host can free its active-client slot promptly.
+    let connections = active_connections()
+        .lock()
+        .map(|mut active| active.drain().map(|(_, conn)| conn).collect::<Vec<_>>())
+        .unwrap_or_default();
+    for conn in connections {
+        conn.close(0u32.into(), reason);
+    }
+}
 
 /// Returns the shared Tokio runtime for session/network work.
 ///

--- a/crates/zedra-session/src/session.rs
+++ b/crates/zedra-session/src/session.rs
@@ -167,8 +167,9 @@ impl Session {
                 };
 
                 match result {
-                    Ok((client, sync, terminals)) => {
+                    Ok((client, sync, terminals, active_connection)) => {
                         handle.set_user_disconnect(false);
+                        handle.set_active_connection(active_connection);
                         handle.set_rpc_client(client.clone());
                         handle.set_session_id(Some(sync.session_id.clone()));
                         handle.set_session_token(Some(sync.session_token));
@@ -277,7 +278,9 @@ impl Session {
                             }
                         }
 
+                        handle.detach_terminals();
                         handle.clear_rpc_client();
+                        handle.clear_active_connection();
                         if abort_signal.is_cancelled() || handle.user_disconnect() {
                             connector.abort();
                             break;
@@ -299,6 +302,14 @@ impl Session {
     pub fn disconnect(&self) {
         self.cancel_abort_signal();
         self.handle.clear_session();
+    }
+
+    /// Close the current transport without marking the session as manually
+    /// disconnected. App lifecycle hooks use this to release host occupancy
+    /// while preserving the saved workspace for foreground reconnect.
+    pub fn close_transport_for_lifecycle(&self, reason: &'static [u8]) {
+        self.handle.detach_terminals();
+        self.handle.close_active_connection(reason);
     }
 
     fn reset_abort_signal(&self) -> CancellationToken {
@@ -324,8 +335,13 @@ impl Session {
                     "HostEvent: terminal created id={} launch_cmd={:?}",
                     id, launch_cmd,
                 );
-                let terminal = RemoteTerminal::new(id.clone());
-                handle.add_terminal(terminal.clone());
+                let terminal = if let Some(terminal) = handle.terminal(id) {
+                    terminal
+                } else {
+                    let terminal = RemoteTerminal::new(id.clone());
+                    handle.add_terminal(terminal.clone());
+                    terminal
+                };
                 if let Err(e) = terminal.attach_remote(client).await {
                     warn!(
                         "Failed to attach host-created terminal {}: {e}",

--- a/crates/zedra-session/src/terminal.rs
+++ b/crates/zedra-session/src/terminal.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tracing::*;
@@ -10,14 +10,28 @@ use crate::session_runtime;
 #[derive(Clone)]
 pub struct RemoteTerminal(Arc<RemoteTerminalInner>);
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum AttachState {
+    #[default]
+    Detached,
+    Attaching,
+    Attached,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AttachTask {
+    Input,
+    Output,
+}
+
 #[derive(Default)]
 pub struct RemoteTerminalInner {
     id: Mutex<String>,
     input_tx: Mutex<Option<mpsc::Sender<Vec<u8>>>>,
     output_rx: Mutex<Option<mpsc::Receiver<Vec<u8>>>>,
     last_seq: AtomicU64,
-    /// Whether the terminal is currently attached to a remote client.
-    remote_attached: AtomicBool,
+    attach_state: Mutex<AttachState>,
+    attach_generation: AtomicU64,
     input_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
     output_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
@@ -27,13 +41,94 @@ impl RemoteTerminalInner {
         self.last_seq.store(seq, Ordering::Release);
     }
 
-    fn store_channels(&self, input_tx: mpsc::Sender<Vec<u8>>, output_rx: mpsc::Receiver<Vec<u8>>) {
-        if let (Ok(mut input_tx_slot), Ok(mut output_rx_slot)) =
-            (self.input_tx.lock(), self.output_rx.lock())
+    fn begin_attach(&self) -> anyhow::Result<Option<u64>> {
+        let mut state = self
+            .attach_state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("terminal attach state lock poisoned"))?;
+        match *state {
+            AttachState::Detached => {
+                *state = AttachState::Attaching;
+                let generation = self
+                    .attach_generation
+                    .fetch_add(1, Ordering::AcqRel)
+                    .wrapping_add(1);
+                Ok(Some(generation))
+            }
+            AttachState::Attaching | AttachState::Attached => Ok(None),
+        }
+    }
+
+    fn attach_failed(&self, generation: u64) {
+        let Ok(mut state) = self.attach_state.lock() else {
+            return;
+        };
+        if self.attach_generation.load(Ordering::Acquire) == generation
+            && *state == AttachState::Attaching
         {
-            *input_tx_slot = Some(input_tx);
-            *output_rx_slot = Some(output_rx);
-            self.remote_attached.store(true, Ordering::Release);
+            *state = AttachState::Detached;
+        }
+    }
+
+    fn finish_attach(
+        &self,
+        generation: u64,
+        input_tx: mpsc::Sender<Vec<u8>>,
+        output_rx: mpsc::Receiver<Vec<u8>>,
+    ) -> anyhow::Result<bool> {
+        let mut state = self
+            .attach_state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("terminal attach state lock poisoned"))?;
+        if self.attach_generation.load(Ordering::Acquire) != generation
+            || *state != AttachState::Attaching
+        {
+            return Ok(false);
+        }
+
+        let mut input_tx_slot = self
+            .input_tx
+            .lock()
+            .map_err(|_| anyhow::anyhow!("terminal input channel lock poisoned"))?;
+        let mut output_rx_slot = self
+            .output_rx
+            .lock()
+            .map_err(|_| anyhow::anyhow!("terminal output channel lock poisoned"))?;
+        *input_tx_slot = Some(input_tx);
+        *output_rx_slot = Some(output_rx);
+        *state = AttachState::Attached;
+        Ok(true)
+    }
+
+    fn store_tasks(
+        &self,
+        generation: u64,
+        input_task: tokio::task::JoinHandle<()>,
+        output_task: tokio::task::JoinHandle<()>,
+    ) {
+        if self.attach_generation.load(Ordering::Acquire) != generation {
+            input_task.abort();
+            output_task.abort();
+            return;
+        }
+
+        if let (Ok(mut input_task_slot), Ok(mut output_task_slot)) =
+            (self.input_task.lock(), self.output_task.lock())
+        {
+            if let Some(prev_task) = input_task_slot.take() {
+                prev_task.abort();
+                info!("aborted previous terminal input task from reattach");
+            }
+            if let Some(prev_task) = output_task_slot.take() {
+                prev_task.abort();
+                info!("aborted previous terminal output task from reattach");
+            }
+            *input_task_slot = Some(input_task);
+            *output_task_slot = Some(output_task);
+        } else {
+            input_task.abort();
+            output_task.abort();
+            self.detach_remote();
         }
     }
 
@@ -41,11 +136,82 @@ impl RemoteTerminalInner {
         if let (Ok(mut input_tx_slot), Ok(mut output_rx_slot)) =
             (self.input_tx.lock(), self.output_rx.lock())
         {
-            let input_tx = input_tx_slot.take()?;
-            let output_rx = output_rx_slot.take()?;
-            Some((input_tx, output_rx))
+            match (input_tx_slot.take(), output_rx_slot.take()) {
+                (Some(input_tx), Some(output_rx)) => Some((input_tx, output_rx)),
+                (input_tx, output_rx) => {
+                    *input_tx_slot = input_tx;
+                    *output_rx_slot = output_rx;
+                    None
+                }
+            }
         } else {
             None
+        }
+    }
+
+    fn clear_channels(&self) {
+        if let Ok(mut input_tx_slot) = self.input_tx.lock() {
+            *input_tx_slot = None;
+        }
+        if let Ok(mut output_rx_slot) = self.output_rx.lock() {
+            *output_rx_slot = None;
+        }
+    }
+
+    fn abort_tasks(&self, exiting_task: Option<AttachTask>) {
+        if exiting_task != Some(AttachTask::Input) {
+            if let Ok(mut input_task_slot) = self.input_task.lock() {
+                if let Some(task) = input_task_slot.take() {
+                    task.abort();
+                    info!("aborted terminal input task from detach");
+                }
+            }
+        } else if let Ok(mut input_task_slot) = self.input_task.lock() {
+            let _ = input_task_slot.take();
+        }
+
+        if exiting_task != Some(AttachTask::Output) {
+            if let Ok(mut output_task_slot) = self.output_task.lock() {
+                if let Some(task) = output_task_slot.take() {
+                    task.abort();
+                    info!("aborted terminal output task from detach");
+                }
+            }
+        } else if let Ok(mut output_task_slot) = self.output_task.lock() {
+            let _ = output_task_slot.take();
+        }
+    }
+
+    fn detach_remote(&self) {
+        self.attach_generation.fetch_add(1, Ordering::AcqRel);
+        if let Ok(mut state) = self.attach_state.lock() {
+            *state = AttachState::Detached;
+        }
+        self.clear_channels();
+        self.abort_tasks(None);
+    }
+
+    fn teardown_if_current(&self, generation: u64, exiting_task: AttachTask) {
+        let should_teardown = {
+            let Ok(mut state) = self.attach_state.lock() else {
+                return;
+            };
+            if self.attach_generation.load(Ordering::Acquire) == generation
+                && *state != AttachState::Detached
+            {
+                *state = AttachState::Detached;
+                true
+            } else {
+                false
+            }
+        };
+
+        if should_teardown {
+            // Any TermAttach task exit means the remote stream is no longer a
+            // valid bridge for this generation; stale exits must not clear a
+            // newer attach that has already advanced the generation.
+            self.clear_channels();
+            self.abort_tasks(Some(exiting_task));
         }
     }
 }
@@ -57,7 +223,8 @@ impl RemoteTerminal {
             input_tx: Mutex::new(None),
             output_rx: Mutex::new(None),
             last_seq: AtomicU64::new(0),
-            remote_attached: AtomicBool::new(false),
+            attach_state: Mutex::new(AttachState::Detached),
+            attach_generation: AtomicU64::new(0),
             input_task: Mutex::new(None),
             output_task: Mutex::new(None),
         }))
@@ -79,22 +246,48 @@ impl RemoteTerminal {
         &self,
         client: &irpc::Client<ZedraProto>,
     ) -> Result<(), anyhow::Error> {
-        let (irpc_input_tx, mut irpc_output_rx) = client
+        let term_id = self.id();
+        let Some(generation) = self.0.begin_attach()? else {
+            info!("remote terminal attach already active: {}", term_id);
+            return Ok(());
+        };
+
+        let last_seq = self.last_seq();
+        let (irpc_input_tx, mut irpc_output_rx) = match client
             .bidi_streaming::<TermAttachReq, TermInput, TermOutput>(
                 TermAttachReq {
-                    id: self.id(),
-                    last_seq: self.last_seq(),
+                    id: term_id.clone(),
+                    last_seq,
                 },
                 256,
                 256,
             )
-            .await?;
+            .await
+        {
+            Ok(streams) => streams,
+            Err(e) => {
+                self.0.attach_failed(generation);
+                return Err(e.into());
+            }
+        };
 
-        info!("attached to remote terminal: {}", self.id());
+        info!("attached to remote terminal: {}", term_id);
 
         let (input_tx, mut input_rx) = mpsc::channel::<Vec<u8>>(256);
         let (output_tx, output_rx) = mpsc::channel::<Vec<u8>>(256);
+        match self.0.finish_attach(generation, input_tx, output_rx) {
+            Ok(true) => {}
+            Ok(false) => {
+                info!("dropping stale remote terminal attach: {}", term_id);
+                return Ok(());
+            }
+            Err(e) => {
+                self.0.attach_failed(generation);
+                return Err(e);
+            }
+        }
 
+        let terminal_inner = self.0.clone();
         let input_task = session_runtime().spawn(async move {
             while let Some(data) = input_rx.recv().await {
                 if let Err(e) = irpc_input_tx.send(TermInput { data }).await {
@@ -102,14 +295,8 @@ impl RemoteTerminal {
                     break;
                 }
             }
+            terminal_inner.teardown_if_current(generation, AttachTask::Input);
         });
-        if let Ok(mut input_task_slot) = self.0.input_task.lock() {
-            if let Some(prev_task) = input_task_slot.take() {
-                prev_task.abort();
-                info!("aborted previous terminal input task from reattach");
-            }
-            *input_task_slot = Some(input_task);
-        }
 
         let terminal_inner = self.0.clone();
         let output_task = session_runtime().spawn(async move {
@@ -133,19 +320,17 @@ impl RemoteTerminal {
                     }
                 }
             }
+            terminal_inner.teardown_if_current(generation, AttachTask::Output);
         });
-        if let Ok(mut output_task_slot) = self.0.output_task.lock() {
-            if let Some(prev_task) = output_task_slot.take() {
-                prev_task.abort();
-                info!("aborted previous terminal output task from reattach");
-            }
-            *output_task_slot = Some(output_task);
-        }
 
-        self.0.store_channels(input_tx, output_rx);
-        info!("stored channels for remote terminal: {}", self.id());
+        self.0.store_tasks(generation, input_task, output_task);
+        info!("stored channels for remote terminal: {}", term_id);
 
         Ok(())
+    }
+
+    pub fn detach_remote(&self) {
+        self.0.detach_remote();
     }
 
     /// Takes ownership of the input/output channels.
@@ -175,5 +360,57 @@ impl Drop for RemoteTerminalInner {
                 info!("aborted previous terminal input task from drop");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_attach_is_ignored_while_active() {
+        let terminal = RemoteTerminal::new("term-1".to_string());
+
+        let first_generation = terminal.0.begin_attach().unwrap();
+        assert!(first_generation.is_some());
+        assert_eq!(terminal.0.begin_attach().unwrap(), None);
+
+        terminal.0.attach_failed(first_generation.unwrap());
+        assert!(terminal.0.begin_attach().unwrap().is_some());
+    }
+
+    #[test]
+    fn stale_teardown_does_not_clear_newer_attach_channels() {
+        let terminal = RemoteTerminal::new("term-1".to_string());
+
+        let generation_1 = terminal.0.begin_attach().unwrap().unwrap();
+        let (input_tx_1, _input_rx_1) = mpsc::channel(1);
+        let (_output_tx_1, output_rx_1) = mpsc::channel(1);
+        assert!(
+            terminal
+                .0
+                .finish_attach(generation_1, input_tx_1, output_rx_1)
+                .unwrap()
+        );
+
+        terminal
+            .0
+            .teardown_if_current(generation_1, AttachTask::Input);
+
+        let generation_2 = terminal.0.begin_attach().unwrap().unwrap();
+        let (input_tx_2, _input_rx_2) = mpsc::channel(1);
+        let (_output_tx_2, output_rx_2) = mpsc::channel(1);
+        assert!(
+            terminal
+                .0
+                .finish_attach(generation_2, input_tx_2, output_rx_2)
+                .unwrap()
+        );
+
+        terminal
+            .0
+            .teardown_if_current(generation_1, AttachTask::Output);
+
+        assert!(terminal.take_chanel().is_ok());
     }
 }

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -332,6 +332,16 @@ impl ZedraApp {
             workspace.update(cx, |workspace, cx| workspace.record_current_view(cx));
         }
     }
+
+    #[cfg(target_os = "ios")]
+    pub(crate) fn close_transports_for_lifecycle(
+        &mut self,
+        reason: &'static [u8],
+        cx: &mut Context<Self>,
+    ) {
+        self.workspaces
+            .update(cx, |ws, cx| ws.close_transports_for_lifecycle(reason, cx));
+    }
 }
 
 impl Render for ZedraApp {

--- a/crates/zedra/src/ios/app.rs
+++ b/crates/zedra/src/ios/app.rs
@@ -73,6 +73,36 @@ pub(crate) fn notify_main_window() {
     });
 }
 
+pub(crate) fn close_active_transports_for_lifecycle(reason: &'static [u8]) {
+    IOS_APP_CELL.with(|cell| {
+        IOS_WINDOW.with(|window| {
+            let Some(app_cell) = cell.borrow().as_ref().cloned() else {
+                return;
+            };
+            let Some(window) = *window.borrow() else {
+                return;
+            };
+
+            let Some(window) = window.downcast::<app::ZedraApp>() else {
+                tracing::warn!("Zedra iOS: root window is not ZedraApp during lifecycle close");
+                return;
+            };
+            let Ok(mut app) = app_cell.try_borrow_mut() else {
+                return;
+            };
+            let cx: &mut App = &mut app;
+            let _ = window.update(cx, |view, _window, cx| {
+                view.close_transports_for_lifecycle(reason, cx);
+            });
+        });
+    });
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn zedra_ios_app_will_terminate() {
+    close_active_transports_for_lifecycle(b"client app terminate");
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn zedra_ios_native_floating_button_pressed(callback_id: u32) {
     IOS_APP_CELL.with(|cell| {

--- a/crates/zedra/src/ios/app.rs
+++ b/crates/zedra/src/ios/app.rs
@@ -74,6 +74,8 @@ pub(crate) fn notify_main_window() {
 }
 
 pub(crate) fn close_active_transports_for_lifecycle(reason: &'static [u8]) {
+    zedra_session::close_all_active_connections_for_lifecycle(reason);
+
     IOS_APP_CELL.with(|cell| {
         IOS_WINDOW.with(|window| {
             let Some(app_cell) = cell.borrow().as_ref().cloned() else {

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -418,6 +418,9 @@ pub extern "C" fn zedra_ios_selection_dismiss(callback_id: u32) {
 /// Wire this to the iOS app delegate's `applicationDidEnterBackground`.
 #[unsafe(no_mangle)]
 pub extern "C" fn zedra_ios_app_did_enter_background() {
+    // iOS may not deliver `applicationWillTerminate` after a force-quit from
+    // the app switcher, so release the host slot as soon as the app backgrounds.
+    super::app::close_active_transports_for_lifecycle(b"client app background");
     platform_bridge::clear_pending_alerts();
 }
 

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -418,9 +418,6 @@ pub extern "C" fn zedra_ios_selection_dismiss(callback_id: u32) {
 /// Wire this to the iOS app delegate's `applicationDidEnterBackground`.
 #[unsafe(no_mangle)]
 pub extern "C" fn zedra_ios_app_did_enter_background() {
-    // iOS may not deliver `applicationWillTerminate` after a force-quit from
-    // the app switcher, so release the host slot as soon as the app backgrounds.
-    super::app::close_active_transports_for_lifecycle(b"client app background");
     platform_bridge::clear_pending_alerts();
 }
 

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -1015,6 +1015,11 @@ impl Workspace {
         cx.notify();
     }
 
+    pub fn close_transport_for_lifecycle(&mut self, reason: &'static [u8]) {
+        self.session.close_transport_for_lifecycle(reason);
+        self.latency_sampler.reset();
+    }
+
     pub fn prepare_for_saved_removal(&mut self) {
         self.persist_workspace_state = false;
         self.session.disconnect();

--- a/crates/zedra/src/workspaces.rs
+++ b/crates/zedra/src/workspaces.rs
@@ -269,6 +269,16 @@ impl Workspaces {
         }
     }
 
+    pub fn close_transports_for_lifecycle(
+        &mut self,
+        reason: &'static [u8],
+        cx: &mut Context<Self>,
+    ) {
+        for entry in self.entries.clone() {
+            entry.update(cx, |ws, _cx| ws.close_transport_for_lifecycle(reason));
+        }
+    }
+
     pub fn remove_by_endpoint_addr(&mut self, endpoint_addr: &str, cx: &mut Context<Self>) {
         if let Some(index) = self
             .entries

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -227,8 +227,9 @@
 1. Pair Device A via QR → connected to session S
 2. Start a new `zedra start` for the same workdir on the host (same session)
 3. Pair Device B via the new QR → should attach to session S
-4. Expected: Device B blocked with "Host occupied. Disconnect other device and retry."
-5. Disconnect Device A → Device B can now attach
+4. Expected while Device A is still live: Device B is blocked with "Host occupied. Disconnect other device and retry."
+5. Quit or network-disconnect Device A, then retry Device B after the active-client stale window
+6. Expected: the host evicts the stale Device A connection and Device B attaches without waiting for the full transport timeout
 
 ## 7. `zedra client` RTT Test
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -146,12 +146,14 @@
 
 1. Connect via QR (test 1 above), create at least three terminals, and note their order in the drawer Terminals tab
 2. Force-close the app
-3. Reopen — tap the saved workspace entry in the home screen
-4. Expected: reconnects using stored session ID (no QR needed); terminal
+3. On another client, immediately connect to the same host session using a saved workspace or a fresh host QR
+4. Expected: the second client connects without several `Host occupied` / retry attempts
+5. Disconnect the second client, then reopen the original app and tap the saved workspace entry in the home screen
+6. Expected: reconnects using stored session ID (no QR needed); terminal
    backlog replays any missed output
-5. Expected: the workspace drawer Terminals tab shows the active remote
+7. Expected: the workspace drawer Terminals tab shows the active remote
    terminals from the host without creating a replacement terminal
-6. Expected: terminal cards appear in the same order they had before force-close
+8. Expected: terminal cards appear in the same order they had before force-close
 
 ## 3a. Remove Saved Workspace From Home
 
@@ -187,13 +189,22 @@
 ## 5. Host Unreachable → Retry
 
 1. Connect via QR and create at least three terminals
-2. Take the host machine offline (disable network interface)
-3. Expected: badge shows `Reconnecting (N) · Ns` with a per-second countdown, up to 3 attempts
-4. After 3 attempts: connect view shows "Host unreachable. Check network and host."
-5. Bring host network back up, tap "Retry"
-6. Expected: reconnects successfully
-7. Expected: the workspace drawer Terminals tab preserves the pre-reconnect terminal order
-8. If the host was restarted and no remote terminals remain, expected: a fresh terminal is created and opened
+2. In one terminal, run:
+   ```sh
+   sh -c 'i=0; while true; do echo "tick:$i"; i=$((i+1)); sleep 1; done'
+   ```
+3. In another terminal, run `cat`
+4. Take the host machine offline (disable network interface)
+5. Expected: badge shows `Reconnecting (N) · Ns` with a per-second countdown, up to 3 attempts
+6. After 3 attempts: connect view shows "Host unreachable. Check network and host."
+7. Bring host network back up, tap "Retry"
+8. Expected: reconnects successfully
+9. Expected: the ticking terminal continues receiving new `tick:<n>` output after reconnect, not only replayed backlog
+10. In the `cat` terminal, type `after-reconnect` and press Enter
+11. Expected: `after-reconnect` echoes once, proving the reattached input stream still reaches the PTY
+12. Expected: the workspace drawer Terminals tab preserves the pre-reconnect terminal order
+13. If the host was restarted and no remote terminals remain, expected: a fresh terminal is created and opened
+14. Expected: host logs do not report reconnect teardown as `ERROR zedra_host::rpc_daemon: TermAttach: input receiver error: Io error`
 
 ## 5a. Idle Before Reconnect
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -239,8 +239,16 @@
 2. Start a new `zedra start` for the same workdir on the host (same session)
 3. Pair Device B via the new QR → should attach to session S
 4. Expected while Device A is still live: Device B is blocked with "Host occupied. Disconnect other device and retry."
-5. Quit or network-disconnect Device A, then retry Device B after the active-client stale window
-6. Expected: the host evicts the stale Device A connection and Device B attaches without waiting for the full transport timeout
+5. Manually disconnect Device A, then immediately retry Device B
+6. Expected: Device B attaches on the first retry
+7. Reconnect Device A, then background it without quitting
+8. Immediately retry Device B
+9. Expected: Device B is still blocked because backgrounding alone keeps Device A's session active
+10. Force-quit Device A from the app switcher, then immediately retry Device B
+11. Expected: Device B attaches without several "Host occupied" retry attempts
+12. Reconnect Device A again, then network-disconnect Device A without a graceful client close
+13. Retry Device B after the active-client stale window
+14. Expected: the host evicts the stale Device A connection without waiting for the full transport timeout
 
 ## 7. `zedra client` RTT Test
 

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -142,6 +142,8 @@ extern void gpui_ios_detach_embedded_view(void *window_ptr);
  */
 bool zedra_ios_check_pending_frame(void);
 
+void zedra_ios_app_will_terminate(void);
+
 void zedra_ios_native_floating_button_pressed(uint32_t callback_id);
 
 void zedra_launch_gpui(void);

--- a/ios/Zedra/GPUIRuntimeController.swift
+++ b/ios/Zedra/GPUIRuntimeController.swift
@@ -21,6 +21,9 @@ private func zedra_firebase_initialize()
 @_silgen_name("zedra_ios_send_key_input")
 private func zedra_ios_send_key_input(_ key: UnsafePointer<CChar>)
 
+@_silgen_name("zedra_ios_app_will_terminate")
+private func zedra_ios_app_will_terminate()
+
 final class GPUIRuntimeController: NSObject {
     private var gpuiApp: UnsafeMutableRawPointer?
     private var gpuiWindow: UnsafeMutableRawPointer?
@@ -96,6 +99,7 @@ final class GPUIRuntimeController: NSObject {
     func applicationWillTerminate() {
         keyboardAccessoryController.stopRepeating()
         stopDisplayLink()
+        zedra_ios_app_will_terminate()
         gpui_ios_will_terminate(gpuiApp)
     }
 

--- a/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
@@ -142,6 +142,8 @@ extern void gpui_ios_detach_embedded_view(void *window_ptr);
  */
 bool zedra_ios_check_pending_frame(void);
 
+void zedra_ios_app_will_terminate(void);
+
 void zedra_ios_native_floating_button_pressed(uint32_t callback_id);
 
 void zedra_launch_gpui(void);


### PR DESCRIPTION
## Summary

- Allow the host to replace the active client only when the current connection is closed or stale, while preserving the existing host-occupied response for a live client.
- Close client-side active transports on manual disconnect, reconnect reset, handle drop, and app termination so another client can attach without repeated occupied retries.
- Keep normal iOS backgrounding as an active session, and cover manual disconnect, app quit, and ungraceful network loss in tests/manual verification.

## Notes

- Backgrounding the app intentionally does not release the host slot; force-quit/terminate closes the transport, and stale takeover remains the fallback when a graceful close is not delivered.
- Includes host integration coverage for live-client blocking and second-client attach after the first client closes.