### PR TITLE
fix: reset terminal preview sheet scroll state

### DIFF
--- a/crates/zedra/src/editor/code_editor.rs
+++ b/crates/zedra/src/editor/code_editor.rs
@@ -70,6 +70,7 @@ pub struct EditorView {
     /// True once a gesture has been committed to horizontal scroll.
     /// Stays true until a clearly vertical event overrides it.
     h_scroll_active: bool,
+    on_scroll_boundary_changed: Option<Box<dyn FnMut(bool)>>,
 }
 
 impl EditorView {
@@ -99,18 +100,41 @@ impl EditorView {
             h_scroll_offset: 0.0,
             max_line_chars: 0,
             h_scroll_active: false,
+            on_scroll_boundary_changed: None,
         }
+    }
+
+    pub fn on_scroll_boundary_changed(&mut self, callback: impl FnMut(bool) + 'static) {
+        self.on_scroll_boundary_changed = Some(Box::new(callback));
     }
 
     /// Replace the entire buffer content (e.g. when loading a remote file).
     /// The language is detected from the filename.
     pub fn set_content(&mut self, filename: &str, content: String) {
+        self.set_content_with_initial_line(filename, content, None);
+    }
+
+    pub fn set_content_with_initial_line(
+        &mut self,
+        filename: &str,
+        content: String,
+        initial_line: Option<u32>,
+    ) {
         self.highlighter = Rc::new(Highlighter::from_filename(filename));
         self.buffer.set_text(content);
         self.cached_line_highlights = Rc::new(Vec::new());
         self.lines_dirty = true;
         self.h_scroll_offset = 0.0;
         self.h_scroll_active = false;
+        // A new file owns its vertical origin; reusing this handle leaks the previous offset.
+        self.scroll_handle = UniformListScrollHandle::new();
+
+        let initial_line_ix = initial_line
+            .map(|line| line.saturating_sub(1) as usize)
+            .unwrap_or(0)
+            .min(self.buffer.line_count().saturating_sub(1));
+        self.scroll_handle
+            .scroll_to_item_strict(initial_line_ix, ScrollStrategy::Top);
     }
 
     pub fn apply_parsed_syntax(&mut self, parsed: ParsedEditorSyntax) {
@@ -158,6 +182,23 @@ impl EditorView {
         }
         self.cached_lines = Rc::new(lines);
         self.lines_dirty = false;
+    }
+
+    pub fn is_scrolled_to_file_top(&self) -> bool {
+        let scroll_state = self.scroll_handle.0.borrow();
+        // Opening at `file:line` moves the viewport, but only file line 1 is the file top.
+        if let Some(deferred_scroll) = scroll_state.deferred_scroll_to_item {
+            return deferred_scroll.item_index == 0;
+        }
+
+        scroll_state.base_handle.offset().y >= px(-0.5)
+    }
+
+    fn notify_scroll_boundary_changed(&mut self) {
+        let is_at_top = self.is_scrolled_to_file_top();
+        if let Some(callback) = self.on_scroll_boundary_changed.as_mut() {
+            callback(is_at_top);
+        }
     }
 }
 
@@ -316,6 +357,7 @@ impl Render for EditorView {
                             .set_offset(point(px(0.0), scroll_y_lock));
                         cx.notify();
                     }
