### PR TITLE
fix(ios): restore device log capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10022,6 +10022,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",

--- a/crates/zedra/Cargo.toml
+++ b/crates/zedra/Cargo.toml
@@ -20,6 +20,7 @@ gpui = { path = "../../vendor/zed/crates/gpui", default-features = false }
 http_client = { path = "../../vendor/zed/crates/http_client" }
 anyhow.workspace = true
 tracing.workspace = true
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 log.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/crates/zedra/src/ios/logger.rs
+++ b/crates/zedra/src/ios/logger.rs
@@ -1,15 +1,11 @@
-/// iOS logger that routes through NSLog so output appears in idevicesyslog.
+/// iOS logger that routes Rust logs into the device log stream.
 ///
-/// `os_log` (used by the `oslog` crate) goes to Apple's unified logging
-/// system at OS_LOG_TYPE_INFO level, which idevicesyslog (libimobiledevice)
-/// does not capture. NSLog routes through ASL (Apple System Log), which
-/// idevicesyslog reliably surfaces over USB.
-///
-/// Log lines are formatted as:
-///   `[I dev.zedra.app::module] message`
-/// so the `grep -E 'Zedra|zedra'` filter in the ios-log skill matches them.
+/// `log` crate lines are formatted as `[I dev.zedra.app::module] message`.
+/// `tracing` lines use the compact subscriber format.
 use log::{Level, Log, Metadata, Record};
 use std::ffi::CString;
+use std::io::{self, Write};
+use tracing_subscriber::{EnvFilter, fmt::MakeWriter};
 
 unsafe extern "C" {
     fn zedra_nslog(msg: *const std::ffi::c_char);
@@ -19,9 +15,90 @@ pub struct IosLogger;
 
 impl IosLogger {
     pub fn init(level: log::LevelFilter) {
-        log::set_boxed_logger(Box::new(IosLogger))
-            .map(|()| log::set_max_level(level))
-            .ok();
+        match log::set_boxed_logger(Box::new(IosLogger)) {
+            Ok(()) => log::set_max_level(level),
+            Err(_) => log::set_max_level(level),
+        }
+
+        install_tracing_logger(level);
+    }
+}
+
+fn install_tracing_logger(level: log::LevelFilter) {
+    if level == log::LevelFilter::Off {
+        return;
+    }
+
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .with_env_filter(ios_tracing_filter(level))
+        .with_level(true)
+        .with_target(true)
+        .without_time()
+        .with_writer(IosTracingMakeWriter)
+        .finish();
+
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}
+
+fn ios_tracing_filter(level: log::LevelFilter) -> EnvFilter {
+    let level = match level {
+        log::LevelFilter::Off => "off",
+        log::LevelFilter::Error => "error",
+        log::LevelFilter::Warn => "warn",
+        log::LevelFilter::Info => "info",
+        log::LevelFilter::Debug => "debug",
+        log::LevelFilter::Trace => "trace",
+    };
+
+    if cfg!(feature = "debug-logs") {
+        EnvFilter::new(level)
+    } else {
+        EnvFilter::new(format!(
+            "{level},iroh=warn,iroh_quinn=warn,iroh_relay=warn,quinn=warn"
+        ))
+    }
+}
+
+struct IosTracingMakeWriter;
+
+impl<'a> MakeWriter<'a> for IosTracingMakeWriter {
+    type Writer = IosTracingWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        IosTracingWriter { buffer: Vec::new() }
+    }
+}
+
+struct IosTracingWriter {
+    buffer: Vec<u8>,
+}
+
+impl Write for IosTracingWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buffer.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for IosTracingWriter {
+    fn drop(&mut self) {
+        if self.buffer.is_empty() {
+            return;
+        }
+
+        let message = String::from_utf8_lossy(&self.buffer);
+        write_ios_log(message.trim_end());
+    }
+}
+
+fn write_ios_log(message: &str) {
+    if let Ok(c) = CString::new(message) {
+        unsafe { zedra_nslog(c.as_ptr()) };
     }
 }
 
@@ -50,9 +127,7 @@ impl Log for IosLogger {
             Level::Trace => 'T',
         };
         let msg = format!("[{} {}] {}", level, record.target(), record.args());
-        if let Ok(c) = CString::new(msg) {
-            unsafe { zedra_nslog(c.as_ptr()) };
-        }
+        write_ios_log(&msg);
     }
 
     fn flush(&self) {}

