### PR TITLE
fix: restore windows install tab label

### DIFF
--- a/crates/zedra/src/home_view.rs
+++ b/crates/zedra/src/home_view.rs
@@ -466,7 +466,7 @@ impl Render for HomeView {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum GuideTab {
     MacLinux,
-    Win,
+    Windows,
     Claude,
     Codex,
     OpenCode,
@@ -496,8 +496,8 @@ static GUIDE_TABS: &[GuideTabSpec] = &[
         icon_size: 17.0,
     },
     GuideTabSpec {
-        tab: GuideTab::Win,
-        label: "win",
+        tab: GuideTab::Windows,
+        label: "windows",
         icon: "icons/windows.svg",
         icon_size: 17.0,
     },
@@ -613,7 +613,7 @@ static OPENCODE_RUN_LINES: &[GuideLine] = &[
     },
 ];
 
-static WIN_INSTALL_LINES: &[GuideLine] = &[
+static WINDOWS_INSTALL_LINES: &[GuideLine] = &[
     GuideLine {
         text: "# Install Zedra CLI",
         comment: true,
@@ -624,7 +624,7 @@ static WIN_INSTALL_LINES: &[GuideLine] = &[
     },
 ];
 
-static WIN_RUN_LINES: &[GuideLine] = &[
+static WINDOWS_RUN_LINES: &[GuideLine] = &[
     GuideLine {
         text: "# Start Zedra in the working directory",
         comment: true,
@@ -644,12 +644,12 @@ static MAC_LINUX_BLOCKS: &[GuideBlock] = &[
     },
 ];
 
-static WIN_BLOCKS: &[GuideBlock] = &[
+static WINDOWS_BLOCKS: &[GuideBlock] = &[
     GuideBlock {
-        lines: WIN_INSTALL_LINES,
+        lines: WINDOWS_INSTALL_LINES,
     },
     GuideBlock {
-        lines: WIN_RUN_LINES,
+        lines: WINDOWS_RUN_LINES,
     },
 ];
 
@@ -683,7 +683,7 @@ static OPENCODE_BLOCKS: &[GuideBlock] = &[
 fn guide_blocks(tab: GuideTab) -> &'static [GuideBlock] {
     match tab {
         GuideTab::MacLinux => MAC_LINUX_BLOCKS,
-        GuideTab::Win => WIN_BLOCKS,
+        GuideTab::Windows => WINDOWS_BLOCKS,
         GuideTab::Claude => CLAUDE_BLOCKS,
         GuideTab::Codex => CODEX_BLOCKS,
         GuideTab::OpenCode => OPENCODE_BLOCKS,

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -17,7 +17,7 @@
 ## 0a. Home Install Guide Tabs
 
 1. Open the app with no saved workspaces visible on the Home screen
-2. Switch between the `mac/linux`, `win`, `claude`, `codex`, and `opencode` guide tabs
+2. Switch between the `mac/linux`, `windows`, `claude`, `codex`, and `opencode` guide tabs
 3. Expected: each tab shows the same install commands as the landing page
 4. Tap a command line in each tab
 5. Expected: the tapped command line is copied to the system clipboard without navigating away from Home

--- a/packages/landing/src/pages/index.astro
+++ b/packages/landing/src/pages/index.astro
@@ -15,8 +15,8 @@ const installTabs = [
     ],
   },
   {
-    id: "win",
-    label: "win",
+    id: "windows",
+    label: "windows",
     icon: `<svg class="tab-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3 5.4 10.6 4.3v7.2H3V5.4Zm8.6-1.2L21 2.8v8.7h-9.4V4.2ZM3 12.5h7.6v7.2L3 18.6v-6.1Zm8.6 0H21v8.7l-9.4-1.4v-7.3Z"></path></svg>`,
     blocks: [
       [
@@ -407,7 +407,7 @@ const canonicalUrl = "https://zedra.dev/";
       /* checked-tab state (CSS-only tabs) */
 
       #tab-mac-linux:checked ~ .install-card .label-mac-linux,
-      #tab-win:checked ~ .install-card .label-win,
+      #tab-windows:checked ~ .install-card .label-windows,
       #tab-claude:checked ~ .install-card .label-claude,
       #tab-codex:checked ~ .install-card .label-codex,
       #tab-opencode:checked ~ .install-card .label-opencode {
@@ -416,7 +416,7 @@ const canonicalUrl = "https://zedra.dev/";
       }
 
       #tab-mac-linux:checked ~ .install-card .panel-mac-linux,
-      #tab-win:checked ~ .install-card .panel-win,
+      #tab-windows:checked ~ .install-card .panel-windows,
       #tab-claude:checked ~ .install-card .panel-claude,
       #tab-codex:checked ~ .install-card .panel-codex,
       #tab-opencode:checked ~ .install-card .panel-opencode {


### PR DESCRIPTION
## Summary
- Revert the install guide tab rename from `win` back to `windows` on the landing page and Home screen.
- Update the manual test plan to match.

## Notes
- PR #95 already removed Gemini setup and guide tabs; this follow-up only restores the Windows tab naming.

Made with [Cursor](https://cursor.com)