### PR TITLE
chore(ci): check only zedra crate for iOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,6 @@ jobs:
       - name: Check iOS app crate
         run: cargo check -p zedra --features ios-platform --target aarch64-apple-ios
 
-      - name: Check vendored GPUI iOS crates
-        run: cargo check --manifest-path vendor/zed/Cargo.toml -p gpui_ios -p gpui --target aarch64-apple-ios
-
   js-check:
     name: JS/TS
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove the direct vendored GPUI iOS cargo check from CI.
- Keep iOS Rust CI focused on the `zedra` crate for `aarch64-apple-ios`, which still pulls the GPUI crates through `ios-platform`.
- Update `CONTRIBUTING.md` so contributor PRs target `main` by default.

## Notes
- The CI job still checks out submodules recursively because the app crate depends on `vendor/zed`.