--- a/crates/zedra/src/ios/nslog_bridge.m
+++ b/crates/zedra/src/ios/nslog_bridge.m
@@ -1,8 +1,12 @@
 #import <Foundation/Foundation.h>
+#import <os/log.h>
 
-// Called from Rust's IosLogger to route log output through NSLog.
-// NSLog goes through ASL (Apple System Log), making it visible in
-// idevicesyslog — unlike os_log which requires Console.app or log stream.
+// Called from Rust's iOS logger to route log output into the device log stream.
 void zedra_nslog(const char *msg) {
+    if (msg == NULL) {
+        return;
+    }
+
     NSLog(@"%s", msg);
+    os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_INFO, "%{public}s", msg);
 }

--- a/docs/IOS_WORKFLOW.md
+++ b/docs/IOS_WORKFLOW.md
@@ -41,7 +41,11 @@ ZEDRA_SKIP_RUST_XCODE_BUILD=1 xcodebuild build \
 ./scripts/log-ios.sh                     # stream all logs via USB
 ./scripts/log-ios.sh --filter zedra      # filtered
 ./scripts/log-ios.sh --select-device     # choose device
+./scripts/log-ios.sh --simulator         # stream from a booted simulator
 ```
+
+For physical devices, the log script only shows USB-paired devices visible to
+`libimobiledevice`. Use `--select-device` after switching devices.
 
 ## Build Pipeline
 

--- a/scripts/log-ios.sh
+++ b/scripts/log-ios.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# ios-log.sh — Stream logs from a USB-connected iOS device or running simulator.
+# log-ios.sh — Stream logs from a USB-connected iOS device or running simulator.
 #
 # Usage:
-#   ./scripts/ios-log.sh [--filter <pattern>] [--select-device] [--simulator]
+#   ./scripts/log-ios.sh [--filter <pattern>] [--select-device] [--simulator]
 #
 # Options:
-#   --filter <pattern>   Additional grep pattern on top of default Zedra filter
+#   --filter <pattern>   Additional regex pattern on top of default Zedra filter
 #   --with-native        Include native logs
 #   --select-device      Ignore saved device preference and re-prompt
 #   --simulator          Stream logs from a booted simulator instead of a physical device
@@ -23,6 +23,71 @@ WITH_NATIVE=false
 SELECT_DEVICE=false
 SIMULATOR=false
 PREF_FILE="/tmp/zedra-ios-device-$PPID"
+
+find_tool() {
+    local name="$1"
+
+    if command -v "$name" >/dev/null 2>&1; then
+        command -v "$name"
+    elif [[ -x "/opt/homebrew/bin/$name" ]]; then
+        echo "/opt/homebrew/bin/$name"
+    elif [[ -x "/usr/local/bin/$name" ]]; then
+        echo "/usr/local/bin/$name"
+    else
+        return 1
+    fi
+}
+
+write_saved_device_pref() {
+    printf '%s|%s|%s\n' "$1" "$2" "$3" > "$PREF_FILE"
+}
+
+read_saved_device_pref() {
+    local first=""
+    local second=""
+    local third=""
+
+    IFS='|' read -r first second third < "$PREF_FILE" || return 1
+
+    if [[ "$first" == "dev" || "$first" == "sim" ]]; then
+        DEVICE_TYPE="$first"
+        DEVICE_UDID="${second:-}"
+        DEVICE_NAME="${third:-}"
+    elif [[ -n "$first" && -n "$second" ]]; then
+        # Older run-ios.sh builds saved physical devices as "udid|name".
+        DEVICE_TYPE="dev"
+        DEVICE_UDID="$first"
+        DEVICE_NAME="$second"
+        write_saved_device_pref "$DEVICE_TYPE" "$DEVICE_UDID" "$DEVICE_NAME"
+    else
+        return 1
+    fi
+
+    [[ -n "$DEVICE_UDID" ]]
+}
+
+visible_physical_device_lines() {
+    local idevice_id="$1"
+    local udids=""
+    local xctrace_lines=""
+    local udid=""
+    local line=""
+
+    udids=$("$idevice_id" -l 2>/dev/null || true)
+    [[ -n "$udids" ]] || return 1
+
+    xctrace_lines=$(xcrun xctrace list devices 2>&1 || true)
+    while IFS= read -r udid; do
+        [[ -n "$udid" ]] || continue
+
+        line=$(printf '%s\n' "$xctrace_lines" | grep -F "($udid)" | head -1 || true)
+        if [[ -n "$line" ]]; then
+            printf '%s\n' "$line"
+        else
+            printf 'iOS Device (unknown) (%s)\n' "$udid"
+        fi
+    done <<< "$udids"
+}
 
 # ---------------------------------------------------------------------------
 # Parse arguments
@@ -46,6 +111,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+IDEVICE_ID=$(find_tool idevice_id || true)
+IDEVICESYSLOG=$(find_tool idevicesyslog || true)
+
 # ---------------------------------------------------------------------------
 # Device selection
 # ---------------------------------------------------------------------------
@@ -54,15 +122,16 @@ DEVICE_NAME=""
 DEVICE_TYPE=""  # "sim" or "dev"
 
 if [[ "$SELECT_DEVICE" == false ]] && [[ -f "$PREF_FILE" ]]; then
-    IFS='|' read -r DEVICE_TYPE DEVICE_UDID DEVICE_NAME < "$PREF_FILE"
-    # If --simulator flag contradicts saved type, re-select
-    if [[ "$SIMULATOR" == true && "$DEVICE_TYPE" != "sim" ]] || \
-       [[ "$SIMULATOR" == false && "$DEVICE_TYPE" == "sim" ]]; then
-        DEVICE_UDID=""
-        DEVICE_NAME=""
-        DEVICE_TYPE=""
-    else
-        echo "==> Using saved device: $DEVICE_NAME ($DEVICE_UDID)"
+    if read_saved_device_pref; then
+        # If --simulator flag contradicts saved type, re-select
+        if [[ "$SIMULATOR" == true && "$DEVICE_TYPE" != "sim" ]] || \
+           [[ "$SIMULATOR" == false && "$DEVICE_TYPE" == "sim" ]]; then
+            DEVICE_UDID=""
+            DEVICE_NAME=""
+            DEVICE_TYPE=""
+        else
+            echo "==> Using saved device: $DEVICE_NAME ($DEVICE_UDID)"
+        fi
     fi
 fi
 
@@ -115,17 +184,22 @@ if [[ -z "$DEVICE_UDID" ]]; then
             exit 1
         fi
 
-        echo "sim|$DEVICE_UDID|$DEVICE_NAME" > "$PREF_FILE"
+        write_saved_device_pref "sim" "$DEVICE_UDID" "$DEVICE_NAME"
         echo "==> Selected: $DEVICE_NAME ($DEVICE_UDID)"
     else
         # -----------------------------------------------------------------------
         # Physical device selection
         # -----------------------------------------------------------------------
+        if [[ -z "$IDEVICE_ID" ]]; then
+            echo "Error: idevice_id not found. Install with: brew install libimobiledevice" >&2
+            exit 1
+        fi
+
         echo "==> Enumerating connected devices..."
-        DEVICE_LINES=$(xcrun xctrace list devices 2>&1 | grep -E '^\w.+\(\d+\.\d+' | grep -v Simulator)
+        DEVICE_LINES=$(visible_physical_device_lines "$IDEVICE_ID" || true)
 
         if [[ -z "$DEVICE_LINES" ]]; then
-            echo "Error: No physical iOS devices found. Connect a device or use --simulator." >&2
+            echo "Error: No USB-visible iOS devices found. Connect and trust a device, or use --simulator." >&2
             exit 1
         fi
 
@@ -162,7 +236,7 @@ if [[ -z "$DEVICE_UDID" ]]; then
             exit 1
         fi
 
-        echo "dev|$DEVICE_UDID|$DEVICE_NAME" > "$PREF_FILE"
+        write_saved_device_pref "dev" "$DEVICE_UDID" "$DEVICE_NAME"
         echo "==> Selected: $DEVICE_NAME ($DEVICE_UDID)"
     fi
 fi
@@ -170,7 +244,7 @@ fi
 # ---------------------------------------------------------------------------
 # Stream logs
 # ---------------------------------------------------------------------------
-GREP_PATTERN='\[I |\[W |\[E |\[D |panic|PANIC|crash|CRASH|NSException|Terminating'
+GREP_PATTERN='\[I |\[W |\[E |\[D | INFO | WARN | ERROR | DEBUG | TRACE |panic|PANIC|crash|CRASH|NSException|Terminating'
 if [[ -n "$FILTER" ]]; then
     GREP_PATTERN="$GREP_PATTERN|$FILTER"
 fi
@@ -196,20 +270,71 @@ if [[ "$DEVICE_TYPE" == "sim" ]]; then
         | grep -E "$GREP_PATTERN" --line-buffered --color=auto
 else
     # Physical device: use idevicesyslog (USB, no sudo required)
-    IDEVICESYSLOG="/opt/homebrew/bin/idevicesyslog"
-    if [[ ! -x "$IDEVICESYSLOG" ]]; then
-        echo "Error: idevicesyslog not found at $IDEVICESYSLOG" >&2
+    if [[ -z "$IDEVICESYSLOG" ]]; then
+        echo "Error: idevicesyslog not found." >&2
         echo "Install with: brew install libimobiledevice" >&2
+        exit 1
+    fi
+    if [[ -z "$IDEVICE_ID" ]]; then
+        echo "Error: idevice_id not found. Install with: brew install libimobiledevice" >&2
         exit 1
     fi
 
     # Verify device is visible to libimobiledevice (requires USB pairing)
-    if ! /opt/homebrew/bin/idevice_id -l 2>/dev/null | grep -q "$DEVICE_UDID"; then
+    if ! "$IDEVICE_ID" -l 2>/dev/null | grep -F -q "$DEVICE_UDID"; then
         echo "Error: Device $DEVICE_UDID not visible to idevicesyslog." >&2
         echo "idevicesyslog requires a USB-connected (paired) device." >&2
         exit 1
     fi
 
-    "$IDEVICESYSLOG" -u "$DEVICE_UDID" -p Zedra \
-        | grep -E "$GREP_PATTERN" --line-buffered --color=auto
+    # Run idevicesyslog under a pseudo-terminal. When stdout is a pipe,
+    # idevicesyslog can block-buffer and make filtered logs appear stuck.
+    python3 - "$IDEVICESYSLOG" "$DEVICE_UDID" "$GREP_PATTERN" <<'PY'
+import os
+import pty
+import re
+import select
+import signal
+import sys
+
+tool, udid, pattern = sys.argv[1:4]
+regex = re.compile(pattern)
+
+def stop(_signum, _frame):
+    raise KeyboardInterrupt
+
+signal.signal(signal.SIGINT, stop)
+signal.signal(signal.SIGTERM, stop)
+
+pid, fd = pty.fork()
+if pid == 0:
+    os.execv(tool, [tool, "--no-colors", "-u", udid, "-p", "Zedra"])
+
+buffer = b""
+try:
+    while True:
+        readable, _, _ = select.select([fd], [], [])
+        if fd not in readable:
+            continue
+        chunk = os.read(fd, 4096)
+        if not chunk:
+            break
+        buffer += chunk
+        while b"\n" in buffer:
+            line, buffer = buffer.split(b"\n", 1)
+            text = line.decode(errors="replace").rstrip("\r")
+            if regex.search(text):
+                print(text, flush=True)
+except KeyboardInterrupt:
+    pass
+finally:
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        os.waitpid(pid, 0)
+    except ChildProcessError:
+        pass
+PY
 fi

--- a/scripts/run-ios.sh
+++ b/scripts/run-ios.sh
@@ -95,6 +95,88 @@ LAUNCH_URL=""
 NO_BUILD=false
 PREF_FILE="/tmp/zedra-ios-device-$PPID"
 
+write_saved_device_pref() {
+    printf '%s|%s|%s\n' "$1" "$2" "$3" > "$PREF_FILE"
+}
+
+read_saved_device_pref() {
+    local first=""
+    local second=""
+    local third=""
+
+    IFS='|' read -r first second third < "$PREF_FILE" || return 1
+
+    if [ "$first" = "dev" ] || [ "$first" = "sim" ]; then
+        SAVED_DEVICE_TYPE="$first"
+        SAVED_DEVICE_ID="${second:-}"
+        SAVED_DEVICE_NAME="${third:-}"
+    elif [ -n "$first" ] && [ -n "$second" ]; then
+        # Older script versions saved physical devices as "udid|name".
+        SAVED_DEVICE_TYPE="dev"
+        SAVED_DEVICE_ID="$first"
+        SAVED_DEVICE_NAME="$second"
+        write_saved_device_pref "$SAVED_DEVICE_TYPE" "$SAVED_DEVICE_ID" "$SAVED_DEVICE_NAME"
+    else
+        return 1
+    fi
+
+    [ -n "$SAVED_DEVICE_ID" ]
+}
+
+list_xctrace_physical_devices() {
+    xcrun xctrace list devices 2>&1 | awk '
+        /^== Devices ==/ { in_devices = 1; next }
+        /^==/ { in_devices = 0; next }
+        in_devices && /^[[:alnum:]].*\([0-9]+\.[0-9]+(\.[0-9]+)?\)/ { print }
+    '
+}
+
+latest_built_app() {
+    local product_dir="$1"
+
+    find "$HOME/Library/Developer/Xcode/DerivedData"/Zedra-*/Build/Products/"$product_dir" \
+        -name "Zedra.app" \
+        -type d \
+        -print0 2>/dev/null \
+        | xargs -0 stat -f "%m %N" 2>/dev/null \
+        | sort -rn \
+        | sed -n '1s/^[0-9][0-9]* //p'
+}
+
+terminate_running_zedra_processes() {
+    local device_id="$1"
+    local processes_json
+    processes_json=$(mktemp /tmp/zedra-ios-processes.XXXXXX.json)
+
+    if xcrun devicectl device info processes --device "$device_id" --json-output "$processes_json" --quiet >/dev/null 2>&1; then
+        python3 - "$processes_json" <<'PY' | while IFS= read -r pid; do
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as file:
+    payload = json.load(file)
+
+def visit(value):
+    if isinstance(value, dict):
+        executable = str(value.get("executable", ""))
+        pid = value.get("processIdentifier")
+        if "/Zedra.app/Zedra" in executable and pid is not None:
+            print(pid)
+        for child in value.values():
+            visit(child)
+    elif isinstance(value, list):
+        for child in value:
+            visit(child)
+
+visit(payload)
+PY
+            xcrun devicectl device process terminate --device "$device_id" --pid "$pid" --quiet >/dev/null 2>&1 || true
+        done
+    fi
+
+    rm -f "$processes_json"
+}
+
 args=("$@")
 i=0
 while [ $i -lt ${#args[@]} ]; do
@@ -175,6 +257,7 @@ for runtime, devices in data['devices'].items():
             sys.exit(0)
 " 2>/dev/null)
         echo "==> Target: $SIM_NAME ($BOOTED_ID)"
+        write_saved_device_pref "sim" "$BOOTED_ID" "$SIM_NAME"
 
         if [ "$NO_BUILD" = false ]; then
             # Build Rust libraries (simulator target only)
@@ -194,7 +277,7 @@ for runtime, devices in data['devices'].items():
                 -quiet
 
             # Find the built .app
-            APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData/Zedra-*/Build/Products/${XCODE_CONFIGURATION}-iphonesimulator -name "Zedra.app" -type d 2>/dev/null | head -1)
+            APP_PATH=$(latest_built_app "${XCODE_CONFIGURATION}-iphonesimulator")
 
             if [ -z "$APP_PATH" ]; then
                 echo "Error: Could not find built .app"
@@ -225,31 +308,39 @@ for runtime, devices in data['devices'].items():
 
         if [ -n "$FORCED_DEVICE_ID" ]; then
             # Explicit --device-id takes priority, resolve name/OS from it
-            DEVICE_LINE=$(xcrun xctrace list devices 2>&1 | grep "$FORCED_DEVICE_ID" | head -1)
+            DEVICE_LINE=$(list_xctrace_physical_devices | grep "$FORCED_DEVICE_ID" | head -1)
             if [ -z "$DEVICE_LINE" ]; then
                 echo "Error: Device with UDID '$FORCED_DEVICE_ID' not found."
                 echo ""
                 echo "Available devices:"
-                xcrun xctrace list devices 2>&1 | grep -E '^\w.+\(\d+\.\d+'
+                list_xctrace_physical_devices
                 exit 1
             fi
             DEVICE_ID="$FORCED_DEVICE_ID"
+            DEVICE_NAME_SAVED=$(echo "$DEVICE_LINE" | sed 's/ ([^)]*) ([^)]*)$//' | sed 's/ ([^)]*)$//')
+            write_saved_device_pref "dev" "$DEVICE_ID" "$DEVICE_NAME_SAVED"
         else
             # Check session-scoped pref file (shared with ios-log.sh)
             if [ "$SELECT_DEVICE" = false ] && [ -f "$PREF_FILE" ]; then
-                IFS='|' read -r DEVICE_ID DEVICE_NAME_SAVED < "$PREF_FILE"
-                DEVICE_LINE=$(xcrun xctrace list devices 2>&1 | grep "$DEVICE_ID" | head -1)
-                if [ -z "$DEVICE_LINE" ]; then
-                    echo "Warning: Saved device $DEVICE_ID not found, re-prompting..."
-                    DEVICE_ID=""
-                else
-                    echo "==> Using saved device: $DEVICE_NAME_SAVED ($DEVICE_ID)"
+                SAVED_DEVICE_TYPE=""
+                SAVED_DEVICE_ID=""
+                SAVED_DEVICE_NAME=""
+                if read_saved_device_pref && [ "$SAVED_DEVICE_TYPE" = "dev" ]; then
+                    DEVICE_ID="$SAVED_DEVICE_ID"
+                    DEVICE_NAME_SAVED="$SAVED_DEVICE_NAME"
+                    DEVICE_LINE=$(list_xctrace_physical_devices | grep "$DEVICE_ID" | head -1)
+                    if [ -z "$DEVICE_LINE" ]; then
+                        echo "Warning: Saved device $DEVICE_ID not found, re-prompting..."
+                        DEVICE_ID=""
+                    else
+                        echo "==> Using saved device: $DEVICE_NAME_SAVED ($DEVICE_ID)"
+                    fi
                 fi
             fi
 
             # Interactive selection if no device yet
             if [ -z "$DEVICE_ID" ]; then
-                DEVICE_LINES=$(xcrun xctrace list devices 2>&1 | grep -E '^\w.+\(\d+\.\d+' | grep -v Simulator)
+                DEVICE_LINES=$(list_xctrace_physical_devices)
                 if [ -z "$DEVICE_LINES" ]; then
                     echo "Error: No connected iOS device found." >&2
                     exit 1
@@ -281,7 +372,7 @@ for runtime, devices in data['devices'].items():
                 DEVICE_ID=$(echo "$SELECTED_LINE" | grep -oE '\([A-F0-9a-f-]{25,}\)' | tail -1 | tr -d '()')
                 DEVICE_NAME_SAVED=$(echo "$SELECTED_LINE" | sed 's/ ([^)]*) ([^)]*)$//' | sed 's/ ([^)]*)$//')
                 DEVICE_LINE="$SELECTED_LINE"
-                echo "$DEVICE_ID|$DEVICE_NAME_SAVED" > "$PREF_FILE"
+                write_saved_device_pref "dev" "$DEVICE_ID" "$DEVICE_NAME_SAVED"
             fi
         fi
 
@@ -312,15 +403,15 @@ for runtime, devices in data['devices'].items():
                 -quiet
 
             # Find the built .app
-            APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData/Zedra-*/Build/Products/${XCODE_CONFIGURATION}-iphoneos -name "Zedra.app" -type d 2>/dev/null | head -1)
+            APP_PATH=$(latest_built_app "${XCODE_CONFIGURATION}-iphoneos")
 
             if [ -z "$APP_PATH" ]; then
                 echo "Error: Could not find built .app"
                 exit 1
             fi
 
-            # Kill running app before install to avoid install-over-running-process issues
-            xcrun devicectl device process terminate --device "$DEVICE_ID" --bundle-id "$BUNDLE_ID" 2>/dev/null || true
+            echo "==> Stopping running Zedra processes..."
+            terminate_running_zedra_processes "$DEVICE_ID"
 
             # Install on device
             echo "==> Installing on $DEVICE_NAME..."
@@ -328,6 +419,7 @@ for runtime, devices in data['devices'].items():
         fi
 
         echo "==> Launching..."
+        terminate_running_zedra_processes "$DEVICE_ID"
         if [ -n "$LAUNCH_URL" ]; then
             echo "==> Opening URL: $LAUNCH_URL"
             xcrun devicectl device process launch --device "$DEVICE_ID" --payload-url "$LAUNCH_URL" "$BUNDLE_ID"


### PR DESCRIPTION
## Summary
- Route iOS Rust tracing events into the device log stream.
- Fix iOS log script device selection, filtering, and run app selection/restart behavior so `SelectionDebug` logs can be captured reliably.

## Notes
- Physical logging still requires a USB-paired device visible to `libimobiledevice`.
- This PR is intentionally scoped to iOS log capture; terminal selection and Firebase config changes remain out of scope.
