### PR TITLE
feat(ios): make iOS Firebase config optional for debug

### DIFF
--- a/docs/IOS_WORKFLOW.md
+++ b/docs/IOS_WORKFLOW.md
@@ -78,6 +78,10 @@ Zedra app target
 falls back to `ios/Zedra.xcodeproj` otherwise. Direct `xcodebuild` commands for
 Firebase/CocoaPods builds should use the workspace.
 
+Debug builds do not require `ios/Zedra/GoogleService-Info.plist`; the Firebase
+bridge disables itself when the bundled config is absent. Release builds require
+the plist and the Xcode build fails with an explicit error if it is missing.
+
 **Note**: `Cargo.toml` declares `crate-type = ["cdylib", "staticlib"]`. The
 cdylib is for Android. On iOS, `build-ios.sh` builds the `zedra` package for
 the selected target, fails on cargo errors, and checks for the `.a` before
@@ -206,5 +210,6 @@ Automatic in `ios/project.yml`. Pass `-allowProvisioningUpdates` to xcodebuild.
 - **Stale xcframework**: Xcode builds refresh the matching Rust slice through the `ZedraRustFFI` dependency target. If you skip that target or use `--no-build`, run `build-ios.sh` after Rust changes.
 - **New extern "C" call**: must add weak stub in `crates/zedra/src/ios_stub.c` or staticlib will be stale.
 - **xcodegen required**: after editing `project.yml`, run `cd ios && xcodegen generate`. `run-ios.sh` does this automatically only when `ios/project.yml` is newer than the generated project; set `ZEDRA_FORCE_XCODEGEN=1` to force regeneration.
+- **Firebase config**: Debug builds work without `ios/Zedra/GoogleService-Info.plist`; Release builds require it.
 - **Metal device**: iOS uses `system_default()` directly. macOS `isRemovable()`/`isLowPower()` selectors crash on iOS.
 - **`with_input_handler` log spam**: harmless — UIKit queries text input before IosWindow is registered.

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -133,7 +133,8 @@ Firebase is integrated via CocoaPods. Key files:
 | File | Purpose |
 |------|---------|
 | `ios/Podfile` | `FirebaseAnalytics`, `FirebaseCrashlytics` pods |
-| `ios/Zedra/GoogleService-Info.plist` | Firebase project config (from console) |
+| `ios/Zedra/GoogleService-Info.plist` | Firebase project config (from console); optional for Debug, required for Release |
+| `ios/project.yml` | XcodeGen spec that bundles Firebase config when present and fails Release builds when it is missing |
 | `ios/Zedra/NativeBridge.swift` | Swift C-export bridge: `zedra_firebase_initialize`, `zedra_log_event`, `zedra_record_error`, `zedra_record_panic` |
 | `crates/zedra/src/ios/telemetry.rs` | Rust FFI declarations calling into `NativeBridge.swift` |
 | `crates/zedra/src/telemetry.rs` | `FirebaseBackend` — registers with `zedra_telemetry` |
@@ -144,6 +145,9 @@ enabled, so UIKit rows such as alerts, QR scanner, and custom sheet controllers
 can still appear beside logical Zedra rows in Firebase reports.
 
 **Build**: `pod install` in `ios/`, then build via `.xcworkspace`.
+Debug builds can run without `ios/Zedra/GoogleService-Info.plist`; Firebase
+initialization and event calls become no-ops. Release builds require the plist
+and fail during the Xcode build when it is absent.
 
 ### Android (planned)
 
@@ -221,6 +225,7 @@ and never transmitted alongside it.
 | `crates/zedra-telemetry/src/lib.rs` | `Event` enum, `TelemetryBackend` trait, `send()`, `init()` |
 | `crates/zedra/src/telemetry.rs` | `FirebaseBackend` — registers Firebase with `zedra-telemetry` |
 | `crates/zedra/src/ios/telemetry.rs` | iOS FFI: Rust -> `NativeBridge.swift` -> Firebase SDK |
+| `ios/project.yml` | iOS Firebase config bundling and Release validation |
 | `crates/zedra-host/src/telemetry.rs` | `HostBackend` — bridges GA4 `Ga4` <-> `zedra-telemetry` |
 | `crates/zedra-host/src/ga4.rs` | GA4 Measurement Protocol transport (`track_raw`, `host_panic_sync`) |
 

