### PR TITLE
chore(ci): run rust tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
             -p zedra-terminal \
             -p zedra-host
 
+      - name: Test (non-app crates)
+        run: |
+          cargo test \
+            -p zedra-rpc \
+            -p zedra-session \
+            -p zedra-terminal \
+            -p zedra-host \
+            -p zedra-osc \
+            -p zedra-telemetry
+
   ios-rust-check:
     name: iOS Rust
     runs-on: macos-14
@@ -55,6 +65,9 @@ jobs:
 
       - name: Check vendored GPUI iOS crates
         run: cargo check --manifest-path vendor/zed/Cargo.toml -p gpui_ios -p gpui --target aarch64-apple-ios
+
+      - name: Test app crate
+        run: cargo test -p zedra --features ios-platform
 
   js-check:
     name: JS/TS


### PR DESCRIPTION
## Summary

- Add Rust test coverage to CI for the non-app crates.
- Run the Zedra app crate tests in the iOS Rust job with `ios-platform` enabled.

## Notes

- The app test command matches the existing iOS app feature configuration while still running on the macOS host test target.
- CI still relies on recursive submodule checkout for `vendor/zed` before any Rust job can run.