### PR TITLE
fix(ios): stabilize terminal dictation preview

### DIFF
--- a/crates/zedra-terminal/src/input.rs
+++ b/crates/zedra-terminal/src/input.rs
@@ -4,14 +4,28 @@ use gpui::*;
 
 use crate::terminal::Terminal;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TextInputPreflight {
+    text: String,
+}
+
 pub struct TerminalInputHandler {
     entity: WeakEntity<Terminal>,
     bounds: Bounds<Pixels>,
+    pending_text_input_preflight: Option<TextInputPreflight>,
+    text_input_rewrite_active: bool,
+    text_input_rewrite_guard_active: bool,
 }
 
 impl TerminalInputHandler {
     pub fn new(entity: WeakEntity<Terminal>, bounds: Bounds<Pixels>) -> Self {
-        Self { entity, bounds }
+        Self {
+            entity,
+            bounds,
+            pending_text_input_preflight: None,
+            text_input_rewrite_active: false,
+            text_input_rewrite_guard_active: false,
+        }
     }
 
     fn accepts_text_input_policy() -> bool {
@@ -20,6 +34,10 @@ impl TerminalInputHandler {
 
     fn text_input_traits_policy() -> PlatformTextInputTraits {
         PlatformTextInputTraits::keyboard_suggestions()
+    }
+
+    fn utf16_len(text: &str) -> usize {
+        text.encode_utf16().count()
     }
 
     fn send_text_to_terminal(term: &mut Terminal, text: &str) {
@@ -84,6 +102,24 @@ impl TerminalInputHandler {
         }
     }
 
+    fn apply_streamed_text_input_context_edit(
+        term: &mut Terminal,
+        replacement_range: Option<Range<usize>>,
+        text: &str,
+    ) {
+        term.replace_streamed_text_input_context_range(replacement_range, text);
+    }
+
+    fn flush_streamed_text_input_context(term: &mut Terminal) {
+        if let Some(edit) = term.flush_streamed_text_input_context() {
+            Self::send_keyboard_context_edit_to_terminal(
+                term,
+                edit.backspaces,
+                &edit.text_to_insert,
+            );
+        }
+    }
+
     fn commit_marked_text(term: &mut Terminal, text: &str) {
         let edit = term.commit_marked_text_to_keyboard_context(text);
         Self::send_keyboard_context_edit_to_terminal(term, edit.backspaces, &edit.text_to_insert);
@@ -104,6 +140,202 @@ impl TerminalInputHandler {
         term.update_dictation_hypothesis(replacement_range, text.to_string(), None);
         true
     }
+
+    fn finish_dictation_or_streamed_preview(term: &mut Terminal) {
+        if let Some(edit) = term.commit_streamed_text_input_context() {
+            Self::send_keyboard_context_edit_to_terminal(
+                term,
+                edit.backspaces,
+                &edit.text_to_insert,
+            );
+            return;
+        }
+
+        let text = term.finish_dictation();
+        if let Some(text) = text {
+            Self::send_text_to_terminal(term, &text);
+        }
+    }
+
+    fn should_stage_unconfirmed_text_input(
+        term: &Terminal,
+        replacement_range: Option<&Range<usize>>,
+        text: &str,
+        rewrite_guard_active: bool,
+    ) -> bool {
+        if text.is_empty() {
+            return false;
+        }
+
+        if term.is_dictation_active() || term.has_streamed_text_input_pending_commit() {
+            return true;
+        }
+
+        // IME delete/rewrite flows can replay unconfirmed text after the
+        // confirmed correction; do not let that bootstrap dictation preview.
+        if rewrite_guard_active {
+            return false;
+        }
+
+        if term.has_committed_dictation_pending_cleanup() || term.has_uncommitted_marked_text() {
+            return false;
+        }
+
+        let document_utf16_len = Self::utf16_len(term.text_input_document());
+        let replacement_stays_on_anchor = replacement_range
+            .map(|range| range.start <= document_utf16_len && range.end <= document_utf16_len)
+            .unwrap_or(true);
+
+        // Bootstrap unconfirmed native text only from the empty anchor. Once
+        // it is staged, all rewrites stay in the preview store until an
+        // explicit commit/cancel boundary decides whether it reaches the PTY.
+        term.keyboard_input_context_is_empty()
+            && document_utf16_len <= 1
+            && replacement_stays_on_anchor
+    }
+
+    fn should_keep_text_input_rewrite_active(
+        pending_exists: bool,
+        exact_pending_insert: bool,
+        rewrite_active: bool,
+    ) -> bool {
+        (pending_exists || rewrite_active) && !(exact_pending_insert && !rewrite_active)
+    }
+
+    fn should_clear_text_input_rewrite_for_delete(pending: Option<&TextInputPreflight>) -> bool {
+        pending.is_some_and(|pending| pending.text.is_empty())
+    }
+
+    fn should_mark_text_input_rewrite_active_for_delete(
+        pending: Option<&TextInputPreflight>,
+        rewrite_active: bool,
+    ) -> bool {
+        !Self::should_clear_text_input_rewrite_for_delete(pending)
+            && (rewrite_active || pending.is_some())
+    }
+
+    fn observe_text_input_preflight(&mut self, range: Option<Range<usize>>, text: String) {
+        // A delete or range rewrite often belongs to IME correction; later
+        // unconfirmed inserts in the same burst are context replay.
+        if text.is_empty() || range.as_ref().is_some_and(|range| !range.is_empty()) {
+            self.text_input_rewrite_guard_active = true;
+        }
+        self.pending_text_input_preflight = Some(TextInputPreflight { text });
+        self.text_input_rewrite_active = false;
+    }
+
+    fn consume_insert_text_preflight(&mut self, text: &str) -> bool {
+        let pending = self.pending_text_input_preflight.take();
+        let was_confirmed = pending.is_some() || self.text_input_rewrite_active;
+        let exact_pending_insert = pending.as_ref().is_some_and(|pending| pending.text == text);
+        self.text_input_rewrite_active = Self::should_keep_text_input_rewrite_active(
+            pending.is_some(),
+            exact_pending_insert,
+            self.text_input_rewrite_active,
+        );
+        was_confirmed
+    }
+
+    fn consume_replace_range_preflight(&mut self) -> bool {
+        let was_confirmed =
+            self.pending_text_input_preflight.is_some() || self.text_input_rewrite_active;
+        self.pending_text_input_preflight = None;
+        self.text_input_rewrite_active = false;
+        was_confirmed
+    }
+
+    fn observe_delete_backward(&mut self) {
+        if Self::should_clear_text_input_rewrite_for_delete(
+            self.pending_text_input_preflight.as_ref(),
+        ) {
+            self.pending_text_input_preflight = None;
+            self.text_input_rewrite_active = false;
+            self.text_input_rewrite_guard_active = true;
+            return;
+        }
+
+        if Self::should_mark_text_input_rewrite_active_for_delete(
+            self.pending_text_input_preflight.as_ref(),
+            self.text_input_rewrite_active,
+        ) {
+            self.text_input_rewrite_active = true;
+            self.text_input_rewrite_guard_active = true;
+        }
+    }
+
+    fn clear_text_input_preflight(&mut self) {
+        self.pending_text_input_preflight = None;
+        self.text_input_rewrite_active = false;
+        self.text_input_rewrite_guard_active = false;
+    }
+
+    fn replace_text_input_range(
+        &mut self,
+        replacement_range: Option<Range<usize>>,
+        text: &str,
+        flush_pending_stream: bool,
+        cx: &mut App,
+    ) {
+        let text = text.to_string();
+        let entity = self.entity.clone();
+        if Self::text_resets_keyboard_context(&text) {
+            self.text_input_rewrite_guard_active = false;
+        }
+        let _ = entity.update(cx, move |term, cx| {
+            if flush_pending_stream {
+                // Confirmed input after a speculative preview must first make
+                // the preview ordinary PTY text, then apply the confirmed edit.
+                Self::flush_streamed_text_input_context(term);
+            }
+            if Self::apply_dictation_context_rewrite(term, replacement_range.clone(), &text) {
+                cx.notify();
+                return;
+            }
+
+            if text.is_empty() {
+                if term.consume_committed_dictation_cleanup_delete(replacement_range.clone()) {
+                    cx.notify();
+                } else if term.has_streamed_text_input_pending_commit() {
+                    term.cancel_streamed_text_input_context();
+                    cx.notify();
+                } else if term.has_committed_dictation_pending_cleanup() {
+                    cx.notify();
+                } else if term.has_uncommitted_marked_text() {
+                    term.clear_marked_state();
+                    cx.notify();
+                } else {
+                    Self::apply_keyboard_context_edit(term, replacement_range, &text);
+                    cx.notify();
+                }
+                return;
+            }
+
+            if term.has_streamed_text_input_pending_commit() {
+                term.cancel_streamed_text_input_context();
+            }
+
+            if term.has_committed_dictation_pending_cleanup() {
+                if let Some(edit) = term.reconcile_committed_dictation_text(&text) {
+                    Self::send_keyboard_context_edit_to_terminal(
+                        term,
+                        edit.backspaces,
+                        &edit.text_to_insert,
+                    );
+                    cx.notify();
+                }
+                return;
+            }
+
+            if term.has_uncommitted_marked_text() {
+                Self::commit_marked_text(term, &text);
+                cx.notify();
+                return;
+            }
+
+            Self::apply_keyboard_context_edit(term, replacement_range, &text);
+            cx.notify();
+        });
+    }
 }
 
 impl InputHandler for TerminalInputHandler {
@@ -117,7 +349,8 @@ impl InputHandler for TerminalInputHandler {
             .read_with(_cx, |term, _| {
                 let uses_text_input_document = term.is_dictation_active()
                     || term.has_uncommitted_marked_text()
-                    || term.has_committed_dictation_pending_cleanup();
+                    || term.has_committed_dictation_pending_cleanup()
+                    || term.has_streamed_text_input_pending_commit();
                 let range = if uses_text_input_document {
                     term.text_input_selection_range()
                 } else {
@@ -161,7 +394,8 @@ impl InputHandler for TerminalInputHandler {
             .read_with(_cx, |term, _| {
                 let uses_text_input_document = term.is_dictation_active()
                     || term.has_uncommitted_marked_text()
-                    || term.has_committed_dictation_pending_cleanup();
+                    || term.has_committed_dictation_pending_cleanup()
+                    || term.has_streamed_text_input_pending_commit();
                 let (range, text) = if uses_text_input_document {
                     term.text_input_document_text_for_range(range_utf16.clone())
                 } else {
@@ -172,6 +406,95 @@ impl InputHandler for TerminalInputHandler {
             })
             .ok()
             .flatten()
+    }
+
+    fn should_change_text_in_range(
+        &mut self,
+        replacement_range: Option<Range<usize>>,
+        text: &str,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> bool {
+        self.observe_text_input_preflight(replacement_range, text.to_string());
+        true
+    }
+
+    fn insert_text(&mut self, text: &str, _window: &mut Window, cx: &mut App) {
+        let text = text.to_string();
+        let confirmed_by_preflight = self.consume_insert_text_preflight(&text);
+        let rewrite_guard_active = self.text_input_rewrite_guard_active;
+        let entity = self.entity.clone();
+        let should_preview = entity
+            .read_with(cx, |term, _| {
+                term.is_dictation_active()
+                    || (!confirmed_by_preflight
+                        && Self::should_stage_unconfirmed_text_input(
+                            term,
+                            None,
+                            &text,
+                            rewrite_guard_active,
+                        ))
+            })
+            .unwrap_or(false);
+        if !should_preview {
+            self.replace_text_input_range(None, &text, confirmed_by_preflight, cx);
+            return;
+        }
+
+        let _ = entity.update(cx, move |term, cx| {
+            if Self::apply_dictation_context_rewrite(term, None, &text) {
+                cx.notify();
+                return;
+            }
+
+            Self::apply_streamed_text_input_context_edit(term, None, &text);
+            cx.notify();
+        });
+    }
+
+    fn replace_range(
+        &mut self,
+        replacement_range: Range<usize>,
+        text: &str,
+        _window: &mut Window,
+        cx: &mut App,
+    ) {
+        let text = text.to_string();
+        let confirmed_by_preflight = self.consume_replace_range_preflight();
+        let rewrite_guard_active = self.text_input_rewrite_guard_active;
+        let entity = self.entity.clone();
+        let preview_range = replacement_range.clone();
+        let should_preview = entity
+            .read_with(cx, |term, _| {
+                term.is_dictation_active()
+                    || (!confirmed_by_preflight
+                        && Self::should_stage_unconfirmed_text_input(
+                            term,
+                            Some(&preview_range),
+                            &text,
+                            rewrite_guard_active,
+                        ))
+            })
+            .unwrap_or(false);
+        if !should_preview {
+            self.replace_text_input_range(
+                Some(replacement_range),
+                &text,
+                confirmed_by_preflight,
+                cx,
+            );
+            return;
+        }
+
+        let _ = entity.update(cx, move |term, cx| {
+            if Self::apply_dictation_context_rewrite(term, Some(replacement_range.clone()), &text) {
+                cx.notify();
+                return;
+            }
+
+            Self::apply_streamed_text_input_context_edit(term, Some(replacement_range), &text);
+            cx.notify();
+        });
     }
 
     fn replace_text_in_range(
@@ -192,6 +515,9 @@ impl InputHandler for TerminalInputHandler {
 
             if text.is_empty() {
                 if term.consume_committed_dictation_cleanup_delete(replacement_range.clone()) {
+                    cx.notify();
+                } else if term.has_streamed_text_input_pending_commit() {
+                    term.cancel_streamed_text_input_context();
                     cx.notify();
                 } else if term.has_committed_dictation_pending_cleanup() {
                     // Critical: UIKit cleanup deletes are synthetic after a
@@ -224,6 +550,10 @@ impl InputHandler for TerminalInputHandler {
                 return;
             }
 
+            if term.has_streamed_text_input_pending_commit() {
+                term.cancel_streamed_text_input_context();
+            }
+
             if term.has_committed_dictation_pending_cleanup() {
                 if let Some(edit) = term.reconcile_committed_dictation_text(&text) {
                     Self::send_keyboard_context_edit_to_terminal(
@@ -249,63 +579,25 @@ impl InputHandler for TerminalInputHandler {
         });
     }
 
-    fn replace_text_in_range_from_context(
-        &mut self,
-        replacement_range: Option<Range<usize>>,
-        text: &str,
-        _window: &mut Window,
-        cx: &mut App,
-    ) {
-        let text = text.to_string();
+    fn delete_backward(&mut self, _window: &mut Window, cx: &mut App) {
+        self.observe_delete_backward();
         let entity = self.entity.clone();
-        let _ = entity.update(cx, move |term, cx| {
-            if Self::apply_dictation_context_rewrite(term, replacement_range.clone(), &text) {
+        let _ = entity.update(cx, |term, cx| {
+            if term.is_dictation_active() {
+                term.cancel_dictation();
                 cx.notify();
                 return;
             }
 
-            if text.is_empty() {
-                if term.consume_committed_dictation_cleanup_delete(replacement_range.clone()) {
-                    cx.notify();
-                } else if term.has_committed_dictation_pending_cleanup() {
-                    cx.notify();
-                } else if term.has_uncommitted_marked_text() {
-                    term.clear_marked_state();
-                    cx.notify();
-                } else {
-                    Self::apply_keyboard_context_edit(term, replacement_range, &text);
-                    cx.notify();
-                }
-                return;
-            }
-
-            if term.has_committed_dictation_pending_cleanup() {
-                if let Some(edit) = term.reconcile_committed_dictation_text(&text) {
-                    Self::send_keyboard_context_edit_to_terminal(
-                        term,
-                        edit.backspaces,
-                        &edit.text_to_insert,
-                    );
-                    cx.notify();
-                }
+            if term.has_streamed_text_input_pending_commit() {
+                // The preview text has not reached the PTY yet, so backspace must
+                // only cancel the synthetic marked store.
+                term.cancel_streamed_text_input_context();
+                cx.notify();
                 return;
             }
 
             if term.has_uncommitted_marked_text() {
-                Self::commit_marked_text(term, &text);
-                cx.notify();
-                return;
-            }
-
-            Self::apply_keyboard_context_edit(term, replacement_range, &text);
-            cx.notify();
-        });
-    }
-
-    fn delete_backward(&mut self, _window: &mut Window, cx: &mut App) {
-        let entity = self.entity.clone();
-        let _ = entity.update(cx, |term, cx| {
-            if term.is_dictation_active() || term.has_uncommitted_marked_text() {
                 term.clear_marked_state();
                 cx.notify();
                 return;
@@ -327,34 +619,54 @@ impl InputHandler for TerminalInputHandler {
     fn replace_and_mark_text_in_range(
         &mut self,
         replacement_range: Option<Range<usize>>,
-        new_text: &str,
-        _new_selected_range: Option<Range<usize>>,
+        marked_text: &str,
+        selected_range: Option<Range<usize>>,
         _window: &mut Window,
         cx: &mut App,
     ) {
-        let text = new_text.to_string();
+        self.clear_text_input_preflight();
+        let text = marked_text.to_string();
         let entity = self.entity.clone();
         let _ = entity.update(cx, move |term, cx| {
             // Both IME composition and dictation hypothesis use marked text.
-            term.replace_marked_text_in_range(replacement_range, text, _new_selected_range);
+            term.replace_marked_text_in_range(replacement_range, text, selected_range);
             cx.notify();
         });
     }
 
-    fn dictation_started(&mut self, _window: &mut Window, cx: &mut App) {
+    fn insert_dictation_result_placeholder(&mut self, _window: &mut Window, cx: &mut App) {
+        self.clear_text_input_preflight();
         let entity = self.entity.clone();
         let _ = entity.update(cx, |term, cx| {
+            if term.has_streamed_text_input_pending_commit() && !term.is_dictation_active() {
+                // The stream is already represented by marked text and preview;
+                // a late placeholder must not clear the range UIKit still needs.
+                cx.notify();
+                return;
+            }
             term.begin_dictation();
             cx.notify();
         });
     }
 
-    fn insert_dictation_text(&mut self, text: &str, _window: &mut Window, cx: &mut App) {
+    fn insert_dictation_result(&mut self, text: &str, _window: &mut Window, cx: &mut App) {
+        self.clear_text_input_preflight();
         let text = text.to_string();
         let entity = self.entity.clone();
         let _ = entity.update(cx, move |term, cx| {
-            if term.is_dictation_active() {
-                term.update_dictation_hypothesis(None, text, None);
+            if let Some(edit) = term.reconcile_late_dictation_result_after_cleanup(&text) {
+                Self::send_keyboard_context_edit_to_terminal(
+                    term,
+                    edit.backspaces,
+                    &edit.text_to_insert,
+                );
+            } else if term.is_dictation_active() {
+                term.update_dictation_hypothesis(None, text.clone(), None);
+                Self::finish_dictation_or_streamed_preview(term);
+            } else if term.has_streamed_text_input_pending_commit() {
+                let replacement_range = term.marked_text_range();
+                Self::apply_streamed_text_input_context_edit(term, replacement_range, &text);
+                Self::finish_dictation_or_streamed_preview(term);
             } else if term.has_committed_dictation_pending_cleanup() {
                 // Critical: after committing a streamed dictation hypothesis,
                 // UIKit can still deliver a final dictation insertion while it
@@ -368,18 +680,28 @@ impl InputHandler for TerminalInputHandler {
         });
     }
 
-    fn dictation_ended(&mut self, _window: &mut Window, cx: &mut App) {
+    fn remove_dictation_result_placeholder(
+        &mut self,
+        will_insert_result: bool,
+        _window: &mut Window,
+        cx: &mut App,
+    ) {
+        self.clear_text_input_preflight();
         let entity = self.entity.clone();
-        let _ = entity.update(cx, |term, cx| {
-            let text = term.finish_dictation();
-            if let Some(text) = text {
-                Self::send_text_to_terminal(term, &text);
-            };
+        let _ = entity.update(cx, move |term, cx| {
+            if will_insert_result {
+                cx.notify();
+                return;
+            }
+
+            if term.is_dictation_active() || term.has_streamed_text_input_pending_commit() {
+                Self::finish_dictation_or_streamed_preview(term);
+            }
             cx.notify();
         });
     }
 
-    fn dictation_recording_ended(&mut self, _window: &mut Window, cx: &mut App) {
+    fn dictation_recording_did_end(&mut self, _window: &mut Window, cx: &mut App) {
         let entity = self.entity.clone();
         let _ = entity.update(cx, |term, cx| {
             term.dictation_recording_ended();
@@ -387,7 +709,8 @@ impl InputHandler for TerminalInputHandler {
         });
     }
 
-    fn dictation_cancelled(&mut self, _window: &mut Window, cx: &mut App) {
+    fn dictation_recognition_failed(&mut self, _window: &mut Window, cx: &mut App) {
+        self.clear_text_input_preflight();
         let entity = self.entity.clone();
         let _ = entity.update(cx, |term, cx| {
             term.cancel_dictation();
@@ -396,6 +719,7 @@ impl InputHandler for TerminalInputHandler {
     }
 
     fn unmark_text(&mut self, _window: &mut Window, cx: &mut App) {
+        self.clear_text_input_preflight();
         let entity = self.entity.clone();
         let _ = entity.update(cx, |term, cx| {
             // UIKit can call unmarkText between dictation hypothesis updates
@@ -403,7 +727,8 @@ impl InputHandler for TerminalInputHandler {
             // UITextInput clients. Preserve the marked range until a real
             // commit or deletion clears it so UIDictationController can still
             // find its previous hypothesis.
-            if term.unmark_text() {
+            let cleared = term.unmark_text();
+            if cleared {
                 cx.notify();
             }
         });
@@ -442,7 +767,7 @@ impl InputHandler for TerminalInputHandler {
 
 #[cfg(test)]
 mod tests {
-    use super::TerminalInputHandler;
+    use super::{TerminalInputHandler, TextInputPreflight};
     use crate::terminal::{Terminal, TerminalEvent};
     use gpui::{
         PlatformTextAutocapitalization, PlatformTextInputTrait, PlatformTextInputTraits, px,
@@ -490,5 +815,132 @@ mod tests {
 
         assert_eq!(terminal.text_input_document(), " Hi");
         assert_eq!(terminal.marked_text_range(), Some(1..3));
+    }
+
+    #[test]
+    fn unconfirmed_text_input_stages_only_from_empty_anchor() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        assert!(TerminalInputHandler::should_stage_unconfirmed_text_input(
+            &terminal, None, "h", false
+        ));
+        assert!(TerminalInputHandler::should_stage_unconfirmed_text_input(
+            &terminal, None, "hey", false
+        ));
+        assert!(!TerminalInputHandler::should_stage_unconfirmed_text_input(
+            &terminal, None, "h", true
+        ));
+        assert!(!TerminalInputHandler::should_stage_unconfirmed_text_input(
+            &terminal, None, "hey", true
+        ));
+
+        terminal.replace_keyboard_input_context_range(None, "x");
+        assert!(!TerminalInputHandler::should_stage_unconfirmed_text_input(
+            &terminal,
+            Some(&(0..1)),
+            "xe",
+            false,
+        ));
+    }
+
+    #[test]
+    fn unconfirmed_text_input_does_not_promote_after_context_was_committed() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        terminal.replace_keyboard_input_context_range(None, "h");
+
+        assert!(!TerminalInputHandler::should_stage_unconfirmed_text_input(
+            &terminal,
+            Some(&(0..1)),
+            "ho",
+            false,
+        ));
+    }
+
+    #[test]
+    fn insert_text_without_preflight_preview_continues_pending_stream() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        terminal.replace_streamed_text_input_context_range(None, "hey");
+
+        assert!(TerminalInputHandler::should_stage_unconfirmed_text_input(
+            &terminal,
+            Some(&(0..3)),
+            "hey there",
+            false,
+        ));
+    }
+
+    #[test]
+    fn text_input_rewrite_guard_blocks_unconfirmed_replay_burst() {
+        let terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        assert!(!TerminalInputHandler::should_stage_unconfirmed_text_input(
+            &terminal, None, "d", true
+        ));
+        assert!(!TerminalInputHandler::should_stage_unconfirmed_text_input(
+            &terminal, None, "dúng", true
+        ));
+    }
+
+    #[test]
+    fn insert_text_without_preflight_preview_follows_active_dictation_lifecycle() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        terminal.begin_dictation();
+
+        assert!(TerminalInputHandler::should_stage_unconfirmed_text_input(
+            &terminal,
+            Some(&(1..1)),
+            "I",
+            true,
+        ));
+    }
+
+    #[test]
+    fn text_input_preflight_rewrite_state_stays_terminal_owned() {
+        assert!(
+            !TerminalInputHandler::should_keep_text_input_rewrite_active(true, true, false),
+            "ordinary key insert should not leave an IME rewrite open"
+        );
+        assert!(
+            TerminalInputHandler::should_keep_text_input_rewrite_active(true, false, false),
+            "validated Telex rewrite can insert different text than shouldChangeText"
+        );
+        assert!(
+            TerminalInputHandler::should_keep_text_input_rewrite_active(false, false, true),
+            "multi-step IME rewrite remains confirmed until unmarkText"
+        );
+    }
+
+    #[test]
+    fn delete_preflight_without_replacement_clears_terminal_rewrite_state() {
+        let plain_delete = TextInputPreflight {
+            text: String::new(),
+        };
+        let rewrite_delete = TextInputPreflight {
+            text: "o".to_string(),
+        };
+
+        assert!(
+            TerminalInputHandler::should_clear_text_input_rewrite_for_delete(Some(&plain_delete))
+        );
+        assert!(
+            !TerminalInputHandler::should_mark_text_input_rewrite_active_for_delete(
+                Some(&plain_delete),
+                true
+            )
+        );
+        assert!(
+            !TerminalInputHandler::should_clear_text_input_rewrite_for_delete(Some(
+                &rewrite_delete
+            ))
+        );
+        assert!(
+            TerminalInputHandler::should_mark_text_input_rewrite_active_for_delete(
+                Some(&rewrite_delete),
+                false
+            )
+        );
     }
 }

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -233,6 +233,13 @@ pub struct IMEState {
     /// True after a dictation hypothesis has been committed while keeping the
     /// synthetic text store available for UIKit's trailing dictation queries.
     pub committed_dictation_pending_cleanup: bool,
+    /// True while an unconfirmed text-input stream is previewed but not yet
+    /// committed to the PTY. The marked range must stay available for UIKit
+    /// dictation reconciliation.
+    pub streamed_text_input_pending_commit: bool,
+    /// Committed dictation text whose native cleanup delete has already been
+    /// consumed, but whose late `insertDictationResult` may still arrive.
+    pub late_dictation_result_after_cleanup: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -743,6 +750,8 @@ impl Terminal {
         state.selected_range = Some(selection_range.clone());
         state.dictation_preview_visible = false;
         state.committed_dictation_pending_cleanup = false;
+        state.streamed_text_input_pending_commit = false;
+        state.late_dictation_result_after_cleanup = None;
 
         let (backspaces, text_to_insert) =
             Self::diff_keyboard_input_context(&committed_before, &state.document_text);
@@ -753,6 +762,161 @@ impl Terminal {
             document_text: state.document_text.clone(),
             selection_range,
         }
+    }
+
+    pub fn replace_streamed_text_input_context_range(
+        &mut self,
+        replacement_range: Option<Range<usize>>,
+        text: &str,
+    ) -> KeyboardInputContextEdit {
+        let state = self.ime_state_mut();
+        let document_len = Self::utf16_len(&state.document_text);
+        let replacement_range = replacement_range
+            .or_else(|| state.selected_range.clone())
+            .unwrap_or(document_len..document_len);
+        let (document_text, inserted_range) =
+            Self::replace_utf16_range(&state.document_text, replacement_range, text);
+        state.document_text = document_text;
+        state.marked_text = text.to_string();
+        state.marked_range = (!text.is_empty()).then_some(inserted_range.clone());
+        let selection_range = inserted_range.end..inserted_range.end;
+        state.selected_range = Some(selection_range.clone());
+        state.dictation_active = false;
+        state.dictation_preview_visible = !text.is_empty();
+        state.committed_dictation_pending_cleanup = false;
+        state.streamed_text_input_pending_commit = !text.is_empty();
+        state.late_dictation_result_after_cleanup = None;
+
+        // UIKit's dictation controller reconciles by asking for the previous
+        // hypothesis in the marked range. Keep the live hypothesis out of the
+        // PTY until the dictation lifecycle commits it, but preserve only that
+        // inserted hypothesis, not pre-existing terminal input in the synthetic
+        // document.
+        let committed_before = state.committed_text.clone();
+        let (backspaces, text_to_insert) =
+            Self::diff_keyboard_input_context(&committed_before, &state.document_text);
+        let edit = KeyboardInputContextEdit {
+            backspaces,
+            text_to_insert,
+            document_text: state.document_text.clone(),
+            selection_range,
+        };
+        if !text.is_empty() {
+            self.emit_dictation_preview_changed(Some(text.to_string()));
+        }
+        edit
+    }
+
+    pub fn commit_streamed_text_input_context(&mut self) -> Option<KeyboardInputContextEdit> {
+        self.finish_streamed_text_input_context(true)
+    }
+
+    pub fn flush_streamed_text_input_context(&mut self) -> Option<KeyboardInputContextEdit> {
+        self.finish_streamed_text_input_context(false)
+    }
+
+    fn finish_streamed_text_input_context(
+        &mut self,
+        keep_native_cleanup_store: bool,
+    ) -> Option<KeyboardInputContextEdit> {
+        let (edit, should_hide_preview) = {
+            let state = self.ime_state.as_mut()?;
+            if state.dictation_active
+                || !state.streamed_text_input_pending_commit
+                || state.marked_text.is_empty()
+            {
+                return None;
+            }
+
+            let committed_before = state.committed_text.clone();
+            let (backspaces, text_to_insert) =
+                Self::diff_keyboard_input_context(&committed_before, &state.document_text);
+            let selection_range = state.selected_range.clone().unwrap_or_else(|| {
+                let len = Self::utf16_len(&state.document_text);
+                len..len
+            });
+            state.committed_text = state.document_text.clone();
+            state.committed_dictation_pending_cleanup = keep_native_cleanup_store;
+            state.streamed_text_input_pending_commit = false;
+            state.late_dictation_result_after_cleanup = None;
+            let should_hide_preview = state.dictation_preview_visible;
+            state.dictation_preview_visible = false;
+            if !keep_native_cleanup_store {
+                state.marked_text.clear();
+                state.marked_range = None;
+            }
+
+            (
+                KeyboardInputContextEdit {
+                    backspaces,
+                    text_to_insert,
+                    document_text: state.document_text.clone(),
+                    selection_range,
+                },
+                should_hide_preview,
+            )
+        };
+
+        if should_hide_preview {
+            self.emit_dictation_preview_changed(None);
+        }
+        Some(edit)
+    }
+
+    pub fn cancel_streamed_text_input_context(&mut self) -> bool {
+        let should_hide_preview = {
+            let Some(state) = self.ime_state.as_mut() else {
+                return false;
+            };
+            if !state.streamed_text_input_pending_commit {
+                return false;
+            }
+
+            let should_hide_preview = state.dictation_preview_visible;
+            state.document_text = state.committed_text.clone();
+            state.marked_text.clear();
+            state.marked_range = None;
+            state.selected_range = (!state.document_text.is_empty()).then(|| {
+                let len = Self::utf16_len(&state.document_text);
+                len..len
+            });
+            state.dictation_preview_visible = false;
+            state.committed_dictation_pending_cleanup = false;
+            state.streamed_text_input_pending_commit = false;
+            state.late_dictation_result_after_cleanup = None;
+            should_hide_preview
+        };
+
+        if should_hide_preview {
+            self.emit_dictation_preview_changed(None);
+        }
+        true
+    }
+
+    pub fn dismiss_dictation_preview(&mut self) -> bool {
+        // Tap-to-dismiss is the escape hatch for false-positive staged streams.
+        if self.cancel_streamed_text_input_context() {
+            return true;
+        }
+
+        if self.is_dictation_active() {
+            self.cancel_dictation();
+            return true;
+        }
+
+        let should_hide_preview = {
+            let Some(state) = self.ime_state.as_mut() else {
+                return false;
+            };
+            let should_hide_preview = state.dictation_preview_visible;
+            state.dictation_preview_visible = false;
+            should_hide_preview
+        };
+
+        if should_hide_preview {
+            self.emit_dictation_preview_changed(None);
+        }
+        should_hide_preview
     }
 
     pub fn delete_keyboard_input_context_backward(&mut self) -> Option<KeyboardInputContextEdit> {
@@ -783,6 +947,8 @@ impl Terminal {
         state.selected_range = Some(inserted_range.clone());
         state.dictation_preview_visible = false;
         state.committed_dictation_pending_cleanup = false;
+        state.streamed_text_input_pending_commit = false;
+        state.late_dictation_result_after_cleanup = None;
 
         let (backspaces, text_to_insert) =
             Self::diff_keyboard_input_context(&committed_before, &state.document_text);
@@ -816,6 +982,8 @@ impl Terminal {
         state.selected_range = Some(selection_range.clone());
         state.dictation_preview_visible = false;
         state.committed_dictation_pending_cleanup = false;
+        state.streamed_text_input_pending_commit = false;
+        state.late_dictation_result_after_cleanup = None;
 
         // Marked IME preedit lives only in the native text store. Diff against
         // committed_text so committing Japanese/Vietnamese candidates does not
@@ -890,13 +1058,16 @@ impl Terminal {
     /// Clear the marked text.
     pub fn clear_marked_state(&mut self) {
         if let Some(state) = self.ime_state.as_mut() {
-            let restore_committed_text =
-                !state.dictation_active && !state.committed_dictation_pending_cleanup;
+            let restore_committed_text = !state.dictation_active
+                && !state.committed_dictation_pending_cleanup
+                && !state.streamed_text_input_pending_commit;
             state.marked_text.clear();
             state.marked_range = None;
             state.selected_range = None;
             state.dictation_preview_visible = false;
             state.committed_dictation_pending_cleanup = false;
+            state.streamed_text_input_pending_commit = false;
+            state.late_dictation_result_after_cleanup = None;
             if !state.dictation_active {
                 if restore_committed_text {
                     state.document_text = state.committed_text.clone();
@@ -920,6 +1091,8 @@ impl Terminal {
             state.selected_range = None;
             state.dictation_preview_visible = false;
             state.committed_dictation_pending_cleanup = false;
+            state.streamed_text_input_pending_commit = false;
+            state.late_dictation_result_after_cleanup = None;
         }
     }
 
@@ -940,14 +1113,29 @@ impl Terminal {
             .is_some_and(|state| state.committed_dictation_pending_cleanup)
     }
 
+    pub fn has_streamed_text_input_pending_commit(&self) -> bool {
+        self.ime_state
+            .as_ref()
+            .is_some_and(|state| state.streamed_text_input_pending_commit)
+    }
+
+    pub fn has_late_dictation_result_after_cleanup(&self) -> bool {
+        self.ime_state
+            .as_ref()
+            .is_some_and(|state| state.late_dictation_result_after_cleanup.is_some())
+    }
+
     pub fn has_uncommitted_marked_text(&self) -> bool {
-        self.marked_text().is_some() && !self.has_committed_dictation_pending_cleanup()
+        self.marked_text().is_some()
+            && !self.has_committed_dictation_pending_cleanup()
+            && !self.has_streamed_text_input_pending_commit()
     }
 
     pub fn unmark_text(&mut self) -> bool {
         let should_clear = if let Some(state) = self.ime_state.as_ref() {
-            let should_preserve =
-                state.dictation_active || state.committed_dictation_pending_cleanup;
+            let should_preserve = state.dictation_active
+                || state.committed_dictation_pending_cleanup
+                || state.streamed_text_input_pending_commit;
             !should_preserve && (state.marked_range.is_some() || !state.marked_text.is_empty())
         } else {
             false
@@ -967,7 +1155,10 @@ impl Terminal {
         let Some(state) = self.ime_state.as_mut() else {
             return false;
         };
-        if state.dictation_active || !state.committed_dictation_pending_cleanup {
+        if state.dictation_active
+            || !(state.committed_dictation_pending_cleanup
+                || state.streamed_text_input_pending_commit)
+        {
             return false;
         }
 
@@ -984,17 +1175,63 @@ impl Terminal {
             return false;
         }
 
-        // Critical: after dictation commits, UIKit may delete the whole marked
-        // placeholder as cleanup. That must clear only our synthetic text store;
-        // sending terminal backspaces here would erase the already-committed
-        // dictated command.
-        state.document_text.clear();
-        state.committed_text.clear();
+        let late_dictation_result_after_cleanup = state
+            .committed_dictation_pending_cleanup
+            .then(|| {
+                if state.marked_text.is_empty() {
+                    state.committed_text.clone()
+                } else {
+                    state.marked_text.clone()
+                }
+            })
+            .filter(|text| !text.is_empty());
+        let restore_committed_text =
+            state.streamed_text_input_pending_commit && !state.committed_dictation_pending_cleanup;
+        let should_hide_preview = state.dictation_preview_visible;
+        // Critical: native cleanup deletes operate on the synthetic text store.
+        // Before commit they cancel the preview; after commit they must not
+        // backspace terminal output that already received the dictated command.
+        if restore_committed_text {
+            state.document_text = state.committed_text.clone();
+        } else {
+            state.document_text.clear();
+            state.committed_text.clear();
+        }
         state.marked_text.clear();
         state.marked_range = None;
-        state.selected_range = None;
+        state.selected_range = (!state.document_text.is_empty()).then(|| {
+            let len = Self::utf16_len(&state.document_text);
+            len..len
+        });
+        state.dictation_preview_visible = false;
         state.committed_dictation_pending_cleanup = false;
+        state.streamed_text_input_pending_commit = false;
+        state.late_dictation_result_after_cleanup = late_dictation_result_after_cleanup;
+        if should_hide_preview {
+            self.emit_dictation_preview_changed(None);
+        }
         true
+    }
+
+    pub fn reconcile_late_dictation_result_after_cleanup(
+        &mut self,
+        text: &str,
+    ) -> Option<KeyboardInputContextEdit> {
+        let state = self.ime_state.as_mut()?;
+        let committed_text = state.late_dictation_result_after_cleanup.take()?;
+        // Late final results after cleanup are corrections to committed text,
+        // not a second transcript insertion.
+        let (backspaces, text_to_insert) = if text.is_empty() {
+            (0, String::new())
+        } else {
+            Self::diff_keyboard_input_context(&committed_text, text)
+        };
+        Some(KeyboardInputContextEdit {
+            backspaces,
+            text_to_insert,
+            document_text: String::new(),
+            selection_range: 0..0,
+        })
     }
 
     pub fn reconcile_committed_dictation_text(
@@ -1019,6 +1256,8 @@ impl Terminal {
         let selection_range = inserted_range.end..inserted_range.end;
         state.selected_range = Some(selection_range.clone());
         state.committed_dictation_pending_cleanup = true;
+        state.streamed_text_input_pending_commit = false;
+        state.late_dictation_result_after_cleanup = None;
 
         let (backspaces, text_to_insert) =
             Self::diff_keyboard_input_context(&committed_text, &state.marked_text);
@@ -1054,6 +1293,8 @@ impl Terminal {
             state.document_text = document_text;
             state.marked_text = text.clone();
             state.committed_dictation_pending_cleanup = false;
+            state.streamed_text_input_pending_commit = false;
+            state.late_dictation_result_after_cleanup = None;
             state.marked_range = if text.is_empty() && !state.dictation_active {
                 None
             } else {
@@ -1100,7 +1341,8 @@ impl Terminal {
     pub fn begin_dictation(&mut self) {
         let emit_empty_preview = {
             let state = self.ime_state_mut();
-            if state.committed_dictation_pending_cleanup {
+            if state.committed_dictation_pending_cleanup || state.streamed_text_input_pending_commit
+            {
                 state.document_text.clear();
                 state.committed_text.clear();
                 state.marked_text.clear();
@@ -1108,11 +1350,15 @@ impl Terminal {
                 state.selected_range = None;
                 state.dictation_preview_visible = false;
                 state.committed_dictation_pending_cleanup = false;
+                state.streamed_text_input_pending_commit = false;
+                state.late_dictation_result_after_cleanup = None;
             }
             let already_active = state.dictation_active;
             let mut emit_empty_preview = false;
             state.dictation_active = true;
             state.committed_dictation_pending_cleanup = false;
+            state.streamed_text_input_pending_commit = false;
+            state.late_dictation_result_after_cleanup = None;
             if !already_active {
                 state.dictation_preview_visible = true;
                 if state.document_text.is_empty() {
@@ -1162,6 +1408,8 @@ impl Terminal {
             let text = state.marked_text.clone();
             state.committed_text = text.clone();
             state.committed_dictation_pending_cleanup = !text.is_empty();
+            state.streamed_text_input_pending_commit = false;
+            state.late_dictation_result_after_cleanup = None;
             (
                 if text.is_empty() { None } else { Some(text) },
                 should_hide_preview,
@@ -1178,8 +1426,12 @@ impl Terminal {
 
     pub fn dictation_recording_ended(&mut self) {
         let should_hide_preview = if let Some(state) = self.ime_state.as_mut() {
-            let should_hide_preview = state.dictation_active && state.dictation_preview_visible;
-            state.dictation_preview_visible = false;
+            let should_hide_preview = state.dictation_active
+                && state.dictation_preview_visible
+                && !state.streamed_text_input_pending_commit;
+            if should_hide_preview {
+                state.dictation_preview_visible = false;
+            }
             should_hide_preview
         } else {
             false
@@ -1197,6 +1449,8 @@ impl Terminal {
             should_hide_preview = state.dictation_preview_visible;
             state.dictation_preview_visible = false;
             state.committed_dictation_pending_cleanup = false;
+            state.streamed_text_input_pending_commit = false;
+            state.late_dictation_result_after_cleanup = None;
             state.committed_text.clear();
         }
         self.clear_marked_state();
@@ -2419,10 +2673,21 @@ mod tests {
     #[test]
     fn cancel_dictation_clears_text_input_store() {
         let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+        let mut events = terminal.subscribe_events();
+
         terminal.begin_dictation();
+        match events.try_recv().expect("expected empty preview") {
+            super::TerminalEvent::DictationPreviewChanged(Some(text)) => assert_eq!(text, ""),
+            event => panic!("expected empty dictation preview, got {event:?}"),
+        }
+
         terminal.set_marked_text("echo hello".to_string());
 
         terminal.cancel_dictation();
+        match events.try_recv().expect("expected preview dismissal") {
+            super::TerminalEvent::DictationPreviewChanged(None) => {}
+            event => panic!("expected dictation preview dismissal, got {event:?}"),
+        }
 
         assert!(!terminal.is_dictation_active());
         assert_eq!(terminal.marked_text(), None);
@@ -2561,6 +2826,271 @@ mod tests {
         assert_eq!(terminal.marked_text(), Some("Hello h"));
         assert_eq!(terminal.marked_text_range(), Some(0..7));
         assert_eq!(terminal.text_input_selection_range(), 7..7);
+    }
+
+    #[test]
+    fn streamed_text_input_preserves_marked_store_for_reconciliation() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        assert_eq!(
+            terminal.replace_streamed_text_input_context_range(Some(0..1), "hey"),
+            super::KeyboardInputContextEdit {
+                backspaces: 0,
+                text_to_insert: "hey".to_string(),
+                document_text: "hey".to_string(),
+                selection_range: 3..3,
+            }
+        );
+
+        assert!(!terminal.is_dictation_active());
+        assert!(!terminal.has_committed_dictation_pending_cleanup());
+        assert!(terminal.has_streamed_text_input_pending_commit());
+        assert!(!terminal.has_uncommitted_marked_text());
+        assert_eq!(terminal.marked_text(), Some("hey"));
+        assert_eq!(terminal.marked_text_range(), Some(0..3));
+        assert_eq!(terminal.text_input_document(), "hey");
+        assert_eq!(terminal.text_input_selection_range(), 3..3);
+    }
+
+    #[test]
+    fn streamed_text_input_rewrites_preview_without_committing_until_end() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+        let mut events = terminal.subscribe_events();
+
+        terminal.replace_streamed_text_input_context_range(Some(0..1), "hey");
+        match events.try_recv().expect("expected first preview") {
+            super::TerminalEvent::DictationPreviewChanged(Some(text)) => assert_eq!(text, "hey"),
+            event => panic!("expected first preview, got {event:?}"),
+        }
+        assert_eq!(
+            terminal.replace_streamed_text_input_context_range(Some(0..3), "hey how"),
+            super::KeyboardInputContextEdit {
+                backspaces: 0,
+                text_to_insert: "hey how".to_string(),
+                document_text: "hey how".to_string(),
+                selection_range: 7..7,
+            }
+        );
+        match events.try_recv().expect("expected updated preview") {
+            super::TerminalEvent::DictationPreviewChanged(Some(text)) => {
+                assert_eq!(text, "hey how");
+            }
+            event => panic!("expected updated preview, got {event:?}"),
+        }
+
+        assert_eq!(terminal.marked_text(), Some("hey how"));
+        assert_eq!(terminal.marked_text_range(), Some(0..7));
+        assert!(terminal.has_streamed_text_input_pending_commit());
+        assert_eq!(terminal.reconcile_committed_dictation_text("hey how"), None);
+        assert_eq!(
+            terminal.commit_streamed_text_input_context(),
+            Some(super::KeyboardInputContextEdit {
+                backspaces: 0,
+                text_to_insert: "hey how".to_string(),
+                document_text: "hey how".to_string(),
+                selection_range: 7..7,
+            })
+        );
+        match events.try_recv().expect("expected preview dismissal") {
+            super::TerminalEvent::DictationPreviewChanged(None) => {}
+            event => panic!("expected preview dismissal, got {event:?}"),
+        }
+        assert!(terminal.has_committed_dictation_pending_cleanup());
+        assert!(!terminal.has_streamed_text_input_pending_commit());
+        assert_eq!(terminal.commit_streamed_text_input_context(), None);
+    }
+
+    #[test]
+    fn streamed_text_input_can_flush_as_plain_keyboard_input() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+        let mut events = terminal.subscribe_events();
+
+        terminal.replace_streamed_text_input_context_range(Some(0..1), "h");
+        match events.try_recv().expect("expected staged preview") {
+            super::TerminalEvent::DictationPreviewChanged(Some(text)) => assert_eq!(text, "h"),
+            event => panic!("expected staged preview, got {event:?}"),
+        }
+        assert_eq!(terminal.marked_text(), Some("h"));
+        assert_eq!(terminal.marked_text_range(), Some(0..1));
+        assert!(terminal.has_streamed_text_input_pending_commit());
+
+        assert_eq!(
+            terminal.flush_streamed_text_input_context(),
+            Some(super::KeyboardInputContextEdit {
+                backspaces: 0,
+                text_to_insert: "h".to_string(),
+                document_text: "h".to_string(),
+                selection_range: 1..1,
+            })
+        );
+        match events.try_recv().expect("expected preview dismissal") {
+            super::TerminalEvent::DictationPreviewChanged(None) => {}
+            event => panic!("expected preview dismissal, got {event:?}"),
+        }
+        assert_eq!(terminal.marked_text(), None);
+        assert_eq!(terminal.marked_text_range(), None);
+        assert!(!terminal.has_streamed_text_input_pending_commit());
+        assert!(!terminal.has_committed_dictation_pending_cleanup());
+    }
+
+    #[test]
+    fn streamed_text_input_cleanup_delete_only_clears_synthetic_store() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        terminal.replace_streamed_text_input_context_range(Some(0..1), "hey");
+
+        assert!(terminal.consume_committed_dictation_cleanup_delete(Some(0..3)));
+        assert_eq!(terminal.marked_text(), None);
+        assert_eq!(terminal.marked_text_range(), None);
+        assert_eq!(terminal.text_input_document(), " ");
+        assert!(!terminal.has_streamed_text_input_pending_commit());
+        assert!(!terminal.has_late_dictation_result_after_cleanup());
+    }
+
+    #[test]
+    fn late_dictation_result_after_streamed_cleanup_does_not_duplicate_commit() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        terminal.replace_streamed_text_input_context_range(Some(0..1), "hello world");
+        assert_eq!(
+            terminal.commit_streamed_text_input_context(),
+            Some(super::KeyboardInputContextEdit {
+                backspaces: 0,
+                text_to_insert: "hello world".to_string(),
+                document_text: "hello world".to_string(),
+                selection_range: 11..11,
+            })
+        );
+        assert!(terminal.consume_committed_dictation_cleanup_delete(Some(0..11)));
+        assert!(terminal.has_late_dictation_result_after_cleanup());
+
+        assert_eq!(
+            terminal.reconcile_late_dictation_result_after_cleanup("hello world"),
+            Some(super::KeyboardInputContextEdit {
+                backspaces: 0,
+                text_to_insert: String::new(),
+                document_text: String::new(),
+                selection_range: 0..0,
+            })
+        );
+        assert!(!terminal.has_late_dictation_result_after_cleanup());
+    }
+
+    #[test]
+    fn late_dictation_result_after_streamed_cleanup_reconciles_final_correction() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        terminal.replace_streamed_text_input_context_range(Some(0..1), "hello worl");
+        assert_eq!(
+            terminal.commit_streamed_text_input_context(),
+            Some(super::KeyboardInputContextEdit {
+                backspaces: 0,
+                text_to_insert: "hello worl".to_string(),
+                document_text: "hello worl".to_string(),
+                selection_range: 10..10,
+            })
+        );
+        assert!(terminal.consume_committed_dictation_cleanup_delete(Some(0..10)));
+
+        assert_eq!(
+            terminal.reconcile_late_dictation_result_after_cleanup("hello world"),
+            Some(super::KeyboardInputContextEdit {
+                backspaces: 0,
+                text_to_insert: "d".to_string(),
+                document_text: String::new(),
+                selection_range: 0..0,
+            })
+        );
+    }
+
+    #[test]
+    fn streamed_text_input_marks_only_inserted_hypothesis_after_existing_context() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        terminal.replace_keyboard_input_context_range(None, "x");
+        assert_eq!(
+            terminal.replace_streamed_text_input_context_range(None, "hey"),
+            super::KeyboardInputContextEdit {
+                backspaces: 0,
+                text_to_insert: "hey".to_string(),
+                document_text: "xhey".to_string(),
+                selection_range: 4..4,
+            }
+        );
+
+        assert_eq!(terminal.marked_text(), Some("hey"));
+        assert_eq!(terminal.marked_text_range(), Some(1..4));
+        assert_eq!(terminal.text_input_document(), "xhey");
+    }
+
+    #[test]
+    fn cancelling_streamed_text_input_preview_restores_committed_context() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+        let mut events = terminal.subscribe_events();
+
+        terminal.replace_keyboard_input_context_range(None, "x");
+        terminal.replace_streamed_text_input_context_range(None, "hey");
+        events.try_recv().expect("expected preview");
+
+        assert!(terminal.cancel_streamed_text_input_context());
+        match events.try_recv().expect("expected preview dismissal") {
+            super::TerminalEvent::DictationPreviewChanged(None) => {}
+            event => panic!("expected preview dismissal, got {event:?}"),
+        }
+        assert_eq!(terminal.marked_text(), None);
+        assert_eq!(terminal.marked_text_range(), None);
+        assert_eq!(terminal.text_input_document(), "x");
+        assert_eq!(terminal.text_input_selection_range(), 1..1);
+        assert!(!terminal.has_streamed_text_input_pending_commit());
+    }
+
+    #[test]
+    fn dismissing_dictation_preview_cancels_streamed_text_input_preview() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+        let mut events = terminal.subscribe_events();
+
+        terminal.replace_keyboard_input_context_range(None, "x");
+        terminal.replace_streamed_text_input_context_range(None, "hey");
+        events.try_recv().expect("expected preview");
+
+        assert!(terminal.dismiss_dictation_preview());
+        match events.try_recv().expect("expected preview dismissal") {
+            super::TerminalEvent::DictationPreviewChanged(None) => {}
+            event => panic!("expected preview dismissal, got {event:?}"),
+        }
+        assert_eq!(terminal.marked_text(), None);
+        assert_eq!(terminal.text_input_document(), "x");
+        assert!(!terminal.has_streamed_text_input_pending_commit());
+    }
+
+    #[test]
+    fn streamed_text_input_recording_end_keeps_preview_until_commit() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+        let mut events = terminal.subscribe_events();
+
+        terminal.replace_streamed_text_input_context_range(Some(0..1), "hello");
+        events.try_recv().expect("expected preview");
+
+        terminal.dictation_recording_ended();
+        assert!(
+            events.try_recv().is_err(),
+            "recording end should not hide a pending streamed preview"
+        );
+        assert!(terminal.has_streamed_text_input_pending_commit());
+
+        assert_eq!(
+            terminal.commit_streamed_text_input_context(),
+            Some(super::KeyboardInputContextEdit {
+                backspaces: 0,
+                text_to_insert: "hello".to_string(),
+                document_text: "hello".to_string(),
+                selection_range: 5..5,
+            })
+        );
+        match events.try_recv().expect("expected preview dismissal") {
+            super::TerminalEvent::DictationPreviewChanged(None) => {}
+            event => panic!("expected preview dismissal, got {event:?}"),
+        }
     }
 
     #[test]

--- a/crates/zedra-terminal/src/view.rs
+++ b/crates/zedra-terminal/src/view.rs
@@ -263,6 +263,14 @@ impl TerminalView {
         self.terminal.read(cx).input_sender()
     }
 
+    pub fn dismiss_dictation_preview(&mut self, cx: &mut Context<Self>) {
+        self.terminal.update(cx, |terminal, cx| {
+            if terminal.dismiss_dictation_preview() {
+                cx.notify();
+            }
+        });
+    }
+
     pub fn attach_channel(
         &mut self,
         input_tx: mpsc::Sender<Vec<u8>>,

--- a/crates/zedra/src/ios/app.rs
+++ b/crates/zedra/src/ios/app.rs
@@ -122,6 +122,22 @@ pub extern "C" fn zedra_ios_native_floating_button_pressed(callback_id: u32) {
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn zedra_ios_dictation_preview_dismiss(preview_id: u32) {
+    IOS_APP_CELL.with(|cell| {
+        let Some(app_cell) = cell.borrow().as_ref().cloned() else {
+            return;
+        };
+
+        let Ok(mut app) = app_cell.try_borrow_mut() else {
+            return;
+        };
+
+        let cx: &mut App = &mut app;
+        platform_bridge::dispatch_native_dictation_preview_dismiss(preview_id, cx);
+    });
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn zedra_launch_gpui() {
     let log_level = if cfg!(feature = "debug-logs") {
         log::LevelFilter::Debug

--- a/crates/zedra/src/platform_bridge.rs
+++ b/crates/zedra/src/platform_bridge.rs
@@ -210,6 +210,7 @@ static NATIVE_NOTIFICATION_CALLBACKS: OnceLock<Mutex<HashMap<u32, Box<dyn FnOnce
 thread_local! {
     static PENDING_CUSTOM_SHEET_VIEW: std::cell::RefCell<Option<AnyView>> = const { std::cell::RefCell::new(None) };
     static NATIVE_FLOATING_BUTTON_CALLBACKS: RefCell<HashMap<u32, Box<dyn FnMut(&mut App)>>> = RefCell::new(HashMap::new());
+    static NATIVE_DICTATION_PREVIEW_DISMISS_CALLBACKS: RefCell<HashMap<u32, Box<dyn FnMut(&mut App)>>> = RefCell::new(HashMap::new());
 }
 
 fn alert_callbacks() -> &'static Mutex<HashMap<u32, Box<dyn FnOnce(Option<usize>) + Send>>> {
@@ -351,12 +352,28 @@ pub(crate) fn allocate_native_dictation_preview_id() -> u32 {
     NEXT_NATIVE_DICTATION_PREVIEW_ID.fetch_add(1, Ordering::Relaxed)
 }
 
+pub(crate) fn set_native_dictation_preview_dismiss_callback(
+    id: u32,
+    on_dismiss: impl FnMut(&mut App) + 'static,
+) {
+    NATIVE_DICTATION_PREVIEW_DISMISS_CALLBACKS.with(|callbacks| {
+        callbacks.borrow_mut().insert(id, Box::new(on_dismiss));
+    });
+}
+
 pub(crate) fn update_native_dictation_preview(id: u32, options: NativeDictationPreviewOptions) {
     bridge().update_native_dictation_preview(id, &options);
 }
 
 pub(crate) fn hide_native_dictation_preview(id: u32) {
     bridge().hide_native_dictation_preview(id);
+}
+
+pub(crate) fn remove_native_dictation_preview(id: u32) {
+    NATIVE_DICTATION_PREVIEW_DISMISS_CALLBACKS.with(|callbacks| {
+        callbacks.borrow_mut().remove(&id);
+    });
+    hide_native_dictation_preview(id);
 }
 
 pub fn show_native_notification(options: NativeNotificationOptions) {
@@ -413,6 +430,14 @@ pub fn dispatch_selection_dismiss(callback_id: u32) {
 pub fn dispatch_native_floating_button_press(callback_id: u32, cx: &mut App) {
     NATIVE_FLOATING_BUTTON_CALLBACKS.with(|callbacks| {
         if let Some(callback) = callbacks.borrow_mut().get_mut(&callback_id) {
+            callback(cx);
+        }
+    });
+}
+
+pub fn dispatch_native_dictation_preview_dismiss(preview_id: u32, cx: &mut App) {
+    NATIVE_DICTATION_PREVIEW_DISMISS_CALLBACKS.with(|callbacks| {
+        if let Some(callback) = callbacks.borrow_mut().get_mut(&preview_id) {
             callback(cx);
         }
     });

--- a/crates/zedra/src/ui/input.rs
+++ b/crates/zedra/src/ui/input.rs
@@ -815,9 +815,9 @@ impl EntityInputHandler for Input {
 
     fn replace_and_mark_text_in_range(
         &mut self,
-        range_utf16: Option<Range<usize>>,
-        new_text: &str,
-        new_selected_range_utf16: Option<Range<usize>>,
+        replacement_range_utf16: Option<Range<usize>>,
+        marked_text: &str,
+        selected_range_utf16: Option<Range<usize>>,
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -827,23 +827,40 @@ impl EntityInputHandler for Input {
 
         // Critical: native IMEs keep provisional composition in marked text.
         // Replacing it as committed text breaks Vietnamese/Japanese updates.
-        let range = self.active_replacement_range(range_utf16);
-        self.replace_range_with_marked_text(range, new_text, new_selected_range_utf16, cx);
+        let range = self.active_replacement_range(replacement_range_utf16);
+        self.replace_range_with_marked_text(range, marked_text, selected_range_utf16, cx);
     }
 
-    fn dictation_started(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+    fn insert_dictation_result_placeholder(
+        &mut self,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         self.begin_dictation(cx);
     }
 
-    fn insert_dictation_text(&mut self, text: &str, _window: &mut Window, cx: &mut Context<Self>) {
-        self.insert_live_dictation_text(text, cx);
+    fn remove_dictation_result_placeholder(
+        &mut self,
+        will_insert_result: bool,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !will_insert_result {
+            self.finish_dictation(cx);
+        }
     }
 
-    fn dictation_ended(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+    fn insert_dictation_result(
+        &mut self,
+        text: &str,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.insert_live_dictation_text(text, cx);
         self.finish_dictation(cx);
     }
 
-    fn dictation_cancelled(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+    fn dictation_recognition_failed(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         self.cancel_dictation(cx);
     }
 

--- a/crates/zedra/src/workspace_terminal.rs
+++ b/crates/zedra/src/workspace_terminal.rs
@@ -340,6 +340,17 @@ impl WorkspaceTerminal {
             );
         }
 
+        let dictation_preview_id = platform_bridge::allocate_native_dictation_preview_id();
+        let terminal_view_for_preview_dismiss = terminal_view.clone();
+        platform_bridge::set_native_dictation_preview_dismiss_callback(
+            dictation_preview_id,
+            move |cx| {
+                let _ = terminal_view_for_preview_dismiss.update(cx, |terminal_view, cx| {
+                    terminal_view.dismiss_dictation_preview(cx);
+                });
+            },
+        );
+
         Self {
             terminal_id,
             workspace_state,
@@ -350,7 +361,7 @@ impl WorkspaceTerminal {
             is_alt_screen: false,
             last_synced_keyboard_inset: px(0.0),
             scroll_to_bottom_button_id: native_floating_button_id(),
-            dictation_preview_id: platform_bridge::allocate_native_dictation_preview_id(),
+            dictation_preview_id,
             scroll_to_bottom_button_visible: false,
             scroll_to_bottom_button_hide_pending: false,
             scroll_to_bottom_button_hide_generation: 0,
@@ -536,6 +547,6 @@ impl Render for WorkspaceTerminal {
 impl Drop for WorkspaceTerminal {
     fn drop(&mut self) {
         hide_native_floating_button(self.scroll_to_bottom_button_id);
-        platform_bridge::hide_native_dictation_preview(self.dictation_preview_id);
+        platform_bridge::remove_native_dictation_preview(self.dictation_preview_id);
     }
 }

--- a/docs/GPUI_INPUT_DICTATION.md
+++ b/docs/GPUI_INPUT_DICTATION.md
@@ -7,14 +7,17 @@ input, but the lifecycle is not the same as ordinary `insertText`.
 ## Contract
 
 - `GPUIMetalView` remains the single native `UITextInput` responder.
-- `gpui_ios` detects dictation lifecycle callbacks and forwards them through
-  `InputHandler`.
+- `gpui_ios` forwards UIKit selector-shaped text and dictation callbacks through
+  `InputHandler`; it does not synthesize dictation start/end/cancel state.
 - The app input handler owns the synthetic text store it exposes back to UIKit.
 - Dictation hypothesis text is stored as marked text until it is committed or
   cancelled.
-- Terminal commit sends the final transcript to the PTY once.
-- The native preview overlay is display-only and must not be the source of text
-  truth.
+- Terminal input may preview `insertText` / `replaceRange` text that arrives
+  without a terminal-observed `shouldChangeTextInRange` preflight while
+  preserving a marked range for UIKit reconciliation, then commit the stream to
+  the PTY once.
+- The native preview overlay is display-only when used and must not be the
+  source of text truth.
 
 ## iOS Flow
 
@@ -41,6 +44,14 @@ insertDictationResultPlaceholder
 may still query `markedTextRange` and `textInRange` after that callback, so it
 must not clear the marked-text store.
 
+On iOS 16 and newer, UIKit may stream dictated words through `insertText` or
+`replaceRange` before exposing a useful dictation-start signal. `gpui_ios`
+forwards UIKit selector-shaped calls, including `shouldChangeTextInRange`,
+`insertText`, and `replaceRange`, without deciding whether they are dictation.
+Terminal input may then stage a safe selector sequence as a live preview backed
+by marked text, not as terminal output. The first unconfirmed selector must not
+be sent to the PTY and "promoted" later.
+
 ## Synthetic Text Store
 
 Dictation requires a stable document model even for surfaces like the terminal
@@ -51,60 +62,76 @@ small synthetic document:
 - the current marked dictation hypothesis during active dictation
 - the recently committed hypothesis briefly after commit for trailing UIKit
   reconciliation queries
+- preview text derived from an `insertText` / `replaceRange` sequence that still
+  needs a marked range so UIKit can find the previous hypothesis
 
 The marked range must remain available while UIKit is replacing its previous
 hypothesis. Clearing it too early can make `UIDictationController` cancel with
 “Could not find the last hypothesis”.
 
-## Duplicate Guard
+## Terminal Routing
+
+`gpui_ios` exposes raw callbacks only. `TerminalInputHandler` owns the routing:
+
+- confirmed `shouldChangeTextInRange` flows update the terminal keyboard
+  context and send minimal PTY diffs
+- raw `setMarkedText` flows stay in the marked-text store until committed
+- unconfirmed `insertText` / `replaceRange` can stage a preview only from the
+  empty anchor or from an already active preview/dictation flow
+- live preview text is committed only when UIKit finalizes the dictation stream
+
+Normal multi-character `insertText` is not treated as dictation by length. The
+bridge must not infer preview or lifecycle state from phrase shape. Vietnamese
+Telex, Japanese IME, suggestions, and dictation all share `insertText` and
+`replaceRange`.
 
 When UIKit removes the dictation placeholder with `willInsertResult=false`, the
-streamed marked text is treated as final and committed. Some stop paths can then
-send a late final insert. The streamed-commit guard ignores that late insert so
-the terminal does not receive duplicate transcript text.
+terminal treats the streamed marked text as final and commits it. If UIKit later
+sends a final `insertDictationResult`, the terminal reconciles it as a correction
+against the already committed transcript instead of inserting a duplicate.
 
-Normal multi-character `insertText` must not be treated as dictation by length
-alone. Dictation buffering requires a native or platform-flow signal:
-
-- `UITextInputContext.isDictationInputExpected`
-- `UITextInputMode.primaryLanguage == "dictation"`
-- a recent wide context query that marks a pending dictation insert
-- an already active insert-text dictation stream
-- an `insertText` transaction that was not preceded by
-  `shouldChangeTextInRange`
-
-The bridge must not infer dictation from phrase shape alone. Vietnamese Telex,
-Japanese IME, suggestions, and dictation all share `insertText` and
-`replaceRange`, so routing has to come from native state or an already active
-dictation lifecycle.
+Vietnamese Telex delete/rewrite can replay unconfirmed text after the confirmed
+correction. A terminal-owned rewrite guard keeps that replay on the ordinary
+keyboard path instead of bootstrapping dictation preview. If confirmed keyboard
+input follows a staged preview, the preview is flushed as ordinary PTY text
+before the confirmed edit applies.
 
 ## Preview Overlay
 
 `TerminalEvent::DictationPreviewChanged` carries live hypothesis text from
-`zedra-terminal` to the app layer. `WorkspaceTerminal` forwards it through
-`platform_bridge` to `Presentations.swift`, where UIKit renders a compact native
-glass/material overlay above the keyboard.
+`zedra-terminal` to the app layer for preview-backed dictation flows. The
+terminal stream path emits this event for live hypotheses and hides it when the
+stream commits or cancels.
+`WorkspaceTerminal` forwards preview events through `platform_bridge` to
+`Presentations.swift`, where UIKit renders a compact native glass/material
+overlay above the keyboard.
 
 The overlay caches the last rendered text, bottom offset, and window bounds so
-repeated identical updates do not relayout or replay animations.
+repeated identical updates do not relayout or replay animations. Tapping the
+overlay hides it and asks the owning terminal view to cancel its pending preview
+state, so a false-positive preview has an explicit escape hatch.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `vendor/zed/crates/gpui/src/platform.rs` | `InputHandler` dictation hooks |
-| `vendor/zed/crates/gpui_ios/src/ios/window.rs` | UIKit dictation callback routing and duplicate guard |
+| `vendor/zed/crates/gpui/src/platform.rs` | Raw selector-shaped `InputHandler` hooks |
+| `vendor/zed/crates/gpui_ios/src/ios/window.rs` | UIKit text-input callback forwarding |
 | `crates/zedra-terminal/src/input.rs` | Terminal `InputHandler` bridge |
 | `crates/zedra-terminal/src/terminal.rs` | Synthetic marked-text state and preview events |
 | `crates/zedra/src/workspace_terminal.rs` | Active-terminal preview routing |
+| `crates/zedra/src/platform_bridge.rs` | Preview id allocation and tap-dismiss callback registry |
 | `ios/Zedra/Presentations.swift` | Native dictation preview overlay |
 
 ## Validation
 
 Use targeted checks:
 
-```bash
+```sh
 cargo test -p zedra-terminal --lib dictation
+cargo test -p zedra-terminal --lib streamed_text_input
+cargo test -p zedra-terminal --lib unconfirmed_text_input
+cargo test -p zedra-terminal --lib text_input_rewrite_guard
 cargo check --manifest-path vendor/zed/Cargo.toml -p gpui_ios -p gpui
 ./scripts/build-ios.sh --sim
 ```

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -386,15 +386,17 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:1:1\033\\/tmp/zedra-long-code.rs:
 1. Connect to a session on a physical iPhone and open the terminal view
 2. Tap the terminal so the software keyboard appears
 3. Tap the keyboard dictation microphone and dictate a short command fragment such as `echo hello`
-4. Expected: a compact native glass/material preview appears above the keyboard and updates with the live dictated text
+4. Expected: recognized text appears in the native dictation preview while the terminal output stays stable during live hypothesis rewrites
 5. Stop dictation
-6. Expected: the preview hides, and the dictated text stays inserted in the PTY once, without being removed, without a stuck marked-text underline, and without duplicate characters
+6. Expected: the dictated text commits to the PTY once when dictation finalizes, without being removed, without a stuck marked-text underline, without duplicate characters, and without a `UIDictationController` hypothesis-cancel log
 7. Repeat with a longer phrase and stop immediately after the last words
 8. Expected: the final committed PTY text includes the last words, with no `UIDictationController` hypothesis-cancel log
-9. Repeat with a dictated phrase that includes a newline or return command
-10. Expected: newline input is routed as terminal enter rather than leaving literal marked text behind
-11. Start dictation again, then cancel or force recognition failure by stopping before speech is recognized
-12. Expected: the preview hides, the terminal remains focused, no stale dictation text is committed, and normal keyboard typing still reaches the PTY
+9. While preview text is visible, tap the preview bubble
+10. Expected: the preview dismisses immediately and does not stay stuck above the keyboard
+11. Repeat with a dictated phrase that includes a newline or return command
+12. Expected: newline input is routed as terminal enter rather than leaving literal marked text behind
+13. Start dictation again, then cancel or force recognition failure by stopping before speech is recognized
+14. Expected: the terminal remains focused, no stale dictation text is committed, and normal keyboard typing still reaches the PTY
 
 ## 11c. Native Keyboard Suggestions On iOS
 
@@ -414,7 +416,7 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:1:1\033\\/tmp/zedra-long-code.rs:
 14. Type prose and accept an available native suggestion
 15. Expected: the suggestion inserts into the commit message, while smart punctuation and autocapitalization remain disabled
 16. Switch the software keyboard to Vietnamese Telex and type `lee`, `chaf`, `toois`, `vois`, `ddungs`, and `uw ` in the terminal
-17. Expected: the PTY receives `lê`, `chà`, `tối`, `với`, `đúng`, and `ư `, without duplicate base consonants such as `llê` or `chhà`, without placing the tone on the final vowel as `tôí`, without duplicating a replayed composed cluster as `vơới`, without dropping preserved prefixes such as `đ`, and without dropping the standalone composed character before the space
+17. Expected: the PTY receives `lê`, `chà`, `tối`, `với`, `đúng`, and `ư `, without duplicate base consonants such as `llê` or `chhà`, without placing the tone on the final vowel as `tôí`, without duplicating a replayed composed cluster as `vơới`, without dropping preserved prefixes such as `đ`, without dropping the standalone composed character before the space, and without showing the dictation preview while typing or backspacing
 18. Switch to a Japanese keyboard, type a short marked composition, and accept a candidate
 19. Expected: the marked text commits once to the PTY, the candidate UI anchors near the terminal input area, and there is no repeated `variant selector cell index number could not be found` warning
 
@@ -427,17 +429,19 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:1:1\033\\/tmp/zedra-long-code.rs:
 5. Terminal, native suggestion: type `teh`, accept the keyboard suggestion `the`, then type `hel` and accept `hello`
 6. Expected: replacements are sent as minimal PTY diffs, with no extra backspaces, no duplicate prefix, and no stuck native marked range
 7. Terminal, dictation: dictate a phrase, stop immediately after the final word, then wait for any late final transcript update
-8. Expected: the preview hides on recording stop, the late hypothesis stays in the dictation store, final text includes the last words, and there is no `UIDictationController` hypothesis-cancel log
+8. Expected: streamed text updates the preview first, commits to the PTY once at finalization, late native reconciliation does not duplicate or delete PTY text, and there is no `UIDictationController` hypothesis-cancel log
 9. Terminal, native dictation stream: dictate `hello, how's it going` and watch the first `insertText` word plus following `replaceRange` rewrites
-10. Expected: the first word moves directly into dictation preview without streaming to the PTY first, and finalization commits once without a hypothesis-cancel log
-11. Cross-flow: after a dictation commit, press backspace repeatedly, then type `hel` and accept `hello`
-12. Expected: dictation cleanup does not delete already-committed terminal text, repeated backspace continues through the PTY, and the following suggestion starts from a fresh keyboard context
-13. Cross-flow: start a Japanese marked composition, cancel it, then accept a native suggestion in the same terminal focus session
-14. Expected: cancelled marked text does not poison the following suggestion replacement or leave stale candidate UI
-15. Commit message input: type Japanese marked text, accept a candidate, then accept a native suggestion
-16. Expected: normal input uses the same native IME protocol correctly, with marked text committed once and suggestions replacing only the requested range
-17. Commit message input, dictation: tap the microphone, dictate a short phrase, then stop dictation
-18. Expected: the dictated phrase remains in the input after UIKit commits, the final cleanup delete does not clear the field, and any late `insertDictationResult` does not duplicate the phrase
+10. Expected: the first word and following rewrites update the preview while the synthetic marked range remains available for UIKit reconciliation; the final transcript commits once, with no hypothesis-cancel log
+11. Terminal, native dictation preview: tap the visible preview bubble before finalization
+12. Expected: the preview dismisses and the terminal does not keep a stuck streamed preview state
+13. Cross-flow: after a dictation commit, press backspace repeatedly, then type `hel` and accept `hello`
+14. Expected: dictation cleanup does not delete already-committed terminal text, repeated backspace continues through the PTY, and the following suggestion starts from a fresh keyboard context
+15. Cross-flow: start a Japanese marked composition, cancel it, then accept a native suggestion in the same terminal focus session
+16. Expected: cancelled marked text does not poison the following suggestion replacement or leave stale candidate UI
+17. Commit message input: type Japanese marked text, accept a candidate, then accept a native suggestion
+18. Expected: normal input uses the same native IME protocol correctly, with marked text committed once and suggestions replacing only the requested range
+19. Commit message input, dictation: tap the microphone, dictate a short phrase, then stop dictation
+20. Expected: the dictated phrase remains in the input after UIKit commits, the final cleanup delete does not clear the field, and any late `insertDictationResult` does not duplicate the phrase
 
 ## 11e. Terminal Keyboard Accessory Arrow Repeat On iOS
 

--- a/ios/Zedra/Presentations.swift
+++ b/ios/Zedra/Presentations.swift
@@ -43,6 +43,9 @@ private func zedra_ios_text_input_dismiss(_ callbackID: UInt32)
 @_silgen_name("zedra_ios_native_floating_button_pressed")
 private func zedra_ios_native_floating_button_pressed(_ callbackID: UInt32)
 
+@_silgen_name("zedra_ios_dictation_preview_dismiss")
+private func zedra_ios_dictation_preview_dismiss(_ previewID: UInt32)
+
 @_silgen_name("zedra_ios_native_notification_action")
 private func zedra_ios_native_notification_action(_ callbackID: UInt32)
 
@@ -499,7 +502,7 @@ private final class NativeFloatingButtonController {
 private final class NativeDictationPreviewController {
     static let shared = NativeDictationPreviewController()
 
-    private final class Overlay {
+    private final class Overlay: NSObject {
         private static let enterDuration: TimeInterval = 0.22
         private static let exitDuration: TimeInterval = 0.16
         private static let initialScale = CGAffineTransform(scaleX: 0.94, y: 0.94)
@@ -507,8 +510,10 @@ private final class NativeDictationPreviewController {
         private static let labelInsets = UIEdgeInsets(top: 10, left: 14, bottom: 10, right: 14)
         private static let maxContentHeight: CGFloat = 72
 
+        let previewID: UInt32
         let effectView: UIVisualEffectView
         let label: UILabel
+        weak var owner: NativeDictationPreviewController?
         weak var window: UIWindow?
         private var isVisible = false
         private var animationGeneration: UInt64 = 0
@@ -516,20 +521,38 @@ private final class NativeDictationPreviewController {
         private var lastBottomOffset: CGFloat?
         private var lastWindowBounds = CGRect.null
 
-        init() {
+        init(previewID: UInt32, owner: NativeDictationPreviewController) {
+            self.previewID = previewID
+            self.owner = owner
             effectView = UIVisualEffectView(effect: nil)
+            label = UILabel()
+
+            super.init()
+
             effectView.clipsToBounds = true
             effectView.transform = Self.initialScale
-            effectView.isUserInteractionEnabled = false
+            effectView.isUserInteractionEnabled = true
+            effectView.isAccessibilityElement = true
             effectView.accessibilityLabel = "Dictation preview"
+            effectView.accessibilityHint = "Double tap to dismiss"
+            effectView.accessibilityTraits.insert(.button)
 
-            label = UILabel()
             label.font = UIFont.monospacedSystemFont(ofSize: 13, weight: .medium)
             label.textColor = UIColor(white: 1.0, alpha: 0.92)
             label.numberOfLines = 3
             label.lineBreakMode = .byTruncatingTail
             label.alpha = 0
             effectView.contentView.addSubview(label)
+
+            let tapGesture = UITapGestureRecognizer(
+                target: self,
+                action: #selector(dismissFromTap)
+            )
+            effectView.addGestureRecognizer(tapGesture)
+        }
+
+        @objc private func dismissFromTap() {
+            owner?.dismissFromTap(previewID: previewID)
         }
 
         func update(in window: UIWindow, text: String, bottomOffset: CGFloat) {
@@ -680,7 +703,7 @@ private final class NativeDictationPreviewController {
         DispatchQueue.main.async {
             let window = NativePresentationBridge.activeWindow()
             let overlay = self.overlays[previewID] ?? {
-                let overlay = Overlay()
+                let overlay = Overlay(previewID: previewID, owner: self)
                 self.overlays[previewID] = overlay
                 return overlay
             }()
@@ -696,6 +719,11 @@ private final class NativeDictationPreviewController {
                 self.overlays.removeValue(forKey: previewID)
             }
         }
+    }
+
+    private func dismissFromTap(previewID: UInt32) {
+        hide(previewID: previewID)
+        zedra_ios_dictation_preview_dismiss(previewID)
     }
 }
 


### PR DESCRIPTION
## Summary

- keep GPUI/iOS text input as raw selector forwarding while terminal input owns dictation and IME routing
- stage unconfirmed dictation streams as preview-backed marked text, then commit once and reconcile UIKit cleanup or late final results
- add native preview tap-to-dismiss plus updated dictation docs and manual test coverage

## Notes

- Includes the `vendor/zed` gitlink update to `a440c6f72e` for raw text input selector hooks.
- iOS device runtime verification is still manual.