--- a/ios/Zedra.xcodeproj/project.pbxproj
+++ b/ios/Zedra.xcodeproj/project.pbxproj
@@ -32,7 +32,6 @@
 		980622780D44495907582D63 /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47A99A911DFEB67B22FF841B /* Network.framework */; };
 		A69ED82EFBA5E7757C5DBF77 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C6681ECC3A80F94D9F1A0A /* CoreFoundation.framework */; };
 		A7EEE2EFA03F51452EA9FEFE /* ZedraFFI.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9A9EA625E2ED4114945F081 /* ZedraFFI.xcframework */; };
-		AC71CFF172BCC3FE83A29DF5 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CB837291612FBC7C669A4883 /* GoogleService-Info.plist */; };
 		BE058F99FCA4058A88807631 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33FBCE1A928EAF32E817D1DE /* CoreText.framework */; };
 		C4615C398F2572ED57528BB1 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E0368E716FAFC7DC17C3B7B1 /* UIKit.framework */; };
 		C6719995D3E0E4499805BFA7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 94CC8ED9DAA6944067FF57DB /* main.m */; };
@@ -73,7 +72,6 @@
 		B9A9EA625E2ED4114945F081 /* ZedraFFI.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = ZedraFFI.xcframework; sourceTree = "<group>"; };
 		C1CC23275A2211DE5D4991B1 /* GPUIRuntimeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPUIRuntimeController.swift; sourceTree = "<group>"; };
 		C27468FDB02BEAEEF9A0835F /* Pods-Zedra.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zedra.debug.xcconfig"; path = "Target Support Files/Pods-Zedra/Pods-Zedra.debug.xcconfig"; sourceTree = "<group>"; };
-		CB837291612FBC7C669A4883 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		CBA9E86324F7D522B45D5BF8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E0368E716FAFC7DC17C3B7B1 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		E2710A21022C473FA88BF88A /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
@@ -156,7 +154,6 @@
 			isa = PBXGroup;
 			children = (
 				CBA9E86324F7D522B45D5BF8 /* Assets.xcassets */,
-				CB837291612FBC7C669A4883 /* GoogleService-Info.plist */,
 				C1CC23275A2211DE5D4991B1 /* GPUIRuntimeController.swift */,
 				F48626960A7B8482AA6C9676 /* Info.plist */,
 				69F922850E131108EA0DCDA2 /* KeyboardSupporter.swift */,
@@ -180,6 +177,7 @@
 				909545E704A1285F03F00F56 /* Sources */,
 				3D0993EE512488A75299992B /* Resources */,
 				B904AB45BFDAA98506246086 /* Frameworks */,
+				8CA192F395F9B0CD6745F5AB /* Firebase Config */,
 				9B92177DC22DAAB553CD16E4 /* Firebase Crashlytics dSYM Upload */,
 				8F7199AD59B2972E2A956EC9 /* [CP] Copy Pods Resources */,
 			);
@@ -234,7 +232,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				8D2C90EFA428CCCDE0B092E7 /* Assets.xcassets in Resources */,
-				AC71CFF172BCC3FE83A29DF5 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -278,6 +275,24 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Zedra/Pods-Zedra-resources.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		8CA192F395F9B0CD6745F5AB /* Firebase Config */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Firebase Config";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nGOOGLE_SERVICE_PLIST=\"${SRCROOT}/Zedra/GoogleService-Info.plist\"\nAPP_BUNDLE=\"${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME:-${PRODUCT_NAME}.app}\"\nDESTINATION=\"${APP_BUNDLE}/GoogleService-Info.plist\"\n\nif [ -f \"$GOOGLE_SERVICE_PLIST\" ]; then\n  mkdir -p \"$APP_BUNDLE\"\n  cp \"$GOOGLE_SERVICE_PLIST\" \"$DESTINATION\"\n  exit 0\nfi\n\ncase \"${CONFIGURATION:-}\" in\n  Release*)\n    echo \"error: Missing $GOOGLE_SERVICE_PLIST. Release builds require Firebase configuration.\"\n    exit 1\n    ;;\n  *)\n    echo \"warning: Missing $GOOGLE_SERVICE_PLIST. Firebase is disabled for this debug build.\"\n    ;;\nesac\n";
 		};
 		9B92177DC22DAAB553CD16E4 /* Firebase Crashlytics dSYM Upload */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/Zedra.xcodeproj/project.pbxproj
