### PR TITLE
fix: build Linux releases on Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,13 @@ jobs:
           # - target: x86_64-apple-darwin
           #   runner: macos-14
           #   cross: false
+          # Build Linux artifacts on Ubuntu 22.04 so GNU binaries do not inherit
+          # ubuntu-latest's newer glibc baseline.
           - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             cross: false
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             cross: true
 
     runs-on: ${{ matrix.runner }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9997,7 +9997,7 @@ dependencies = [
 
 [[package]]
 name = "zedra"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "android_logger",
  "anyhow",
@@ -10048,7 +10048,7 @@ dependencies = [
 
 [[package]]
 name = "zedra-host"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10086,11 +10086,11 @@ dependencies = [
 
 [[package]]
 name = "zedra-osc"
-version = "0.2.3"
+version = "0.2.4"
 
 [[package]]
 name = "zedra-rpc"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "base64-url",
@@ -10110,7 +10110,7 @@ dependencies = [
 
 [[package]]
 name = "zedra-session"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "ed25519-dalek 2.2.0",
@@ -10131,14 +10131,14 @@ dependencies = [
 
 [[package]]
 name = "zedra-telemetry"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "zedra-terminal"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "alacritty_terminal",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["vendor"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 
 [workspace.dependencies]


### PR DESCRIPTION
## Summary

- build GNU/Linux release artifacts on Ubuntu 22.04 instead of `ubuntu-latest`
- keep the existing arm64 Linux `cross` build path while pinning its runner to the same Ubuntu baseline
- bump the workspace package version to `0.2.4`

## Notes

- Fixes #72.
- Existing release artifacts need a rerun or replacement release before Ubuntu 22.04 users receive the fixed binary.