### PR TITLE
feat: support Windows host CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,34 @@ jobs:
           ZEDRA_GA_MEASUREMENT_ID: ${{ secrets.ZEDRA_GA_MEASUREMENT_ID }}
           ZEDRA_GA_API_SECRET: ${{ secrets.ZEDRA_GA_API_SECRET }}
         run: |
+          if [[ "${{ matrix.target }}" == *windows* ]]; then
+            export RUSTFLAGS="-C target-feature=+crt-static"
+          fi
+
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build -p zedra-host --release --target ${{ matrix.target }}
           else
             cargo build -p zedra-host --release --target ${{ matrix.target }}
           fi
+
+      - name: Smoke test CLI
+        if: ${{ !matrix.cross }}
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+          binary="./zedra"
+          if [[ "${{ matrix.target }}" == *windows* ]]; then
+            binary="./zedra.exe"
+          fi
+
+          version_output="$("$binary" --version)"
+          if [ -z "$version_output" ]; then
+            echo "zedra --version produced no output" >&2
+            exit 1
+          fi
+
+          "$binary" --help > zedra-help.txt
+          grep -q "Commands" zedra-help.txt
 
       - name: Package
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,15 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-22.04
             cross: true
+            smoke_test: false
           - target: x86_64-pc-windows-msvc
             runner: windows-2022
             cross: false
+            smoke_test: true
           - target: aarch64-pc-windows-msvc
             runner: windows-2022
             cross: false
+            smoke_test: false
 
     runs-on: ${{ matrix.runner }}
     steps:
@@ -70,7 +73,7 @@ jobs:
           fi
 
       - name: Smoke test CLI
-        if: ${{ !matrix.cross }}
+        if: ${{ matrix.smoke_test != false }}
         shell: bash
         run: |
           cd target/${{ matrix.target }}/release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,10 @@ jobs:
             runner: ubuntu-22.04
             cross: true
           - target: x86_64-pc-windows-msvc
-            runner: windows-latest
+            runner: windows-2022
+            cross: false
+          - target: aarch64-pc-windows-msvc
+            runner: windows-2022
             cross: false
 
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-latest
             cross: true
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            cross: false
 
     runs-on: ${{ matrix.runner }}
     steps:
@@ -46,6 +49,7 @@ jobs:
         run: cargo install cross --locked
 
       - name: Build
+        shell: bash
         env:
           ZEDRA_GA_MEASUREMENT_ID: ${{ secrets.ZEDRA_GA_MEASUREMENT_ID }}
           ZEDRA_GA_API_SECRET: ${{ secrets.ZEDRA_GA_API_SECRET }}
@@ -57,9 +61,14 @@ jobs:
           fi
 
       - name: Package
+        shell: bash
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf zedra-${{ matrix.target }}.tar.gz zedra
+          binary="zedra"
+          if [[ "${{ matrix.target }}" == *windows* ]]; then
+            binary="zedra.exe"
+          fi
+          tar czf zedra-${{ matrix.target }}.tar.gz "$binary"
           shasum -a 256 zedra-${{ matrix.target }}.tar.gz > zedra-${{ matrix.target }}.tar.gz.sha256 || \
             sha256sum zedra-${{ matrix.target }}.tar.gz > zedra-${{ matrix.target }}.tar.gz.sha256
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10079,6 +10079,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "windows-sys 0.61.2",
  "zedra-osc",
  "zedra-rpc",
  "zedra-telemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9997,7 +9997,7 @@ dependencies = [
 
 [[package]]
 name = "zedra"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "android_logger",
  "anyhow",
@@ -10049,7 +10049,7 @@ dependencies = [
 
 [[package]]
 name = "zedra-host"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10088,11 +10088,11 @@ dependencies = [
 
 [[package]]
 name = "zedra-osc"
-version = "0.2.4"
+version = "0.2.5"
 
 [[package]]
 name = "zedra-rpc"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "base64-url",
@@ -10112,7 +10112,7 @@ dependencies = [
 
 [[package]]
 name = "zedra-session"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "ed25519-dalek 2.2.0",
@@ -10133,14 +10133,14 @@ dependencies = [
 
 [[package]]
 name = "zedra-telemetry"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "zedra-terminal"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "alacritty_terminal",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["vendor"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ zedra start
 zedra start --detach
 ```
 
+Windows:
+
+```powershell
+irm https://zedra.dev/install.ps1 | iex
+zedra start --detach
+```
+
 **Claude Code**
 ```shell
 # Config Zedra skills for Claude

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ zedra start --detach
 Windows:
 
 ```powershell
-irm https://zedra.dev/install.ps1 | iex
+powershell -c "irm https://zedra.dev/install.ps1 | iex"
 zedra start --detach
 ```
 

--- a/crates/zedra-host/Cargo.toml
+++ b/crates/zedra-host/Cargo.toml
@@ -63,10 +63,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hostname = "0.4"
 sysinfo = "0.31.4"
 
-# Unix process signaling (for workspace lock PID check)
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
-
 # Error handling
 anyhow.workspace = true
 
@@ -84,6 +80,16 @@ serde_bytes.workspace = true
 zedra-osc = { path = "../zedra-osc" }
 zedra-rpc = { path = "../zedra-rpc" }
 zedra-telemetry.workspace = true
+
+# Unix process signaling (for workspace lock PID check)
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/zedra-host/src/api.rs
+++ b/crates/zedra-host/src/api.rs
@@ -10,6 +10,7 @@
 //   POST /api/qr                  — create and return a fresh one-time pairing QR
 //   POST /api/qr/static           — create and return a static pairing QR
 //   POST /api/terminal            — create a terminal in the active session
+//   POST /api/shutdown            — request a clean local daemon shutdown
 //
 // Auth: every request must carry  Authorization: Bearer <token>
 //       where <token> is the contents of  <config_dir>/api-token
@@ -44,6 +45,7 @@ pub struct ApiState {
     pub endpoint: iroh::Endpoint,
     pub relay_urls: Vec<String>,
     pub token: String,
+    pub shutdown_tx: Option<tokio::sync::watch::Sender<bool>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -316,6 +318,22 @@ async fn create_terminal_handler(
     }
 }
 
+async fn shutdown_handler(State(s): State<ApiState>, headers: HeaderMap) -> impl IntoResponse {
+    if !verify_token(&headers, &s.token) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "unauthorized"})),
+        )
+            .into_response();
+    }
+
+    if let Some(tx) = &s.shutdown_tx {
+        let _ = tx.send(true);
+    }
+
+    (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response()
+}
+
 // ---------------------------------------------------------------------------
 // Server startup
 // ---------------------------------------------------------------------------
@@ -330,6 +348,7 @@ pub async fn start(state: ApiState) -> anyhow::Result<std::net::SocketAddr> {
         .route("/api/qr", post(create_pairing_qr_handler))
         .route("/api/qr/static", post(create_static_pairing_qr_handler))
         .route("/api/terminal", post(create_terminal_handler))
+        .route("/api/shutdown", post(shutdown_handler))
         .with_state(state);
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -369,6 +388,7 @@ mod tests {
             endpoint: endpoint.clone(),
             relay_urls: vec!["https://test.relay.zedra.dev".to_string()],
             token: "test-token".to_string(),
+            shutdown_tx: None,
         })
         .await
         .unwrap();
@@ -434,6 +454,49 @@ mod tests {
                 _ => panic!("expected static active pairing slot"),
             }
         }
+
+        endpoint.close().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_endpoint_requires_token_and_signals() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity = Arc::new(HostIdentity::load_or_generate_for_workdir(dir.path()).unwrap());
+        let registry = Arc::new(SessionRegistry::new());
+        let daemon_state = Arc::new(DaemonState::new(dir.path().to_path_buf(), identity));
+        let endpoint = iroh::Endpoint::builder()
+            .relay_mode(iroh::RelayMode::Disabled)
+            .secret_key(iroh::SecretKey::from(rand::random::<[u8; 32]>()))
+            .bind()
+            .await
+            .unwrap();
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+        let addr = start(ApiState {
+            registry,
+            daemon_state,
+            endpoint: endpoint.clone(),
+            relay_urls: vec!["https://test.relay.zedra.dev".to_string()],
+            token: "test-token".to_string(),
+            shutdown_tx: Some(shutdown_tx),
+        })
+        .await
+        .unwrap();
+
+        let client = reqwest::Client::new();
+        let url = format!("http://{addr}/api/shutdown");
+        let unauthorized = client.post(&url).send().await.unwrap();
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+        assert!(!*shutdown_rx.borrow());
+
+        let authorized = client
+            .post(&url)
+            .bearer_auth("test-token")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(authorized.status(), StatusCode::OK);
+        shutdown_rx.changed().await.unwrap();
+        assert!(*shutdown_rx.borrow());
 
         endpoint.close().await;
     }

--- a/crates/zedra-host/src/api.rs
+++ b/crates/zedra-host/src/api.rs
@@ -10,7 +10,6 @@
 //   POST /api/qr                  — create and return a fresh one-time pairing QR
 //   POST /api/qr/static           — create and return a static pairing QR
 //   POST /api/terminal            — create a terminal in the active session
-//   POST /api/shutdown            — request a clean local daemon shutdown
 //
 // Auth: every request must carry  Authorization: Bearer <token>
 //       where <token> is the contents of  <config_dir>/api-token
@@ -45,7 +44,6 @@ pub struct ApiState {
     pub endpoint: iroh::Endpoint,
     pub relay_urls: Vec<String>,
     pub token: String,
-    pub shutdown_tx: Option<tokio::sync::watch::Sender<bool>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -318,22 +316,6 @@ async fn create_terminal_handler(
     }
 }
 
-async fn shutdown_handler(State(s): State<ApiState>, headers: HeaderMap) -> impl IntoResponse {
-    if !verify_token(&headers, &s.token) {
-        return (
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({"error": "unauthorized"})),
-        )
-            .into_response();
-    }
-
-    if let Some(tx) = &s.shutdown_tx {
-        let _ = tx.send(true);
-    }
-
-    (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response()
-}
-
 // ---------------------------------------------------------------------------
 // Server startup
 // ---------------------------------------------------------------------------
@@ -348,7 +330,6 @@ pub async fn start(state: ApiState) -> anyhow::Result<std::net::SocketAddr> {
         .route("/api/qr", post(create_pairing_qr_handler))
         .route("/api/qr/static", post(create_static_pairing_qr_handler))
         .route("/api/terminal", post(create_terminal_handler))
-        .route("/api/shutdown", post(shutdown_handler))
         .with_state(state);
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -388,7 +369,6 @@ mod tests {
             endpoint: endpoint.clone(),
             relay_urls: vec!["https://test.relay.zedra.dev".to_string()],
             token: "test-token".to_string(),
-            shutdown_tx: None,
         })
         .await
         .unwrap();
@@ -454,49 +434,6 @@ mod tests {
                 _ => panic!("expected static active pairing slot"),
             }
         }
-
-        endpoint.close().await;
-    }
-
-    #[tokio::test]
-    async fn shutdown_endpoint_requires_token_and_signals() {
-        let dir = tempfile::tempdir().unwrap();
-        let identity = Arc::new(HostIdentity::load_or_generate_for_workdir(dir.path()).unwrap());
-        let registry = Arc::new(SessionRegistry::new());
-        let daemon_state = Arc::new(DaemonState::new(dir.path().to_path_buf(), identity));
-        let endpoint = iroh::Endpoint::builder()
-            .relay_mode(iroh::RelayMode::Disabled)
-            .secret_key(iroh::SecretKey::from(rand::random::<[u8; 32]>()))
-            .bind()
-            .await
-            .unwrap();
-        let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
-        let addr = start(ApiState {
-            registry,
-            daemon_state,
-            endpoint: endpoint.clone(),
-            relay_urls: vec!["https://test.relay.zedra.dev".to_string()],
-            token: "test-token".to_string(),
-            shutdown_tx: Some(shutdown_tx),
-        })
-        .await
-        .unwrap();
-
-        let client = reqwest::Client::new();
-        let url = format!("http://{addr}/api/shutdown");
-        let unauthorized = client.post(&url).send().await.unwrap();
-        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
-        assert!(!*shutdown_rx.borrow());
-
-        let authorized = client
-            .post(&url)
-            .bearer_auth("test-token")
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(authorized.status(), StatusCode::OK);
-        shutdown_rx.changed().await.unwrap();
-        assert!(*shutdown_rx.borrow());
 
         endpoint.close().await;
     }