+++ b/ios/Zedra.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 		};
 		8CA192F395F9B0CD6745F5AB /* Firebase Config */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -296,6 +297,7 @@
 		};
 		9B92177DC22DAAB553CD16E4 /* Firebase Crashlytics dSYM Upload */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -312,7 +314,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${PODS_ROOT}/FirebaseCrashlytics/run";
+			shellScript = "set -eu\n\nGOOGLE_SERVICE_PLIST=\"${SRCROOT}/Zedra/GoogleService-Info.plist\"\n\nif [ ! -f \"$GOOGLE_SERVICE_PLIST\" ]; then\n  case \"${CONFIGURATION:-}\" in\n    Release*)\n      echo \"error: Missing $GOOGLE_SERVICE_PLIST. Release builds require Firebase configuration.\"\n      exit 1\n      ;;\n    *)\n      echo \"warning: Skipping Firebase Crashlytics dSYM upload because $GOOGLE_SERVICE_PLIST is missing.\"\n      exit 0\n      ;;\n  esac\nfi\n\n\"${PODS_ROOT}/FirebaseCrashlytics/run\"\n";
 		};
 		FF282E57A73EF1F4E2A2C291 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/Zedra/NativeBridge.swift
+++ b/ios/Zedra/NativeBridge.swift
@@ -31,6 +31,34 @@ private final class CStringStorage {
     }
 }
 
