### PR TITLE
feat: workspace rename and long-press action sheet

### DIFF
--- a/crates/zedra/src/home_view.rs
+++ b/crates/zedra/src/home_view.rs
@@ -1,13 +1,12 @@
 use std::sync::OnceLock;
-use std::time::Duration;
 
+use futures::StreamExt as _;
 use gpui::*;
 use zedra_session::ConnectPhase;
 use zedra_telemetry::*;
 
 use crate::button::outline_button;
 use crate::fonts;
-use crate::pending::{PendingSlot, spawn_periodic_task};
 use crate::platform_bridge::{self, AlertButton, HapticFeedback};
 use crate::theme;
 use crate::transport_badge::{ConnectionStatusIndicator, phase_indicator_color};
@@ -27,21 +26,50 @@ pub enum HomeEvent {
 
 impl EventEmitter<HomeEvent> for HomeView {}
 
-/// Pending workspace delete confirmed via native alert.
-static PENDING_DELETE: PendingSlot<String> = PendingSlot::new();
+enum HomeAction {
+    Disconnect {
+        endpoint_addr: String,
+        display_name: String,
+    },
+    ConfirmDisconnect {
+        endpoint_addr: String,
+    },
+    Delete {
+        endpoint_addr: String,
+        display_name: String,
+    },
+    ConfirmDelete {
+        endpoint_addr: String,
+    },
+    BeginRename {
+        endpoint_addr: String,
+        current_name: String,
+    },
+    ConfirmRename {
+        endpoint_addr: String,
+        name: String,
+    },
+}
 
 pub struct HomeView {
     workspaces: Entity<Workspaces>,
     focus_handle: FocusHandle,
     selected_guide_tab: GuideTab,
-    _pending_delete_task: Task<()>,
+    action_tx: futures::channel::mpsc::UnboundedSender<HomeAction>,
+    _action_task: Task<()>,
 }
 
 impl HomeView {
     pub fn new(workspaces: Entity<Workspaces>, cx: &mut Context<Self>) -> Self {
-        let pending_delete_task = spawn_periodic_task(cx, Duration::from_millis(50), |this, cx| {
-            if let Some(endpoint_addr) = PENDING_DELETE.take() {
-                this.process_pending_delete(endpoint_addr, cx);
+        let (action_tx, mut action_rx) = futures::channel::mpsc::unbounded::<HomeAction>();
+        let action_task = cx.spawn(async move |this, cx| {
+            while let Some(action) = action_rx.next().await {
+                if this
+                    .update(cx, |view, cx| view.process_action(action, cx))
+                    .is_err()
+                {
+                    break;
+                }
             }
         });
 
@@ -49,7 +77,8 @@ impl HomeView {
             workspaces,
             focus_handle: cx.focus_handle(),
             selected_guide_tab: GuideTab::Curl,
-            _pending_delete_task: pending_delete_task,
+            action_tx,
+            _action_task: action_task,
         }
     }
 
@@ -87,34 +116,132 @@ impl HomeView {
         cx.emit(HomeEvent::NavigateToWorkspace);
     }
 
-    fn handle_workspace_remove(&self, item_idx: usize, cx: &mut Context<Self>) {
+    fn handle_workspace_long_press(&self, item_idx: usize, cx: &mut Context<Self>) {
         let states = self.workspaces.read(cx).states();
         let Some(state) = states.get(item_idx) else {
             return;
         };
+        let endpoint_addr = state.read(cx).endpoint_addr.clone();
+        let display = state.read(cx).display_name().to_string();
+        let tx = self.action_tx.clone();
 
-        let endpoint_addr = state.read(cx).endpoint_addr.to_string();
-        let display = state.read(cx).project_name.to_string();
-
-        platform_bridge::show_alert(
+        platform_bridge::show_selection(
             "",
-            &format!("Remove {} workspace?", display),
+            "",
             vec![
+                AlertButton::default("Rename"),
+                AlertButton::default("Disconnect"),
                 AlertButton::destructive("Delete"),
-                AlertButton::cancel("Cancel"),
             ],
-            move |button_index| {
-                if button_index == 0 {
-                    PENDING_DELETE.set(endpoint_addr.clone());
+            move |choice| match choice {
+                Some(0) => {
+                    let _ = tx.unbounded_send(HomeAction::BeginRename {
+                        endpoint_addr,
+                        current_name: display,
+                    });
                 }
+                Some(1) => {
+                    let _ = tx.unbounded_send(HomeAction::Disconnect {
+                        endpoint_addr,
+                        display_name: display,
+                    });
+                }
+                Some(2) => {
+                    let _ = tx.unbounded_send(HomeAction::Delete {
+                        endpoint_addr,
+                        display_name: display,
+                    });
+                }
+                _ => {}
             },
         );
     }
 
-    fn process_pending_delete(&self, endpoint_addr: String, cx: &mut Context<Self>) {
-        self.workspaces.update(cx, |ws, cx| {
-            ws.remove_by_endpoint_addr(&endpoint_addr, cx);
-        });
+    fn process_action(&mut self, action: HomeAction, cx: &mut Context<Self>) {
+        match action {
+            HomeAction::Disconnect {
+                endpoint_addr,
+                display_name,
+            } => {
+                let tx = self.action_tx.clone();
+                platform_bridge::show_alert(
+                    "",
+                    &format!("Disconnect from {}?", display_name),
+                    vec![
+                        AlertButton::destructive("Disconnect"),
+                        AlertButton::cancel("Cancel"),
+                    ],
+                    move |button_index| {
+                        if button_index == 0 {
+                            let _ =
+                                tx.unbounded_send(HomeAction::ConfirmDisconnect { endpoint_addr });
+                        }
+                    },
+                );
+            }
+            HomeAction::ConfirmDisconnect { endpoint_addr } => {
+                self.workspaces.update(cx, |ws, cx| {
+                    ws.disconnect_by_endpoint_addr(&endpoint_addr, cx);
+                });
+            }
+            HomeAction::Delete {
+                endpoint_addr,
+                display_name,
+            } => {
+                let tx = self.action_tx.clone();
+                platform_bridge::show_alert(
+                    "",
+                    &format!("Remove {} workspace?", display_name),
+                    vec![
+                        AlertButton::destructive("Delete"),
+                        AlertButton::cancel("Cancel"),
+                    ],
+                    move |button_index| {
+                        if button_index == 0 {
+                            let _ = tx.unbounded_send(HomeAction::ConfirmDelete { endpoint_addr });
+                        }
+                    },
+                );
+            }
+            HomeAction::ConfirmDelete { endpoint_addr } => {
+                self.workspaces.update(cx, |ws, cx| {
+                    ws.remove_by_endpoint_addr(&endpoint_addr, cx);
+                });
+            }
+            HomeAction::BeginRename {
+                endpoint_addr,
+                current_name,
+            } => {
+                let tx = self.action_tx.clone();
+                platform_bridge::show_text_input(
+                    "Rename workspace",
+                    "Workspace name",
+                    &current_name,
+                    move |result| {
+                        if let Some(value) = result {
+                            let _ = tx.unbounded_send(HomeAction::ConfirmRename {
+                                endpoint_addr,
+                                name: value,
+                            });
+                        }
+                    },
+                );
+            }
+            HomeAction::ConfirmRename {
+                endpoint_addr,
+                name,
+            } => {
+                let trimmed = name.trim();
+                let custom_name = if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                };
+                self.workspaces.update(cx, |ws, cx| {
+                    ws.rename_workspace(&endpoint_addr, custom_name, cx)
+                });
+            }
+        }
     }
 
     fn select_guide_tab(&mut self, tab: GuideTab, cx: &mut Context<Self>) {
@@ -234,11 +361,8 @@ impl Render for HomeView {
                     _ => "Reconnect",
                 };
 
-                let project_name = if state.project_name.is_empty() {
-                    "Workspace".to_string()
-                } else {
-                    state.project_name.to_string()
-                };
+                let name = state.display_name();
+                let project_name = if name.is_empty() { "Workspace" } else { name }.to_string();
                 let strip_path = state.strip_path.to_string();
                 let hostname = state.hostname.to_string();
                 let subtitle = match (hostname.is_empty(), strip_path.is_empty()) {
@@ -736,7 +860,8 @@ fn workspace_card(
             this.handle_workspace_tap(index, window, cx);
         }))
         .on_long_press(cx.listener(move |this, _event, _window, cx| {
-            this.handle_workspace_remove(index, cx);
+            platform_bridge::trigger_haptic(HapticFeedback::ImpactMedium);
+            this.handle_workspace_long_press(index, cx);
         }))
         .child(
             div()

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -140,6 +140,14 @@ unsafe extern "C" {
         duration_secs: f32,
         auto_close: bool,
     );
+    /// Present a native text-input dialog (UIAlertController with UITextField).
+    /// Result delivered via `zedra_ios_text_input_result` or `zedra_ios_text_input_dismiss`.
+    fn ios_present_text_input(
+        callback_id: u32,
+        title: *const std::ffi::c_char,
+        placeholder: *const std::ffi::c_char,
+        initial_value: *const std::ffi::c_char,
+    );
 }
 
 impl PlatformBridge for IosBridge {
@@ -377,6 +385,23 @@ impl PlatformBridge for IosBridge {
             );
         }
     }
+
+    fn present_text_input(&self, id: u32, title: &str, placeholder: &str, initial_value: &str) {
+        use std::ffi::CString;
+
+        let title = CString::new(title).unwrap_or_else(|_| CString::new("").unwrap());
+        let placeholder = CString::new(placeholder).unwrap_or_else(|_| CString::new("").unwrap());
+        let initial_value =
+            CString::new(initial_value).unwrap_or_else(|_| CString::new("").unwrap());
+        unsafe {
+            ios_present_text_input(
+                id,
+                title.as_ptr(),
+                placeholder.as_ptr(),
+                initial_value.as_ptr(),
+            );
+        }
+    }
 }
 
 /// Called from the native alert handler after the user taps a button.
@@ -409,6 +434,26 @@ pub extern "C" fn zedra_ios_selection_result(callback_id: u32, button_index: i32
 #[unsafe(no_mangle)]
 pub extern "C" fn zedra_ios_selection_dismiss(callback_id: u32) {
     platform_bridge::dispatch_selection_dismiss(callback_id);
+}
+
+/// Called when the user confirms a text-input dialog with the entered value.
+#[unsafe(no_mangle)]
+pub extern "C" fn zedra_ios_text_input_result(callback_id: u32, value: *const std::ffi::c_char) {
+    let text = if value.is_null() {
+        String::new()
+    } else {
+        unsafe { std::ffi::CStr::from_ptr(value) }
+            .to_str()
+            .unwrap_or("")
+            .to_string()
+    };
+    platform_bridge::dispatch_text_input_result(callback_id, text);
+}
+
+/// Called when a text-input dialog is cancelled or dismissed.
+#[unsafe(no_mangle)]
+pub extern "C" fn zedra_ios_text_input_dismiss(callback_id: u32) {
+    platform_bridge::dispatch_text_input_dismiss(callback_id);
 }
 
 /// Called from the native app delegate when the app enters the background.

--- a/crates/zedra/src/ios_stub.c
+++ b/crates/zedra/src/ios_stub.c
@@ -67,6 +67,11 @@ __attribute__((weak)) void ios_present_custom_sheet(
     float corner_radius,
     _Bool modal_in_presentation) {}
 __attribute__((weak)) void ios_trigger_haptic(int kind) {}
+__attribute__((weak)) void ios_present_text_input(
+    unsigned int callback_id,
+    const char *title,
+    const char *placeholder,
+    const char *initial_value) {}
 
 // Firebase Analytics + Crashlytics stubs.
 // Real implementations live in ios/Zedra/ZedraFirebase.m and override at Xcode link time.

--- a/crates/zedra/src/platform_bridge.rs
+++ b/crates/zedra/src/platform_bridge.rs
@@ -199,6 +199,9 @@ static ALERT_CALLBACKS: OnceLock<Mutex<HashMap<u32, Box<dyn FnOnce(Option<usize>
 static NEXT_SELECTION_ID: AtomicU32 = AtomicU32::new(1);
 static SELECTION_CALLBACKS: OnceLock<Mutex<HashMap<u32, Box<dyn FnOnce(Option<usize>) + Send>>>> =
     OnceLock::new();
+static NEXT_TEXT_INPUT_ID: AtomicU32 = AtomicU32::new(1);
+static TEXT_INPUT_CALLBACKS: OnceLock<Mutex<HashMap<u32, Box<dyn FnOnce(Option<String>) + Send>>>> =
+    OnceLock::new();
 static NEXT_NATIVE_FLOATING_BUTTON_ID: AtomicU32 = AtomicU32::new(1);
 static NEXT_NATIVE_DICTATION_PREVIEW_ID: AtomicU32 = AtomicU32::new(1);
 static NEXT_NATIVE_NOTIFICATION_ID: AtomicU32 = AtomicU32::new(1);
@@ -219,6 +222,10 @@ fn selection_callbacks() -> &'static Mutex<HashMap<u32, Box<dyn FnOnce(Option<us
 
 fn native_notification_callbacks() -> &'static Mutex<HashMap<u32, Box<dyn FnOnce() + Send>>> {
     NATIVE_NOTIFICATION_CALLBACKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn text_input_callbacks() -> &'static Mutex<HashMap<u32, Box<dyn FnOnce(Option<String>) + Send>>> {
+    TEXT_INPUT_CALLBACKS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// Present a native alert dialog with the given title, message, and buttons.
@@ -259,6 +266,39 @@ pub fn show_selection(
         .unwrap()
         .insert(id, Box::new(on_result));
     bridge().present_selection(id, title, message, &buttons);
+}
+
+/// Present a native text-input dialog (UIAlertController with a UITextField on iOS).
+///
+/// `on_result` receives `Some(text)` when the user confirms, or `None` when cancelled.
+pub fn show_text_input(
+    title: &str,
+    placeholder: &str,
+    initial_value: &str,
+    on_result: impl FnOnce(Option<String>) + Send + 'static,
+) {
+    let id = NEXT_TEXT_INPUT_ID.fetch_add(1, Ordering::Relaxed);
+    text_input_callbacks()
+        .lock()
+        .unwrap()
+        .insert(id, Box::new(on_result));
+    bridge().present_text_input(id, title, placeholder, initial_value);
+}
+
+/// Called by the platform after the user confirms a text-input dialog.
+pub fn dispatch_text_input_result(callback_id: u32, value: String) {
+    let cb = text_input_callbacks().lock().unwrap().remove(&callback_id);
+    if let Some(cb) = cb {
+        cb(Some(value));
+    }
+}
+
+/// Called by the platform after a text-input dialog is dismissed without confirming.
+pub fn dispatch_text_input_dismiss(callback_id: u32) {
+    let cb = text_input_callbacks().lock().unwrap().remove(&callback_id);
+    if let Some(cb) = cb {
+        cb(None);
+    }
 }
 
 /// Present a configurable native custom sheet.
@@ -431,6 +471,16 @@ pub fn clear_pending_alerts() {
             );
         }
     }
+    if let Ok(mut map) = text_input_callbacks().lock() {
+        let count = map.len();
+        map.clear();
+        if count > 0 {
+            tracing::debug!(
+                "clear_pending_alerts: dropped {} unacknowledged text input dialog(s)",
+                count
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -524,6 +574,11 @@ pub trait PlatformBridge: Send + Sync + 'static {
     fn hide_native_dictation_preview(&self, _id: u32) {}
     /// Display a native in-app notification banner.
     fn present_native_notification(&self, _id: u32, _options: &NativeNotificationOptions) {}
+    /// Display a native text-input dialog.
+    /// The platform should call `dispatch_text_input_result(id, value)` on confirm,
+    /// or `dispatch_text_input_dismiss(id)` on cancel.
+    fn present_text_input(&self, _id: u32, _title: &str, _placeholder: &str, _initial_value: &str) {
+    }
 }
 
 static BRIDGE: OnceLock<Box<dyn PlatformBridge>> = OnceLock::new();

--- a/crates/zedra/src/quick_action_panel.rs
+++ b/crates/zedra/src/quick_action_panel.rs
@@ -224,7 +224,7 @@ impl Render for QuickActionPanel {
                                             .font_weight(FontWeight::MEDIUM)
                                             .min_w_0()
                                             .truncate()
-                                            .child(state.project_name.to_string()),
+                                            .child(state.display_name().to_string()),
                                     ),
                             )
                             .child(

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -2498,7 +2498,7 @@ impl Render for WorkspaceContent {
         let top_inset = status_bar_inset();
         let this = cx.weak_entity();
         let workspace_state = self.workspace_state.read(cx);
-        let title = workspace_state.project_name.to_string();
+        let title = workspace_state.display_name().to_string();
         let default_subtitle = workspace_state.strip_path.to_string();
         let connect_phase = workspace_state.connect_phase.clone();
         let mainview_measure = canvas(

--- a/crates/zedra/src/workspace_drawer.rs
+++ b/crates/zedra/src/workspace_drawer.rs
@@ -172,7 +172,7 @@ impl WorkspaceDrawer {
 
     pub fn title_by_tab(&self, tab: DrawerTab, cx: &mut Context<Self>) -> (String, String) {
         let workspace_state = self.workspace_state.read(cx);
-        let title = workspace_state.project_name.to_string();
+        let title = workspace_state.display_name().to_string();
 
         let subtitle = match tab {
             DrawerTab::FileExplorer => match self.file_display_mode {

--- a/crates/zedra/src/workspace_state.rs
+++ b/crates/zedra/src/workspace_state.rs
@@ -83,6 +83,8 @@ pub struct WorkspaceState {
     pub session_id: String,
     pub strip_path: String,
     pub project_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_name: Option<String>,
     pub workdir: String,
     pub homedir: String,
     pub hostname: String,
@@ -126,6 +128,7 @@ impl PartialEq for WorkspaceState {
             && self.session_id == other.session_id
             && self.strip_path == other.strip_path
             && self.project_name == other.project_name
+            && self.custom_name == other.custom_name
             && self.workdir == other.workdir
             && self.homedir == other.homedir
             && self.hostname == other.hostname
@@ -198,6 +201,22 @@ impl WorkspaceState {
     pub fn mark_disconnected(&mut self, cx: &mut Context<Self>) {
         self.clear_runtime_state_for_disconnect();
 
+        cx.emit(WorkspaceStateEvent::StateChanged);
+        cx.notify();
+    }
+
+    /// The name shown in the UI. Returns `custom_name` if set, otherwise `project_name`.
+    pub fn display_name(&self) -> &str {
+        self.custom_name
+            .as_deref()
+            .unwrap_or(self.project_name.as_str())
+    }
+
+    pub fn set_custom_name(&mut self, name: Option<String>, cx: &mut Context<Self>) {
+        if self.custom_name == name {
+            return;
+        }
+        self.custom_name = name;
         cx.emit(WorkspaceStateEvent::StateChanged);
         cx.notify();
     }

--- a/crates/zedra/src/workspaces.rs
+++ b/crates/zedra/src/workspaces.rs
@@ -284,6 +284,30 @@ impl Workspaces {
         self.remove_saved(endpoint_addr, cx);
     }
 
+    pub fn rename_workspace(
+        &mut self,
+        endpoint_addr: &str,
+        custom_name: Option<String>,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(state) = self
+            .states
+            .iter()
+            .find(|s| s.read(cx).endpoint_addr == endpoint_addr)
+            .cloned()
+        {
+            state.update(cx, |s, cx| s.set_custom_name(custom_name.clone(), cx));
+            // Active workspaces auto-persist via their WorkspaceStateEvent::StateChanged
+            // subscription in workspace.rs. Only upsert directly for saved-only states.
+            let is_active = self.entry_by_endpoint_addr(endpoint_addr, cx).is_some();
+            if !is_active {
+                WorkspaceState::upsert(state.read(cx).clone())
+                    .map_err(|e| error!("Failed to persist renamed workspace: {e}"))
+                    .ok();
+            }
+        }
+    }
+
     pub fn remove_saved(&mut self, endpoint_addr: &str, cx: &mut Context<Self>) {
         WorkspaceState::remove_by_endpoint_add(endpoint_addr)
             .map_err(|e| error!("Failed to remove workspace state: {e}"))

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -294,6 +294,15 @@ extern void ios_present_native_notification(uint32_t callback_id,
                                             bool auto_close);
 
 /**
+ * Present a native text-input dialog (UIAlertController with UITextField).
+ * Result delivered via `zedra_ios_text_input_result` or `zedra_ios_text_input_dismiss`.
+ */
+extern void ios_present_text_input(uint32_t callback_id,
+                                   const char *title,
+                                   const char *placeholder,
+                                   const char *initial_value);
+
+/**
  * Called from the native alert handler after the user taps a button.
  *
  * `callback_id` matches the value passed to `ios_present_alert`.
@@ -316,6 +325,16 @@ void zedra_ios_selection_result(uint32_t callback_id, int32_t button_index);
  * Called when an action sheet is dismissed without selecting an item.
  */
 void zedra_ios_selection_dismiss(uint32_t callback_id);
+
+/**
+ * Called when the user confirms a text-input dialog with the entered value.
+ */
+void zedra_ios_text_input_result(uint32_t callback_id, const char *value);
+
+/**
+ * Called when a text-input dialog is cancelled or dismissed.
+ */
+void zedra_ios_text_input_dismiss(uint32_t callback_id);
 
 /**
  * Called from the native app delegate when the app enters the background.

--- a/ios/Zedra/Presentations.swift
+++ b/ios/Zedra/Presentations.swift
@@ -34,6 +34,12 @@ private func zedra_ios_unmount_custom_sheet_content()
 @_silgen_name("zedra_ios_sheet_content_is_at_top")
 private func zedra_ios_sheet_content_is_at_top() -> Bool
 
+@_silgen_name("zedra_ios_text_input_result")
+private func zedra_ios_text_input_result(_ callbackID: UInt32, _ value: UnsafePointer<CChar>?)
+
+@_silgen_name("zedra_ios_text_input_dismiss")
+private func zedra_ios_text_input_dismiss(_ callbackID: UInt32)
+
 @_silgen_name("zedra_ios_native_floating_button_pressed")
 private func zedra_ios_native_floating_button_pressed(_ callbackID: UInt32)
 
@@ -1277,12 +1283,7 @@ private enum PresentationCoordinator {
             let sheet = UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
             let delegate = PresentationDismissDelegate(callbackID: callbackID, isSelection: true)
             sheet.presentationController?.delegate = delegate
-            objc_setAssociatedObject(
-                sheet,
-                dismissAssociationKey,
-                delegate,
-                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
-            )
+            objc_setAssociatedObject(sheet, dismissAssociationKey, delegate, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
             for index in 0..<buttonLabels.count {
                 let style = buttonStyles[safe: index] ?? .default
@@ -1297,7 +1298,49 @@ private enum PresentationCoordinator {
                 sheet.addAction(action)
             }
 
+            // Required by HIG and UIKit: enables backdrop dismiss on iPhone.
+            sheet.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
+                delegate.handled = true
+                zedra_ios_selection_dismiss(callbackID)
+            })
+
             presenter.present(sheet, animated: true)
+        }
+    }
+
+    static func presentTextInput(
+        callbackID: UInt32,
+        title: String?,
+        placeholder: String?,
+        initialValue: String?
+    ) {
+        DispatchQueue.main.async {
+            guard let presenter = NativePresentationBridge.topViewController() else { return }
+
+            let alert = UIAlertController(
+                title: title?.isEmpty == false ? title : nil,
+                message: nil,
+                preferredStyle: .alert
+            )
+            alert.addTextField { field in
+                field.placeholder = placeholder
+                field.text = initialValue
+                field.clearButtonMode = .whileEditing
+                field.autocapitalizationType = .words
+                field.returnKeyType = .done
+            }
+            alert.addAction(UIAlertAction(title: "Save", style: .default) { _ in
+                let value = alert.textFields?.first?.text ?? ""
+                value.withCString { ptr in
+                    zedra_ios_text_input_result(callbackID, ptr)
+                }
+            })
+            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
+                zedra_ios_text_input_dismiss(callbackID)
+            })
+            presenter.present(alert, animated: true) {
+                alert.textFields?.first?.selectAll(nil)
+            }
         }
     }
 
@@ -1630,6 +1673,21 @@ func ios_present_selection(
             count: buttonCount,
             labels: imageNames
         )
+    )
+}
+
+@_cdecl("ios_present_text_input")
+func ios_present_text_input(
+    _ callbackID: UInt32,
+    _ title: UnsafePointer<CChar>?,
+    _ placeholder: UnsafePointer<CChar>?,
+    _ initialValue: UnsafePointer<CChar>?
+) {
+    PresentationCoordinator.presentTextInput(
+        callbackID: callbackID,
+        title: NativePresentationBridge.string(title),
+        placeholder: NativePresentationBridge.string(placeholder),
+        initialValue: NativePresentationBridge.string(initialValue)
     )
 }
 

--- a/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
@@ -294,6 +294,15 @@ extern void ios_present_native_notification(uint32_t callback_id,
                                             bool auto_close);
 
 /**
+ * Present a native text-input dialog (UIAlertController with UITextField).
+ * Result delivered via `zedra_ios_text_input_result` or `zedra_ios_text_input_dismiss`.
+ */
+extern void ios_present_text_input(uint32_t callback_id,
+                                   const char *title,
+                                   const char *placeholder,
+                                   const char *initial_value);
+
+/**
  * Called from the native alert handler after the user taps a button.
  *
  * `callback_id` matches the value passed to `ios_present_alert`.
@@ -316,6 +325,16 @@ void zedra_ios_selection_result(uint32_t callback_id, int32_t button_index);
  * Called when an action sheet is dismissed without selecting an item.
  */
 void zedra_ios_selection_dismiss(uint32_t callback_id);
+
+/**
+ * Called when the user confirms a text-input dialog with the entered value.
+ */
+void zedra_ios_text_input_result(uint32_t callback_id, const char *value);
+
+/**
+ * Called when a text-input dialog is cancelled or dismissed.
+ */
+void zedra_ios_text_input_dismiss(uint32_t callback_id);
 
 /**
  * Called from the native app delegate when the app enters the background.


### PR DESCRIPTION
- Add `custom_name` field to `WorkspaceState` with `display_name()` accessor that returns custom name when set, falling back to project name
- Replace polling-based native→GPUI messaging with mpsc channel + cx.spawn recv loop in HomeView
- Long-press workspace card shows action sheet: Rename / Disconnect / Delete, each with a confirmation alert before acting
- Rename uses native UIAlertController with UITextField; persists via WorkspaceState::upsert (saved-only) or StateChanged subscription (active)
- Add `show_text_input` / `present_text_input` FFI path following the same callback registry pattern as alerts and selections
- Add `ios_present_text_input` weak stub to ios_stub.c
- Action sheet cancel button added automatically in Swift for HIG compliance and backdrop dismiss on iPhone
- Switch all display sites to display_name(): home view, workspace header, drawer, quick action panel