### PR TITLE
fix(session): don't reuse QR ticket on reconnect

### DIFF
--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -956,7 +956,9 @@ impl Workspace {
             return;
         };
 
-        if self.session_state.read(cx).snapshot.register_ms.is_some() {
+        // Ticket is only needed for initial registration. Once we have a session_id
+        // the ticket has already been consumed on the host and must not be reused.
+        if request.session_id.is_some() {
             request.ticket = None;
         }
 


### PR DESCRIPTION
## Summary

- `restart_connection` guarded ticket removal on `register_ms` being set in the session snapshot
- `reset_timing` clears `register_ms` on every `BindingEndpoint` event (start of each reconnect attempt), so after the first automatic reconnect the guard was gone
- Subsequent `restart_connection` calls passed the ticket again → host rejected with "The QR code was used"
- Fix: strip ticket whenever `session_id` is already known — the ticket is only needed for initial registration, and `session_id` is always populated from the ticket at scan time

## Notes

Root condition: scan QR → connect successfully → session drops → automatic reconnect fires (clears `register_ms`) → session drops again → manual reconnect reuses the consumed ticket.