+private enum ZedraFirebase {
+    private static let lock = NSLock()
+    private static var configured = false
+    private static var missingConfigLogged = false
+
+    static func configureIfAvailable() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if configured || FirebaseApp.app() != nil {
+            configured = true
+            return true
+        }
+
+        guard Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") != nil else {
+            if !missingConfigLogged {
+                NSLog("Zedra Firebase disabled: GoogleService-Info.plist is not bundled")
+                missingConfigLogged = true
+            }
+            return false
+        }
+
+        FirebaseApp.configure()
+        configured = FirebaseApp.app() != nil
+        return configured
+    }
+}
+
 @_cdecl("ios_get_app_version")
 func ios_get_app_version() -> UnsafePointer<CChar>? {
     let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
@@ -51,7 +79,7 @@ func ios_get_documents_directory() -> UnsafePointer<CChar>? {
 
 @_cdecl("zedra_firebase_initialize")
 func zedra_firebase_initialize_bridge() {
-    FirebaseApp.configure()
+    _ = ZedraFirebase.configureIfAvailable()
 }
 
 @_cdecl("ios_trigger_haptic")
@@ -100,6 +128,7 @@ func zedra_log_event(
     _ values: UnsafePointer<UnsafePointer<CChar>?>?,
     _ count: Int32
 ) {
+    guard ZedraFirebase.configureIfAvailable() else { return }
     guard let name = NativePresentationBridge.string(name) else { return }
 
     var params: [String: String] = [:]
@@ -121,6 +150,7 @@ func zedra_record_error(
     _ file: UnsafePointer<CChar>?,
     _ line: Int32
 ) {
+    guard ZedraFirebase.configureIfAvailable() else { return }
     guard let message = NativePresentationBridge.string(message) else { return }
     let fileString = NativePresentationBridge.string(file) ?? "unknown"
     let fullMessage = "[\(fileString):\(line)] \(message)"
@@ -130,6 +160,7 @@ func zedra_record_error(
 
 @_cdecl("zedra_record_panic")
 func zedra_record_panic(_ message: UnsafePointer<CChar>?, _ location: UnsafePointer<CChar>?) {
+    guard ZedraFirebase.configureIfAvailable() else { return }
     guard let message = NativePresentationBridge.string(message) else { return }
     let locationString = NativePresentationBridge.string(location) ?? "unknown"
     let fullMessage = "Rust panic at \(locationString): \(message)"
@@ -140,6 +171,7 @@ func zedra_record_panic(_ message: UnsafePointer<CChar>?, _ location: UnsafePoin
 
 @_cdecl("zedra_set_user_id")
 func zedra_set_user_id(_ userID: UnsafePointer<CChar>?) {
+    guard ZedraFirebase.configureIfAvailable() else { return }
     guard let userID = NativePresentationBridge.string(userID) else { return }
     Analytics.setUserID(userID)
     Crashlytics.crashlytics().setUserID(userID)
@@ -147,6 +179,7 @@ func zedra_set_user_id(_ userID: UnsafePointer<CChar>?) {
 
 @_cdecl("zedra_set_custom_key")
 func zedra_set_custom_key(_ key: UnsafePointer<CChar>?, _ value: UnsafePointer<CChar>?) {
+    guard ZedraFirebase.configureIfAvailable() else { return }
     guard let key = NativePresentationBridge.string(key), let value = NativePresentationBridge.string(value) else {
         return
     }
@@ -155,6 +188,7 @@ func zedra_set_custom_key(_ key: UnsafePointer<CChar>?, _ value: UnsafePointer<C
 
 @_cdecl("zedra_set_collection_enabled")
 func zedra_set_collection_enabled(_ enabled: Int32) {
+    guard ZedraFirebase.configureIfAvailable() else { return }
     let isEnabled = enabled != 0
     Analytics.setAnalyticsCollectionEnabled(isEnabled)
     Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(isEnabled)

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -68,8 +68,28 @@ targets:
               echo "warning: Missing $GOOGLE_SERVICE_PLIST. Firebase is disabled for this debug build."
               ;;
           esac
+        basedOnDependencyAnalysis: false
       - name: "Firebase Crashlytics dSYM Upload"
-        script: "${PODS_ROOT}/FirebaseCrashlytics/run"
+        script: |
+          set -eu
+
+          GOOGLE_SERVICE_PLIST="${SRCROOT}/Zedra/GoogleService-Info.plist"
+
+          if [ ! -f "$GOOGLE_SERVICE_PLIST" ]; then
+            case "${CONFIGURATION:-}" in
+              Release*)
+                echo "error: Missing $GOOGLE_SERVICE_PLIST. Release builds require Firebase configuration."
+                exit 1
+                ;;
+              *)
+                echo "warning: Skipping Firebase Crashlytics dSYM upload because $GOOGLE_SERVICE_PLIST is missing."
+                exit 0
+                ;;
+            esac
+          fi
+
+          "${PODS_ROOT}/FirebaseCrashlytics/run"
+        basedOnDependencyAnalysis: false
         inputFiles:
           - "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}"
           - "$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)"

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -20,6 +20,8 @@ targets:
     platform: iOS
     sources:
       - path: Zedra
+        excludes:
+          - GoogleService-Info.plist
     dependencies:
       - target: ZedraRustFFI
         link: false
@@ -43,6 +45,29 @@ targets:
           - CFBundleURLSchemes: [zedra]
             CFBundleURLName: dev.zedra.app
     postBuildScripts:
+      - name: "Firebase Config"
+        script: |
+          set -eu
+
+          GOOGLE_SERVICE_PLIST="${SRCROOT}/Zedra/GoogleService-Info.plist"
+          APP_BUNDLE="${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME:-${PRODUCT_NAME}.app}"
+          DESTINATION="${APP_BUNDLE}/GoogleService-Info.plist"
+
+          if [ -f "$GOOGLE_SERVICE_PLIST" ]; then
+            mkdir -p "$APP_BUNDLE"
+            cp "$GOOGLE_SERVICE_PLIST" "$DESTINATION"
+            exit 0
+          fi
+
+          case "${CONFIGURATION:-}" in
+            Release*)
+              echo "error: Missing $GOOGLE_SERVICE_PLIST. Release builds require Firebase configuration."
+              exit 1
+              ;;
+            *)
+              echo "warning: Missing $GOOGLE_SERVICE_PLIST. Firebase is disabled for this debug build."
+              ;;
+          esac
       - name: "Firebase Crashlytics dSYM Upload"
         script: "${PODS_ROOT}/FirebaseCrashlytics/run"
         inputFiles:


### PR DESCRIPTION
## Summary
- Stop treating `ios/Zedra/GoogleService-Info.plist` as a required Xcode resource input.
- Add a Firebase config build phase that bundles the plist when present, warns and disables Firebase for Debug when absent, and fails Release builds with an explicit error when absent.
- Guard the iOS Firebase bridge so Firebase calls are no-ops unless the bundled plist is available and Firebase configured successfully.
- Skip the Crashlytics dSYM upload phase in Debug when the Firebase plist is absent, while still failing Release builds without the plist.
- Document the Debug/Release Firebase config policy in the iOS workflow and telemetry docs.