--- a/crates/zedra-host/src/client.rs
+++ b/crates/zedra-host/src/client.rs
@@ -19,7 +19,7 @@ use zedra_rpc::proto::{
 // Host info file — written by `zedra start`, read by `zedra client`
 // ---------------------------------------------------------------------------
 
-/// Persisted alongside daemon.lock so `zedra client` can auto-connect.
+/// Persisted under the workspace config directory so `zedra client` can auto-connect.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HostInfo {
     /// Iroh endpoint public key (full hex).
@@ -35,7 +35,7 @@ pub fn host_info_path(config_dir: &Path) -> PathBuf {
     config_dir.join("host-info.json")
 }
 
-/// Write host info alongside the daemon lock (called from `zedra start`).
+/// Write host info for `zedra client` auto-discovery (called from `zedra start`).
 pub fn write_host_info(config_dir: &Path, info: &HostInfo) -> Result<()> {
     let path = host_info_path(config_dir);
     let json = serde_json::to_string_pretty(info)?;

--- a/crates/zedra-host/src/identity.rs
+++ b/crates/zedra-host/src/identity.rs
@@ -4,9 +4,9 @@
 // instances on the same machine have distinct iroh NodeIds and don't
 // conflict on the relay.
 //
-// Keys are stored at:
-//   ~/.config/zedra/identity.key           (base, used by `zedra qr` without --workdir)
-//   ~/.config/zedra/workspaces/<hash>/identity.key  (per-workspace)
+// Keys are stored under the platform config root:
+//   Unix:    ~/.config/zedra/
+//   Windows: %APPDATA%\zedra\
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
@@ -87,7 +87,7 @@ impl HostIdentity {
     }
 }
 
-/// Path for the host-level telemetry ID file (`~/.config/zedra/telemetry_id`).
+/// Path for the host-level telemetry ID file.
 ///
 /// Shared across all workspaces on the same machine so connection counts
 /// roll up to a single host identity in telemetry.
@@ -95,9 +95,6 @@ pub fn telemetry_id_path() -> Result<PathBuf> {
     Ok(zedra_config_dir()?.join("telemetry_id"))
 }
 
-/// Returns the per-workspace config directory:
-/// `~/.config/zedra/workspaces/<hash>/`
-///
 /// Exported so other modules can co-locate their persistent state alongside
 /// the identity key without duplicating the hash logic.
 pub fn workspace_config_dir(workdir: &Path) -> Result<PathBuf> {
@@ -105,8 +102,28 @@ pub fn workspace_config_dir(workdir: &Path) -> Result<PathBuf> {
     Ok(zedra_config_dir()?.join("workspaces").join(hash))
 }
 
-/// Returns `~/.config/zedra/` as the config root on all platforms.
-fn zedra_config_dir() -> Result<PathBuf> {
+/// Returns Zedra's host config root.
+///
+/// Unix keeps the existing `~/.config/zedra` path for compatibility. Windows
+/// uses the roaming AppData config directory so lock, log, identity, and session
+/// files land in the native per-user location.
+pub fn zedra_config_dir() -> Result<PathBuf> {
+    #[cfg(windows)]
+    {
+        let config = directories::BaseDirs::new()
+            .map(|b| b.config_dir().join("zedra"))
+            .ok_or_else(|| anyhow::anyhow!("Could not determine config directory"))?;
+        return Ok(config);
+    }
+
+    #[cfg(not(windows))]
+    {
+        unix_zedra_config_dir()
+    }
+}
+
+#[cfg(not(windows))]
+fn unix_zedra_config_dir() -> Result<PathBuf> {
     let home = std::env::var_os("HOME")
         .map(PathBuf::from)
         .or_else(|| directories::BaseDirs::new().map(|b| b.home_dir().to_path_buf()))

--- a/crates/zedra-host/src/identity.rs
+++ b/crates/zedra-host/src/identity.rs
@@ -104,9 +104,8 @@ pub fn workspace_config_dir(workdir: &Path) -> Result<PathBuf> {
 
 /// Returns Zedra's host config root.
 ///
-/// Unix keeps the existing `~/.config/zedra` path for compatibility. Windows
-/// uses the roaming AppData config directory so lock, log, identity, and session
-/// files land in the native per-user location.
+/// Unix: `$HOME/.config/zedra`
+/// Windows: `%APPDATA%\zedra` via `directories::BaseDirs::config_dir()`
 pub fn zedra_config_dir() -> Result<PathBuf> {
     #[cfg(windows)]
     {

--- a/crates/zedra-host/src/lib.rs
+++ b/crates/zedra-host/src/lib.rs
@@ -11,6 +11,7 @@ pub mod identity;
 pub mod iroh_listener;
 pub mod metrics;
 pub mod net_monitor;
+pub mod paths;
 pub mod pty;
 pub mod qr;
 pub mod rpc_daemon;

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -397,9 +397,86 @@ fn start_detached(options: DetachedStartOptions) -> Result<DetachedStartResult> 
     })
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn start_detached(options: DetachedStartOptions) -> Result<DetachedStartResult> {
+    use std::os::windows::process::CommandExt;
+    use std::process::Stdio;
+
+    const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+    const DETACHED_PROCESS: u32 = 0x0000_0008;
+
+    if let Some(existing) = workspace_lock::read_lock_info(&options.workdir)? {
+        if workspace_lock::is_process_alive(existing.pid) {
+            anyhow::bail!(
+                "Zedra daemon is already running for this workspace.\n\
+                 \n\
+                 \x20 PID:      {}\n\
+                 \x20 Workdir:  {}\n\
+                 \x20 Host:     {}\n\
+                 \x20 Started:  {}\n\
+                 \n\
+                 Run `zedra stop` from this workspace to stop it.\n\
+                 From another directory, add `--workdir <path>`.",
+                existing.pid,
+                existing.workdir,
+                existing.hostname,
+                existing.running_for(),
+            );
+        }
+    }
+
+    let config_dir = identity::workspace_config_dir(&options.workdir)?;
+    std::fs::create_dir_all(&config_dir)?;
+    let log_path = config_dir.join("daemon.log");
+    let mut log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)?;
+    writeln!(
+        log,
+        "\n--- zedra detached start parent_pid={} workdir={} ---",
+        std::process::id(),
+        options.workdir.display()
+    )?;
+
+    let mut command = std::process::Command::new(std::env::current_exe()?);
+    command
+        .args(detached_start_child_args(&options))
+        .current_dir(&options.workdir)
+        .env("ZEDRA_DETACHED", "1")
+        .creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log.try_clone()?))
+        .stderr(Stdio::from(log));
+
+    let mut child = command.spawn()?;
+    let child_pid = child.id();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        if let Some(status) = child.try_wait()? {
+            anyhow::bail!(
+                "detached zedra-host exited early with status {}. See log: {}",
+                status,
+                log_path.display()
+            );
+        }
+        if let Some(info) = workspace_lock::read_lock_info(&options.workdir)? {
+            if info.pid == child_pid {
+                break;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    Ok(DetachedStartResult {
+        pid: child_pid,
+        workdir: options.workdir,
+    })
+}
+
+#[cfg(all(not(unix), not(windows)))]
 fn start_detached(_options: DetachedStartOptions) -> Result<DetachedStartResult> {
-    anyhow::bail!("`zedra start --detach` is only supported on Unix platforms.");
+    anyhow::bail!("`zedra start --detach` is not supported on this platform.");
 }
 
 fn telemetry_disabled(no_telemetry: bool) -> bool {
@@ -616,6 +693,7 @@ async fn main() -> Result<()> {
                 workdir.clone(),
                 host_identity.clone(),
             ));
+            let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
 
             // 1. Bind iroh endpoint with configured relay URLs.
             let endpoint_relay_urls: Vec<String> = if relay_url.is_empty() {
@@ -769,6 +847,7 @@ async fn main() -> Result<()> {
                     token: token.clone(),
                     endpoint: endpoint.clone(),
                     relay_urls: endpoint_relay_urls.clone(),
+                    shutdown_tx: Some(shutdown_tx.clone()),
                 })
                 .await
                 {
@@ -823,8 +902,18 @@ async fn main() -> Result<()> {
                 });
             }
 
-            // 5. Run iroh accept loop (blocks main)
-            iroh_listener::run_accept_loop(&endpoint, registry, state).await?;
+            // 5. Run iroh accept loop until the endpoint closes or local stop requests shutdown.
+            tokio::select! {
+                result = iroh_listener::run_accept_loop(&endpoint, registry, state) => {
+                    result?;
+                }
+                changed = shutdown_rx.changed() => {
+                    if changed.is_ok() && *shutdown_rx.borrow() {
+                        tracing::info!("Local shutdown requested; closing iroh endpoint.");
+                        endpoint.close().await;
+                    }
+                }
+            }
         }
 
         Commands::Status { workdir } => {
@@ -1150,7 +1239,8 @@ async fn main() -> Result<()> {
                 .canonicalize()
                 .unwrap_or_else(|_| std::path::PathBuf::from(&workdir));
 
-            match workspace_lock::read_lock_info(&workdir)? {
+            let lock_info = workspace_lock::read_lock_info(&workdir)?;
+            match &lock_info {
                 None => {
                     utils::eprintln_error(format!(
                         "No running Zedra daemon found for: {}",
@@ -1178,7 +1268,19 @@ async fn main() -> Result<()> {
                 }
             }
 
-            workspace_lock::kill_and_unlock(&workdir, grace)?;
+            let mut stopped = false;
+            if let Some(info) = &lock_info {
+                if workspace_lock::is_process_alive(info.pid) {
+                    match request_daemon_shutdown(&workdir, info.pid, grace).await {
+                        Ok(true) => stopped = true,
+                        Ok(false) => {}
+                        Err(e) => tracing::warn!("Failed to request local daemon shutdown: {}", e),
+                    }
+                }
+            }
+            if !stopped {
+                workspace_lock::kill_and_unlock(&workdir, grace)?;
+            }
             utils::eprintln_success("Stopped.");
         }
     }
@@ -1231,6 +1333,45 @@ fn should_proceed_with_update(input: &str) -> bool {
 
 fn daemon_log_path(workdir: &Path) -> Result<PathBuf> {
     Ok(identity::workspace_config_dir(workdir)?.join("daemon.log"))
+}
+
+async fn request_daemon_shutdown(workdir: &Path, pid: u32, grace_secs: u64) -> Result<bool> {
+    let config_dir = identity::workspace_config_dir(workdir)?;
+    let addr = std::fs::read_to_string(config_dir.join("api-addr")).unwrap_or_default();
+    let token = std::fs::read_to_string(config_dir.join("api-token")).unwrap_or_default();
+    let addr = addr.trim();
+    let token = token.trim();
+    if addr.is_empty() || token.is_empty() {
+        return Ok(false);
+    }
+
+    let url = format!("http://{addr}/api/shutdown");
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()?;
+    let resp = match client.post(url).bearer_auth(token).send().await {
+        Ok(resp) => resp,
+        Err(e) => {
+            tracing::warn!("Local shutdown API request failed: {}", e);
+            return Ok(false);
+        }
+    };
+    if !resp.status().is_success() {
+        tracing::warn!("Local shutdown API returned HTTP {}", resp.status());
+        return Ok(false);
+    }
+
+    let poll_interval = std::time::Duration::from_millis(100);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(grace_secs);
+    loop {
+        if !workspace_lock::is_process_alive(pid) {
+            return Ok(true);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
 }
 
 fn read_recent_log_lines(log_path: &Path, lines: usize) -> Result<String> {

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -438,6 +438,10 @@ fn start_detached(options: DetachedStartOptions) -> Result<DetachedStartResult> 
         std::process::id(),
         options.workdir.display()
     )?;
+    let launch_shell = zedra_host::pty::detect_parent_shell();
+    if let Some(shell) = &launch_shell {
+        writeln!(log, "detected_launch_shell={shell}")?;
+    }
 
     let mut command = std::process::Command::new(std::env::current_exe()?);
     command
@@ -448,6 +452,9 @@ fn start_detached(options: DetachedStartOptions) -> Result<DetachedStartResult> 
         .stdin(Stdio::null())
         .stdout(Stdio::from(log.try_clone()?))
         .stderr(Stdio::from(log));
+    if let Some(shell) = launch_shell {
+        command.env("ZEDRA_LAUNCH_SHELL", shell);
+    }
 
     let mut child = command.spawn()?;
     let child_pid = child.id();

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -693,7 +693,6 @@ async fn main() -> Result<()> {
                 workdir.clone(),
                 host_identity.clone(),
             ));
-            let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
 
             // 1. Bind iroh endpoint with configured relay URLs.
             let endpoint_relay_urls: Vec<String> = if relay_url.is_empty() {
@@ -847,7 +846,6 @@ async fn main() -> Result<()> {
                     token: token.clone(),
                     endpoint: endpoint.clone(),
                     relay_urls: endpoint_relay_urls.clone(),
-                    shutdown_tx: Some(shutdown_tx.clone()),
                 })
                 .await
                 {
@@ -902,18 +900,8 @@ async fn main() -> Result<()> {
                 });
             }
 
-            // 5. Run iroh accept loop until the endpoint closes or local stop requests shutdown.
-            tokio::select! {
-                result = iroh_listener::run_accept_loop(&endpoint, registry, state) => {
-                    result?;
-                }
-                changed = shutdown_rx.changed() => {
-                    if changed.is_ok() && *shutdown_rx.borrow() {
-                        tracing::info!("Local shutdown requested; closing iroh endpoint.");
-                        endpoint.close().await;
-                    }
-                }
-            }
+            // 5. Run iroh accept loop until the endpoint closes or the process exits.
+            iroh_listener::run_accept_loop(&endpoint, registry, state).await?;
         }
 
         Commands::Status { workdir } => {
@@ -1268,19 +1256,7 @@ async fn main() -> Result<()> {
                 }
             }
 
-            let mut stopped = false;
-            if let Some(info) = &lock_info {
-                if workspace_lock::is_process_alive(info.pid) {
-                    match request_daemon_shutdown(&workdir, info.pid, grace).await {
-                        Ok(true) => stopped = true,
-                        Ok(false) => {}
-                        Err(e) => tracing::warn!("Failed to request local daemon shutdown: {}", e),
-                    }
-                }
-            }
-            if !stopped {
-                workspace_lock::kill_and_unlock(&workdir, grace)?;
-            }
+            workspace_lock::kill_and_unlock(&workdir, grace)?;
             utils::eprintln_success("Stopped.");
         }
     }
@@ -1333,45 +1309,6 @@ fn should_proceed_with_update(input: &str) -> bool {
 
 fn daemon_log_path(workdir: &Path) -> Result<PathBuf> {
     Ok(identity::workspace_config_dir(workdir)?.join("daemon.log"))
-}
-
-async fn request_daemon_shutdown(workdir: &Path, pid: u32, grace_secs: u64) -> Result<bool> {
-    let config_dir = identity::workspace_config_dir(workdir)?;
-    let addr = std::fs::read_to_string(config_dir.join("api-addr")).unwrap_or_default();
-    let token = std::fs::read_to_string(config_dir.join("api-token")).unwrap_or_default();
-    let addr = addr.trim();
-    let token = token.trim();
-    if addr.is_empty() || token.is_empty() {
-        return Ok(false);
-    }
-
-    let url = format!("http://{addr}/api/shutdown");
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(2))
-        .build()?;
-    let resp = match client.post(url).bearer_auth(token).send().await {
-        Ok(resp) => resp,
-        Err(e) => {
-            tracing::warn!("Local shutdown API request failed: {}", e);
-            return Ok(false);
-        }
-    };
-    if !resp.status().is_success() {
-        tracing::warn!("Local shutdown API returned HTTP {}", resp.status());
-        return Ok(false);
-    }
-
-    let poll_interval = std::time::Duration::from_millis(100);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(grace_secs);
-    loop {
-        if !workspace_lock::is_process_alive(pid) {
-            return Ok(true);
-        }
-        if std::time::Instant::now() >= deadline {
-            return Ok(false);
-        }
-        tokio::time::sleep(poll_interval).await;
-    }
 }
 
 fn read_recent_log_lines(log_path: &Path, lines: usize) -> Result<String> {

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -1163,7 +1163,7 @@ async fn main() -> Result<()> {
                 eprintln!();
                 #[cfg(windows)]
                 utils::eprintln_warn(format!(
-                    "{} running daemon(s) found. Stop them before update:",
+                    "{} running daemon(s) found. They will keep using the old version until restarted:",
                     alive.len()
                 ));
                 #[cfg(not(windows))]
@@ -1175,15 +1175,6 @@ async fn main() -> Result<()> {
                     eprintln!("  pid {}  {}", lock.pid, lock.workdir);
                 }
                 eprintln!();
-
-                #[cfg(windows)]
-                {
-                    // Windows locks every running zedra.exe, including detached
-                    // daemons, so the updater can only replace the CLI after they exit.
-                    utils::eprintln_error("Stop running daemons before updating on Windows.");
-                    utils::eprintln_shell_command("zedra stop -w <dir>");
-                    std::process::exit(1);
-                }
             }
 
             // Confirm unless --yes

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -760,9 +760,10 @@ async fn main() -> Result<()> {
                 match version_check::check_latest_version().await {
                     Ok(Some(ref latest)) => {
                         let update_msg = format!(
-                            "New version available: {} (current: v{}). Run `zedra update`.",
+                            "New version available: {} (current: v{}). {}",
                             latest,
-                            env!("CARGO_PKG_VERSION")
+                            env!("CARGO_PKG_VERSION"),
+                            update_instruction()
                         );
                         utils::eprintln_warn(update_msg);
                         zedra_telemetry::send(Event::UpdateChecked {
@@ -1306,6 +1307,16 @@ fn classify_update_error(e: &anyhow::Error) -> &'static str {
     } else {
         "unknown"
     }
+}
+
+#[cfg(windows)]
+fn update_instruction() -> &'static str {
+    "Run `irm https://zedra.dev/install.ps1 | iex`."
+}
+
+#[cfg(not(windows))]
+fn update_instruction() -> &'static str {
+    "Run `zedra update`."
 }
 
 fn should_proceed_with_update(input: &str) -> bool {

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use zedra_host::client as zedra_client;
 use zedra_host::ga4::Ga4;
 use zedra_host::{
-    api, identity, iroh_listener, metrics, net_monitor, qr, rpc_daemon, session_registry, utils,
-    version_check, workspace_lock,
+    api, identity, iroh_listener, metrics, net_monitor, paths, qr, rpc_daemon, session_registry,
+    utils, version_check, workspace_lock,
 };
 use zedra_rpc::ZedraPairingTicket;
 use zedra_telemetry::Event;
@@ -517,6 +517,12 @@ fn render_cli_version() -> String {
     format!("{}\n", env!("CARGO_PKG_VERSION"))
 }
 
+fn resolve_workdir(workdir: impl AsRef<Path>) -> PathBuf {
+    let fallback = workdir.as_ref().to_path_buf();
+    let workdir = fallback.canonicalize().unwrap_or(fallback);
+    paths::user_path(&workdir)
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -565,9 +571,7 @@ async fn main() -> Result<()> {
             count,
             relay_only,
         } => {
-            let workdir = std::path::PathBuf::from(workdir)
-                .canonicalize()
-                .unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let workdir = resolve_workdir(workdir);
             zedra_client::run(&workdir, count, relay_only).await?;
         }
 
@@ -581,9 +585,7 @@ async fn main() -> Result<()> {
             relay_only,
             static_qr,
         } => {
-            let workdir = std::path::PathBuf::from(workdir)
-                .canonicalize()
-                .unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let workdir = resolve_workdir(workdir);
             let pairing_mode = if static_qr {
                 session_registry::PairingSlotMode::Static
             } else {
@@ -913,9 +915,7 @@ async fn main() -> Result<()> {
         }
 
         Commands::Status { workdir } => {
-            let workdir = std::path::PathBuf::from(workdir)
-                .canonicalize()
-                .unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let workdir = resolve_workdir(workdir);
             let config_dir = identity::workspace_config_dir(&workdir)?;
             let addr = std::fs::read_to_string(config_dir.join("api-addr")).unwrap_or_default();
             let token = std::fs::read_to_string(config_dir.join("api-token")).unwrap_or_default();
@@ -950,9 +950,7 @@ async fn main() -> Result<()> {
         }
 
         Commands::Metrics { workdir } => {
-            let workdir = std::path::PathBuf::from(workdir)
-                .canonicalize()
-                .unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let workdir = resolve_workdir(workdir);
             let snapshot = metrics::snapshot(&workdir)?;
             let http = reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(2))
@@ -970,9 +968,7 @@ async fn main() -> Result<()> {
             json,
             static_qr,
         } => {
-            let workdir = std::path::PathBuf::from(workdir)
-                .canonicalize()
-                .unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let workdir = resolve_workdir(workdir);
             let pairing_mode = if static_qr {
                 session_registry::PairingSlotMode::Static
             } else {
@@ -994,9 +990,7 @@ async fn main() -> Result<()> {
             workdir,
             launch_cmd,
         } => {
-            let workdir = std::path::PathBuf::from(workdir)
-                .canonicalize()
-                .unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let workdir = resolve_workdir(workdir);
             let config_dir = identity::workspace_config_dir(&workdir)?;
             let addr = std::fs::read_to_string(config_dir.join("api-addr")).unwrap_or_default();
             let token = std::fs::read_to_string(config_dir.join("api-token")).unwrap_or_default();
@@ -1106,9 +1100,7 @@ async fn main() -> Result<()> {
         }
 
         Commands::Logs { workdir, lines } => {
-            let workdir = std::path::PathBuf::from(workdir)
-                .canonicalize()
-                .unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let workdir = resolve_workdir(workdir);
             let log_path = daemon_log_path(&workdir)?;
             if !log_path.exists() {
                 utils::eprintln_error(format!("No daemon log found for: {}", workdir.display()));
@@ -1237,9 +1229,7 @@ async fn main() -> Result<()> {
         }
 
         Commands::Stop { workdir, grace } => {
-            let workdir = std::path::PathBuf::from(&workdir)
-                .canonicalize()
-                .unwrap_or_else(|_| std::path::PathBuf::from(&workdir));
+            let workdir = resolve_workdir(&workdir);
 
             let lock_info = workspace_lock::read_lock_info(&workdir)?;
             match &lock_info {

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -1161,6 +1161,12 @@ async fn main() -> Result<()> {
             let alive: Vec<_> = instances.iter().filter(|(_, _, alive)| *alive).collect();
             if !alive.is_empty() {
                 eprintln!();
+                #[cfg(windows)]
+                utils::eprintln_warn(format!(
+                    "{} running daemon(s) found. Stop them before update:",
+                    alive.len()
+                ));
+                #[cfg(not(windows))]
                 utils::eprintln_warn(format!(
                     "{} running daemon(s) found. Restart them after update:",
                     alive.len()
@@ -1169,6 +1175,15 @@ async fn main() -> Result<()> {
                     eprintln!("  pid {}  {}", lock.pid, lock.workdir);
                 }
                 eprintln!();
+
+                #[cfg(windows)]
+                {
+                    // Windows locks every running zedra.exe, including detached
+                    // daemons, so the updater can only replace the CLI after they exit.
+                    utils::eprintln_error("Stop running daemons before updating on Windows.");
+                    utils::eprintln_shell_command("zedra stop -w <dir>");
+                    std::process::exit(1);
+                }
             }
 
             // Confirm unless --yes
@@ -1300,7 +1315,11 @@ fn classify_update_error(e: &anyhow::Error) -> &'static str {
         "download_failed"
     } else if msg.contains("archive did not contain") || msg.contains("failed to extract") {
         "extract_failed"
-    } else if msg.contains("failed to install") || msg.contains("failed to rename") {
+    } else if msg.contains("failed to install")
+        || msg.contains("failed to rename")
+        || msg.contains("install directory is not writable")
+        || msg.contains("failed to start PowerShell")
+    {
         "install_failed"
     } else if msg.contains("failed to resolve latest") {
         "version_resolve_failed"
@@ -1309,12 +1328,6 @@ fn classify_update_error(e: &anyhow::Error) -> &'static str {
     }
 }
 
-#[cfg(windows)]
-fn update_instruction() -> &'static str {
-    "Run `irm https://zedra.dev/install.ps1 | iex`."
-}
-
-#[cfg(not(windows))]
 fn update_instruction() -> &'static str {
     "Run `zedra update`."
 }

--- a/crates/zedra-host/src/paths.rs
+++ b/crates/zedra-host/src/paths.rs
@@ -1,0 +1,61 @@
+use std::path::{Path, PathBuf};
+
+/// Convert Windows verbatim paths like `\\?\C:\repo` back to normal user paths.
+///
+/// `std::fs::canonicalize` can return verbatim paths on Windows. They are useful
+/// for Win32 APIs, but PowerShell shows them as provider paths in prompts.
+pub fn user_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        return windows_user_path(path);
+    }
+
+    #[cfg(not(windows))]
+    {
+        path.to_path_buf()
+    }
+}
+
+#[cfg(any(windows, test))]
+fn windows_user_path(path: &Path) -> PathBuf {
+    let path_text = path.to_string_lossy();
+    if let Some(stripped) = path_text.strip_prefix(r"\\?\UNC\") {
+        PathBuf::from(format!(r"\\{stripped}"))
+    } else if let Some(stripped) = path_text.strip_prefix(r"\\?\") {
+        PathBuf::from(stripped)
+    } else {
+        path.to_path_buf()
+    }
+}
+
+pub fn user_path_string(path: &Path) -> String {
+    user_path(path).to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_windows_verbatim_drive_prefix() {
+        assert_eq!(
+            windows_user_path(Path::new(r"\\?\C:\Users\zedra\zedra")),
+            PathBuf::from(r"C:\Users\zedra\zedra")
+        );
+    }
+
+    #[test]
+    fn strips_windows_verbatim_unc_prefix() {
+        assert_eq!(
+            windows_user_path(Path::new(r"\\?\UNC\server\share\repo")),
+            PathBuf::from(r"\\server\share\repo")
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn user_path_is_noop_off_windows() {
+        let path = Path::new("/tmp/repo");
+        assert_eq!(user_path(path), PathBuf::from("/tmp/repo"));
+    }
+}

--- a/crates/zedra-host/src/pty.rs
+++ b/crates/zedra-host/src/pty.rs
@@ -23,6 +23,7 @@ pub struct SpawnOptions {
     pub launch_cmd: Option<String>,
 }
 
+#[cfg(not(windows))]
 fn launch_script(launch_cmd: &str) -> String {
     format!("{launch_cmd}\nexec \"$SHELL\" -l")
 }
@@ -43,18 +44,9 @@ impl ShellSession {
             .openpty(pty_size)
             .map_err(|e| anyhow::anyhow!("Failed to open PTY: {}", e))?;
 
-        // Determine shell to use
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
-
+        let shell = default_shell();
         let mut cmd = CommandBuilder::new(&shell);
-        if let Some(launch_cmd) = &opts.launch_cmd {
-            // Avoid typing into the PTY before the shell has drawn its prompt.
-            cmd.arg("-l");
-            cmd.arg("-c");
-            cmd.arg(launch_script(launch_cmd));
-        } else {
-            cmd.arg("-l"); // Login shell
-        }
+        configure_shell_command(&mut cmd, opts.launch_cmd.as_deref());
 
         // Start in the session working directory if provided.
         if let Some(dir) = &opts.workdir {
@@ -64,23 +56,12 @@ impl ShellSession {
         // Build a sanitized environment: start clean, allow only safe variables.
         // This prevents daemon secrets (AWS keys, tokens, etc.) from leaking into shells.
         cmd.env_clear();
-        let allowed = [
-            "HOME",
-            "PATH",
-            "SHELL",
-            "TERM",
-            "LANG",
-            "USER",
-            "LOGNAME",
-            "COLORTERM",
-            "XDG_RUNTIME_DIR",
-        ];
-        for key in &allowed {
+        for key in allowed_env_vars() {
             if let Ok(val) = std::env::var(key) {
                 cmd.env(key, val);
             }
         }
-        cmd.env("SHELL", &shell);
+        set_shell_env(&mut cmd, &shell);
         // Always set a known-good TERM; override any inherited value.
         cmd.env("TERM", "xterm-256color");
         cmd.env("COLORTERM", "truecolor");
@@ -122,10 +103,91 @@ impl ShellSession {
     }
 }
 
+#[cfg(windows)]
+fn default_shell() -> String {
+    std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+}
+
+#[cfg(not(windows))]
+fn default_shell() -> String {
+    std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string())
+}
+
+#[cfg(windows)]
+fn configure_shell_command(cmd: &mut CommandBuilder, launch_cmd: Option<&str>) {
+    cmd.arg("/d");
+    if let Some(launch_cmd) = launch_cmd.filter(|command| !command.is_empty()) {
+        cmd.arg("/k");
+        cmd.arg(launch_cmd);
+    }
+}
+
+#[cfg(not(windows))]
+fn configure_shell_command(cmd: &mut CommandBuilder, launch_cmd: Option<&str>) {
+    if let Some(launch_cmd) = launch_cmd.filter(|command| !command.is_empty()) {
+        // Avoid typing into the PTY before the shell has drawn its prompt.
+        cmd.arg("-l");
+        cmd.arg("-c");
+        cmd.arg(launch_script(launch_cmd));
+    } else {
+        cmd.arg("-l"); // Login shell
+    }
+}
+
+#[cfg(windows)]
+fn allowed_env_vars() -> &'static [&'static str] {
+    &[
+        "APPDATA",
+        "COMSPEC",
+        "ComSpec",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "LANG",
+        "LOCALAPPDATA",
+        "PATH",
+        "PATHEXT",
+        "Path",
+        "ProgramFiles",
+        "SystemRoot",
+        "TEMP",
+        "TMP",
+        "USERNAME",
+        "USERPROFILE",
+        "WINDIR",
+    ]
+}
+
+#[cfg(not(windows))]
+fn allowed_env_vars() -> &'static [&'static str] {
+    &[
+        "HOME",
+        "PATH",
+        "SHELL",
+        "TERM",
+        "LANG",
+        "USER",
+        "LOGNAME",
+        "COLORTERM",
+        "XDG_RUNTIME_DIR",
+    ]
+}
+
+#[cfg(windows)]
+fn set_shell_env(cmd: &mut CommandBuilder, shell: &str) {
+    cmd.env("COMSPEC", shell);
+    cmd.env("ComSpec", shell);
+}
+
+#[cfg(not(windows))]
+fn set_shell_env(cmd: &mut CommandBuilder, shell: &str) {
+    cmd.env("SHELL", shell);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(not(windows))]
     #[test]
     fn launch_script_runs_command_before_interactive_shell() {
         assert_eq!(
@@ -134,6 +196,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn launch_command_runs_without_typed_echo() {
         let session = ShellSession::spawn(

--- a/crates/zedra-host/src/pty.rs
+++ b/crates/zedra-host/src/pty.rs
@@ -23,7 +23,6 @@ pub struct SpawnOptions {
     pub launch_cmd: Option<String>,
 }
 
-#[cfg(not(windows))]
 fn launch_script(launch_cmd: &str) -> String {
     format!("{launch_cmd}\nexec \"$SHELL\" -l")
 }
@@ -46,7 +45,7 @@ impl ShellSession {
 
         let shell = default_shell();
         let mut cmd = CommandBuilder::new(&shell);
-        configure_shell_command(&mut cmd, opts.launch_cmd.as_deref());
+        configure_shell_command(&mut cmd, &shell, opts.launch_cmd.as_deref())?;
 
         // Start in the session working directory if provided.
         if let Some(dir) = &opts.workdir {
@@ -105,7 +104,8 @@ impl ShellSession {
 
 #[cfg(windows)]
 fn default_shell() -> String {
-    std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+    windows_shell_from_env(&["ZEDRA_SHELL", "SHELL", "COMSPEC", "ComSpec"])
+        .unwrap_or_else(|| "cmd.exe".to_string())
 }
 
 #[cfg(not(windows))]
@@ -114,16 +114,55 @@ fn default_shell() -> String {
 }
 
 #[cfg(windows)]
-fn configure_shell_command(cmd: &mut CommandBuilder, launch_cmd: Option<&str>) {
-    cmd.arg("/d");
-    if let Some(launch_cmd) = launch_cmd.filter(|command| !command.is_empty()) {
-        cmd.arg("/k");
-        cmd.arg(launch_cmd);
+fn shell_from_env(keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| {
+        std::env::var(key)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    })
+}
+
+#[cfg(windows)]
+fn windows_shell_from_env(keys: &[&str]) -> Option<String> {
+    shell_from_env(keys).map(|shell| normalize_windows_shell_path(&shell))
+}
+
+#[cfg(any(windows, test))]
+fn normalize_windows_shell_path(shell: &str) -> String {
+    if shell.starts_with('/') && !shell.starts_with("//") {
+        let file_name = shell
+            .rsplit('/')
+            .find(|part| !part.is_empty())
+            .unwrap_or(shell);
+        if file_name.contains('.') {
+            file_name.to_string()
+        } else {
+            format!("{file_name}.exe")
+        }
+    } else {
+        shell.to_string()
     }
 }
 
+#[cfg(windows)]
+fn configure_shell_command(
+    cmd: &mut CommandBuilder,
+    shell: &str,
+    launch_cmd: Option<&str>,
+) -> Result<()> {
+    for arg in windows_shell_args(shell, launch_cmd)? {
+        cmd.arg(arg);
+    }
+    Ok(())
+}
+
 #[cfg(not(windows))]
-fn configure_shell_command(cmd: &mut CommandBuilder, launch_cmd: Option<&str>) {
+fn configure_shell_command(
+    cmd: &mut CommandBuilder,
+    _shell: &str,
+    launch_cmd: Option<&str>,
+) -> Result<()> {
     if let Some(launch_cmd) = launch_cmd.filter(|command| !command.is_empty()) {
         // Avoid typing into the PTY before the shell has drawn its prompt.
         cmd.arg("-l");
@@ -131,6 +170,80 @@ fn configure_shell_command(cmd: &mut CommandBuilder, launch_cmd: Option<&str>) {
         cmd.arg(launch_script(launch_cmd));
     } else {
         cmd.arg("-l"); // Login shell
+    }
+    Ok(())
+}
+
+#[cfg(any(windows, test))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WindowsShellKind {
+    Cmd,
+    PowerShell,
+    Posix,
+    Unknown,
+}
+
+#[cfg(any(windows, test))]
+fn windows_shell_args(shell: &str, launch_cmd: Option<&str>) -> Result<Vec<String>> {
+    let launch_cmd = launch_cmd.filter(|command| !command.is_empty());
+
+    match windows_shell_kind(shell) {
+        WindowsShellKind::Cmd => {
+            let mut args = vec!["/d".to_string()];
+            if let Some(launch_cmd) = launch_cmd {
+                args.push("/k".to_string());
+                args.push(launch_cmd.to_string());
+            }
+            Ok(args)
+        }
+        WindowsShellKind::PowerShell => {
+            let mut args = vec!["-NoLogo".to_string()];
+            if let Some(launch_cmd) = launch_cmd {
+                args.push("-NoExit".to_string());
+                args.push("-Command".to_string());
+                args.push(launch_cmd.to_string());
+            }
+            Ok(args)
+        }
+        WindowsShellKind::Posix => {
+            let mut args = vec!["-l".to_string()];
+            if let Some(launch_cmd) = launch_cmd {
+                args.push("-c".to_string());
+                args.push(launch_script(launch_cmd));
+            }
+            Ok(args)
+        }
+        WindowsShellKind::Unknown => {
+            if launch_cmd.is_some() {
+                anyhow::bail!(
+                    "launch commands are not supported for Windows shell `{}`; \
+                     set ZEDRA_SHELL to cmd.exe, pwsh.exe, powershell.exe, or bash.exe",
+                    shell
+                );
+            }
+            Ok(Vec::new())
+        }
+    }
+}
+
+#[cfg(any(windows, test))]
+fn windows_shell_kind(shell: &str) -> WindowsShellKind {
+    let file_name = shell
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(shell)
+        .to_ascii_lowercase();
+    let stem = file_name
+        .strip_suffix(".exe")
+        .or_else(|| file_name.strip_suffix(".cmd"))
+        .or_else(|| file_name.strip_suffix(".bat"))
+        .unwrap_or(&file_name);
+
+    match stem {
+        "cmd" => WindowsShellKind::Cmd,
+        "pwsh" | "powershell" => WindowsShellKind::PowerShell,
+        "bash" | "sh" | "zsh" | "fish" => WindowsShellKind::Posix,
+        _ => WindowsShellKind::Unknown,
     }
 }
 
@@ -151,6 +264,7 @@ fn allowed_env_vars() -> &'static [&'static str] {
         "SystemRoot",
         "TEMP",
         "TMP",
+        "SHELL",
         "USERNAME",
         "USERPROFILE",
         "WINDIR",
@@ -174,8 +288,11 @@ fn allowed_env_vars() -> &'static [&'static str] {
 
 #[cfg(windows)]
 fn set_shell_env(cmd: &mut CommandBuilder, shell: &str) {
-    cmd.env("COMSPEC", shell);
-    cmd.env("ComSpec", shell);
+    cmd.env("SHELL", shell);
+    if windows_shell_kind(shell) == WindowsShellKind::Cmd {
+        cmd.env("COMSPEC", shell);
+        cmd.env("ComSpec", shell);
+    }
 }
 
 #[cfg(not(windows))]
@@ -187,13 +304,54 @@ fn set_shell_env(cmd: &mut CommandBuilder, shell: &str) {
 mod tests {
     use super::*;
 
-    #[cfg(not(windows))]
     #[test]
     fn launch_script_runs_command_before_interactive_shell() {
         assert_eq!(
             launch_script("echo ready"),
             "echo ready\nexec \"$SHELL\" -l"
         );
+    }
+
+    #[test]
+    fn windows_shell_kind_matches_common_shell_names() {
+        assert_eq!(windows_shell_kind("cmd.exe"), WindowsShellKind::Cmd);
+        assert_eq!(windows_shell_kind("/usr/bin/bash"), WindowsShellKind::Posix);
+        assert_eq!(
+            windows_shell_kind(r"C:\Program Files\PowerShell\7\pwsh.exe"),
+            WindowsShellKind::PowerShell
+        );
+        assert_eq!(
+            windows_shell_kind(r"C:\Program Files\Git\bin\bash.exe"),
+            WindowsShellKind::Posix
+        );
+        assert_eq!(windows_shell_kind("nu.exe"), WindowsShellKind::Unknown);
+    }
+
+    #[test]
+    fn windows_shell_normalizes_posix_paths_for_win32_spawn() {
+        assert_eq!(normalize_windows_shell_path("/usr/bin/bash"), "bash.exe");
+        assert_eq!(normalize_windows_shell_path("/bin/zsh"), "zsh.exe");
+        assert_eq!(
+            normalize_windows_shell_path(r"C:\Program Files\Git\bin\bash.exe"),
+            r"C:\Program Files\Git\bin\bash.exe"
+        );
+    }
+
+    #[test]
+    fn windows_shell_args_match_shell_family() {
+        assert_eq!(
+            windows_shell_args("cmd.exe", Some("echo ready")).unwrap(),
+            vec!["/d", "/k", "echo ready"]
+        );
+        assert_eq!(
+            windows_shell_args("pwsh.exe", Some("Write-Host ready")).unwrap(),
+            vec!["-NoLogo", "-NoExit", "-Command", "Write-Host ready"]
+        );
+        assert_eq!(
+            windows_shell_args(r"C:\Program Files\Git\bin\bash.exe", Some("echo ready")).unwrap(),
+            vec!["-l", "-c", "echo ready\nexec \"$SHELL\" -l"]
+        );
+        assert!(windows_shell_args("nu.exe", Some("echo ready")).is_err());
     }
 
     #[cfg(not(windows))]

--- a/crates/zedra-host/src/pty.rs
+++ b/crates/zedra-host/src/pty.rs
@@ -104,7 +104,11 @@ impl ShellSession {
 
 #[cfg(windows)]
 fn default_shell() -> String {
-    windows_shell_from_env(&["ZEDRA_SHELL", "SHELL", "COMSPEC", "ComSpec"])
+    windows_shell_from_env(&["ZEDRA_SHELL"])
+        .or_else(|| windows_shell_from_env(&["ZEDRA_LAUNCH_SHELL"]))
+        .or_else(detect_parent_shell)
+        .or_else(|| windows_shell_from_env(&["SHELL"]))
+        .or_else(|| windows_shell_from_env(&["COMSPEC", "ComSpec"]))
         .unwrap_or_else(|| "cmd.exe".to_string())
 }
 
@@ -126,6 +130,45 @@ fn shell_from_env(keys: &[&str]) -> Option<String> {
 #[cfg(windows)]
 fn windows_shell_from_env(keys: &[&str]) -> Option<String> {
     shell_from_env(keys).map(|shell| normalize_windows_shell_path(&shell))
+}
+
+#[cfg(windows)]
+pub fn detect_parent_shell() -> Option<String> {
+    detect_parent_shell_for_pid(std::process::id())
+}
+
+#[cfg(windows)]
+fn detect_parent_shell_for_pid(pid: u32) -> Option<String> {
+    use sysinfo::{Pid, System};
+
+    let system = System::new_all();
+    let mut current_pid = Pid::from_u32(pid);
+
+    for _ in 0..8 {
+        let parent_pid = system.process(current_pid)?.parent()?;
+        let parent = system.process(parent_pid)?;
+        if let Some(shell) = shell_from_process_names(
+            parent.exe().and_then(|path| path.to_str()),
+            parent.name().to_str(),
+        ) {
+            return Some(shell);
+        }
+        current_pid = parent_pid;
+    }
+
+    None
+}
+
+#[cfg(any(windows, test))]
+fn shell_from_process_names(exe: Option<&str>, name: Option<&str>) -> Option<String> {
+    exe.and_then(shell_from_process_name)
+        .or_else(|| name.and_then(shell_from_process_name))
+}
+
+#[cfg(any(windows, test))]
+fn shell_from_process_name(process_name: &str) -> Option<String> {
+    (windows_shell_kind(process_name) != WindowsShellKind::Unknown)
+        .then(|| normalize_windows_shell_path(process_name))
 }
 
 #[cfg(any(windows, test))]
@@ -335,6 +378,22 @@ mod tests {
             normalize_windows_shell_path(r"C:\Program Files\Git\bin\bash.exe"),
             r"C:\Program Files\Git\bin\bash.exe"
         );
+    }
+
+    #[test]
+    fn windows_shell_uses_detected_process_path_before_name() {
+        assert_eq!(
+            shell_from_process_names(
+                Some(r"C:\Program Files\PowerShell\7\pwsh.exe"),
+                Some("WindowsTerminal.exe"),
+            ),
+            Some(r"C:\Program Files\PowerShell\7\pwsh.exe".to_string())
+        );
+        assert_eq!(
+            shell_from_process_names(None, Some("powershell.exe")),
+            Some("powershell.exe".to_string())
+        );
+        assert_eq!(shell_from_process_names(None, Some("cargo.exe")), None);
     }
 
     #[test]

--- a/crates/zedra-host/src/pty.rs
+++ b/crates/zedra-host/src/pty.rs
@@ -1,6 +1,7 @@
 // PTY spawning for shell sessions
 // Uses portable-pty for cross-platform PTY support
 
+use crate::paths;
 use anyhow::Result;
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use std::io::{Read, Write};
@@ -49,7 +50,7 @@ impl ShellSession {
 
         // Start in the session working directory if provided.
         if let Some(dir) = &opts.workdir {
-            cmd.cwd(dir);
+            cmd.cwd(paths::user_path(dir));
         }
 
         // Build a sanitized environment: start clean, allow only safe variables.

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -46,10 +46,25 @@ fn collect_host_env(workdir: &std::path::Path) -> HostEnvInfo {
             .ok()
             .and_then(|h| h.into_string().ok())
             .unwrap_or_else(|| "unknown".to_string()),
-        username: std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
+        username: current_username(),
         workdir: workdir.to_string_lossy().into_owned(),
-        home_dir: std::env::var("HOME").ok(),
+        home_dir: current_home_dir(),
     }
+}
+
+fn current_username() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn current_home_dir() -> Option<String> {
+    std::env::var("HOME")
+        .ok()
+        .or_else(|| std::env::var("USERPROFILE").ok())
+        .or_else(|| {
+            directories::BaseDirs::new().map(|base| base.home_dir().to_string_lossy().into_owned())
+        })
 }
 
 async fn build_sync_result(

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -15,6 +15,7 @@ use crate::git::GitRepo;
 use crate::host_info;
 use crate::identity::SharedIdentity;
 use crate::metrics;
+use crate::paths;
 use crate::pty::{ShellSession, SpawnOptions};
 use crate::session_registry::{
     ActiveClientConnection, AttachResult, ConsumeSlotResult, HostShellState, HostTermMeta,
@@ -47,7 +48,7 @@ fn collect_host_env(workdir: &std::path::Path) -> HostEnvInfo {
             .and_then(|h| h.into_string().ok())
             .unwrap_or_else(|| "unknown".to_string()),
         username: current_username(),
-        workdir: workdir.to_string_lossy().into_owned(),
+        workdir: paths::user_path_string(workdir),
         home_dir: current_home_dir(),
     }
 }
@@ -166,7 +167,7 @@ fn initial_host_meta(opts: &SpawnOptions) -> HostTermMeta {
     meta.cwd = opts
         .workdir
         .as_ref()
-        .map(|path| path.to_string_lossy().into_owned());
+        .map(|path| paths::user_path_string(path));
     if let Some(command) = opts
         .launch_cmd
         .as_ref()

--- a/crates/zedra-host/src/version_check.rs
+++ b/crates/zedra-host/src/version_check.rs
@@ -107,12 +107,13 @@ const WINDOWS_UPDATE_SCRIPT: &str = r#"param(
 $ErrorActionPreference = "Stop"
 Wait-Process -Id $ParentPid -ErrorAction SilentlyContinue
 
-$backup = "$Destination.old"
-Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
-Move-Item -LiteralPath $Destination -Destination $backup -Force
-
+$backup = "$Destination.old.$([Guid]::NewGuid().ToString("N"))"
 try {
+    Move-Item -LiteralPath $Destination -Destination $backup -Force
     Copy-Item -LiteralPath $Source -Destination $Destination -Force
+
+    # Running daemons can keep the renamed image locked, so old backups are
+    # intentionally best-effort cleanup. Ref: https://docs.rs/self-replace/latest/self_replace/#implementation
     Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
 } catch {
     if ((Test-Path -LiteralPath $backup) -and -not (Test-Path -LiteralPath $Destination)) {

--- a/crates/zedra-host/src/version_check.rs
+++ b/crates/zedra-host/src/version_check.rs
@@ -22,6 +22,12 @@ pub async fn check_latest_version() -> Result<Option<String>> {
 
 /// Download the specified release and replace the current binary.
 pub async fn self_update(tag: &str) -> Result<String> {
+    #[cfg(windows)]
+    {
+        let _ = tag;
+        bail!("self-update is not supported on Windows yet. Re-run the installer: irm https://zedra.dev/install.ps1 | iex");
+    }
+
     let tag = tag.to_string();
 
     let platform = detect_platform()?;
@@ -159,6 +165,7 @@ fn detect_platform() -> Result<String> {
     let os = match os {
         "macos" => "apple-darwin",
         "linux" => "unknown-linux-gnu",
+        "windows" => "pc-windows-msvc",
         other => bail!("unsupported OS: {other}"),
     };
 
@@ -205,6 +212,10 @@ mod tests {
     fn test_detect_platform() {
         // Should not fail on the current platform
         let p = detect_platform().unwrap();
-        assert!(p.contains("apple-darwin") || p.contains("unknown-linux-gnu"));
+        assert!(
+            p.contains("apple-darwin")
+                || p.contains("unknown-linux-gnu")
+                || p.contains("pc-windows-msvc")
+        );
     }
 }

--- a/crates/zedra-host/src/version_check.rs
+++ b/crates/zedra-host/src/version_check.rs
@@ -5,6 +5,8 @@
 
 use crate::utils;
 use anyhow::{bail, Context, Result};
+use std::path::Path;
+
 const REPO: &str = "tanlethanh/zedra";
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -22,12 +24,6 @@ pub async fn check_latest_version() -> Result<Option<String>> {
 
 /// Download the specified release and replace the current binary.
 pub async fn self_update(tag: &str) -> Result<String> {
-    #[cfg(windows)]
-    {
-        let _ = tag;
-        bail!("self-update is not supported on Windows yet. Re-run the installer: irm https://zedra.dev/install.ps1 | iex");
-    }
-
     let tag = tag.to_string();
 
     let platform = detect_platform()?;
@@ -84,48 +80,169 @@ pub async fn self_update(tag: &str) -> Result<String> {
     let mut archive = tar::Archive::new(decoder);
     archive.unpack(tmp_dir.path())?;
 
-    let extracted = tmp_dir.path().join("zedra");
+    let extracted = tmp_dir.path().join(binary_name());
     if !extracted.exists() {
-        bail!("archive did not contain 'zedra' binary");
+        bail!("archive did not contain '{}' binary", binary_name());
     }
 
-    // Replace current binary via atomic rename
     let current_exe =
         std::env::current_exe().context("cannot determine current executable path")?;
     let current_exe = current_exe
         .canonicalize()
         .unwrap_or_else(|_| current_exe.clone());
 
-    // On macOS/Linux: rename the old binary out of the way, move new one in,
-    // then delete old. This avoids "text file busy" on some systems.
+    replace_current_binary(&extracted, &current_exe, tmp_dir)?;
+
+    Ok(tag)
+}
+
+#[cfg(windows)]
+const WINDOWS_UPDATE_SCRIPT: &str = r#"param(
+    [int]$ParentPid,
+    [string]$Source,
+    [string]$Destination,
+    [string]$StagingDir
+)
+
+$ErrorActionPreference = "Stop"
+Wait-Process -Id $ParentPid -ErrorAction SilentlyContinue
+
+$backup = "$Destination.old"
+Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
+Move-Item -LiteralPath $Destination -Destination $backup -Force
+
+try {
+    Copy-Item -LiteralPath $Source -Destination $Destination -Force
+    Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
+} catch {
+    if ((Test-Path -LiteralPath $backup) -and -not (Test-Path -LiteralPath $Destination)) {
+        Move-Item -LiteralPath $backup -Destination $Destination -Force
+    }
+    throw
+} finally {
+    Remove-Item -LiteralPath $StagingDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+"#;
+
+fn binary_name() -> &'static str {
+    if cfg!(windows) {
+        "zedra.exe"
+    } else {
+        "zedra"
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_current_binary(
+    extracted: &Path,
+    current_exe: &Path,
+    _tmp_dir: tempfile::TempDir,
+) -> Result<()> {
+    // Rename the old binary out of the way, move new one in, then delete old.
+    // This avoids "text file busy" on some systems.
     let backup = current_exe.with_extension("old");
     if backup.exists() {
         let _ = std::fs::remove_file(&backup);
     }
-    std::fs::rename(&current_exe, &backup).with_context(|| {
+    std::fs::rename(current_exe, &backup).with_context(|| {
         format!(
             "failed to rename current binary at {}",
             current_exe.display()
         )
     })?;
-    match std::fs::copy(&extracted, &current_exe) {
+    match std::fs::copy(extracted, current_exe) {
         Ok(_) => {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
                 let _ =
-                    std::fs::set_permissions(&current_exe, std::fs::Permissions::from_mode(0o755));
+                    std::fs::set_permissions(current_exe, std::fs::Permissions::from_mode(0o755));
             }
             let _ = std::fs::remove_file(&backup);
         }
         Err(e) => {
             // Rollback
-            let _ = std::fs::rename(&backup, &current_exe);
+            let _ = std::fs::rename(&backup, current_exe);
             bail!("failed to install new binary: {e}");
         }
     }
 
-    Ok(tag)
+    Ok(())
+}
+
+#[cfg(windows)]
+fn replace_current_binary(
+    extracted: &Path,
+    current_exe: &Path,
+    tmp_dir: tempfile::TempDir,
+) -> Result<()> {
+    assert_parent_writable(current_exe)?;
+
+    let script_path = tmp_dir.path().join("finish-update.ps1");
+    std::fs::write(&script_path, WINDOWS_UPDATE_SCRIPT)
+        .context("failed to write Windows update helper")?;
+
+    let staging_dir = tmp_dir.keep();
+    let spawn_result =
+        spawn_windows_update_helper(&script_path, extracted, current_exe, &staging_dir);
+    if let Err(err) = spawn_result {
+        let _ = std::fs::remove_dir_all(&staging_dir);
+        return Err(err);
+    }
+
+    utils::eprintln_note("Windows will finish replacing zedra.exe after this command exits.");
+    Ok(())
+}
+
+#[cfg(windows)]
+fn assert_parent_writable(current_exe: &Path) -> Result<()> {
+    let parent = current_exe
+        .parent()
+        .context("cannot determine current executable directory")?;
+    let probe = parent.join(format!(".zedra-update-write-test-{}", std::process::id()));
+    std::fs::write(&probe, b"zedra")
+        .with_context(|| format!("install directory is not writable: {}", parent.display()))?;
+    let _ = std::fs::remove_file(&probe);
+    Ok(())
+}
+
+#[cfg(windows)]
+fn spawn_windows_update_helper(
+    script_path: &Path,
+    extracted: &Path,
+    current_exe: &Path,
+    staging_dir: &Path,
+) -> Result<()> {
+    let parent_pid = std::process::id().to_string();
+    let mut last_error = None;
+    for shell in ["powershell.exe", "pwsh.exe"] {
+        let result = std::process::Command::new(shell)
+            .arg("-NoProfile")
+            .arg("-ExecutionPolicy")
+            .arg("Bypass")
+            .arg("-File")
+            .arg(script_path)
+            .arg(parent_pid.as_str())
+            .arg(extracted)
+            .arg(current_exe)
+            .arg(staging_dir)
+            .spawn();
+
+        match result {
+            Ok(_) => return Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                last_error = Some(err);
+            }
+            Err(err) => {
+                return Err(err).with_context(|| format!("failed to start {shell}"));
+            }
+        }
+    }
+
+    match last_error {
+        Some(err) => Err(err).context("failed to start PowerShell for Windows self-update"),
+        None => bail!("failed to start PowerShell for Windows self-update"),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -217,5 +334,14 @@ mod tests {
                 || p.contains("unknown-linux-gnu")
                 || p.contains("pc-windows-msvc")
         );
+    }
+
+    #[test]
+    fn test_binary_name_matches_platform() {
+        if cfg!(windows) {
+            assert_eq!(binary_name(), "zedra.exe");
+        } else {
+            assert_eq!(binary_name(), "zedra");
+        }
     }
 }

--- a/crates/zedra-host/src/workspace_lock.rs
+++ b/crates/zedra-host/src/workspace_lock.rs
@@ -1,7 +1,7 @@
 // workspace_lock.rs — PID lock file to prevent duplicate zedra-host instances
 // on the same workspace directory.
 //
-// Lock file: ~/.config/zedra/workspaces/<hash>/daemon.lock
+// Lock file: <platform config>/zedra/workspaces/<hash>/daemon.lock
 // Contains:  JSON with PID, workdir path, hostname, and start timestamp.
 //
 // Acquire semantics:
@@ -13,12 +13,15 @@
 //
 // Stop command (`kill_and_unlock`):
 //   - Reads the lock file for the given workdir.
-//   - Sends SIGTERM; polls up to 5 s; escalates to SIGKILL if needed.
+//   - On Unix, sends SIGTERM; polls up to the grace period; escalates to SIGKILL.
+//   - On Windows, terminates the process if the local shutdown API did not work.
 //   - Removes the lock file.
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+
+use crate::identity;
 
 // ---------------------------------------------------------------------------
 // Lock metadata
@@ -140,18 +143,13 @@ pub fn acquire(workdir: &Path) -> Result<WorkspaceLock> {
     Ok(WorkspaceLock { path: lock_path })
 }
 
-/// Scan all workspace config directories under `~/.config/zedra/workspaces/`
+/// Scan all workspace config directories under Zedra's platform config root
 /// and return every instance that has a lock file, along with whether its
 /// process is still alive and the path to its config directory.
 pub fn scan_all_instances() -> Vec<(PathBuf, LockInfo, bool)> {
-    let workspaces_dir = match (|| -> Option<PathBuf> {
-        let home = std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .or_else(|| directories::BaseDirs::new().map(|b| b.home_dir().to_path_buf()))?;
-        Some(home.join(".config").join("zedra").join("workspaces"))
-    })() {
-        Some(d) => d,
-        None => return Vec::new(),
+    let workspaces_dir = match identity::zedra_config_dir() {
+        Ok(dir) => dir.join("workspaces"),
+        Err(_) => return Vec::new(),
     };
 
     let entries = match std::fs::read_dir(&workspaces_dir) {
@@ -187,12 +185,11 @@ pub fn read_lock_info(workdir: &Path) -> Result<Option<LockInfo>> {
 /// Stop the daemon owning `workdir`'s lock.
 ///
 /// 1. Reads the lock file to get the PID and confirm it is alive.
-/// 2. Sends SIGTERM and waits up to `grace_secs` for a clean exit.
-/// 3. Sends SIGKILL if the process is still running after the grace period.
+/// 2. Sends the platform stop request and waits up to `grace_secs`.
+/// 3. Escalates if the process is still running after the grace period.
 /// 4. Removes the lock file.
 ///
 /// Returns an error if there is no lock file or the process cannot be stopped.
-#[cfg(unix)]
 pub fn kill_and_unlock(workdir: &Path, grace_secs: u64) -> Result<()> {
     let lock_path = lock_file_path(workdir)?;
 
@@ -212,13 +209,7 @@ pub fn kill_and_unlock(workdir: &Path, grace_secs: u64) -> Result<()> {
         return Ok(());
     }
 
-    tracing::info!(
-        "Sending SIGTERM to PID {} (workdir: {}, started: {})",
-        info.pid,
-        info.workdir,
-        info.running_for()
-    );
-    send_signal(info.pid, libc::SIGTERM)?;
+    request_process_exit(&info)?;
 
     // Poll for clean exit.
     let poll_interval = std::time::Duration::from_millis(200);
@@ -232,13 +223,7 @@ pub fn kill_and_unlock(workdir: &Path, grace_secs: u64) -> Result<()> {
         }
     }
 
-    // Grace period expired — escalate to SIGKILL.
-    tracing::warn!(
-        "Process {} did not exit after {}s; sending SIGKILL.",
-        info.pid,
-        grace_secs
-    );
-    send_signal(info.pid, libc::SIGKILL)?;
+    escalate_process_exit(info.pid, grace_secs)?;
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = std::fs::remove_file(&lock_path);
 
@@ -250,36 +235,17 @@ pub fn kill_and_unlock(workdir: &Path, grace_secs: u64) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub fn kill_and_unlock(_workdir: &Path, _grace_secs: u64) -> Result<()> {
-    anyhow::bail!("'zedra stop' is not supported on this platform.");
-}
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Path: `~/.config/zedra/workspaces/<hash>/daemon.lock`
+/// Path: `<platform config>/zedra/workspaces/<hash>/daemon.lock`
 fn lock_file_path(workdir: &Path) -> Result<PathBuf> {
-    let home = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .or_else(|| directories::BaseDirs::new().map(|b| b.home_dir().to_path_buf()))
-        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
-    let config = home.join(".config").join("zedra");
-    let hash = path_hash(workdir);
-    let path = config.join("workspaces").join(&hash).join("daemon.lock");
+    let path = identity::workspace_config_dir(workdir)?.join("daemon.lock");
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     Ok(path)
-}
-
-/// Same 16-hex-char hash used by `identity.rs` for the workspace directory.
-fn path_hash(workdir: &Path) -> String {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    workdir.to_string_lossy().hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
 }
 
 /// Try to create the lock file atomically; fail if it already exists.
@@ -320,10 +286,66 @@ pub fn is_process_alive(pid: u32) -> bool {
     errno == libc::EPERM
 }
 
-#[cfg(not(unix))]
+#[cfg(all(not(unix), not(windows)))]
 pub fn is_process_alive(pid: u32) -> bool {
     let _ = pid;
     true
+}
+
+/// Send a graceful process exit request.
+#[cfg(unix)]
+fn request_process_exit(info: &LockInfo) -> Result<()> {
+    tracing::info!(
+        "Sending SIGTERM to PID {} (workdir: {}, started: {})",
+        info.pid,
+        info.workdir,
+        info.running_for()
+    );
+    send_signal(info.pid, libc::SIGTERM)
+}
+
+#[cfg(windows)]
+fn request_process_exit(info: &LockInfo) -> Result<()> {
+    // `zedra stop` tries the authenticated local shutdown API before this
+    // fallback. Windows has no Unix-style SIGTERM, so the fallback is terminate.
+    tracing::warn!(
+        "Terminating PID {} (workdir: {}, started: {})",
+        info.pid,
+        info.workdir,
+        info.running_for()
+    );
+    terminate_process(info.pid)
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn request_process_exit(_info: &LockInfo) -> Result<()> {
+    anyhow::bail!("'zedra stop' is not supported on this platform.");
+}
+
+/// Escalate when graceful stop did not exit within the grace period.
+#[cfg(unix)]
+fn escalate_process_exit(pid: u32, grace_secs: u64) -> Result<()> {
+    tracing::warn!(
+        "Process {} did not exit after {}s; sending SIGKILL.",
+        pid,
+        grace_secs
+    );
+    send_signal(pid, libc::SIGKILL)
+}
+
+#[cfg(windows)]
+fn escalate_process_exit(pid: u32, grace_secs: u64) -> Result<()> {
+    tracing::warn!(
+        "Process {} did not exit after {}s; terminating again.",
+        pid,
+        grace_secs
+    );
+    terminate_process(pid)
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn escalate_process_exit(_pid: u32, _grace_secs: u64) -> Result<()> {
+    anyhow::bail!("'zedra stop' is not supported on this platform.");
 }
 
 /// Send a signal to a process.
@@ -334,5 +356,51 @@ fn send_signal(pid: u32, signal: libc::c_int) -> Result<()> {
         Ok(())
     } else {
         Err(std::io::Error::last_os_error()).context(format!("kill({}, {})", pid, signal))
+    }
+}
+
+#[cfg(windows)]
+pub fn is_process_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return false;
+        }
+
+        let mut exit_code = 0;
+        let ok = GetExitCodeProcess(handle, &mut exit_code) != 0;
+        let _ = CloseHandle(handle);
+        ok && exit_code == STILL_ACTIVE
+    }
+}
+
+#[cfg(windows)]
+fn terminate_process(pid: u32) -> Result<()> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, TerminateProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
+    };
+
+    unsafe {
+        let handle = OpenProcess(
+            PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION,
+            0,
+            pid,
+        );
+        if handle.is_null() {
+            return Err(std::io::Error::last_os_error()).context(format!("OpenProcess({pid})"));
+        }
+        let ok = TerminateProcess(handle, 0) != 0;
+        let _ = CloseHandle(handle);
+        if ok {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error()).context(format!("TerminateProcess({pid})"))
+        }
     }
 }

--- a/crates/zedra-host/src/workspace_lock.rs
+++ b/crates/zedra-host/src/workspace_lock.rs
@@ -102,6 +102,13 @@ pub fn acquire(workdir: &Path) -> Result<WorkspaceLock> {
     let lock_path = lock_file_path(workdir)?;
     let info = LockInfo::new(workdir);
 
+    for legacy_path in legacy_lock_file_candidates(workdir)? {
+        if let Some(existing) = read_lock_file(&legacy_path) {
+            ensure_lock_is_available(&legacy_path, &existing)?;
+            let _ = std::fs::remove_file(&legacy_path);
+        }
+    }
+
     // Attempt atomic creation first.
     if try_write_exclusive(&lock_path, &info).is_ok() {
         return Ok(WorkspaceLock { path: lock_path });
@@ -109,31 +116,7 @@ pub fn acquire(workdir: &Path) -> Result<WorkspaceLock> {
 
     // File already exists — check if owner is still alive.
     if let Some(existing) = read_lock_file(&lock_path) {
-        if is_process_alive(existing.pid) {
-            anyhow::bail!(
-                "zedra-host is already running for this workspace.\n\
-                 \n\
-                 \x20 PID:      {}\n\
-                 \x20 Workdir:  {}\n\
-                 \x20 Host:     {}\n\
-                 \x20 Started:  {}\n\
-                 \x20 Lock:     {}\n\
-                 \n\
-                 Run 'zedra stop --workdir {}' to stop it.",
-                existing.pid,
-                existing.workdir,
-                existing.hostname,
-                existing.running_for(),
-                lock_path.display(),
-                existing.workdir,
-            );
-        }
-        // Stale lock — previous instance died without cleanup.
-        tracing::warn!(
-            "Removing stale lock file (PID {} is no longer running, was serving {})",
-            existing.pid,
-            existing.workdir,
-        );
+        ensure_lock_is_available(&lock_path, &existing)?;
     }
 
     // Overwrite stale / unreadable lock with our metadata.
@@ -147,23 +130,31 @@ pub fn acquire(workdir: &Path) -> Result<WorkspaceLock> {
 /// and return every instance that has a lock file, along with whether its
 /// process is still alive and the path to its config directory.
 pub fn scan_all_instances() -> Vec<(PathBuf, LockInfo, bool)> {
-    let workspaces_dir = match identity::zedra_config_dir() {
+    let current_workspaces_dir = match identity::zedra_config_dir() {
         Ok(dir) => dir.join("workspaces"),
         Err(_) => return Vec::new(),
     };
-
-    let entries = match std::fs::read_dir(&workspaces_dir) {
-        Ok(e) => e,
-        Err(_) => return Vec::new(),
-    };
+    let mut workspaces_dirs = vec![current_workspaces_dir.clone()];
+    if let Ok(legacy_dir) = legacy_zedra_config_dir() {
+        let legacy_workspaces_dir = legacy_dir.join("workspaces");
+        if legacy_workspaces_dir != current_workspaces_dir {
+            workspaces_dirs.push(legacy_workspaces_dir);
+        }
+    }
 
     let mut result = Vec::new();
-    for entry in entries.flatten() {
-        let config_dir = entry.path();
-        let lock_path = config_dir.join("daemon.lock");
-        if let Some(info) = read_lock_file(&lock_path) {
-            let alive = is_process_alive(info.pid);
-            result.push((config_dir, info, alive));
+    for workspaces_dir in workspaces_dirs {
+        let entries = match std::fs::read_dir(&workspaces_dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let config_dir = entry.path();
+            let lock_path = config_dir.join("daemon.lock");
+            if let Some(info) = read_lock_file(&lock_path) {
+                let alive = is_process_alive(info.pid);
+                result.push((config_dir, info, alive));
+            }
         }
     }
 
@@ -175,11 +166,7 @@ pub fn scan_all_instances() -> Vec<(PathBuf, LockInfo, bool)> {
 /// Read the lock file metadata for a workspace without acquiring the lock.
 /// Returns `None` if no lock file exists or it cannot be parsed.
 pub fn read_lock_info(workdir: &Path) -> Result<Option<LockInfo>> {
-    let lock_path = lock_file_path(workdir)?;
-    if !lock_path.exists() {
-        return Ok(None);
-    }
-    Ok(read_lock_file(&lock_path))
+    Ok(read_lock_info_with_path(workdir)?.map(|(_, info)| info))
 }
 
 /// Stop the daemon owning `workdir`'s lock.
@@ -191,12 +178,12 @@ pub fn read_lock_info(workdir: &Path) -> Result<Option<LockInfo>> {
 ///
 /// Returns an error if there is no lock file or the process cannot be stopped.
 pub fn kill_and_unlock(workdir: &Path, grace_secs: u64) -> Result<()> {
-    let lock_path = lock_file_path(workdir)?;
+    let current_lock_path = current_lock_file_path(workdir)?;
 
-    let info = read_lock_file(&lock_path).ok_or_else(|| {
+    let (lock_path, info) = read_lock_info_with_path(workdir)?.ok_or_else(|| {
         anyhow::anyhow!(
             "No running zedra-host found for this workspace.\nLock file: {}",
-            lock_path.display()
+            current_lock_path.display()
         )
     })?;
 
@@ -241,11 +228,116 @@ pub fn kill_and_unlock(workdir: &Path, grace_secs: u64) -> Result<()> {
 
 /// Path: `<platform config>/zedra/workspaces/<hash>/daemon.lock`
 fn lock_file_path(workdir: &Path) -> Result<PathBuf> {
-    let path = identity::workspace_config_dir(workdir)?.join("daemon.lock");
+    let path = current_lock_file_path(workdir)?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     Ok(path)
+}
+
+fn current_lock_file_path(workdir: &Path) -> Result<PathBuf> {
+    Ok(identity::workspace_config_dir(workdir)?.join("daemon.lock"))
+}
+
+fn read_lock_info_with_path(workdir: &Path) -> Result<Option<(PathBuf, LockInfo)>> {
+    read_first_lock_file(lock_file_candidates(workdir)?)
+}
+
+fn read_first_lock_file(
+    paths: impl IntoIterator<Item = PathBuf>,
+) -> Result<Option<(PathBuf, LockInfo)>> {
+    let mut first_stale = None;
+    for path in paths {
+        if let Some(info) = read_lock_file(&path) {
+            if is_process_alive(info.pid) {
+                return Ok(Some((path, info)));
+            }
+            if first_stale.is_none() {
+                first_stale = Some((path, info));
+            }
+        }
+    }
+    Ok(first_stale)
+}
+
+fn lock_file_candidates(workdir: &Path) -> Result<Vec<PathBuf>> {
+    let current = current_lock_file_path(workdir)?;
+    let mut paths = vec![current.clone()];
+    for legacy_path in legacy_lock_file_candidates(workdir)? {
+        if legacy_path != current {
+            paths.push(legacy_path);
+        }
+    }
+    Ok(paths)
+}
+
+fn legacy_lock_file_candidates(workdir: &Path) -> Result<Vec<PathBuf>> {
+    let current = current_lock_file_path(workdir)?;
+    let legacy = match legacy_lock_file_path(workdir) {
+        Ok(path) => path,
+        Err(err) => {
+            tracing::debug!("Skipping legacy lock lookup: {}", err);
+            return Ok(Vec::new());
+        }
+    };
+    if legacy == current {
+        Ok(Vec::new())
+    } else {
+        Ok(vec![legacy])
+    }
+}
+
+fn legacy_lock_file_path(workdir: &Path) -> Result<PathBuf> {
+    Ok(legacy_zedra_config_dir()?
+        .join("workspaces")
+        .join(legacy_path_hash(workdir))
+        .join("daemon.lock"))
+}
+
+fn legacy_zedra_config_dir() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| directories::BaseDirs::new().map(|b| b.home_dir().to_path_buf()))
+        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+    Ok(home.join(".config").join("zedra"))
+}
+
+/// Previous releases wrote only the daemon lock under this DefaultHasher path.
+fn legacy_path_hash(workdir: &Path) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    workdir.to_string_lossy().hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn ensure_lock_is_available(lock_path: &Path, existing: &LockInfo) -> Result<()> {
+    if is_process_alive(existing.pid) {
+        anyhow::bail!(
+            "zedra-host is already running for this workspace.\n\
+             \n\
+             \x20 PID:      {}\n\
+             \x20 Workdir:  {}\n\
+             \x20 Host:     {}\n\
+             \x20 Started:  {}\n\
+             \x20 Lock:     {}\n\
+             \n\
+             Run 'zedra stop --workdir {}' to stop it.",
+            existing.pid,
+            existing.workdir,
+            existing.hostname,
+            existing.running_for(),
+            lock_path.display(),
+            existing.workdir,
+        );
+    }
+
+    tracing::warn!(
+        "Removing stale lock file {} (PID {} is no longer running, was serving {})",
+        lock_path.display(),
+        existing.pid,
+        existing.workdir,
+    );
+    Ok(())
 }
 
 /// Try to create the lock file atomically; fail if it already exists.
@@ -361,10 +453,13 @@ fn send_signal(pid: u32, signal: libc::c_int) -> Result<()> {
 
 #[cfg(windows)]
 pub fn is_process_alive(pid: u32) -> bool {
-    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::System::Threading::{
         GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
     };
+
+    // GetExitCodeProcess returns a DWORD; windows-sys's STILL_ACTIVE is NTSTATUS.
+    const STILL_ACTIVE_EXIT_CODE: u32 = 259;
 
     unsafe {
         let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
@@ -375,7 +470,75 @@ pub fn is_process_alive(pid: u32) -> bool {
         let mut exit_code = 0;
         let ok = GetExitCodeProcess(handle, &mut exit_code) != 0;
         let _ = CloseHandle(handle);
-        ok && exit_code == STILL_ACTIVE
+        ok && exit_code == STILL_ACTIVE_EXIT_CODE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_lock(path: &Path, pid: u32, workdir: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let info = LockInfo {
+            pid,
+            workdir: workdir.to_string(),
+            hostname: "test-host".to_string(),
+            started_secs: 1,
+        };
+        overwrite_lock(path, &info).unwrap();
+    }
+
+    #[test]
+    fn read_first_lock_file_falls_back_to_legacy_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let current = dir.path().join("current").join("daemon.lock");
+        let legacy = dir.path().join("legacy").join("daemon.lock");
+        write_lock(&legacy, 42, "/legacy");
+
+        let (path, info) = read_first_lock_file(vec![current, legacy.clone()])
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(path, legacy);
+        assert_eq!(info.pid, 42);
+        assert_eq!(info.workdir, "/legacy");
+    }
+
+    #[test]
+    fn read_first_lock_file_prefers_current_path_when_liveness_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let current = dir.path().join("current").join("daemon.lock");
+        let legacy = dir.path().join("legacy").join("daemon.lock");
+        write_lock(&current, 999_999_001, "/current");
+        write_lock(&legacy, 999_999_002, "/legacy");
+
+        let (path, info) = read_first_lock_file(vec![current.clone(), legacy])
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(path, current);
+        assert_eq!(info.pid, 999_999_001);
+        assert_eq!(info.workdir, "/current");
+    }
+
+    #[test]
+    fn read_first_lock_file_prefers_live_legacy_over_stale_current() {
+        let dir = tempfile::tempdir().unwrap();
+        let current = dir.path().join("current").join("daemon.lock");
+        let legacy = dir.path().join("legacy").join("daemon.lock");
+        write_lock(&current, 999_999_001, "/current");
+        write_lock(&legacy, std::process::id(), "/legacy");
+
+        let (path, info) = read_first_lock_file(vec![current, legacy.clone()])
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(path, legacy);
+        assert_eq!(info.pid, std::process::id());
+        assert_eq!(info.workdir, "/legacy");
     }
 }
 

--- a/crates/zedra-host/src/workspace_lock.rs
+++ b/crates/zedra-host/src/workspace_lock.rs
@@ -3,7 +3,7 @@
 //
 // Lock file:
 //   Unix:    $HOME/.config/zedra/workspaces/<DefaultHasher(workdir)>/daemon.lock
-//   Windows: %APPDATA%\zedra\workspaces\<stable workspace hash>\daemon.lock
+//   Windows: %APPDATA%\zedra\workspaces\<DefaultHasher(workdir)>\daemon.lock
 // Contains:  JSON with PID, workdir path, hostname, and start timestamp.
 //
 // Acquire semantics:
@@ -250,27 +250,13 @@ fn lock_file_path(workdir: &Path) -> Result<PathBuf> {
     Ok(path)
 }
 
-#[cfg(windows)]
 fn lock_config_dir(workdir: &Path) -> Result<PathBuf> {
-    identity::workspace_config_dir(workdir)
-}
-
-/// Unix lock path hashes the workdir with `DefaultHasher`.
-#[cfg(not(windows))]
-fn lock_config_dir(workdir: &Path) -> Result<PathBuf> {
-    let home = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .or_else(|| directories::BaseDirs::new().map(|b| b.home_dir().to_path_buf()))
-        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
-    Ok(home
-        .join(".config")
-        .join("zedra")
+    Ok(identity::zedra_config_dir()?
         .join("workspaces")
-        .join(path_hash(workdir)))
+        .join(lock_path_hash(workdir)))
 }
 
-#[cfg(not(windows))]
-fn path_hash(workdir: &Path) -> String {
+fn lock_path_hash(workdir: &Path) -> String {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     workdir.to_string_lossy().hash(&mut hasher);

--- a/crates/zedra-host/src/workspace_lock.rs
+++ b/crates/zedra-host/src/workspace_lock.rs
@@ -102,13 +102,6 @@ pub fn acquire(workdir: &Path) -> Result<WorkspaceLock> {
     let lock_path = lock_file_path(workdir)?;
     let info = LockInfo::new(workdir);
 
-    for legacy_path in legacy_lock_file_candidates(workdir)? {
-        if let Some(existing) = read_lock_file(&legacy_path) {
-            ensure_lock_is_available(&legacy_path, &existing)?;
-            let _ = std::fs::remove_file(&legacy_path);
-        }
-    }
-
     // Attempt atomic creation first.
     if try_write_exclusive(&lock_path, &info).is_ok() {
         return Ok(WorkspaceLock { path: lock_path });
@@ -116,7 +109,31 @@ pub fn acquire(workdir: &Path) -> Result<WorkspaceLock> {
 
     // File already exists — check if owner is still alive.
     if let Some(existing) = read_lock_file(&lock_path) {
-        ensure_lock_is_available(&lock_path, &existing)?;
+        if is_process_alive(existing.pid) {
+            anyhow::bail!(
+                "zedra-host is already running for this workspace.\n\
+                 \n\
+                 \x20 PID:      {}\n\
+                 \x20 Workdir:  {}\n\
+                 \x20 Host:     {}\n\
+                 \x20 Started:  {}\n\
+                 \x20 Lock:     {}\n\
+                 \n\
+                 Run 'zedra stop --workdir {}' to stop it.",
+                existing.pid,
+                existing.workdir,
+                existing.hostname,
+                existing.running_for(),
+                lock_path.display(),
+                existing.workdir,
+            );
+        }
+        // Stale lock — previous instance died without cleanup.
+        tracing::warn!(
+            "Removing stale lock file (PID {} is no longer running, was serving {})",
+            existing.pid,
+            existing.workdir,
+        );
     }
 
     // Overwrite stale / unreadable lock with our metadata.
@@ -130,31 +147,23 @@ pub fn acquire(workdir: &Path) -> Result<WorkspaceLock> {
 /// and return every instance that has a lock file, along with whether its
 /// process is still alive and the path to its config directory.
 pub fn scan_all_instances() -> Vec<(PathBuf, LockInfo, bool)> {
-    let current_workspaces_dir = match identity::zedra_config_dir() {
+    let workspaces_dir = match identity::zedra_config_dir() {
         Ok(dir) => dir.join("workspaces"),
         Err(_) => return Vec::new(),
     };
-    let mut workspaces_dirs = vec![current_workspaces_dir.clone()];
-    if let Ok(legacy_dir) = legacy_zedra_config_dir() {
-        let legacy_workspaces_dir = legacy_dir.join("workspaces");
-        if legacy_workspaces_dir != current_workspaces_dir {
-            workspaces_dirs.push(legacy_workspaces_dir);
-        }
-    }
+
+    let entries = match std::fs::read_dir(&workspaces_dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
 
     let mut result = Vec::new();
-    for workspaces_dir in workspaces_dirs {
-        let entries = match std::fs::read_dir(&workspaces_dir) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        for entry in entries.flatten() {
-            let config_dir = entry.path();
-            let lock_path = config_dir.join("daemon.lock");
-            if let Some(info) = read_lock_file(&lock_path) {
-                let alive = is_process_alive(info.pid);
-                result.push((config_dir, info, alive));
-            }
+    for entry in entries.flatten() {
+        let config_dir = entry.path();
+        let lock_path = config_dir.join("daemon.lock");
+        if let Some(info) = read_lock_file(&lock_path) {
+            let alive = is_process_alive(info.pid);
+            result.push((config_dir, info, alive));
         }
     }
 
@@ -166,7 +175,11 @@ pub fn scan_all_instances() -> Vec<(PathBuf, LockInfo, bool)> {
 /// Read the lock file metadata for a workspace without acquiring the lock.
 /// Returns `None` if no lock file exists or it cannot be parsed.
 pub fn read_lock_info(workdir: &Path) -> Result<Option<LockInfo>> {
-    Ok(read_lock_info_with_path(workdir)?.map(|(_, info)| info))
+    let lock_path = lock_file_path(workdir)?;
+    if !lock_path.exists() {
+        return Ok(None);
+    }
+    Ok(read_lock_file(&lock_path))
 }
 
 /// Stop the daemon owning `workdir`'s lock.
@@ -178,12 +191,12 @@ pub fn read_lock_info(workdir: &Path) -> Result<Option<LockInfo>> {
 ///
 /// Returns an error if there is no lock file or the process cannot be stopped.
 pub fn kill_and_unlock(workdir: &Path, grace_secs: u64) -> Result<()> {
-    let current_lock_path = current_lock_file_path(workdir)?;
+    let lock_path = lock_file_path(workdir)?;
 
-    let (lock_path, info) = read_lock_info_with_path(workdir)?.ok_or_else(|| {
+    let info = read_lock_file(&lock_path).ok_or_else(|| {
         anyhow::anyhow!(
             "No running zedra-host found for this workspace.\nLock file: {}",
-            current_lock_path.display()
+            lock_path.display()
         )
     })?;
 
@@ -228,116 +241,37 @@ pub fn kill_and_unlock(workdir: &Path, grace_secs: u64) -> Result<()> {
 
 /// Path: `<platform config>/zedra/workspaces/<hash>/daemon.lock`
 fn lock_file_path(workdir: &Path) -> Result<PathBuf> {
-    let path = current_lock_file_path(workdir)?;
+    let path = lock_config_dir(workdir)?.join("daemon.lock");
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     Ok(path)
 }
 
-fn current_lock_file_path(workdir: &Path) -> Result<PathBuf> {
-    Ok(identity::workspace_config_dir(workdir)?.join("daemon.lock"))
+#[cfg(windows)]
+fn lock_config_dir(workdir: &Path) -> Result<PathBuf> {
+    identity::workspace_config_dir(workdir)
 }
 
-fn read_lock_info_with_path(workdir: &Path) -> Result<Option<(PathBuf, LockInfo)>> {
-    read_first_lock_file(lock_file_candidates(workdir)?)
-}
-
-fn read_first_lock_file(
-    paths: impl IntoIterator<Item = PathBuf>,
-) -> Result<Option<(PathBuf, LockInfo)>> {
-    let mut first_stale = None;
-    for path in paths {
-        if let Some(info) = read_lock_file(&path) {
-            if is_process_alive(info.pid) {
-                return Ok(Some((path, info)));
-            }
-            if first_stale.is_none() {
-                first_stale = Some((path, info));
-            }
-        }
-    }
-    Ok(first_stale)
-}
-
-fn lock_file_candidates(workdir: &Path) -> Result<Vec<PathBuf>> {
-    let current = current_lock_file_path(workdir)?;
-    let mut paths = vec![current.clone()];
-    for legacy_path in legacy_lock_file_candidates(workdir)? {
-        if legacy_path != current {
-            paths.push(legacy_path);
-        }
-    }
-    Ok(paths)
-}
-
-fn legacy_lock_file_candidates(workdir: &Path) -> Result<Vec<PathBuf>> {
-    let current = current_lock_file_path(workdir)?;
-    let legacy = match legacy_lock_file_path(workdir) {
-        Ok(path) => path,
-        Err(err) => {
-            tracing::debug!("Skipping legacy lock lookup: {}", err);
-            return Ok(Vec::new());
-        }
-    };
-    if legacy == current {
-        Ok(Vec::new())
-    } else {
-        Ok(vec![legacy])
-    }
-}
-
-fn legacy_lock_file_path(workdir: &Path) -> Result<PathBuf> {
-    Ok(legacy_zedra_config_dir()?
-        .join("workspaces")
-        .join(legacy_path_hash(workdir))
-        .join("daemon.lock"))
-}
-
-fn legacy_zedra_config_dir() -> Result<PathBuf> {
+#[cfg(not(windows))]
+fn lock_config_dir(workdir: &Path) -> Result<PathBuf> {
     let home = std::env::var_os("HOME")
         .map(PathBuf::from)
         .or_else(|| directories::BaseDirs::new().map(|b| b.home_dir().to_path_buf()))
         .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
-    Ok(home.join(".config").join("zedra"))
+    Ok(home
+        .join(".config")
+        .join("zedra")
+        .join("workspaces")
+        .join(path_hash(workdir)))
 }
 
-/// Previous releases wrote only the daemon lock under this DefaultHasher path.
-fn legacy_path_hash(workdir: &Path) -> String {
+#[cfg(not(windows))]
+fn path_hash(workdir: &Path) -> String {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     workdir.to_string_lossy().hash(&mut hasher);
     format!("{:016x}", hasher.finish())
-}
-
-fn ensure_lock_is_available(lock_path: &Path, existing: &LockInfo) -> Result<()> {
-    if is_process_alive(existing.pid) {
-        anyhow::bail!(
-            "zedra-host is already running for this workspace.\n\
-             \n\
-             \x20 PID:      {}\n\
-             \x20 Workdir:  {}\n\
-             \x20 Host:     {}\n\
-             \x20 Started:  {}\n\
-             \x20 Lock:     {}\n\
-             \n\
-             Run 'zedra stop --workdir {}' to stop it.",
-            existing.pid,
-            existing.workdir,
-            existing.hostname,
-            existing.running_for(),
-            lock_path.display(),
-            existing.workdir,
-        );
-    }
-
-    tracing::warn!(
-        "Removing stale lock file {} (PID {} is no longer running, was serving {})",
-        lock_path.display(),
-        existing.pid,
-        existing.workdir,
-    );
-    Ok(())
 }
 
 /// Try to create the lock file atomically; fail if it already exists.
@@ -471,74 +405,6 @@ pub fn is_process_alive(pid: u32) -> bool {
         let ok = GetExitCodeProcess(handle, &mut exit_code) != 0;
         let _ = CloseHandle(handle);
         ok && exit_code == STILL_ACTIVE_EXIT_CODE
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn write_lock(path: &Path, pid: u32, workdir: &str) {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).unwrap();
-        }
-        let info = LockInfo {
-            pid,
-            workdir: workdir.to_string(),
-            hostname: "test-host".to_string(),
-            started_secs: 1,
-        };
-        overwrite_lock(path, &info).unwrap();
-    }
-
-    #[test]
-    fn read_first_lock_file_falls_back_to_legacy_path() {
-        let dir = tempfile::tempdir().unwrap();
-        let current = dir.path().join("current").join("daemon.lock");
-        let legacy = dir.path().join("legacy").join("daemon.lock");
-        write_lock(&legacy, 42, "/legacy");
-
-        let (path, info) = read_first_lock_file(vec![current, legacy.clone()])
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(path, legacy);
-        assert_eq!(info.pid, 42);
-        assert_eq!(info.workdir, "/legacy");
-    }
-
-    #[test]
-    fn read_first_lock_file_prefers_current_path_when_liveness_matches() {
-        let dir = tempfile::tempdir().unwrap();
-        let current = dir.path().join("current").join("daemon.lock");
-        let legacy = dir.path().join("legacy").join("daemon.lock");
-        write_lock(&current, 999_999_001, "/current");
-        write_lock(&legacy, 999_999_002, "/legacy");
-
-        let (path, info) = read_first_lock_file(vec![current.clone(), legacy])
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(path, current);
-        assert_eq!(info.pid, 999_999_001);
-        assert_eq!(info.workdir, "/current");
-    }
-
-    #[test]
-    fn read_first_lock_file_prefers_live_legacy_over_stale_current() {
-        let dir = tempfile::tempdir().unwrap();
-        let current = dir.path().join("current").join("daemon.lock");
-        let legacy = dir.path().join("legacy").join("daemon.lock");
-        write_lock(&current, 999_999_001, "/current");
-        write_lock(&legacy, std::process::id(), "/legacy");
-
-        let (path, info) = read_first_lock_file(vec![current, legacy.clone()])
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(path, legacy);
-        assert_eq!(info.pid, std::process::id());
-        assert_eq!(info.workdir, "/legacy");
     }
 }
 

--- a/crates/zedra-host/src/workspace_lock.rs
+++ b/crates/zedra-host/src/workspace_lock.rs
@@ -14,7 +14,7 @@
 // Stop command (`kill_and_unlock`):
 //   - Reads the lock file for the given workdir.
 //   - On Unix, sends SIGTERM; polls up to the grace period; escalates to SIGKILL.
-//   - On Windows, terminates the process if the local shutdown API did not work.
+//   - On Windows, terminates the process because detached processes have no SIGTERM equivalent.
 //   - Removes the lock file.
 
 use anyhow::{Context, Result};
@@ -332,8 +332,7 @@ fn request_process_exit(info: &LockInfo) -> Result<()> {
 
 #[cfg(windows)]
 fn request_process_exit(info: &LockInfo) -> Result<()> {
-    // `zedra stop` tries the authenticated local shutdown API before this
-    // fallback. Windows has no Unix-style SIGTERM, so the fallback is terminate.
+    // Detached Windows hosts have no Unix-style SIGTERM equivalent.
     tracing::warn!(
         "Terminating PID {} (workdir: {}, started: {})",
         info.pid,

--- a/crates/zedra-host/src/workspace_lock.rs
+++ b/crates/zedra-host/src/workspace_lock.rs
@@ -1,7 +1,9 @@
 // workspace_lock.rs — PID lock file to prevent duplicate zedra-host instances
 // on the same workspace directory.
 //
-// Lock file: <platform config>/zedra/workspaces/<hash>/daemon.lock
+// Lock file:
+//   Unix:    $HOME/.config/zedra/workspaces/<DefaultHasher(workdir)>/daemon.lock
+//   Windows: %APPDATA%\zedra\workspaces\<stable workspace hash>\daemon.lock
 // Contains:  JSON with PID, workdir path, hostname, and start timestamp.
 //
 // Acquire semantics:
@@ -239,7 +241,7 @@ pub fn kill_and_unlock(workdir: &Path, grace_secs: u64) -> Result<()> {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Path: `<platform config>/zedra/workspaces/<hash>/daemon.lock`
+/// Path of the platform-specific workspace lock file.
 fn lock_file_path(workdir: &Path) -> Result<PathBuf> {
     let path = lock_config_dir(workdir)?.join("daemon.lock");
     if let Some(parent) = path.parent() {
@@ -253,6 +255,7 @@ fn lock_config_dir(workdir: &Path) -> Result<PathBuf> {
     identity::workspace_config_dir(workdir)
 }
 
+/// Unix lock path hashes the workdir with `DefaultHasher`.
 #[cfg(not(windows))]
 fn lock_config_dir(workdir: &Path) -> Result<PathBuf> {
     let home = std::env::var_os("HOME")

--- a/crates/zedra-session/src/state.rs
+++ b/crates/zedra-session/src/state.rs
@@ -411,12 +411,7 @@ impl SessionState {
                 snap.username = sync.username;
                 snap.workdir = sync.workdir.clone();
                 snap.homedir = sync.home_dir.clone().unwrap_or_default();
-                snap.project_name = sync
-                    .workdir
-                    .rsplit('/')
-                    .next()
-                    .unwrap_or(&sync.workdir)
-                    .to_string();
+                snap.project_name = project_name_from_workdir(&sync.workdir);
                 let home = sync.home_dir.as_deref().unwrap_or("");
                 snap.strip_path = if !home.is_empty() && sync.workdir.starts_with(home) {
                     format!("~{}", &sync.workdir[home.len()..])
@@ -601,6 +596,16 @@ fn classify_ip(ip: std::net::IpAddr) -> NetworkHint {
     }
 }
 
+fn project_name_from_workdir(workdir: &str) -> String {
+    workdir
+        .trim_end_matches(['/', '\\'])
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|name| !name.is_empty())
+        .unwrap_or(workdir)
+        .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -664,6 +669,17 @@ mod tests {
 
         state.apply_event(ConnectEvent::Connected { total_ms: 10 });
         assert!(matches!(state.phase, ConnectPhase::Connected));
+    }
+
+    #[test]
+    fn sync_extracts_project_name_from_windows_workdir() {
+        let mut state = SessionState::new();
+        let mut sync = sync_session_result();
+        sync.workdir = r"C:\Users\zedra\zedra".into();
+
+        state.apply_event(ConnectEvent::SyncComplete { sync, sync_ms: 7 });
+
+        assert_eq!(state.snapshot.project_name, "zedra");
     }
 
     #[test]

--- a/crates/zedra/assets/icons/windows.svg
+++ b/crates/zedra/assets/icons/windows.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M3 5.4 10.6 4.3v7.2H3V5.4Zm8.6-1.2L21 2.8v8.7h-9.4V4.2ZM3 12.5h7.6v7.2L3 18.6v-6.1Zm8.6 0H21v8.7l-9.4-1.4v-7.3Z"/>
+</svg>

--- a/crates/zedra/src/home_view.rs
+++ b/crates/zedra/src/home_view.rs
@@ -76,7 +76,7 @@ impl HomeView {
         Self {
             workspaces,
             focus_handle: cx.focus_handle(),
-            selected_guide_tab: GuideTab::Curl,
+            selected_guide_tab: GuideTab::MacLinux,
             action_tx,
             _action_task: action_task,
         }
@@ -465,7 +465,8 @@ impl Render for HomeView {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum GuideTab {
-    Curl,
+    MacLinux,
+    Windows,
     Claude,
     Codex,
     OpenCode,
@@ -490,9 +491,15 @@ struct GuideLine {
 
 static GUIDE_TABS: &[GuideTabSpec] = &[
     GuideTabSpec {
-        tab: GuideTab::Curl,
-        label: "curl",
+        tab: GuideTab::MacLinux,
+        label: "mac-linux",
         icon: "icons/terminal.svg",
+        icon_size: 17.0,
+    },
+    GuideTabSpec {
+        tab: GuideTab::Windows,
+        label: "windows",
+        icon: "icons/windows.svg",
         icon_size: 17.0,
     },
     GuideTabSpec {
@@ -521,7 +528,7 @@ static GUIDE_TABS: &[GuideTabSpec] = &[
     },
 ];
 
-static CURL_INSTALL_LINES: &[GuideLine] = &[
+static MAC_LINUX_INSTALL_LINES: &[GuideLine] = &[
     GuideLine {
         text: "# Install Zedra CLI",
         comment: true,
@@ -532,7 +539,7 @@ static CURL_INSTALL_LINES: &[GuideLine] = &[
     },
 ];
 
-static CURL_RUN_LINES: &[GuideLine] = &[
+static MAC_LINUX_RUN_LINES: &[GuideLine] = &[
     GuideLine {
         text: "# Start Zedra in the working directory",
         comment: true,
@@ -635,12 +642,43 @@ static GEMINI_RUN_LINES: &[GuideLine] = &[
     },
 ];
 
-static CURL_BLOCKS: &[GuideBlock] = &[
+static WINDOWS_INSTALL_LINES: &[GuideLine] = &[
+    GuideLine {
+        text: "# Install Zedra CLI",
+        comment: true,
+    },
+    GuideLine {
+        text: "powershell -c \"irm https://zedra.dev/install.ps1 | iex\"",
+        comment: false,
+    },
+];
+
+static WINDOWS_RUN_LINES: &[GuideLine] = &[
+    GuideLine {
+        text: "# Start Zedra in the working directory",
+        comment: true,
+    },
+    GuideLine {
+        text: "zedra start",
+        comment: false,
+    },
+];
+
+static MAC_LINUX_BLOCKS: &[GuideBlock] = &[
     GuideBlock {
-        lines: CURL_INSTALL_LINES,
+        lines: MAC_LINUX_INSTALL_LINES,
     },
     GuideBlock {
-        lines: CURL_RUN_LINES,
+        lines: MAC_LINUX_RUN_LINES,
+    },
+];
+
+static WINDOWS_BLOCKS: &[GuideBlock] = &[
+    GuideBlock {
+        lines: WINDOWS_INSTALL_LINES,
+    },
+    GuideBlock {
+        lines: WINDOWS_RUN_LINES,
     },
 ];
 
@@ -682,7 +720,8 @@ static GEMINI_BLOCKS: &[GuideBlock] = &[
 
 fn guide_blocks(tab: GuideTab) -> &'static [GuideBlock] {
     match tab {
-        GuideTab::Curl => CURL_BLOCKS,
+        GuideTab::MacLinux => MAC_LINUX_BLOCKS,
+        GuideTab::Windows => WINDOWS_BLOCKS,
         GuideTab::Claude => CLAUDE_BLOCKS,
         GuideTab::Codex => CODEX_BLOCKS,
         GuideTab::OpenCode => OPENCODE_BLOCKS,
@@ -765,7 +804,7 @@ fn guide_tab_button(
 ) -> impl IntoElement {
     div()
         .id(SharedString::from(format!("home-guide-tab-{}", spec.label)))
-        .w(px(48.0))
+        .w(px(42.0))
         .h(px(34.0))
         .flex()
         .items_center()

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -75,6 +75,23 @@ Scan the printed QR from the app, or pass the URL during development:
 ./scripts/run-ios.sh sim --no-build --launch-url 'zedra://connect?ticket=...'
 ```
 
+### Windows Host CLI
+
+Windows support is for the host daemon, not a native desktop client. Use the MSVC Rust toolchain and Git for Windows.
+
+```sh
+rustup toolchain install stable-x86_64-pc-windows-msvc
+cargo build -p zedra-host
+.\target\debug\zedra.exe start --workdir C:\path\to\project --detach
+.\target\debug\zedra.exe qr --workdir C:\path\to\project
+.\target\debug\zedra.exe status --workdir C:\path\to\project
+.\target\debug\zedra.exe logs --workdir C:\path\to\project
+.\target\debug\zedra.exe client --workdir C:\path\to\project --count 3
+.\target\debug\zedra.exe stop --workdir C:\path\to\project
+```
+
+Runtime files are stored under `%APPDATA%\zedra\workspaces\<hash>\`, including `daemon.lock`, `daemon.log`, `sessions.json`, `host-info.json`, and API discovery files. Terminal sessions use `%ComSpec%` (`cmd.exe`) by default; install Git, language tools, and agent CLIs on `PATH` before starting the daemon.
+
 ## Pre-Commit Checks
 
 ```bash

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -90,7 +90,7 @@ cargo build -p zedra-host
 .\target\debug\zedra.exe stop --workdir C:\path\to\project
 ```
 
-Runtime files are stored under `%APPDATA%\zedra\workspaces\`. `daemon.lock` uses the lock hash for the workdir; `daemon.log`, `sessions.json`, `host-info.json`, and API discovery files use the stable workspace hash. Terminal sessions use `%ComSpec%` (`cmd.exe`) by default; install Git, language tools, and agent CLIs on `PATH` before starting the daemon.
+Runtime files are stored under `%APPDATA%\zedra\workspaces\`. `daemon.lock` uses the lock hash for the workdir; `daemon.log`, `sessions.json`, `host-info.json`, and API discovery files use the stable workspace hash. Terminal sessions use `ZEDRA_SHELL` when set, then `SHELL`, then `%ComSpec%` (`cmd.exe`). Supported launch shells are `cmd.exe`, `pwsh.exe`, `powershell.exe`, and Git Bash/POSIX-style shells; set `ZEDRA_SHELL` before starting the daemon if you want a non-default shell.
 
 ## Pre-Commit Checks
 

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -90,7 +90,7 @@ cargo build -p zedra-host
 .\target\debug\zedra.exe stop --workdir C:\path\to\project
 ```
 
-Runtime files are stored under `%APPDATA%\zedra\workspaces\<hash>\`, including `daemon.lock`, `daemon.log`, `sessions.json`, `host-info.json`, and API discovery files. Terminal sessions use `%ComSpec%` (`cmd.exe`) by default; install Git, language tools, and agent CLIs on `PATH` before starting the daemon.
+Runtime files are stored under `%APPDATA%\zedra\workspaces\`. `daemon.lock` uses the lock hash for the workdir; `daemon.log`, `sessions.json`, `host-info.json`, and API discovery files use the stable workspace hash. Terminal sessions use `%ComSpec%` (`cmd.exe`) by default; install Git, language tools, and agent CLIs on `PATH` before starting the daemon.
 
 ## Pre-Commit Checks
 

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -80,7 +80,7 @@ Scan the printed QR from the app, or pass the URL during development:
 Windows support is for the host daemon, not a native desktop client.
 
 ```powershell
-irm https://zedra.dev/install.ps1 | iex
+powershell -c "irm https://zedra.dev/install.ps1 | iex"
 zedra start --workdir C:\path\to\project --detach
 zedra qr --workdir C:\path\to\project
 zedra status --workdir C:\path\to\project

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -90,7 +90,7 @@ cargo build -p zedra-host
 .\target\debug\zedra.exe stop --workdir C:\path\to\project
 ```
 
-Runtime files are stored under `%APPDATA%\zedra\workspaces\`. `daemon.lock` uses the lock hash for the workdir; `daemon.log`, `sessions.json`, `host-info.json`, and API discovery files use the stable workspace hash. Terminal sessions use `ZEDRA_SHELL` when set, then `SHELL`, then `%ComSpec%` (`cmd.exe`). Supported launch shells are `cmd.exe`, `pwsh.exe`, `powershell.exe`, and Git Bash/POSIX-style shells; set `ZEDRA_SHELL` before starting the daemon if you want a non-default shell.
+Runtime files are stored under `%APPDATA%\zedra\workspaces\`. `daemon.lock` uses the lock hash for the workdir; `daemon.log`, `sessions.json`, `host-info.json`, and API discovery files use the stable workspace hash. Terminal sessions use `ZEDRA_SHELL` when set, otherwise Zedra detects the shell that launched the host, then falls back to `SHELL`, then `%ComSpec%` (`cmd.exe`). Supported launch shells are `cmd.exe`, `pwsh.exe`, `powershell.exe`, and Git Bash/POSIX-style shells.
 
 ## Pre-Commit Checks
 

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -77,20 +77,21 @@ Scan the printed QR from the app, or pass the URL during development:
 
 ### Windows Host CLI
 
-Windows support is for the host daemon, not a native desktop client. Use the MSVC Rust toolchain and Git for Windows.
+Windows support is for the host daemon, not a native desktop client.
 
-```sh
-rustup toolchain install stable-x86_64-pc-windows-msvc
-cargo build -p zedra-host
-.\target\debug\zedra.exe start --workdir C:\path\to\project --detach
-.\target\debug\zedra.exe qr --workdir C:\path\to\project
-.\target\debug\zedra.exe status --workdir C:\path\to\project
-.\target\debug\zedra.exe logs --workdir C:\path\to\project
-.\target\debug\zedra.exe client --workdir C:\path\to\project --count 3
-.\target\debug\zedra.exe stop --workdir C:\path\to\project
+```powershell
+irm https://zedra.dev/install.ps1 | iex
+zedra start --workdir C:\path\to\project --detach
+zedra qr --workdir C:\path\to\project
+zedra status --workdir C:\path\to\project
+zedra logs --workdir C:\path\to\project
+zedra client --workdir C:\path\to\project --count 3
+zedra stop --workdir C:\path\to\project
 ```
 
 Runtime files are stored under `%APPDATA%\zedra\workspaces\`. `daemon.lock` uses the lock hash for the workdir; `daemon.log`, `sessions.json`, `host-info.json`, and API discovery files use the stable workspace hash. Terminal sessions use `ZEDRA_SHELL` when set, otherwise Zedra detects the shell that launched the host, then falls back to `SHELL`, then `%ComSpec%` (`cmd.exe`). Supported launch shells are `cmd.exe`, `pwsh.exe`, `powershell.exe`, and Git Bash/POSIX-style shells.
+
+To build from source instead, install the MSVC Rust toolchain and Git for Windows, then run `cargo build -p zedra-host`.
 
 ## Pre-Commit Checks
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -128,6 +128,24 @@
 22. Connect to an older host that does not support docs-tree RPCs
 23. Expected: the docs tree shows an unsupported-host message and the refresh icon no longer stays in the building state
 
+## 1d. Windows Host CLI
+
+1. On an x86_64 Windows machine with the MSVC Rust toolchain and Git for Windows installed, build the host: `cargo build -p zedra-host`
+2. Start the daemon from PowerShell: `.\target\debug\zedra.exe start --workdir C:\path\to\repo --detach`
+3. Expected: startup succeeds, Windows may show a firewall prompt, and `daemon.log` plus `daemon.lock` are written under `%APPDATA%\zedra\workspaces\<hash>\`
+4. Run `.\target\debug\zedra.exe status --workdir C:\path\to\repo`
+5. Expected: status shows the running daemon, endpoint, workspace path, sessions, and terminal count without Unix path assumptions
+6. Run `.\target\debug\zedra.exe qr --workdir C:\path\to\repo`, scan from the mobile app, then disconnect and reconnect the app without scanning again
+7. Expected: QR pairing succeeds, reconnect uses the saved session identity, and relay fallback still works if direct P2P is unavailable
+8. Open a terminal from the app
+9. Expected: a Windows PTY opens with a `cmd.exe` prompt, keystrokes echo, resize works, and commands available on `PATH` run normally
+10. Run `.\target\debug\zedra.exe client --workdir C:\path\to\repo --count 3`
+11. Expected: the CLI client authenticates without QR and prints three RTT samples
+12. Run `.\target\debug\zedra.exe logs --workdir C:\path\to\repo`
+13. Expected: recent daemon log lines are printed from the AppData workspace directory
+14. Run `.\target\debug\zedra.exe stop --workdir C:\path\to\repo`
+15. Expected: the daemon exits, the lock file is removed, and a follow-up `status` reports no running daemon
+
 ## 2. QR Already Consumed
 
 1. Start host: `zedra start --workdir .`

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -138,9 +138,9 @@
 6. Run `.\target\debug\zedra.exe qr --workdir C:\path\to\repo`, scan from the mobile app, then disconnect and reconnect the app without scanning again
 7. Expected: QR pairing succeeds, reconnect uses the saved session identity, and relay fallback still works if direct P2P is unavailable
 8. Open a terminal from the app
-9. Expected: a Windows PTY opens with the selected shell prompt (`ZEDRA_SHELL`, `SHELL`, or `%ComSpec%`), keystrokes echo, resize works, and commands available on `PATH` run normally
-10. Stop the daemon, set `$env:ZEDRA_SHELL = "pwsh.exe"` in PowerShell, restart the daemon, and open another terminal from the app
-11. Expected: the terminal opens in PowerShell and launch commands still leave an interactive shell after they run
+9. Expected: a Windows PTY opens with the shell that launched the host, keystrokes echo, resize works, and commands available on `PATH` run normally
+10. Stop the daemon, set `$env:ZEDRA_SHELL = "cmd.exe"` in PowerShell, restart the daemon, and open another terminal from the app
+11. Expected: the terminal opens in `cmd.exe`; clear `ZEDRA_SHELL`, restart from PowerShell, and launch commands still leave an interactive PowerShell after they run
 12. Run `.\target\debug\zedra.exe client --workdir C:\path\to\repo --count 3`
 13. Expected: the CLI client authenticates without QR and prints three RTT samples
 14. Run `.\target\debug\zedra.exe logs --workdir C:\path\to\repo`

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -132,7 +132,7 @@
 
 1. On an x86_64 Windows machine with the MSVC Rust toolchain and Git for Windows installed, build the host: `cargo build -p zedra-host`
 2. Start the daemon from PowerShell: `.\target\debug\zedra.exe start --workdir C:\path\to\repo --detach`
-3. Expected: startup succeeds, Windows may show a firewall prompt, and `daemon.log` plus `daemon.lock` are written under `%APPDATA%\zedra\workspaces\<hash>\`
+3. Expected: startup succeeds, Windows may show a firewall prompt, and `daemon.lock` plus `daemon.log` are written under `%APPDATA%\zedra\workspaces\` using their respective workspace hashes
 4. Run `.\target\debug\zedra.exe status --workdir C:\path\to\repo`
 5. Expected: status shows the running daemon, endpoint, workspace path, sessions, and terminal count without Unix path assumptions
 6. Run `.\target\debug\zedra.exe qr --workdir C:\path\to\repo`, scan from the mobile app, then disconnect and reconnect the app without scanning again

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -146,8 +146,14 @@
 14. Expected: the CLI client authenticates without QR and prints three RTT samples
 15. Run `zedra logs --workdir C:\path\to\repo`
 16. Expected: recent daemon log lines are printed from the AppData workspace directory
-17. Run `zedra stop --workdir C:\path\to\repo`
-18. Expected: the daemon exits, the lock file is removed, and a follow-up `status` reports no running daemon
+17. Run `zedra update --version <current-release-tag> --yes` while the daemon is still running
+18. Expected: the update is rejected with a message to stop running daemons first
+19. Run `zedra stop --workdir C:\path\to\repo`
+20. Expected: the daemon exits, the lock file is removed, and a follow-up `status` reports no running daemon
+21. Run `zedra update --version <current-release-tag> --yes`
+22. Expected: the update downloads the Windows release asset, verifies the checksum when available, and reports that `zedra.exe` will be replaced after the command exits
+23. Open a new PowerShell window and run `zedra --version`
+24. Expected: the command prints the release version
 
 ## 2. QR Already Consumed
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -138,13 +138,15 @@
 6. Run `.\target\debug\zedra.exe qr --workdir C:\path\to\repo`, scan from the mobile app, then disconnect and reconnect the app without scanning again
 7. Expected: QR pairing succeeds, reconnect uses the saved session identity, and relay fallback still works if direct P2P is unavailable
 8. Open a terminal from the app
-9. Expected: a Windows PTY opens with a `cmd.exe` prompt, keystrokes echo, resize works, and commands available on `PATH` run normally
-10. Run `.\target\debug\zedra.exe client --workdir C:\path\to\repo --count 3`
-11. Expected: the CLI client authenticates without QR and prints three RTT samples
-12. Run `.\target\debug\zedra.exe logs --workdir C:\path\to\repo`
-13. Expected: recent daemon log lines are printed from the AppData workspace directory
-14. Run `.\target\debug\zedra.exe stop --workdir C:\path\to\repo`
-15. Expected: the daemon exits, the lock file is removed, and a follow-up `status` reports no running daemon
+9. Expected: a Windows PTY opens with the selected shell prompt (`ZEDRA_SHELL`, `SHELL`, or `%ComSpec%`), keystrokes echo, resize works, and commands available on `PATH` run normally
+10. Stop the daemon, set `$env:ZEDRA_SHELL = "pwsh.exe"` in PowerShell, restart the daemon, and open another terminal from the app
+11. Expected: the terminal opens in PowerShell and launch commands still leave an interactive shell after they run
+12. Run `.\target\debug\zedra.exe client --workdir C:\path\to\repo --count 3`
+13. Expected: the CLI client authenticates without QR and prints three RTT samples
+14. Run `.\target\debug\zedra.exe logs --workdir C:\path\to\repo`
+15. Expected: recent daemon log lines are printed from the AppData workspace directory
+16. Run `.\target\debug\zedra.exe stop --workdir C:\path\to\repo`
+17. Expected: the daemon exits, the lock file is removed, and a follow-up `status` reports no running daemon
 
 ## 2. QR Already Consumed
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -130,23 +130,24 @@
 
 ## 1d. Windows Host CLI
 
-1. On an x86_64 Windows machine with the MSVC Rust toolchain and Git for Windows installed, build the host: `cargo build -p zedra-host`
-2. Start the daemon from PowerShell: `.\target\debug\zedra.exe start --workdir C:\path\to\repo --detach`
-3. Expected: startup succeeds, Windows may show a firewall prompt, and `daemon.lock` plus `daemon.log` are written under `%APPDATA%\zedra\workspaces\` using their respective workspace hashes
-4. Run `.\target\debug\zedra.exe status --workdir C:\path\to\repo`
-5. Expected: status shows the running daemon, endpoint, workspace path, sessions, and terminal count without Unix path assumptions
-6. Run `.\target\debug\zedra.exe qr --workdir C:\path\to\repo`, scan from the mobile app, then disconnect and reconnect the app without scanning again
-7. Expected: QR pairing succeeds, reconnect uses the saved session identity, and relay fallback still works if direct P2P is unavailable
-8. Open a terminal from the app
-9. Expected: a Windows PTY opens with the shell that launched the host, keystrokes echo, resize works, and commands available on `PATH` run normally
-10. Stop the daemon, set `$env:ZEDRA_SHELL = "cmd.exe"` in PowerShell, restart the daemon, and open another terminal from the app
-11. Expected: the terminal opens in `cmd.exe`; clear `ZEDRA_SHELL`, restart from PowerShell, and launch commands still leave an interactive PowerShell after they run
-12. Run `.\target\debug\zedra.exe client --workdir C:\path\to\repo --count 3`
-13. Expected: the CLI client authenticates without QR and prints three RTT samples
-14. Run `.\target\debug\zedra.exe logs --workdir C:\path\to\repo`
-15. Expected: recent daemon log lines are printed from the AppData workspace directory
-16. Run `.\target\debug\zedra.exe stop --workdir C:\path\to\repo`
-17. Expected: the daemon exits, the lock file is removed, and a follow-up `status` reports no running daemon
+1. On an x86_64 Windows machine, run `irm https://zedra.dev/install.ps1 | iex` from PowerShell
+2. Expected: `zedra.exe` is installed under `%LOCALAPPDATA%\Programs\zedra\bin`, the directory is added to the user `Path`, and `zedra --help` works from the current shell
+3. Start the daemon from PowerShell: `zedra start --workdir C:\path\to\repo --detach`
+4. Expected: startup succeeds, Windows may show a firewall prompt, and `daemon.lock` plus `daemon.log` are written under `%APPDATA%\zedra\workspaces\` using their respective workspace hashes
+5. Run `zedra status --workdir C:\path\to\repo`
+6. Expected: status shows the running daemon, endpoint, workspace path, sessions, and terminal count without Unix path assumptions
+7. Run `zedra qr --workdir C:\path\to\repo`, scan from the mobile app, then disconnect and reconnect the app without scanning again
+8. Expected: QR pairing succeeds, reconnect uses the saved session identity, and relay fallback still works if direct P2P is unavailable
+9. Open a terminal from the app
+10. Expected: a Windows PTY opens with the shell that launched the host, keystrokes echo, resize works, and commands available on `PATH` run normally
+11. Stop the daemon, set `$env:ZEDRA_SHELL = "cmd.exe"` in PowerShell, restart the daemon, and open another terminal from the app
+12. Expected: the terminal opens in `cmd.exe`; clear `ZEDRA_SHELL`, restart from PowerShell, and launch commands still leave an interactive PowerShell after they run
+13. Run `zedra client --workdir C:\path\to\repo --count 3`
+14. Expected: the CLI client authenticates without QR and prints three RTT samples
+15. Run `zedra logs --workdir C:\path\to\repo`
+16. Expected: recent daemon log lines are printed from the AppData workspace directory
+17. Run `zedra stop --workdir C:\path\to\repo`
+18. Expected: the daemon exits, the lock file is removed, and a follow-up `status` reports no running daemon
 
 ## 2. QR Already Consumed
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -17,7 +17,7 @@
 ## 0a. Home Install Guide Tabs
 
 1. Open the app with no saved workspaces visible on the Home screen
-2. Switch between the `curl`, `claude`, `codex`, `opencode`, and `gemini` guide tabs
+2. Switch between the `mac/linux`, `windows`, `claude`, `codex`, `opencode`, and `gemini` guide tabs
 3. Expected: each tab shows the same install commands as the landing page
 4. Tap a command line in each tab
 5. Expected: the tapped command line is copied to the system clipboard without navigating away from Home
@@ -130,7 +130,7 @@
 
 ## 1d. Windows Host CLI
 
-1. On an x86_64 Windows machine, run `irm https://zedra.dev/install.ps1 | iex` from PowerShell
+1. On an x86_64 Windows machine, run `powershell -c "irm https://zedra.dev/install.ps1 | iex"` from Command Prompt or Windows Terminal
 2. Expected: `zedra.exe` is installed under `%LOCALAPPDATA%\Programs\zedra\bin`, the directory is added to the user `Path`, and `zedra --help` works from the current shell
 3. Start the daemon from PowerShell: `zedra start --workdir C:\path\to\repo --detach`
 4. Expected: startup succeeds, Windows may show a firewall prompt, and `daemon.lock` plus `daemon.log` are written under `%APPDATA%\zedra\workspaces\` using their respective workspace hashes

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -147,7 +147,7 @@
 15. Run `zedra logs --workdir C:\path\to\repo`
 16. Expected: recent daemon log lines are printed from the AppData workspace directory
 17. Run `zedra update --version <current-release-tag> --yes` while the daemon is still running
-18. Expected: the update is rejected with a message to stop running daemons first
+18. Expected: the update succeeds and warns that running daemons keep using the old version until restarted
 19. Run `zedra stop --workdir C:\path\to\repo`
 20. Expected: the daemon exits, the lock file is removed, and a follow-up `status` reports no running daemon
 21. Run `zedra update --version <current-release-tag> --yes`

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -48,7 +48,13 @@ Invoke-WebRequest https://raw.githubusercontent.com/tanlethanh/zedra/main/script
 .\install.ps1 -Version v0.2.0
 ```
 
-**Update** — run the install script again; it overwrites the existing binary.
+**Update:**
+```bash
+zedra update
+```
+
+On Windows, stop running `zedra` daemons before updating because Windows locks
+the running `zedra.exe`.
 
 The Unix script installs to `~/.local/bin/zedra` by default. Override with `--prefix /usr/local/bin` or `ZEDRA_PREFIX`.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,7 +34,7 @@ curl -fsSL https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/insta
 
 **First install on Windows:**
 ```powershell
-irm https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/install.ps1 | iex
+powershell -c "irm https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/install.ps1 | iex"
 ```
 
 **Specific version:**

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -53,8 +53,8 @@ Invoke-WebRequest https://raw.githubusercontent.com/tanlethanh/zedra/main/script
 zedra update
 ```
 
-On Windows, stop running `zedra` daemons before updating because Windows locks
-the running `zedra.exe`.
+On Windows, running `zedra` daemons keep using the old `zedra.exe` image until
+you restart them after the update.
 
 The Unix script installs to `~/.local/bin/zedra` by default. Override with `--prefix /usr/local/bin` or `ZEDRA_PREFIX`.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -32,20 +32,40 @@ Pushing the tag triggers `.github/workflows/release.yml`, which:
 curl -fsSL https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/install.sh | sh
 ```
 
+**First install on Windows:**
+```powershell
+irm https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/install.ps1 | iex
+```
+
 **Specific version:**
 ```bash
 curl -fsSL https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/install.sh | sh -s -- --version v0.2.0
 ```
 
+**Specific version on Windows:**
+```powershell
+Invoke-WebRequest https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/install.ps1 -OutFile install.ps1
+.\install.ps1 -Version v0.2.0
+```
+
 **Update** — run the install script again; it overwrites the existing binary.
 
-The script installs to `~/.local/bin/zedra` by default. Override with `--prefix /usr/local/bin` or `ZEDRA_PREFIX`.
+The Unix script installs to `~/.local/bin/zedra` by default. Override with `--prefix /usr/local/bin` or `ZEDRA_PREFIX`.
+
+The Windows script installs to `%LOCALAPPDATA%\Programs\zedra\bin\zedra.exe` by default and adds that directory to the user `Path`. Override with `-Prefix` or `ZEDRA_PREFIX`.
 
 ## Verify a release locally
 
 ```bash
 cargo build -p zedra-host --release
 ./target/release/zedra --help
+```
+
+On Windows:
+
+```powershell
+cargo build -p zedra-host --release
+.\target\release\zedra.exe --help
 ```
 
 ---

--- a/packages/landing/src/pages/index.astro
+++ b/packages/landing/src/pages/index.astro
@@ -317,13 +317,22 @@ const canonicalUrl = "https://zedra.dev/";
 
       .tab-list {
         display: flex;
-        flex-wrap: wrap;
-        gap: 12px;
+        flex-wrap: nowrap;
+        gap: 10px;
+        overflow-x: auto;
+        overflow-y: hidden;
         padding: 8px 14px 0;
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+      }
+
+      .tab-list::-webkit-scrollbar {
+        display: none;
       }
 
       .tab-label {
         display: inline-flex;
+        flex: 0 0 auto;
         align-items: center;
         gap: 8px;
         padding: 7px 2px 9px;
@@ -332,6 +341,7 @@ const canonicalUrl = "https://zedra.dev/";
         background: transparent;
         color: var(--muted);
         font-size: 0.78rem;
+        white-space: nowrap;
         cursor: pointer;
         transition:
           color 0.18s,
@@ -646,6 +656,16 @@ const canonicalUrl = "https://zedra.dev/";
         .install-card {
           height: auto;
           min-height: 180px;
+        }
+
+        .tab-list {
+          gap: 8px;
+          padding-inline: 12px;
+        }
+
+        .tab-label {
+          gap: 6px;
+          font-size: 0.76rem;
         }
 
         .demo-card {

--- a/packages/landing/src/pages/index.astro
+++ b/packages/landing/src/pages/index.astro
@@ -21,7 +21,7 @@ const installTabs = [
     blocks: [
       [
         { text: "# Install Zedra CLI", comment: true },
-        { text: "irm https://zedra.dev/install.ps1 | iex" },
+        { text: 'powershell -c "irm https://zedra.dev/install.ps1 | iex"' },
       ],
       [{ text: "# Start Zedra in the working directory", comment: true }, { text: "zedra start" }],
     ],

--- a/packages/landing/src/pages/index.astro
+++ b/packages/landing/src/pages/index.astro
@@ -3,13 +3,25 @@
 // Copy text = non-comment lines joined by \n.
 const installTabs = [
   {
-    id: "curl",
-    label: "curl",
+    id: "mac-linux",
+    label: "mac/linux",
     icon: `<svg class="tab-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>`,
     blocks: [
       [
         { text: "# Install Zedra CLI", comment: true },
         { text: "curl -fsSL zedra.dev/install.sh | sh" },
+      ],
+      [{ text: "# Start Zedra in the working directory", comment: true }, { text: "zedra start" }],
+    ],
+  },
+  {
+    id: "windows",
+    label: "windows",
+    icon: `<svg class="tab-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3 5.4 10.6 4.3v7.2H3V5.4Zm8.6-1.2L21 2.8v8.7h-9.4V4.2ZM3 12.5h7.6v7.2L3 18.6v-6.1Zm8.6 0H21v8.7l-9.4-1.4v-7.3Z"></path></svg>`,
+    blocks: [
+      [
+        { text: "# Install Zedra CLI", comment: true },
+        { text: "irm https://zedra.dev/install.ps1 | iex" },
       ],
       [{ text: "# Start Zedra in the working directory", comment: true }, { text: "zedra start" }],
     ],
@@ -396,7 +408,8 @@ const canonicalUrl = "https://zedra.dev/";
 
       /* checked-tab state (CSS-only tabs) */
 
-      #tab-curl:checked ~ .install-card .label-curl,
+      #tab-mac-linux:checked ~ .install-card .label-mac-linux,
+      #tab-windows:checked ~ .install-card .label-windows,
       #tab-claude:checked ~ .install-card .label-claude,
       #tab-codex:checked ~ .install-card .label-codex,
       #tab-opencode:checked ~ .install-card .label-opencode,
@@ -405,7 +418,8 @@ const canonicalUrl = "https://zedra.dev/";
         border-bottom-color: var(--text);
       }
 
-      #tab-curl:checked ~ .install-card .panel-curl,
+      #tab-mac-linux:checked ~ .install-card .panel-mac-linux,
+      #tab-windows:checked ~ .install-card .panel-windows,
       #tab-claude:checked ~ .install-card .panel-claude,
       #tab-codex:checked ~ .install-card .panel-codex,
       #tab-opencode:checked ~ .install-card .panel-opencode,

--- a/packages/landing/vercel.json
+++ b/packages/landing/vercel.json
@@ -10,6 +10,11 @@
       "statusCode": 302
     },
     {
+      "source": "/install.ps1",
+      "destination": "https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/install.ps1",
+      "statusCode": 302
+    },
+    {
       "source": "/opencode.sh",
       "destination": "https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/opencode.sh",
       "statusCode": 302

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -78,17 +78,26 @@ function Verify-ZedraChecksum {
     )
 
     try {
-        $expectedText = (Invoke-WebRequest -Uri $ChecksumUrl -UseBasicParsing).Content
+        $response = Invoke-WebRequest -Uri $ChecksumUrl -UseBasicParsing
     } catch {
         Write-Host "  (checksum file not available, skipping verification)"
         return
     }
 
-    $expectedHash = ($expectedText -split "\s+")[0].Trim().ToLowerInvariant()
-    if ([string]::IsNullOrWhiteSpace($expectedHash)) {
+    $content = $response.Content
+    if ($content -is [byte[]]) {
+        # Windows PowerShell can expose extensionless GitHub assets as raw bytes.
+        $expectedText = [System.Text.Encoding]::UTF8.GetString($content)
+    } else {
+        $expectedText = [string]$content
+    }
+
+    $match = [regex]::Match($expectedText, "(?im)^\s*([a-f0-9]{64})\b")
+    if (-not $match.Success) {
         Write-Host "  (checksum file empty, skipping verification)"
         return
     }
+    $expectedHash = $match.Groups[1].Value.ToLowerInvariant()
 
     $actualHash = (Get-FileHash -Algorithm SHA256 -Path $ArchivePath).Hash.ToLowerInvariant()
     if ($actualHash -ne $expectedHash) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -107,6 +107,30 @@ function Verify-ZedraChecksum {
     Write-Host "  Checksum verified."
 }
 
+function Invoke-ZedraDownload {
+    param(
+        [string]$Url,
+        [string]$OutFile,
+        [string]$Version,
+        [string]$Target
+    )
+
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing
+    } catch {
+        $statusCode = $null
+        if ($null -ne $_.Exception.Response) {
+            $statusCode = [int]$_.Exception.Response.StatusCode
+        }
+
+        if ($statusCode -eq 404) {
+            throw "release $Version does not include a prebuilt Windows binary for $Target. Try a newer release with Windows assets, or build from source with: cargo install --git https://github.com/$Repo zedra-host"
+        }
+
+        throw "failed to download $Url. $($_.Exception.Message)"
+    }
+}
+
 function Assert-PrefixWritable {
     param([string]$InstallPrefix)
 
@@ -209,7 +233,7 @@ function Install-Zedra {
     try {
         $archivePath = Join-Path $tmpDir $archiveName
         Write-Host "  Downloading $archiveUrl..."
-        Invoke-WebRequest -Uri $archiveUrl -OutFile $archivePath -UseBasicParsing
+        Invoke-ZedraDownload -Url $archiveUrl -OutFile $archivePath -Version $resolvedVersion -Target $target
 
         Verify-ZedraChecksum -ArchivePath $archivePath -ChecksumUrl $checksumUrl
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,7 +1,7 @@
 # Zedra Host installer for Windows.
 #
 # Usage:
-#   irm https://zedra.dev/install.ps1 | iex
+#   powershell -c "irm https://zedra.dev/install.ps1 | iex"
 #
 # Optional direct usage after download:
 #   .\install.ps1 -Version v0.2.4 -Prefix "$env:LOCALAPPDATA\Programs\zedra\bin"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -46,6 +46,7 @@ function Get-ZedraTarget {
 
     switch ($arch.ToUpperInvariant()) {
         "AMD64" { return "x86_64-pc-windows-msvc" }
+        "ARM64" { return "aarch64-pc-windows-msvc" }
         default {
             throw "pre-built Windows binaries are not available for architecture: $arch. Build from source with: cargo install --git https://github.com/$Repo zedra-host"
         }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,240 @@
+# Zedra Host installer for Windows.
+#
+# Usage:
+#   irm https://zedra.dev/install.ps1 | iex
+#
+# Optional direct usage after download:
+#   .\install.ps1 -Version v0.2.4 -Prefix "$env:LOCALAPPDATA\Programs\zedra\bin"
+
+param(
+    [string]$Version = "",
+    [string]$Prefix = "",
+    [switch]$NoPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Repo = "tanlethanh/zedra"
+$Binary = "zedra.exe"
+
+function Get-DefaultPrefix {
+    $localAppData = [Environment]::GetFolderPath("LocalApplicationData")
+    if ([string]::IsNullOrWhiteSpace($localAppData)) {
+        $localAppData = Join-Path $HOME "AppData\Local"
+    }
+    Join-Path $localAppData "Programs\zedra\bin"
+}
+
+function Resolve-InstallPrefix {
+    param([string]$RequestedPrefix)
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedPrefix)) {
+        return $RequestedPrefix
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:ZEDRA_PREFIX)) {
+        return $env:ZEDRA_PREFIX
+    }
+    Get-DefaultPrefix
+}
+
+function Get-ZedraTarget {
+    $arch = $env:PROCESSOR_ARCHITEW6432
+    if ([string]::IsNullOrWhiteSpace($arch)) {
+        $arch = $env:PROCESSOR_ARCHITECTURE
+    }
+
+    switch ($arch.ToUpperInvariant()) {
+        "AMD64" { return "x86_64-pc-windows-msvc" }
+        default {
+            throw "pre-built Windows binaries are not available for architecture: $arch. Build from source with: cargo install --git https://github.com/$Repo zedra-host"
+        }
+    }
+}
+
+function Resolve-ZedraVersion {
+    param([string]$RequestedVersion)
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedVersion)) {
+        return $RequestedVersion
+    }
+
+    try {
+        $headers = @{ "User-Agent" = "zedra-installer" }
+        $release = Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$Repo/releases/latest"
+        if ([string]::IsNullOrWhiteSpace($release.tag_name)) {
+            throw "missing tag_name"
+        }
+        return $release.tag_name
+    } catch {
+        throw "failed to resolve latest version. Specify one with -Version. $($_.Exception.Message)"
+    }
+}
+
+function Verify-ZedraChecksum {
+    param(
+        [string]$ArchivePath,
+        [string]$ChecksumUrl
+    )
+
+    try {
+        $expectedText = (Invoke-WebRequest -Uri $ChecksumUrl -UseBasicParsing).Content
+    } catch {
+        Write-Host "  (checksum file not available, skipping verification)"
+        return
+    }
+
+    $expectedHash = ($expectedText -split "\s+")[0].Trim().ToLowerInvariant()
+    if ([string]::IsNullOrWhiteSpace($expectedHash)) {
+        Write-Host "  (checksum file empty, skipping verification)"
+        return
+    }
+
+    $actualHash = (Get-FileHash -Algorithm SHA256 -Path $ArchivePath).Hash.ToLowerInvariant()
+    if ($actualHash -ne $expectedHash) {
+        throw "checksum mismatch! expected: $expectedHash actual: $actualHash"
+    }
+
+    Write-Host "  Checksum verified."
+}
+
+function Assert-PrefixWritable {
+    param([string]$InstallPrefix)
+
+    New-Item -ItemType Directory -Force -Path $InstallPrefix | Out-Null
+    $probe = Join-Path $InstallPrefix ".zedra-write-test-$([Guid]::NewGuid())"
+    try {
+        New-Item -ItemType File -Path $probe -Force | Out-Null
+    } catch {
+        throw "install directory is not writable: $InstallPrefix. Choose another directory with -Prefix or ZEDRA_PREFIX."
+    } finally {
+        Remove-Item -Path $probe -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Test-PathContains {
+    param(
+        [string]$PathValue,
+        [string]$Entry
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        return $false
+    }
+
+    $target = [System.IO.Path]::GetFullPath($Entry).TrimEnd("\")
+    foreach ($part in ($PathValue -split ";")) {
+        if ([string]::IsNullOrWhiteSpace($part)) {
+            continue
+        }
+        try {
+            $normalized = [System.IO.Path]::GetFullPath($part).TrimEnd("\")
+        } catch {
+            $normalized = $part.TrimEnd("\")
+        }
+        if ([string]::Equals($normalized, $target, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+    }
+
+    $false
+}
+
+function Add-ZedraToPath {
+    param([string]$InstallPrefix)
+
+    if (-not (Test-PathContains $env:Path $InstallPrefix)) {
+        $env:Path = "$InstallPrefix;$env:Path"
+    }
+
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+    if ((Test-PathContains $userPath $InstallPrefix) -or (Test-PathContains $machinePath $InstallPrefix)) {
+        return
+    }
+
+    if ([string]::IsNullOrWhiteSpace($userPath)) {
+        [Environment]::SetEnvironmentVariable("Path", $InstallPrefix, "User")
+    } else {
+        [Environment]::SetEnvironmentVariable("Path", "$userPath;$InstallPrefix", "User")
+    }
+
+    Write-Host "  Added $InstallPrefix to the user PATH. Open a new terminal to use it everywhere."
+}
+
+function Warn-IfShadowed {
+    param([string]$InstalledBinary)
+
+    $command = Get-Command "zedra.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -eq $command -or [string]::IsNullOrWhiteSpace($command.Source)) {
+        return
+    }
+
+    $resolvedInstalled = [System.IO.Path]::GetFullPath($InstalledBinary)
+    $resolvedCommand = [System.IO.Path]::GetFullPath($command.Source)
+    if (-not [string]::Equals($resolvedInstalled, $resolvedCommand, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Write-Warning "zedra.exe on PATH resolves to $resolvedCommand. Move this install directory earlier in PATH or remove the older installation."
+    }
+}
+
+function Install-Zedra {
+    param(
+        [string]$Version = "",
+        [string]$Prefix = "",
+        [switch]$NoPath
+    )
+
+    $installPrefix = Resolve-InstallPrefix $Prefix
+    $target = Get-ZedraTarget
+    $resolvedVersion = Resolve-ZedraVersion $Version
+
+    Write-Host "Installing zedra $resolvedVersion for $target..."
+
+    $baseUrl = "https://github.com/$Repo/releases/download/$resolvedVersion"
+    $archiveName = "zedra-$target.tar.gz"
+    $archiveUrl = "$baseUrl/$archiveName"
+    $checksumUrl = "$archiveUrl.sha256"
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "zedra-install-$([Guid]::NewGuid())"
+
+    New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+    try {
+        $archivePath = Join-Path $tmpDir $archiveName
+        Write-Host "  Downloading $archiveUrl..."
+        Invoke-WebRequest -Uri $archiveUrl -OutFile $archivePath -UseBasicParsing
+
+        Verify-ZedraChecksum -ArchivePath $archivePath -ChecksumUrl $checksumUrl
+
+        Write-Host "  Extracting..."
+        if (-not (Get-Command "tar.exe" -ErrorAction SilentlyContinue)) {
+            throw "tar.exe was not found. Install a current Windows 10/11 build or extract $archiveName manually."
+        }
+        & tar.exe -xzf $archivePath -C $tmpDir
+        if ($LASTEXITCODE -ne 0) {
+            throw "failed to extract $archiveName"
+        }
+
+        $extracted = Join-Path $tmpDir $Binary
+        if (-not (Test-Path $extracted)) {
+            throw "archive did not contain $Binary"
+        }
+
+        Assert-PrefixWritable $installPrefix
+        $installedBinary = Join-Path $installPrefix $Binary
+
+        Write-Host "  Installing to $installedBinary..."
+        Copy-Item -Force $extracted $installedBinary
+
+        if (-not $NoPath) {
+            Add-ZedraToPath $installPrefix
+        }
+
+        Write-Host ""
+        Write-Host "Installed zedra to $installedBinary"
+        Warn-IfShadowed $installedBinary
+        Write-Host "Run 'zedra --help' to get started."
+    } finally {
+        Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Install-Zedra -Version $Version -Prefix $Prefix -NoPath:$NoPath

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,7 +52,7 @@ detect_platform() {
         Linux)  os="unknown-linux-gnu" ;;
         MINGW*|MSYS*|CYGWIN*)
             echo "Error: use the Windows PowerShell installer instead:"
-            echo "  irm https://zedra.dev/install.ps1 | iex"
+            echo "  powershell -c \"irm https://zedra.dev/install.ps1 | iex\""
             exit 1
             ;;
         *)      echo "Error: unsupported OS: $os"; exit 1 ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,6 +50,11 @@ detect_platform() {
     case "$os" in
         Darwin) os="apple-darwin" ;;
         Linux)  os="unknown-linux-gnu" ;;
+        MINGW*|MSYS*|CYGWIN*)
+            echo "Error: use the Windows PowerShell installer instead:"
+            echo "  irm https://zedra.dev/install.ps1 | iex"
+            exit 1
+            ;;
         *)      echo "Error: unsupported OS: $os"; exit 1 ;;
     esac
     case "$arch" in


### PR DESCRIPTION
## Summary
- Add Windows host CLI platform support for config paths, detached start, stop/shutdown, process liveness, and PTY shell startup.
- Keep Unix behavior intact while moving host runtime files through a shared platform config root.
- Document Windows setup and add manual verification coverage for pairing, reconnect, relay fallback, logs, client, and terminal sessions.

## Notes
Closes #76.

A local Windows target check was attempted from macOS, but C dependencies require Windows SDK headers (`windows.h` / `assert.h`) that are not available on this machine.