### PR TITLE
fix: sync quick action workspace terminal selection

### DIFF
--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -28,6 +28,12 @@ fn app_view_descriptor(screen: AppScreen) -> Option<ViewDescriptor> {
     }
 }
 
+/// Workspace content projects `Workspaces.active_index`, so same-screen
+/// workspace navigation still needs to remount the active workspace view.
+fn should_update_drawer_content(current: AppScreen, next: AppScreen) -> bool {
+    current != next || next == AppScreen::Workspace
+}
+
 pub struct ZedraApp {
     screen: AppScreen,
     home_view: Entity<HomeView>,
@@ -296,11 +302,16 @@ impl ZedraApp {
 
     fn set_screen(&mut self, screen: AppScreen, cx: &mut Context<Self>) {
         let screen_changed = self.screen != screen;
+        let should_update_content = should_update_drawer_content(self.screen, screen);
         if screen_changed {
             self.screen = screen;
+        }
+
+        if should_update_content {
             self.update_drawer_content(cx);
             cx.notify();
         }
+
         if screen_changed {
             self.record_current_view(cx);
         }
@@ -374,7 +385,7 @@ pub fn open_zedra_window(app: &mut App, window_options: WindowOptions) -> Result
 mod tests {
     use super::{
         AppScreen, app_view_descriptor, screen_after_workspace_disconnect,
-        should_process_pending_ticket,
+        should_process_pending_ticket, should_update_drawer_content,
     };
     use crate::telemetry::view_telemetry;
 
@@ -402,5 +413,21 @@ mod tests {
     #[test]
     fn manual_workspace_disconnect_returns_home() {
         assert_eq!(screen_after_workspace_disconnect(), AppScreen::Home);
+    }
+
+    #[test]
+    fn workspace_navigation_refreshes_content_even_on_same_screen() {
+        assert!(should_update_drawer_content(
+            AppScreen::Workspace,
+            AppScreen::Workspace
+        ));
+        assert!(should_update_drawer_content(
+            AppScreen::Home,
+            AppScreen::Workspace
+        ));
+        assert!(!should_update_drawer_content(
+            AppScreen::Home,
+            AppScreen::Home
+        ));
     }
 }

--- a/crates/zedra/src/quick_action_panel.rs
+++ b/crates/zedra/src/quick_action_panel.rs
@@ -20,6 +20,15 @@ pub enum QuickActionEvent {
 
 impl EventEmitter<QuickActionEvent> for QuickActionPanel {}
 
+fn is_active_terminal_card(
+    active_workspace_index: Option<usize>,
+    workspace_index: usize,
+    active_terminal_id: Option<&str>,
+    terminal_id: &str,
+) -> bool {
+    active_workspace_index == Some(workspace_index) && active_terminal_id == Some(terminal_id)
+}
+
 pub struct QuickActionPanel {
     workspaces: Entity<Workspaces>,
     focus_handle: FocusHandle,
@@ -94,6 +103,7 @@ impl Render for QuickActionPanel {
 
         let workspaces = self.workspaces.read(cx);
         let ws_count = workspaces.len();
+        let active_workspace_index = workspaces.active_index();
 
         let panel = div()
             .w_full()
@@ -269,10 +279,12 @@ impl Render for QuickActionPanel {
                 for (i, tid) in state.terminal_ids.iter().enumerate() {
                     let tid_click = tid.clone();
                     let tid_del = tid.clone();
-                    let is_active = state
-                        .active_terminal_id
-                        .clone()
-                        .is_some_and(|id| id == *tid);
+                    let is_active = is_active_terminal_card(
+                        active_workspace_index,
+                        index,
+                        state.active_terminal_id.as_deref(),
+                        tid,
+                    );
                     let meta = terminal_state.read(cx).meta(tid);
 
                     let on_close = Box::new(cx.listener(move |this, _event, _window, cx| {
@@ -334,5 +346,33 @@ impl Render for QuickActionPanel {
             .child(div().h(px(bottom_inset)));
 
         panel.track_focus(&self.focus_handle).child(content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_active_terminal_card;
+
+    #[test]
+    fn terminal_card_active_requires_active_workspace_and_terminal() {
+        assert!(is_active_terminal_card(
+            Some(1),
+            1,
+            Some("term-2"),
+            "term-2"
+        ));
+        assert!(!is_active_terminal_card(
+            Some(0),
+            1,
+            Some("term-2"),
+            "term-2"
+        ));
+        assert!(!is_active_terminal_card(
+            Some(1),
+            1,
+            Some("term-1"),
+            "term-2"
+        ));
+        assert!(!is_active_terminal_card(None, 1, Some("term-2"), "term-2"));
     }
 }

--- a/crates/zedra/src/workspaces.rs
+++ b/crates/zedra/src/workspaces.rs
@@ -64,6 +64,10 @@ impl Workspaces {
         self.active_index.and_then(|i| self.entries.get(i))
     }
 
+    pub fn active_index(&self) -> Option<usize> {
+        self.active_index
+    }
+
     pub fn active_view(&self) -> Option<AnyView> {
         self.active().map(|e| AnyView::from(e.clone()))
     }


### PR DESCRIPTION
## Summary

- Refresh the mounted workspace view when quick-action navigation targets the workspace screen while already on it.
- Derive quick-action terminal active state from both the active workspace index and that workspace's active terminal id.
- Add focused regression tests for same-screen workspace remounting and active terminal card derivation.

## Notes

- CI owns validation per repo convention.
- The branch diff against `main` contains only the quick-action app files.