### PR TITLE
fix(ios): avoid duplicate selection cancel action

### DIFF
--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -59,6 +59,16 @@
 6. Expected: manual `screen_view` events include `screen_name` and `screen_class` for `Home`, `Settings`, `Quick Actions`, `Workspace Connecting`, `Workspace Editor`, `Workspace Markdown`, `Workspace Git Diff`, `Workspace Terminal`, each drawer tab, `Custom Sheet Editor`, and `Custom Sheet Markdown`
 7. Expected: native automatic rows such as `UIViewController`, `CustomSheetViewController`, `UIAlertController`, and `ZedraQRScannerVC` are still present because native Firebase screen reporting remains enabled
 
+## 0e. Developer Native Selection
+
+1. Run a Debug iOS build and open Settings
+2. Tap `Native Selection` in the Developer section
+3. Expected: a native action sheet opens without crashing and shows `First Action`, `Second Action`, `Destructive Action`, and `Cancel`
+4. Tap `Cancel`
+5. Expected: the action sheet dismisses without running another action
+6. Open `Native Selection` again, then tap outside the sheet
+7. Expected: the sheet dismisses without crashing
+
 ## 1. Normal QR Scan → Connect
 
 1. Start host daemon: `zedra start --workdir .`

--- a/ios/Zedra/Presentations.swift
+++ b/ios/Zedra/Presentations.swift
@@ -1313,6 +1313,7 @@ private enum PresentationCoordinator {
             sheet.presentationController?.delegate = delegate
             objc_setAssociatedObject(sheet, dismissAssociationKey, delegate, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
+            let hasCancelAction = buttonStyles.prefix(buttonLabels.count).contains(.cancel)
             for index in 0..<buttonLabels.count {
                 let style = buttonStyles[safe: index] ?? .default
                 let action = UIAlertAction(title: buttonLabels[index], style: style.uiKitStyle) { _ in
@@ -1326,11 +1327,13 @@ private enum PresentationCoordinator {
                 sheet.addAction(action)
             }
 
-            // Required by HIG and UIKit: enables backdrop dismiss on iPhone.
-            sheet.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
-                delegate.handled = true
-                zedra_ios_selection_dismiss(callbackID)
-            })
+            if !hasCancelAction {
+                // UIKit allows one cancel action; add a dismiss affordance only when callers omit it.
+                sheet.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
+                    delegate.handled = true
+                    zedra_ios_selection_dismiss(callbackID)
+                })
+            }
 
             presenter.present(sheet, animated: true)
         }


### PR DESCRIPTION
## Summary
- Avoid adding a synthetic iOS action-sheet cancel button when the caller already provides one.
- Add a manual regression check for the Settings native selection sheet.

## Notes
- Fixes the UIKit crash caused by multiple `UIAlertAction.Style.cancel` actions in the same action sheet.