+                    this.notify_scroll_boundary_changed();
                 }),
             )
             .child(
@@ -408,6 +450,8 @@ impl Render for EditorView {
 mod tests {
     use std::rc::Rc;
 
+    use gpui::{ScrollStrategy, point, px};
+
     use super::{
         CODE_TEXT_COLOR, EditorView, PENDING_SYNTAX_TEXT_COLOR, ParsedEditorSyntax,
         code_text_color_for_highlighter, line_range_for_selection_lines,
@@ -475,5 +519,60 @@ mod tests {
         let mut parsed = Highlighter::from_filename("main.rs");
         parsed.parse("fn main() {}\n");
         assert_eq!(code_text_color_for_highlighter(&parsed), CODE_TEXT_COLOR);
+    }
+
+    #[test]
+    fn set_content_resets_scroll_to_file_top() {
+        let mut editor = EditorView::build(
+            "old line\nold line\n".to_string(),
+            Highlighter::from_filename("old.rs"),
+        );
+        editor
+            .scroll_handle
+            .0
+            .borrow()
+            .base_handle
+            .set_offset(point(px(0.0), px(-120.0)));
+
+        editor.set_content("new.rs", "new line\n".to_string());
+
+        let scroll_state = editor.scroll_handle.0.borrow();
+        assert_eq!(scroll_state.base_handle.offset().y, px(0.0));
+        let deferred_scroll = scroll_state
+            .deferred_scroll_to_item
+            .expect("expected reset scroll target");
+        assert_eq!(deferred_scroll.item_index, 0);
+        assert_eq!(deferred_scroll.strategy, ScrollStrategy::Top);
+        drop(scroll_state);
+        assert!(editor.is_scrolled_to_file_top());
+    }
+
+    #[test]
+    fn initial_line_scroll_is_not_treated_as_file_top() {
+        let mut editor = EditorView::build(String::new(), Highlighter::from_filename("new.rs"));
+
+        editor.set_content_with_initial_line("new.rs", "one\ntwo\nthree\n".to_string(), Some(2));
+
+        let scroll_state = editor.scroll_handle.0.borrow();
+        let deferred_scroll = scroll_state
+            .deferred_scroll_to_item
+            .expect("expected initial line scroll target");
+        assert_eq!(deferred_scroll.item_index, 1);
+        assert_eq!(deferred_scroll.strategy, ScrollStrategy::Top);
+        drop(scroll_state);
+        assert!(!editor.is_scrolled_to_file_top());
+    }
+
+    #[test]
+    fn initial_line_scroll_clamps_to_file_length() {
+        let mut editor = EditorView::build(String::new(), Highlighter::from_filename("new.rs"));
+
+        editor.set_content_with_initial_line("new.rs", "one\ntwo".to_string(), Some(99));
+
+        let scroll_state = editor.scroll_handle.0.borrow();
+        let deferred_scroll = scroll_state
+            .deferred_scroll_to_item
+            .expect("expected clamped initial line scroll target");
+        assert_eq!(deferred_scroll.item_index, 1);
     }
 }

--- a/crates/zedra/src/terminal_preview_view.rs
+++ b/crates/zedra/src/terminal_preview_view.rs
@@ -6,6 +6,7 @@ use zedra_terminal::terminal::{TerminalHyperlink, TerminalHyperlinkTarget};
 use crate::editor::code_editor::{EditorView, ParsedEditorSyntax};
 use crate::editor::markdown::{MarkdownView, is_markdown_path, parse_markdown_source};
 use crate::fonts;
+use crate::native_presentation;
 use crate::placeholder::render_placeholder;
 use crate::theme;
 use crate::workspace_state::WorkspaceState;
@@ -48,7 +49,11 @@ impl TerminalPreviewView {
         Self {
             session_handle,
             workspace_state,
-            editor_view: cx.new(|cx| EditorView::new(cx)),
+            editor_view: cx.new(|cx| {
+                let mut editor = EditorView::new(cx);
+                editor.on_scroll_boundary_changed(native_presentation::set_sheet_content_at_top);
+                editor
+            }),
             markdown_view: cx.new(|_cx| MarkdownView::new_for_sheet(SharedString::default())),
             state: PreviewState::Idle,
             content: PreviewContent::Editor,
@@ -63,6 +68,7 @@ impl TerminalPreviewView {
     pub fn open_hyperlink(&mut self, hyperlink: TerminalHyperlink, cx: &mut Context<Self>) {
         self.open_epoch = self.open_epoch.wrapping_add(1);
         let epoch = self.open_epoch;
+        native_presentation::set_sheet_content_at_top(true);
         match hyperlink.target {
             TerminalHyperlinkTarget::Url { url } => {
                 let prev_task = self.read_task.take();
@@ -146,7 +152,11 @@ impl TerminalPreviewView {
                                 }
                                 this.state = PreviewState::Loaded;
                                 this.editor_view.update(cx, |editor_view, _cx| {
-                                    editor_view.set_content(&filename, content);
+                                    editor_view
+                                        .set_content_with_initial_line(&filename, content, line);
+                                    native_presentation::set_sheet_content_at_top(
+                                        editor_view.is_scrolled_to_file_top(),
+                                    );
                                 });
                                 cx.notify();
                             }) {

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -296,7 +296,7 @@ printf '\033]8;;https://zedra.dev\033\\zedra.dev\033]8;;\033\\\n'
 
 3. Expected before tapping: only the OSC 8 `src/main.rs:12:3` and `zedra.dev` rows show a subtle underline; the plain `src/main.rs:12:3`, `git:(refactor-app-session-architecture)`, `hello`, `README`, `v0.112.0`, `gpt-5.4`, and `/model` rows do not
 4. Tap the underlined OSC 8 `src/main.rs:12:3`
-5. Expected: the terminal file preview opens for `src/main.rs` at line/column metadata
+5. Expected: the terminal file preview opens for `src/main.rs` at line 12/column metadata and does not reuse any previous preview scroll position
 6. Expected: the preview header metadata and code body both render with the app monospace font rather than a proportional fallback
 7. Tap the underlined OSC 8 `zedra.dev`
 8. Expected: the URL opens externally
@@ -309,24 +309,31 @@ printf '\033]8;;https://zedra.dev\033\\zedra.dev\033]8;;\033\\\n'
 2. Run:
 
 ```bash
-cat > /tmp/zedra-long-code.rs <<'EOF'
-fn main() {
-    let message = "this line is intentionally very long so the terminal preview code editor needs horizontal scrolling inside the native custom sheet without moving the sheet detent or dismissing the sheet while the drag is horizontal";
-    println!("{message}");
-}
-EOF
-printf '\033]8;;file:///tmp/zedra-long-code.rs:1:1\033\\/tmp/zedra-long-code.rs:1\033]8;;\033\\\n'
+{
+  printf 'fn main() {\n'
+  for i in $(seq 1 80); do
+    if [ "$i" = 40 ]; then
+      printf '    let message = "this line is intentionally very long so the terminal preview code editor needs horizontal scrolling inside the native custom sheet without moving the sheet detent or dismissing the sheet while the drag is horizontal";\n'
+    else
+      printf '    println!("line %02d");\n' "$i"
+    fi
+  done
+  printf '}\n'
+} > /tmp/zedra-long-code.rs
+printf '\033]8;;file:///tmp/zedra-long-code.rs:41:1\033\\/tmp/zedra-long-code.rs:41\033]8;;\033\\\n'
 ```
 
-3. Tap `/tmp/zedra-long-code.rs:1`
-4. Expected: the preview opens in code editor mode inside the native custom sheet
+3. Tap `/tmp/zedra-long-code.rs:41`
+4. Expected: the preview opens in code editor mode inside the native custom sheet with line 41 at the top of the code body
 5. Expected: Rust keywords and string tokens gain syntax colors after the preview finishes parsing
 6. Swipe horizontally across the long string line
 7. Expected: the code scrolls sideways and the native sheet does not move or dismiss
 8. Swipe mostly vertically inside the preview body
 9. Expected: the preview content scrolls vertically
-10. Scroll to the top of the preview body, then drag downward
-11. Expected: the native sheet moves or dismisses normally from the top edge
+10. Dismiss the sheet, tap `/tmp/zedra-long-code.rs:41` again, then drag downward before line 1 is visible
+11. Expected: the code scrolls toward line 1 first; the opened line is not treated as the file top
+12. Scroll to the top of the preview body, then drag downward
+13. Expected: the native sheet moves or dismisses normally from the top edge
 
 ## 10. Connecting Overlay Layout On Wide Screens
 


### PR DESCRIPTION
## Summary
- reset the terminal preview code editor scroll state when opening a new file link
- open `file:line` previews at the linked line without treating that line as the file top
- update the manual iOS sheet gesture checks for stale offsets and linked-line previews

## Notes
Fixes #82.