### PR TITLE
docs: add contribution templates and PR guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,38 @@
+name: Bug Report
+description: Report a reproducible bug or regression
+labels: bug
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What broke, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduce
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      value: |
+        - Platform:
+        - App / CLI version:
+        - Device / OS:
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Logs, screenshots, recordings, or crash output.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Zedra Website
+    url: https://zedra.dev
+    about: Learn more about Zedra.
+  - name: Discord
+    url: https://discord.gg/39MmkSS8sc
+    about: Discuss questions and ideas with the community.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Suggest a focused improvement or new workflow
+labels: feature
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow or limitation does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should Zedra do?
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Related docs, screenshots, alternatives, or constraints.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+
+-
+
+## Notes
+
+-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ platform, reconnect, terminal input, pairing, or gesture changes, update
 
 ## Pull Requests
 
-Use a fork and open PRs against `dev` unless a maintainer asks for another base.
+Use a fork and open PRs against `main` unless a maintainer asks for another base.
 Keep PRs small and focused; avoid unrelated cleanup, generated churn, and
 dependency updates.
 


### PR DESCRIPTION
## Summary

- Add lightweight GitHub issue forms for bug reports and feature requests.
- Add a minimal pull request template matching the repo Summary/Notes convention.
- Update CONTRIBUTING to direct contributor PRs to main by default.
- Add issue chooser links for the Zedra website and Discord.

## Notes

- Documentation issue template is intentionally omitted.
- Templates stay minimal to keep contributor friction low.