### PR TITLE
fix(terminal): overscan rows for smooth scroll edges

### DIFF
--- a/crates/zedra-terminal/src/element.rs
+++ b/crates/zedra-terminal/src/element.rs
@@ -367,8 +367,10 @@ impl TerminalElement {
             };
             let line = first_cell.point.line.0 + display_offset;
 
-            // Skip cells outside the visible grid (stale circular buffer data)
-            if line < 0 || line >= grid_rows as i32 {
+            // Skip cells outside the visible grid (stale circular buffer data).
+            // One overscan row each side (`-1` and `grid_rows`) is kept so a
+            // partially-revealed row at the edge slides in during smooth scroll.
+            if line < -1 || line > grid_rows as i32 {
                 continue;
             }
 

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -441,6 +441,34 @@ impl Terminal {
             });
         }
 
+        // Overscan: include one grid row just above and below the viewport so
+        // sub-line smooth scrolling slides real content into the edge gap
+        // instead of popping a whole row in once it is fully visible.
+        // `display_iter` yields grid lines in `[-display_offset, rows-1-display_offset]`.
+        {
+            let grid = self.term.grid();
+            let cols = self.size.columns;
+            let display_offset = content.display_offset as i32;
+            let mut push_row = |line: i32| {
+                let row = &grid[Line(line)];
+                for col in 0..cols {
+                    let column = Column(col);
+                    cells.push(IndexedCell {
+                        point: Point::new(Line(line), column),
+                        cell: row[column].clone(),
+                    });
+                }
+            };
+            let above = -display_offset - 1;
+            if above >= grid.topmost_line().0 {
+                push_row(above);
+            }
+            // The below row only exists within the screen while scrolled up.
+            if display_offset >= 1 {
+                push_row(self.size.rows as i32 - display_offset);
+            }
+        }
+
         let cursor_point = content.cursor.point;
         let cursor_char = self.term.grid()[cursor_point].c;
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -225,6 +225,13 @@
 5. Repeat with a non-alt AI CLI session such as `claude`, `codex`, or a `/zedra-start` resumed session
 6. Expected: resumed output uses the current device width without stale wrapping or dumped resize artifacts
 
+## 3c. Terminal Smooth Scroll Edge Rendering
+
+1. Connect via QR and open a terminal with enough output to fill the scrollback
+2. Slowly drag-scroll the terminal through scrollback a fraction of a row at a time
+3. Expected: the row entering at the top edge (and the row leaving at the bottom edge) slides in pixel by pixel
+4. Expected: rows do not pop in only once fully visible, and the edge gap never shows a blank partial row
+
 ## 4. Reconnect After Host Restart
 
 1. Connect via QR, note session ID


### PR DESCRIPTION
## Summary

Terminal sub-line smooth scrolling popped whole rows in/out at the top and bottom edges instead of sliding them.

`Terminal::content()` collected only the viewport rows from `display_iter`, so when `TerminalElement` shifted the grid by `scroll_offset_px` the revealed edge gap had no cell data — the row stayed blank until a whole line committed. `layout_grid` also hard-culled any `line` outside `[0, grid_rows)`.

Fix: emit one overscan grid row above and below the viewport (guarded by `topmost_line()` and `display_offset`) and widen the `layout_grid` cull to `[-1, grid_rows]`. The `overflow_hidden` content mask still clips to element bounds, so only the in-bounds sliver of each overscan row paints — the edge row slides in pixel by pixel.

## Notes

- `selection.rs` and `view.rs` already filter `visible_row` to `[0, grid_rows)`, so overscan rows do not leak into selection or geometry.
- One overscan row each side covers normal scroll (`scroll_offset_px` is always `< step_px`). A multi-row `keyboard_top_reveal_px` gap is a separate feature and is not addressed here.
- Manual verification step added as `## 3c. Terminal Smooth Scroll Edge Rendering`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)