### PR TITLE
feat(zedra): render Mermaid diagrams in markdown preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 .DS_Store
 
 .claude/worktrees/
+.claude/settings.local.json
+.codex/hooks.json
+.opencode/plugins/zedra.js
+.zedra/agent-hooks/
 
 /target
 target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9991,6 +9991,7 @@ dependencies = [
  "anyhow",
  "cbindgen 0.29.2",
  "cc",
+ "chrono",
  "futures",
  "gpui",
  "gpui_android",
@@ -10040,9 +10041,11 @@ version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
+ "chrono",
  "clap",
  "directories",
  "ed25519-dalek 2.2.0",
+ "filetime",
  "flate2",
  "hostname",
  "ignore",
@@ -10083,6 +10086,7 @@ version = "0.2.5"
 dependencies = [
  "anyhow",
  "base64-url",
+ "chrono",
  "hex",
  "hmac",
  "iroh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4136,6 +4136,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
+dependencies = [
+ "serde",
+ "ucd-trie",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,6 +4499,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mermaid-rs-renderer"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b808a8c109e16ba5de1c829bd9326aea0a72c176174ddb681284f56579d892ac"
+dependencies = [
+ "anyhow",
+ "fontdb 0.23.0",
+ "json5",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -8295,6 +8322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10001,6 +10034,7 @@ dependencies = [
  "iroh",
  "jni",
  "log",
+ "mermaid-rs-renderer",
  "ndk",
  "ndk-context",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 
 # Error handling
 anyhow = "1"

--- a/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
@@ -255,6 +255,18 @@ class MainActivity : AppCompatActivity() {
         }
 
         @JvmStatic
+        fun showListPicker(
+            callbackId: Int,
+            title: String?,
+            message: String?,
+            labels: Array<String>,
+            subtitles: Array<String?>,
+            imageNames: Array<String?>,
+        ) {
+            NativePresentations.showListPicker(callbackId, title, message, labels, subtitles, imageNames)
+        }
+
+        @JvmStatic
         fun showTextInput(
             callbackId: Int,
             title: String?,

--- a/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
@@ -175,6 +175,73 @@ object NativePresentations {
     }
 
     @JvmStatic
+    fun showListPicker(
+        callbackId: Int,
+        title: String?,
+        message: String?,
+        labels: Array<String>?,
+        subtitles: Array<String?>?,
+        imageNames: Array<String?>?,
+    ) = onUi {
+        val safeLabels = labels?.takeIf { it.isNotEmpty() } ?: run {
+            MainActivity.nativeSelectionDismiss(callbackId)
+            return@onUi
+        }
+        val activity = requireActivity()
+        val sheet = BottomSheetDialog(activity)
+        val content = LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(16f), dp(12f), dp(16f), dp(12f))
+            if (!title.isNullOrBlank()) {
+                addView(selectionHeader(title, primary = true))
+            }
+            if (!message.isNullOrBlank()) {
+                addView(selectionHeader(message, primary = title.isNullOrBlank()))
+            }
+            val scroll = android.widget.ScrollView(activity).apply {
+                layoutParams = LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    dp(420f),
+                )
+                val list = LinearLayout(activity).apply {
+                    orientation = LinearLayout.VERTICAL
+                }
+                safeLabels.forEachIndexed { index, label ->
+                    val subtitle = subtitles?.getOrNull(index)?.orEmpty().orEmpty()
+                    list.addView(TextView(activity).apply {
+                        text = if (subtitle.isBlank()) label else "$label\n$subtitle"
+                        textSize = 16f
+                        setLineSpacing(0f, 1.1f)
+                        gravity = Gravity.CENTER_VERTICAL
+                        minHeight = dp(56f)
+                        setPadding(dp(8f), dp(10f), dp(8f), dp(10f))
+                        setTextColor(Color.WHITE)
+                        setSelectableItemBackground(this)
+                        setOnClickListener {
+                            MainActivity.nativeSelectionResult(callbackId, index)
+                            sheet.dismiss()
+                        }
+                    }, LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ))
+                    if (index + 1 < safeLabels.size) {
+                        list.addView(MaterialDivider(activity), LinearLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                        ))
+                    }
+                }
+                addView(list)
+            }
+            addView(scroll)
+        }
+        sheet.setContentView(content)
+        sheet.setOnCancelListener { MainActivity.nativeSelectionDismiss(callbackId) }
+        sheet.show()
+    }
+
+    @JvmStatic
     fun showTextInput(
         callbackId: Int,
         title: String?,

--- a/crates/zedra-host/Cargo.toml
+++ b/crates/zedra-host/Cargo.toml
@@ -39,6 +39,7 @@ clap = { version = "4", features = ["derive"] }
 # Serialization
 serde.workspace = true
 serde_json = { workspace = true, features = ["std"] }
+chrono.workspace = true
 
 # Random/crypto
 rand.workspace = true
@@ -93,6 +94,7 @@ windows-sys = { version = "0.61", features = [
 
 [dev-dependencies]
 tempfile = "3"
+filetime = "0.2"
 serde_json.workspace = true
 iroh = { workspace = true, features = ["test-utils"] }
 iroh-relay = { workspace = true, features = ["test-utils"] }

--- a/crates/zedra-host/src/agent.rs
+++ b/crates/zedra-host/src/agent.rs
@@ -1,0 +1,2205 @@
+use crate::agent_cache::AgentCache;
+use crate::claude;
+use crate::installed_agents;
+use crate::session_registry::{HostShellState, HostTermMeta, ServerSession};
+use crate::utils;
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use zedra_rpc::proto::*;
+
+const SKILL_NAMES: &[&str] = &[
+    "zedra-start",
+    "zedra-status",
+    "zedra-stop",
+    "zedra-terminal",
+];
+
+const AGENT_SESSION_DEFAULT_LIMIT: u32 = 50;
+const AGENT_SESSION_MAX_LIMIT: u32 = 200;
+
+pub fn default_agent_session_limit() -> usize {
+    agent_session_limit(0)
+}
+
+pub fn agent_session_limit(limit: u32) -> usize {
+    let configured = std::env::var("ZEDRA_AGENT_SESSION_LIMIT")
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(AGENT_SESSION_DEFAULT_LIMIT);
+    let limit = if limit == 0 { configured } else { limit };
+    limit.clamp(1, AGENT_SESSION_MAX_LIMIT) as usize
+}
+
+pub fn scan_installed_agents() -> AgentInstalledListResult {
+    installed_agents::list_installed_agents()
+}
+
+pub fn scan_agent_list(workdir: &Path) -> AgentListResult {
+    const KINDS: [ManagedAgentKind; 3] = [
+        ManagedAgentKind::Claude,
+        ManagedAgentKind::Codex,
+        ManagedAgentKind::OpenCode,
+    ];
+    let mut agents = Vec::with_capacity(KINDS.len());
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = KINDS
+            .iter()
+            .copied()
+            .map(|kind| (kind, scope.spawn(move || agent_summary_scan(kind, workdir))))
+            .collect();
+        for (kind, handle) in handles {
+            match handle.join() {
+                Ok(summary) => agents.push(summary),
+                // A panic while scanning one provider must not abort the whole
+                // list; degrade that provider and keep the rest.
+                Err(_) => {
+                    tracing::warn!(
+                        "agent list scan thread panicked for {kind:?}; using degraded summary"
+                    );
+                    agents.push(degraded_agent_summary(kind, workdir));
+                }
+            }
+        }
+    });
+    AgentListResult {
+        agents,
+        error: None,
+    }
+}
+
+/// Minimal `AgentSummary` used when a provider's session scan panics. Reuses
+/// only the cheap CLI/setup probes and reports zero counts with a warning.
+fn degraded_agent_summary(kind: ManagedAgentKind, workdir: &Path) -> AgentSummary {
+    let cli = agent_list_cli_summary(kind, workdir);
+    let setup = setup_summary(kind, cli.available, workdir);
+    AgentSummary {
+        kind,
+        display_name: display_name(kind).to_string(),
+        cli,
+        setup,
+        capabilities: capabilities(kind),
+        workspace: AgentWorkspaceSummary {
+            workdir: workdir.to_string_lossy().into_owned(),
+            provider_project_id: None,
+            provider_project_key: None,
+        },
+        sessions: AgentSessionCounts {
+            total: 0,
+            resumable: 0,
+            active_live: 0,
+            latest_session_id: None,
+            latest_session_title: None,
+        },
+        live: AgentLiveSummary {
+            active_terminal_ids: Vec::new(),
+            pending_action_count: 0,
+            latest_event: None,
+        },
+        last_activity_at: None,
+        updated_at: Utc::now(),
+        data_sources: vec![AgentDataSource::Cli, AgentDataSource::Setup],
+        warnings: vec![AgentWarning {
+            code: "session_scan_panicked".to_string(),
+            message: "agent session scan crashed; counts unavailable".to_string(),
+        }],
+        account: account_summary(kind),
+    }
+}
+
+pub fn scan_agent_sessions(
+    kind: ManagedAgentKind,
+    workdir: &Path,
+    limit: u32,
+) -> AgentSessionsResult {
+    let limit = agent_session_limit(limit);
+    match sessions_for_kind_blocking(kind, workdir, limit) {
+        Ok((sessions, total)) => AgentSessionsResult {
+            sessions,
+            total,
+            error: None,
+        },
+        Err(error) => AgentSessionsResult {
+            sessions: Vec::new(),
+            total: 0,
+            error: Some(error),
+        },
+    }
+}
+
+pub async fn list_installed_agents(cache: &AgentCache, refresh: bool) -> AgentInstalledListResult {
+    cache.installed(refresh).await
+}
+
+pub async fn list_agents(
+    cache: &AgentCache,
+    workdir: &Path,
+    session: Option<&Arc<ServerSession>>,
+    refresh: bool,
+) -> AgentListResult {
+    cache.agents(workdir, session, refresh).await
+}
+
+pub async fn list_agent_sessions(
+    cache: &AgentCache,
+    kind: ManagedAgentKind,
+    workdir: &Path,
+    session: Option<&Arc<ServerSession>>,
+    limit: u32,
+    refresh: bool,
+) -> AgentSessionsResult {
+    cache.sessions(kind, workdir, session, limit, refresh).await
+}
+
+pub async fn merge_live_into_agent_list(
+    agents: &mut [AgentSummary],
+    session: Option<&Arc<ServerSession>>,
+) {
+    for agent in agents {
+        agent.live = live_summary(agent.kind, session).await;
+        agent.sessions.active_live = agent.live.active_terminal_ids.len();
+    }
+}
+
+pub async fn merge_live_into_sessions(
+    sessions: &mut [AgentSessionSummary],
+    kind: ManagedAgentKind,
+    session: Option<&Arc<ServerSession>>,
+) {
+    let live = live_sessions(kind, session).await;
+    for summary in sessions {
+        if let Some(live_state) = live.by_session.get(&summary.session_id) {
+            summary.live = live_state.clone();
+            summary.flags.live_bound = true;
+            summary.flags.historical_only = false;
+            if !summary
+                .data_sources
+                .contains(&AgentDataSource::TerminalMetadata)
+            {
+                summary.data_sources.push(AgentDataSource::TerminalMetadata);
+            }
+        }
+    }
+}
+
+pub fn resume_launch_command(kind: ManagedAgentKind, session_id: &str) -> Option<String> {
+    if session_id.trim().is_empty() {
+        return None;
+    }
+    let quoted = shell_quote(session_id);
+    Some(match kind {
+        ManagedAgentKind::Claude => format!("claude --resume {quoted}"),
+        ManagedAgentKind::Codex => format!("codex resume {quoted}"),
+        ManagedAgentKind::OpenCode => format!("opencode --session {quoted}"),
+    })
+}
+
+pub fn normalize_event(
+    kind: ManagedAgentKind,
+    event_name: &str,
+) -> Option<(AgentEventKind, AgentLifecycleStatus)> {
+    let event_name = event_name.trim();
+    if event_name.is_empty() {
+        return None;
+    }
+    match kind {
+        ManagedAgentKind::Claude => normalize_claude_event(event_name),
+        ManagedAgentKind::Codex => normalize_codex_event(event_name),
+        ManagedAgentKind::OpenCode => normalize_opencode_event(event_name),
+    }
+}
+
+pub fn managed_kind_from_slug(raw: &str) -> Option<ManagedAgentKind> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "claude" => Some(ManagedAgentKind::Claude),
+        "codex" => Some(ManagedAgentKind::Codex),
+        "opencode" | "open-code" | "open_code" => Some(ManagedAgentKind::OpenCode),
+        _ => None,
+    }
+}
+
+fn normalize_claude_event(event_name: &str) -> Option<(AgentEventKind, AgentLifecycleStatus)> {
+    Some(match event_name {
+        "Setup" | "InstructionsLoaded" => (
+            AgentEventKind::SessionUpdated,
+            AgentLifecycleStatus::Starting,
+        ),
+        "SessionStart" => (
+            AgentEventKind::SessionStarted,
+            AgentLifecycleStatus::Starting,
+        ),
+        "SessionEnd" => (AgentEventKind::SessionUpdated, AgentLifecycleStatus::Idle),
+        "UserPromptSubmit" | "UserPromptExpansion" => {
+            (AgentEventKind::TurnStarted, AgentLifecycleStatus::Running)
+        }
+        "PreToolUse" => (AgentEventKind::ToolStarted, AgentLifecycleStatus::Running),
+        "PermissionRequest" => (
+            AgentEventKind::PermissionRequested,
+            AgentLifecycleStatus::WaitingForPermission,
+        ),
+        "PermissionDenied" => (
+            AgentEventKind::PermissionResolved,
+            AgentLifecycleStatus::Failed,
+        ),
+        "TaskCreated" | "SubagentStart" => {
+            (AgentEventKind::TaskCreated, AgentLifecycleStatus::Running)
+        }
+        "TaskCompleted" | "SubagentStop" => (
+            AgentEventKind::TaskCompleted,
+            AgentLifecycleStatus::Completed,
+        ),
+        "PostToolUse" => (AgentEventKind::ToolCompleted, AgentLifecycleStatus::Running),
+        "PostToolUseFailure" => (AgentEventKind::ToolFailed, AgentLifecycleStatus::Failed),
+        "PostToolBatch" => (AgentEventKind::ToolCompleted, AgentLifecycleStatus::Running),
+        "Stop" => (
+            AgentEventKind::TurnCompleted,
+            AgentLifecycleStatus::Completed,
+        ),
+        "StopFailure" => (AgentEventKind::TurnFailed, AgentLifecycleStatus::Failed),
+        "TeammateIdle" => (AgentEventKind::SessionUpdated, AgentLifecycleStatus::Idle),
+        "PreCompact" => (
+            AgentEventKind::SessionUpdated,
+            AgentLifecycleStatus::Running,
+        ),
+        "PostCompact" => (AgentEventKind::SessionUpdated, AgentLifecycleStatus::Idle),
+        "ConfigChange" | "CwdChanged" | "WorktreeCreate" | "WorktreeRemove" => (
+            AgentEventKind::SessionUpdated,
+            AgentLifecycleStatus::Running,
+        ),
+        "Elicitation" => (
+            AgentEventKind::PermissionRequested,
+            AgentLifecycleStatus::WaitingForUser,
+        ),
+        "ElicitationResult" => (
+            AgentEventKind::PermissionResolved,
+            AgentLifecycleStatus::Running,
+        ),
+        "Notification" => (AgentEventKind::Notification, AgentLifecycleStatus::Idle),
+        _ => return None,
+    })
+}
+
+fn normalize_codex_event(event_name: &str) -> Option<(AgentEventKind, AgentLifecycleStatus)> {
+    Some(match event_name {
+        "SessionStart" => (
+            AgentEventKind::SessionStarted,
+            AgentLifecycleStatus::Starting,
+        ),
+        "PermissionRequest" => (
+            AgentEventKind::PermissionRequested,
+            AgentLifecycleStatus::WaitingForPermission,
+        ),
+        "PostToolUse" => (AgentEventKind::ToolCompleted, AgentLifecycleStatus::Running),
+        "Stop" => (
+            AgentEventKind::TurnCompleted,
+            AgentLifecycleStatus::Completed,
+        ),
+        name if name.contains("Failure") || name.contains("Failed") => {
+            (AgentEventKind::TurnFailed, AgentLifecycleStatus::Failed)
+        }
+        _ => return None,
+    })
+}
+
+fn normalize_opencode_event(event_name: &str) -> Option<(AgentEventKind, AgentLifecycleStatus)> {
+    Some(match event_name {
+        "session.status" => (
+            AgentEventKind::SessionUpdated,
+            AgentLifecycleStatus::Running,
+        ),
+        "session.idle" => (AgentEventKind::SessionUpdated, AgentLifecycleStatus::Idle),
+        "session.error" => (AgentEventKind::TurnFailed, AgentLifecycleStatus::Failed),
+        "permission.asked" => (
+            AgentEventKind::PermissionRequested,
+            AgentLifecycleStatus::WaitingForPermission,
+        ),
+        "permission.replied" => (
+            AgentEventKind::PermissionResolved,
+            AgentLifecycleStatus::Running,
+        ),
+        "tool.execute.before" => (AgentEventKind::ToolStarted, AgentLifecycleStatus::Running),
+        "tool.execute.after" => (AgentEventKind::ToolCompleted, AgentLifecycleStatus::Running),
+        name if name.starts_with("tool.") && name.ends_with(".error") => {
+            (AgentEventKind::ToolFailed, AgentLifecycleStatus::Failed)
+        }
+        _ => return None,
+    })
+}
+
+fn agent_summary_scan(kind: ManagedAgentKind, workdir: &Path) -> AgentSummary {
+    let now = Utc::now();
+    let cli = agent_list_cli_summary(kind, workdir);
+    let setup = setup_summary(kind, cli.available, workdir);
+    let mut warnings = Vec::new();
+    let counts = match session_counts_for_kind(kind, workdir, &cli) {
+        Ok(counts) => counts,
+        Err(error) => {
+            warnings.push(AgentWarning {
+                code: "session_scan_failed".to_string(),
+                message: error,
+            });
+            SessionCounts::default()
+        }
+    };
+
+    let mut data_sources = vec![AgentDataSource::Cli, AgentDataSource::Setup];
+    if counts.total > 0 {
+        data_sources.push(match kind {
+            ManagedAgentKind::OpenCode => AgentDataSource::ProviderCli,
+            _ => AgentDataSource::HistoricalScan,
+        });
+    }
+
+    AgentSummary {
+        kind,
+        display_name: display_name(kind).to_string(),
+        cli,
+        setup,
+        capabilities: capabilities(kind),
+        workspace: AgentWorkspaceSummary {
+            workdir: workdir.to_string_lossy().into_owned(),
+            provider_project_id: counts.provider_project_id.clone(),
+            provider_project_key: None,
+        },
+        sessions: AgentSessionCounts {
+            total: counts.total,
+            resumable: counts.resumable,
+            active_live: 0,
+            latest_session_id: counts.latest_session_id.clone(),
+            latest_session_title: counts.latest_session_title.clone(),
+        },
+        live: AgentLiveSummary {
+            active_terminal_ids: Vec::new(),
+            pending_action_count: 0,
+            latest_event: None,
+        },
+        last_activity_at: counts.last_activity_at,
+        updated_at: now,
+        data_sources,
+        warnings,
+        account: account_summary(kind),
+    }
+}
+
+#[derive(Default)]
+struct SessionCounts {
+    total: usize,
+    resumable: usize,
+    latest_session_id: Option<String>,
+    latest_session_title: Option<String>,
+    last_activity_at: Option<DateTime<Utc>>,
+    provider_project_id: Option<String>,
+}
+
+fn session_counts_for_kind(
+    kind: ManagedAgentKind,
+    workdir: &Path,
+    cli: &AgentCliSummary,
+) -> Result<SessionCounts, String> {
+    match kind {
+        ManagedAgentKind::Claude => claude_session_counts(workdir),
+        ManagedAgentKind::Codex => codex_session_counts(workdir),
+        ManagedAgentKind::OpenCode => opencode_session_counts(workdir, cli),
+    }
+}
+
+fn claude_session_counts(workdir: &Path) -> Result<SessionCounts, String> {
+    let (total, latest) =
+        claude::session_count_summary(workdir).map_err(|error| error.to_string())?;
+    Ok(SessionCounts {
+        total,
+        resumable: total,
+        latest_session_id: latest.as_ref().map(|session| session.session_id.clone()),
+        latest_session_title: latest.as_ref().and_then(|session| session.title.clone()),
+        last_activity_at: latest
+            .and_then(|session| parse_rfc3339(session.last_activity_at.as_deref())),
+        provider_project_id: None,
+    })
+}
+
+fn codex_session_counts(workdir: &Path) -> Result<SessionCounts, String> {
+    let threads = codex_threads_for_workdir(workdir)?;
+    let latest = threads.first();
+    Ok(SessionCounts {
+        total: threads.len(),
+        resumable: threads.len(),
+        latest_session_id: latest.map(|thread| thread.id.clone()),
+        latest_session_title: latest.and_then(codex_title_from_thread),
+        last_activity_at: latest.and_then(codex_thread_updated_at),
+        provider_project_id: None,
+    })
+}
+
+fn opencode_session_counts(
+    workdir: &Path,
+    _cli: &AgentCliSummary,
+) -> Result<SessionCounts, String> {
+    if !opencode_sessions_available() {
+        return Ok(SessionCounts::default());
+    }
+    let summary = opencode_session_count_summary(workdir)?;
+    Ok(SessionCounts {
+        total: summary.total,
+        resumable: summary.total,
+        latest_session_id: summary.latest.as_ref().map(|session| session.id.clone()),
+        latest_session_title: summary
+            .latest
+            .as_ref()
+            .and_then(|session| session_title(session.title.clone())),
+        last_activity_at: summary
+            .latest
+            .as_ref()
+            .and_then(|session| session.updated)
+            .and_then(DateTime::<Utc>::from_timestamp_millis),
+        provider_project_id: summary
+            .latest
+            .and_then(|session| session.project_id.clone()),
+    })
+}
+
+fn opencode_session_count_summary(workdir: &Path) -> Result<OpenCodeSessionCountSummary, String> {
+    let (json, _) = fetch_opencode_sessions_json()?;
+    let raw: Vec<OpenCodeSessionJson> =
+        serde_json::from_slice(&json).map_err(|error| error.to_string())?;
+    let mut git_cache = HashMap::new();
+    let mut matched = raw
+        .into_iter()
+        .filter(|session| opencode_workdir_matches(workdir, session, &mut git_cache))
+        .collect::<Vec<_>>();
+    matched.sort_by(|left, right| {
+        right
+            .updated
+            .unwrap_or(0)
+            .cmp(&left.updated.unwrap_or(0))
+            .then_with(|| right.id.cmp(&left.id))
+    });
+    Ok(OpenCodeSessionCountSummary {
+        total: matched.len(),
+        latest: matched.into_iter().next(),
+    })
+}
+
+fn sessions_for_kind_blocking(
+    kind: ManagedAgentKind,
+    workdir: &Path,
+    limit: usize,
+) -> Result<(Vec<AgentSessionSummary>, u32), String> {
+    let cli = match kind {
+        ManagedAgentKind::OpenCode => opencode_session_cli_summary(),
+        _ => cli_summary(kind),
+    };
+    let mut sessions = match kind {
+        ManagedAgentKind::Claude => claude_sessions(workdir, &cli, limit),
+        ManagedAgentKind::Codex => codex_sessions(workdir, &cli, limit),
+        ManagedAgentKind::OpenCode => opencode_sessions_limited(workdir, &cli, limit),
+    }?;
+    let total = u32::try_from(sessions.1).unwrap_or(u32::MAX);
+    sessions
+        .0
+        .sort_by(|left, right| right.last_activity_at.cmp(&left.last_activity_at));
+    Ok((sessions.0, total))
+}
+
+fn cli_summary(kind: ManagedAgentKind) -> AgentCliSummary {
+    let program = program_name(kind);
+    match Command::new(program).arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let text = if output.stdout.is_empty() {
+                String::from_utf8_lossy(&output.stderr).into_owned()
+            } else {
+                String::from_utf8_lossy(&output.stdout).into_owned()
+            };
+            AgentCliSummary {
+                available: true,
+                version: first_non_empty_line(&text),
+                error: None,
+            }
+        }
+        Ok(output) => AgentCliSummary {
+            available: false,
+            version: None,
+            error: Some(format!(
+                "`{program} --version` exited with {}",
+                output.status
+            )),
+        },
+        Err(error) => AgentCliSummary {
+            available: false,
+            version: None,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+fn agent_list_cli_summary(kind: ManagedAgentKind, workdir: &Path) -> AgentCliSummary {
+    let available = match kind {
+        ManagedAgentKind::Claude => {
+            command_on_path("claude")
+                || claude::project_dir_for_workdir(&home_path(&[".claude"]), workdir).is_dir()
+        }
+        ManagedAgentKind::Codex => codex_sessions_available(),
+        ManagedAgentKind::OpenCode => opencode_sessions_available(),
+    };
+    if available {
+        AgentCliSummary {
+            available: true,
+            version: None,
+            error: None,
+        }
+    } else {
+        AgentCliSummary {
+            available: false,
+            version: None,
+            error: Some(format!(
+                "{} CLI and local session data not found",
+                program_name(kind)
+            )),
+        }
+    }
+}
+
+fn first_non_empty_line(text: &str) -> Option<String> {
+    text.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
+}
+
+fn setup_summary(kind: ManagedAgentKind, cli_available: bool, workdir: &Path) -> AgentSetupSummary {
+    if !cli_available {
+        return AgentSetupSummary {
+            state: AgentSetupState::MissingCli,
+            skills_installed: false,
+            plugin_installed: false,
+            hooks_installed: false,
+            error: None,
+        };
+    }
+
+    let mut error = None;
+    let (skills_installed, plugin_installed, hooks_installed) = match kind {
+        ManagedAgentKind::Claude => {
+            let status = claude_plugin_status();
+            error = status.error;
+            (
+                false,
+                status.plugin_installed,
+                status.hooks_installed || claude_local_hooks_installed(workdir),
+            )
+        }
+        ManagedAgentKind::Codex => (
+            skills_installed_at(&home_path(&[".agents", "skills"])),
+            false,
+            codex_hooks_installed() || codex_local_hooks_installed(workdir),
+        ),
+        ManagedAgentKind::OpenCode => (
+            skills_installed_at(&home_path(&[".config", "opencode", "skills"])),
+            opencode_plugin_installed(),
+            opencode_hooks_installed() || opencode_local_hooks_installed(workdir),
+        ),
+    };
+    let state = if error.is_some() {
+        AgentSetupState::Error
+    } else if hooks_installed {
+        AgentSetupState::HooksReady
+    } else if skills_installed || plugin_installed {
+        AgentSetupState::SkillsOnly
+    } else {
+        AgentSetupState::NotConfigured
+    };
+
+    AgentSetupSummary {
+        state,
+        skills_installed,
+        plugin_installed,
+        hooks_installed,
+        error,
+    }
+}
+
+#[derive(Default)]
+struct ClaudePluginStatus {
+    plugin_installed: bool,
+    hooks_installed: bool,
+    error: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ClaudeInstalledPluginsFile {
+    plugins: HashMap<String, Vec<ClaudeInstalledPluginEntry>>,
+}
+
+#[derive(Deserialize)]
+struct ClaudeInstalledPluginEntry {
+    #[serde(rename = "installPath")]
+    install_path: String,
+}
+
+const CLAUDE_ZEDRA_PLUGIN_ID: &str = "zedra@zedra";
+
+fn claude_plugin_status() -> ClaudePluginStatus {
+    let path = home_path(&[".claude", "plugins", "installed_plugins.json"]);
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return ClaudePluginStatus::default();
+        }
+        Err(error) => {
+            return ClaudePluginStatus {
+                error: Some(error.to_string()),
+                ..ClaudePluginStatus::default()
+            };
+        }
+    };
+    claude_plugin_status_from_installed_plugins(&contents)
+}
+
+fn claude_plugin_status_from_installed_plugins(contents: &str) -> ClaudePluginStatus {
+    let installed: ClaudeInstalledPluginsFile = match serde_json::from_str(contents) {
+        Ok(installed) => installed,
+        Err(error) => {
+            return ClaudePluginStatus {
+                error: Some(error.to_string()),
+                ..ClaudePluginStatus::default()
+            };
+        }
+    };
+    let Some(entry) = installed
+        .plugins
+        .get(CLAUDE_ZEDRA_PLUGIN_ID)
+        .and_then(|entries| entries.first())
+    else {
+        return ClaudePluginStatus::default();
+    };
+    let install_path = Path::new(&entry.install_path);
+    let hooks_installed = install_path.join("hooks").join("hooks.json").is_file();
+    ClaudePluginStatus {
+        plugin_installed: true,
+        hooks_installed,
+        error: None,
+    }
+}
+
+fn skills_installed_at(base: &Path) -> bool {
+    SKILL_NAMES
+        .iter()
+        .all(|skill| base.join(skill).join("SKILL.md").is_file())
+}
+
+fn codex_hooks_installed() -> bool {
+    std::fs::read_to_string(home_path(&[".codex", "config.toml"]))
+        .map(|contents| contents.contains("zedra") && contents.contains("hook"))
+        .unwrap_or(false)
+}
+
+fn claude_local_hooks_installed(workdir: &Path) -> bool {
+    hook_file_mentions_zedra(&workdir.join(".claude/settings.local.json"))
+}
+
+fn codex_local_hooks_installed(workdir: &Path) -> bool {
+    hook_file_mentions_zedra(&workdir.join(".codex/hooks.json"))
+}
+
+fn opencode_plugin_installed() -> bool {
+    let plugin_dir = home_path(&[".config", "opencode", "plugins"]);
+    ["zedra.js", "zedra.ts", "zedra.mjs"]
+        .iter()
+        .any(|name| plugin_dir.join(name).is_file())
+}
+
+fn opencode_hooks_installed() -> bool {
+    opencode_plugin_installed()
+}
+
+fn opencode_local_hooks_installed(workdir: &Path) -> bool {
+    hook_file_mentions_zedra(&workdir.join(".opencode/plugins/zedra.js"))
+}
+
+fn hook_file_mentions_zedra(path: &Path) -> bool {
+    std::fs::read_to_string(path)
+        .map(|contents| contents.contains("zedra-agent-hook") || contents.contains("agent hook"))
+        .unwrap_or(false)
+}
+
+fn capabilities(kind: ManagedAgentKind) -> AgentCapabilities {
+    AgentCapabilities {
+        list_sessions: true,
+        resume_session: true,
+        live_binding: true,
+        confirm_action: true,
+        select_action: true,
+        lifecycle_events: true,
+        usage_snapshot: matches!(kind, ManagedAgentKind::Claude),
+    }
+}
+
+fn claude_sessions(
+    workdir: &Path,
+    cli: &AgentCliSummary,
+    limit: usize,
+) -> Result<(Vec<AgentSessionSummary>, usize), String> {
+    let list = claude::list_sessions_limited(workdir, limit).map_err(|error| error.to_string())?;
+    let sessions = list
+        .sessions
+        .iter()
+        .map(|session| claude_session_summary(session, cli))
+        .collect();
+    Ok((sessions, list.total))
+}
+
+fn claude_session_summary(
+    session: &claude::ClaudeSessionMetadata,
+    cli: &AgentCliSummary,
+) -> AgentSessionSummary {
+    let pr = session.pr_links.first();
+    AgentSessionSummary {
+        kind: ManagedAgentKind::Claude,
+        session_id: session.session_id.clone(),
+        title: session_title(session.title.clone()),
+        cwd: session.cwd.clone(),
+        created_at: parse_rfc3339(session.created_at.as_deref()),
+        last_activity_at: parse_rfc3339(session.last_activity_at.as_deref()),
+        resume: resume_summary(ManagedAgentKind::Claude, &session.session_id),
+        live: empty_session_live(),
+        provider: AgentProviderSessionInfo {
+            model: None,
+            permission_mode: session.permission_mode.clone(),
+            cli_version: session
+                .claude_version
+                .clone()
+                .or_else(|| cli.version.clone()),
+            origin: session.user_type.clone(),
+            source: None,
+            entrypoint: session.entrypoint.clone(),
+            native_project_id: None,
+            model_provider: Some("anthropic".to_string()),
+        },
+        git: Some(AgentGitSummary {
+            branch: session.git_branch.clone(),
+            worktree: session.worktree.clone(),
+            commit_hash: None,
+            repository_url: None,
+            pr_number: pr.and_then(|pr| pr.number),
+            pr_url: pr.and_then(|pr| pr.url.clone()),
+            pr_repository: pr.and_then(|pr| pr.repository.clone()),
+        }),
+        usage: None,
+        counters: AgentSessionCounters {
+            record_count: session.message_count as u64,
+            message_count: session.message_count as u64,
+            turn_count: 0,
+            tool_count: 0,
+            tool_failure_count: session.task_failed_count as u64,
+            hook_success_count: session.hook_success_count as u64,
+            hook_failure_count: session.hook_failure_count as u64,
+            malformed_record_count: session.malformed_line_count as u64,
+        },
+        flags: AgentSessionFlags {
+            is_sidechain: session.is_sidechain,
+            is_subagent: false,
+            is_archived: false,
+            historical_only: true,
+            live_bound: false,
+        },
+        data_sources: vec![AgentDataSource::HistoricalScan],
+        warnings: malformed_warning(session.malformed_line_count),
+        transcript_size_bytes: file_size_bytes(&session.transcript_path),
+    }
+}
+
+fn codex_sessions(
+    workdir: &Path,
+    cli: &AgentCliSummary,
+    limit: usize,
+) -> Result<(Vec<AgentSessionSummary>, usize), String> {
+    let threads = codex_threads_for_workdir(workdir)?;
+    let total = threads.len();
+    let summaries = threads
+        .into_iter()
+        .take(limit)
+        .map(|thread| codex_session_summary_from_thread(&thread, cli))
+        .collect();
+    Ok((summaries, total))
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexThreadRow {
+    id: String,
+    cwd: String,
+    title: String,
+    rollout_path: String,
+    source: String,
+    model_provider: String,
+    #[serde(default)]
+    cli_version: String,
+    created_at_ms: Option<i64>,
+    updated_at_ms: Option<i64>,
+    #[serde(default)]
+    first_user_message: String,
+    #[serde(default)]
+    preview: String,
+    agent_nickname: Option<String>,
+    agent_role: Option<String>,
+    git_branch: Option<String>,
+    git_sha: Option<String>,
+    git_origin_url: Option<String>,
+    #[serde(default)]
+    approval_mode: String,
+    model: Option<String>,
+}
+
+fn codex_sessions_available() -> bool {
+    command_on_path("codex") || codex_state_db_path().is_some()
+}
+
+fn codex_state_db_path() -> Option<PathBuf> {
+    let dir = home_path(&[".codex"]);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return None;
+    };
+    let mut best: Option<(u64, PathBuf)> = None;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with("state_") || !name.ends_with(".sqlite") {
+            continue;
+        }
+        let Some(version) = name
+            .strip_prefix("state_")
+            .and_then(|suffix| suffix.strip_suffix(".sqlite"))
+            .and_then(|version| version.parse::<u64>().ok())
+        else {
+            continue;
+        };
+        match best {
+            Some((current, _)) if current >= version => {}
+            _ => best = Some((version, entry.path())),
+        }
+    }
+    best.map(|(_, path)| path)
+}
+
+fn fetch_codex_threads_from_db(workdir: &Path) -> Result<Vec<CodexThreadRow>, String> {
+    let db_path =
+        codex_state_db_path().ok_or_else(|| "Codex state database not found".to_string())?;
+    let cwd_keys = codex_workdir_keys(workdir);
+    let cwd_filter = cwd_keys
+        .iter()
+        .map(|cwd| sql_string_literal(cwd))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let query = format!(
+        r#"
+        SELECT
+            id,
+            cwd,
+            title,
+            rollout_path,
+            source,
+            model_provider,
+            cli_version,
+            created_at_ms,
+            updated_at_ms,
+            first_user_message,
+            preview,
+            agent_nickname,
+            agent_role,
+            git_branch,
+            git_sha,
+            git_origin_url,
+            approval_mode,
+            model
+        FROM threads
+        WHERE archived = 0 AND cwd IN ({cwd_filter})
+        ORDER BY updated_at_ms DESC
+    "#
+    );
+    let output = Command::new("sqlite3")
+        .args(["-readonly", "-json"])
+        .arg(&db_path)
+        .arg(&query)
+        .output()
+        .map_err(|error| format!("failed to run sqlite3: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "sqlite3 query failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    if output.stdout.is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_slice(&output.stdout).map_err(|error| error.to_string())
+}
+
+fn codex_threads_for_workdir(workdir: &Path) -> Result<Vec<CodexThreadRow>, String> {
+    fetch_codex_threads_from_db(workdir)
+}
+
+fn codex_workdir_keys(workdir: &Path) -> Vec<String> {
+    let canonical = normalize_path(workdir).to_string_lossy().into_owned();
+    let raw = workdir.to_string_lossy().trim_end_matches('/').to_string();
+    if raw == canonical {
+        vec![canonical]
+    } else {
+        vec![canonical, raw]
+    }
+}
+
+fn sql_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn codex_thread_updated_at(thread: &CodexThreadRow) -> Option<DateTime<Utc>> {
+    thread
+        .updated_at_ms
+        .and_then(DateTime::<Utc>::from_timestamp_millis)
+        .or_else(|| {
+            thread
+                .created_at_ms
+                .and_then(DateTime::<Utc>::from_timestamp_millis)
+        })
+}
+
+fn codex_title_from_thread(thread: &CodexThreadRow) -> Option<String> {
+    sanitize_codex_title_field(&thread.title)
+        .or_else(|| sanitize_codex_title_field(&thread.preview))
+        .or_else(|| sanitize_codex_prompt_fallback(&thread.first_user_message))
+        .or_else(|| {
+            codex_title_from_agent_identity(
+                thread.agent_nickname.as_deref(),
+                thread.agent_role.as_deref(),
+            )
+        })
+}
+
+fn sanitize_codex_title_field(raw: &str) -> Option<String> {
+    let mut line = raw.lines().next()?.trim();
+    if line.is_empty() {
+        return None;
+    }
+    if let Some(rest) = line.strip_prefix("continue ") {
+        let rest = rest.trim();
+        if rest.starts_with('/') || rest.starts_with('~') {
+            line = codex_title_from_path(rest).unwrap_or(rest);
+        }
+    } else if line.starts_with('/') || line.starts_with('~') {
+        line = codex_title_from_path(line).unwrap_or(line);
+    }
+    finalize_codex_title(line)
+}
+
+fn sanitize_codex_prompt_fallback(raw: &str) -> Option<String> {
+    let mut line = raw.lines().next()?.trim();
+    if line.is_empty() {
+        return None;
+    }
+    if let Some(rest) = line.strip_prefix("CWD:") {
+        line = rest.trim();
+        if let Some((_, after_path)) = line.split_once(". ") {
+            line = after_path.trim();
+        }
+    }
+    sanitize_codex_title_field(line)
+}
+
+fn finalize_codex_title(line: &str) -> Option<String> {
+    if line.is_empty() {
+        return None;
+    }
+    let collapsed = line.split_whitespace().collect::<Vec<_>>().join(" ");
+    Some(utils::truncate_chars(&collapsed, 80))
+}
+
+fn codex_title_from_path(path: &str) -> Option<&str> {
+    Path::new(path)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+}
+
+fn codex_session_summary_from_thread(
+    thread: &CodexThreadRow,
+    cli: &AgentCliSummary,
+) -> AgentSessionSummary {
+    let rollout_path = PathBuf::from(&thread.rollout_path);
+    let cli_version = (!thread.cli_version.is_empty()).then_some(thread.cli_version.clone());
+    AgentSessionSummary {
+        kind: ManagedAgentKind::Codex,
+        session_id: thread.id.clone(),
+        title: session_title(codex_title_from_thread(thread)),
+        cwd: Some(thread.cwd.clone()),
+        created_at: thread
+            .created_at_ms
+            .and_then(DateTime::<Utc>::from_timestamp_millis),
+        last_activity_at: codex_thread_updated_at(thread),
+        resume: resume_summary(ManagedAgentKind::Codex, &thread.id),
+        live: empty_session_live(),
+        provider: AgentProviderSessionInfo {
+            model: thread.model.clone(),
+            permission_mode: (!thread.approval_mode.is_empty())
+                .then_some(thread.approval_mode.clone()),
+            cli_version: cli_version.or_else(|| cli.version.clone()),
+            origin: None,
+            source: Some(thread.source.clone()),
+            entrypoint: None,
+            native_project_id: None,
+            model_provider: Some(thread.model_provider.clone()),
+        },
+        git: Some(AgentGitSummary {
+            branch: thread.git_branch.clone(),
+            worktree: None,
+            commit_hash: thread.git_sha.clone(),
+            repository_url: thread.git_origin_url.clone(),
+            pr_number: None,
+            pr_url: None,
+            pr_repository: None,
+        }),
+        usage: None,
+        counters: AgentSessionCounters {
+            record_count: 0,
+            message_count: 0,
+            turn_count: 0,
+            tool_count: 0,
+            tool_failure_count: 0,
+            hook_success_count: 0,
+            hook_failure_count: 0,
+            malformed_record_count: 0,
+        },
+        flags: AgentSessionFlags {
+            is_sidechain: false,
+            is_subagent: false,
+            is_archived: false,
+            historical_only: true,
+            live_bound: false,
+        },
+        data_sources: vec![AgentDataSource::HistoricalScan],
+        warnings: Vec::new(),
+        transcript_size_bytes: file_size_bytes(&rollout_path),
+    }
+}
+
+fn codex_title_from_agent_identity(nickname: Option<&str>, role: Option<&str>) -> Option<String> {
+    let nickname = nickname?.trim();
+    if nickname.is_empty() {
+        return None;
+    }
+    let title = match role.map(str::trim).filter(|role| !role.is_empty()) {
+        Some(role) => format!("{nickname} ({role})"),
+        None => nickname.to_string(),
+    };
+    Some(utils::truncate_chars(&title, 80))
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct OpenCodeSessionJson {
+    id: String,
+    title: Option<String>,
+    updated: Option<i64>,
+    created: Option<i64>,
+    project_id: Option<String>,
+    directory: Option<String>,
+    #[serde(default)]
+    worktree: Option<String>,
+}
+
+struct OpenCodeSessionCountSummary {
+    total: usize,
+    latest: Option<OpenCodeSessionJson>,
+}
+
+fn opencode_db_path() -> PathBuf {
+    home_path(&[".local", "share", "opencode", "opencode.db"])
+}
+
+fn command_on_path(program: &str) -> bool {
+    if program.contains('/') {
+        return Path::new(program).is_file();
+    }
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(program).is_file())
+}
+
+fn opencode_sessions_available() -> bool {
+    opencode_db_path().is_file() || command_on_path("opencode")
+}
+
+fn opencode_session_cli_summary() -> AgentCliSummary {
+    if opencode_sessions_available() {
+        AgentCliSummary {
+            available: true,
+            version: None,
+            error: None,
+        }
+    } else {
+        AgentCliSummary {
+            available: false,
+            version: None,
+            error: Some("OpenCode CLI and database not found".to_string()),
+        }
+    }
+}
+
+fn fetch_opencode_sessions_json() -> Result<(Vec<u8>, &'static str), String> {
+    if let Ok(json) = fetch_opencode_sessions_json_from_db() {
+        return Ok((json, "opencode sqlite"));
+    }
+
+    let output = Command::new("opencode")
+        .args(["session", "list", "--format", "json", "--pure"])
+        .output()
+        .map_err(|error| error.to_string())?;
+    if output.status.success() && !output.stdout.is_empty() {
+        return Ok((output.stdout, "opencode session list"));
+    }
+
+    let cli_error = if output.stderr.is_empty() {
+        format!("`opencode session list` exited with {}", output.status)
+    } else {
+        format!(
+            "`opencode session list` exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+    };
+
+    fetch_opencode_sessions_json_from_db()
+        .map(|json| (json, "opencode sqlite"))
+        .map_err(|fallback_error| format!("{cli_error}; sqlite fallback failed: {fallback_error}"))
+}
+
+fn fetch_opencode_sessions_json_from_db() -> Result<Vec<u8>, String> {
+    let db_path = opencode_db_path();
+    if !db_path.is_file() {
+        return Err(format!(
+            "OpenCode database not found at {}",
+            db_path.display()
+        ));
+    }
+
+    const QUERY: &str = r#"
+        SELECT
+            s.id AS id,
+            s.title AS title,
+            s.directory AS directory,
+            s.time_created AS created,
+            s.time_updated AS updated,
+            s.project_id AS projectId,
+            p.worktree AS worktree
+        FROM session s
+        JOIN project p ON p.id = s.project_id
+        WHERE s.time_archived IS NULL
+        ORDER BY s.time_updated DESC
+    "#;
+
+    let output = Command::new("sqlite3")
+        .args(["-readonly", "-json"])
+        .arg(&db_path)
+        .arg(QUERY)
+        .output()
+        .map_err(|error| format!("failed to run sqlite3: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "sqlite3 query failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    if output.stdout.is_empty() {
+        return Ok(b"[]".to_vec());
+    }
+    Ok(output.stdout)
+}
+
+fn opencode_workdir_matches(
+    workdir: &Path,
+    session: &OpenCodeSessionJson,
+    git_cache: &mut HashMap<PathBuf, Option<PathBuf>>,
+) -> bool {
+    let candidates = [session.directory.as_deref(), session.worktree.as_deref()];
+    for candidate in candidates.into_iter().flatten() {
+        if cwd_matches(workdir, Some(candidate)) {
+            return true;
+        }
+        if share_git_repository(workdir, Path::new(candidate), git_cache) {
+            return true;
+        }
+    }
+    false
+}
+
+fn share_git_repository(
+    left: &Path,
+    right: &Path,
+    cache: &mut HashMap<PathBuf, Option<PathBuf>>,
+) -> bool {
+    let Some(left_common) = git_common_dir(left, cache) else {
+        return false;
+    };
+    let Some(right_common) = git_common_dir(right, cache) else {
+        return false;
+    };
+    left_common == right_common
+}
+
+fn git_common_dir(path: &Path, cache: &mut HashMap<PathBuf, Option<PathBuf>>) -> Option<PathBuf> {
+    let key = normalize_path(path);
+    if let Some(cached) = cache.get(&key) {
+        return cached.clone();
+    }
+    let resolved = resolve_git_common_dir(path);
+    cache.insert(key, resolved.clone());
+    resolved
+}
+
+fn resolve_git_common_dir(path: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let relative = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if relative.is_empty() {
+        return None;
+    }
+    let git_dir = PathBuf::from(&relative);
+    let absolute = if git_dir.is_absolute() {
+        git_dir
+    } else {
+        path.join(git_dir)
+    };
+    Some(normalize_path(&absolute))
+}
+
+fn opencode_sessions_limited(
+    workdir: &Path,
+    cli: &AgentCliSummary,
+    limit: usize,
+) -> Result<(Vec<AgentSessionSummary>, usize), String> {
+    if !cli.available {
+        return Ok((Vec::new(), 0));
+    }
+    let (json, source) = fetch_opencode_sessions_json()?;
+    let mut sessions = opencode_sessions_from_json(workdir, &json, cli, source)?;
+    let total = sessions.len();
+    sessions.truncate(limit);
+    Ok((sessions, total))
+}
+
+fn opencode_sessions_from_json(
+    workdir: &Path,
+    json: &[u8],
+    cli: &AgentCliSummary,
+    source: &str,
+) -> Result<Vec<AgentSessionSummary>, String> {
+    let raw: Vec<OpenCodeSessionJson> =
+        serde_json::from_slice(json).map_err(|error| error.to_string())?;
+    let mut git_cache = HashMap::new();
+    let mut sessions = Vec::new();
+    for session in raw {
+        if !opencode_workdir_matches(workdir, &session, &mut git_cache) {
+            continue;
+        }
+        sessions.push(AgentSessionSummary {
+            kind: ManagedAgentKind::OpenCode,
+            session_id: session.id.clone(),
+            title: session_title(session.title.clone()),
+            cwd: session.directory.clone().or(session.worktree.clone()),
+            created_at: session
+                .created
+                .and_then(DateTime::<Utc>::from_timestamp_millis),
+            last_activity_at: session
+                .updated
+                .and_then(DateTime::<Utc>::from_timestamp_millis),
+            resume: resume_summary(ManagedAgentKind::OpenCode, &session.id),
+            live: empty_session_live(),
+            provider: AgentProviderSessionInfo {
+                model: None,
+                permission_mode: None,
+                cli_version: cli.version.clone(),
+                origin: None,
+                source: Some(source.to_string()),
+                entrypoint: None,
+                native_project_id: session.project_id,
+                model_provider: None,
+            },
+            git: None,
+            usage: None,
+            counters: AgentSessionCounters {
+                record_count: 0,
+                message_count: 0,
+                turn_count: 0,
+                tool_count: 0,
+                tool_failure_count: 0,
+                hook_success_count: 0,
+                hook_failure_count: 0,
+                malformed_record_count: 0,
+            },
+            flags: AgentSessionFlags {
+                is_sidechain: false,
+                is_subagent: false,
+                is_archived: false,
+                historical_only: true,
+                live_bound: false,
+            },
+            data_sources: vec![AgentDataSource::ProviderCli],
+            warnings: Vec::new(),
+            transcript_size_bytes: None,
+        });
+    }
+    sessions.sort_by(|left, right| right.last_activity_at.cmp(&left.last_activity_at));
+    Ok(sessions)
+}
+
+#[derive(Default)]
+struct LiveAgentSessions {
+    active_terminal_ids: Vec<String>,
+    by_session: HashMap<String, AgentSessionLiveSummary>,
+}
+
+async fn live_summary(
+    kind: ManagedAgentKind,
+    session: Option<&Arc<ServerSession>>,
+) -> AgentLiveSummary {
+    let live = live_sessions(kind, session).await;
+    AgentLiveSummary {
+        active_terminal_ids: live.active_terminal_ids,
+        pending_action_count: 0,
+        latest_event: None,
+    }
+}
+
+async fn live_sessions(
+    kind: ManagedAgentKind,
+    session: Option<&Arc<ServerSession>>,
+) -> LiveAgentSessions {
+    let Some(session) = session else {
+        return LiveAgentSessions::default();
+    };
+    let terms = session.terminals.lock().await;
+    let mut live = LiveAgentSessions::default();
+    for (terminal_id, term) in terms.iter() {
+        let Some(meta) = term.host_meta.lock().ok().map(snapshot_meta) else {
+            continue;
+        };
+        if !terminal_matches(kind, &meta) {
+            continue;
+        }
+        live.active_terminal_ids.push(terminal_id.clone());
+        if let Some(session_id) = infer_session_id(kind, &meta) {
+            live.by_session.insert(
+                session_id.clone(),
+                AgentSessionLiveSummary {
+                    terminal_id: Some(terminal_id.clone()),
+                    status: lifecycle_from_shell(meta.shell_state),
+                    pending_action_count: 0,
+                    current_turn_id: None,
+                    latest_event: Some(AgentEventSummary {
+                        kind: AgentEventKind::SessionUpdated,
+                        status: lifecycle_from_shell(meta.shell_state),
+                        at: None,
+                        terminal_id: Some(terminal_id.clone()),
+                        session_id: Some(session_id),
+                        turn_id: None,
+                        tool_name: None,
+                    }),
+                },
+            );
+        }
+    }
+    live.active_terminal_ids.sort();
+    live
+}
+
+fn snapshot_meta(meta: std::sync::MutexGuard<'_, HostTermMeta>) -> HostTermMetaSnapshot {
+    HostTermMetaSnapshot {
+        icon_name: meta.icon_name.clone(),
+        current_command: meta.current_command.clone(),
+        shell_state: meta.shell_state,
+    }
+}
+
+struct HostTermMetaSnapshot {
+    icon_name: Option<String>,
+    current_command: Option<String>,
+    shell_state: HostShellState,
+}
+
+fn terminal_matches(kind: ManagedAgentKind, meta: &HostTermMetaSnapshot) -> bool {
+    let needle = match kind {
+        ManagedAgentKind::Claude => "claude",
+        ManagedAgentKind::Codex => "codex",
+        ManagedAgentKind::OpenCode => "opencode",
+    };
+    meta.icon_name
+        .as_deref()
+        .is_some_and(|icon| icon.to_ascii_lowercase().contains(needle))
+        || meta
+            .current_command
+            .as_deref()
+            .is_some_and(|command| command_mentions(kind, command))
+}
+
+fn command_mentions(kind: ManagedAgentKind, command: &str) -> bool {
+    let low = command.to_ascii_lowercase();
+    match kind {
+        ManagedAgentKind::Claude => low.contains("claude"),
+        ManagedAgentKind::Codex => low.contains("codex"),
+        ManagedAgentKind::OpenCode => low.contains("opencode") || low.contains("open-code"),
+    }
+}
+
+fn infer_session_id(kind: ManagedAgentKind, meta: &HostTermMetaSnapshot) -> Option<String> {
+    let command = meta.current_command.as_deref()?;
+    let tokens = command.split_whitespace().collect::<Vec<_>>();
+    match kind {
+        ManagedAgentKind::Claude => value_after_flag(&tokens, "--resume"),
+        ManagedAgentKind::Codex => {
+            let resume_index = tokens.iter().position(|token| *token == "resume")?;
+            tokens
+                .get(resume_index + 1)
+                .filter(|value| !value.starts_with('-'))
+                .map(|value| value.trim_matches('"').trim_matches('\'').to_string())
+        }
+        ManagedAgentKind::OpenCode => {
+            value_after_flag(&tokens, "--session").or_else(|| value_after_flag(&tokens, "-s"))
+        }
+    }
+}
+
+fn value_after_flag(tokens: &[&str], flag: &str) -> Option<String> {
+    let prefix = format!("{flag}=");
+    for (index, token) in tokens.iter().enumerate() {
+        if *token == flag {
+            return tokens
+                .get(index + 1)
+                .map(|value| value.trim_matches('"').trim_matches('\'').to_string());
+        }
+        if let Some(value) = token.strip_prefix(&prefix) {
+            return Some(value.trim_matches('"').trim_matches('\'').to_string());
+        }
+    }
+    None
+}
+
+fn lifecycle_from_shell(state: HostShellState) -> AgentLifecycleStatus {
+    match state {
+        HostShellState::Unknown => AgentLifecycleStatus::Unknown,
+        HostShellState::Idle => AgentLifecycleStatus::Idle,
+        HostShellState::Running => AgentLifecycleStatus::Running,
+    }
+}
+
+fn resume_summary(kind: ManagedAgentKind, session_id: &str) -> AgentResumeSummary {
+    let available = !session_id.trim().is_empty();
+    AgentResumeSummary {
+        available,
+        unavailable_reason: (!available).then(|| "missing session id".to_string()),
+        action_id: available.then(|| format!("{}:{session_id}", kind_slug(kind))),
+    }
+}
+
+fn empty_session_live() -> AgentSessionLiveSummary {
+    AgentSessionLiveSummary {
+        terminal_id: None,
+        status: AgentLifecycleStatus::Unknown,
+        pending_action_count: 0,
+        current_turn_id: None,
+        latest_event: None,
+    }
+}
+
+fn malformed_warning(count: usize) -> Vec<AgentWarning> {
+    if count == 0 {
+        Vec::new()
+    } else {
+        vec![AgentWarning {
+            code: "malformed_records".to_string(),
+            message: format!("{count} malformed records were ignored"),
+        }]
+    }
+}
+
+fn parse_rfc3339(value: Option<&str>) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value?)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn cwd_matches(workdir: &Path, cwd: Option<&str>) -> bool {
+    let Some(cwd) = cwd else {
+        return false;
+    };
+    paths_equal(workdir, Path::new(cwd))
+}
+
+fn paths_equal(left: &Path, right: &Path) -> bool {
+    if normalize_path(left) == normalize_path(right) {
+        return true;
+    }
+    left.to_string_lossy().trim_end_matches('/') == right.to_string_lossy().trim_end_matches('/')
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn home_path(parts: &[&str]) -> PathBuf {
+    let mut path = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_default();
+    for part in parts {
+        path.push(part);
+    }
+    path
+}
+
+fn display_name(kind: ManagedAgentKind) -> &'static str {
+    match kind {
+        ManagedAgentKind::Claude => "Claude",
+        ManagedAgentKind::Codex => "Codex",
+        ManagedAgentKind::OpenCode => "OpenCode",
+    }
+}
+
+fn session_title(stored: Option<String>) -> Option<String> {
+    stored
+        .map(|title| title.trim().to_string())
+        .filter(|title| !title.is_empty())
+        .or_else(|| Some("Unknown".to_string()))
+}
+
+fn file_size_bytes(path: &Path) -> Option<u64> {
+    std::fs::metadata(path).ok().map(|meta| meta.len())
+}
+
+fn account_summary(kind: ManagedAgentKind) -> AgentAccountSummary {
+    let fields = match kind {
+        ManagedAgentKind::Claude => claude_account_fields(),
+        ManagedAgentKind::Codex => codex_account_fields(),
+        ManagedAgentKind::OpenCode => opencode_account_fields(),
+    };
+    AgentAccountSummary { fields }
+}
+
+fn claude_account_fields() -> Vec<AgentInfoField> {
+    let mut fields = Vec::new();
+    let settings_path = home_path(&[".claude", "settings.json"]);
+    if let Ok(value) = read_json_file(&settings_path) {
+        push_json_string(&mut fields, "Model", &value, &["model"]);
+        push_json_string(&mut fields, "Effort", &value, &["effortLevel"]);
+        push_json_string(
+            &mut fields,
+            "Permission mode",
+            &value,
+            &["permissions", "defaultMode"],
+        );
+        push_json_bool(
+            &mut fields,
+            "Onboarding complete",
+            &value,
+            &["hasCompletedOnboarding"],
+        );
+    }
+    let stats_path = home_path(&[".claude", "stats-cache.json"]);
+    if let Ok(value) = read_json_file(&stats_path) {
+        push_json_u64(&mut fields, "Total sessions", &value, &["totalSessions"]);
+        push_json_u64(&mut fields, "Total messages", &value, &["totalMessages"]);
+        if let Some(total_cost) = claude_total_cost_usd(&value) {
+            fields.push(AgentInfoField {
+                label: "Total cost (USD)".to_string(),
+                value: format!("{total_cost:.4}"),
+            });
+        }
+    }
+    fields
+}
+
+fn codex_account_fields() -> Vec<AgentInfoField> {
+    let mut fields = Vec::new();
+    let auth_path = home_path(&[".codex", "auth.json"]);
+    fields.push(AgentInfoField {
+        label: "Logged in".to_string(),
+        value: if auth_path.is_file() {
+            "yes".to_string()
+        } else {
+            "no".to_string()
+        },
+    });
+    if let Ok(contents) = std::fs::read_to_string(&auth_path) {
+        if let Ok(value) = serde_json::from_str::<Value>(&contents) {
+            push_json_string(&mut fields, "Last refresh", &value, &["last_refresh"]);
+        }
+    }
+    let config_path = home_path(&[".codex", "config.toml"]);
+    if let Ok(contents) = std::fs::read_to_string(&config_path) {
+        for line in contents.lines() {
+            let line = line.trim();
+            if line.starts_with("model ") {
+                fields.push(AgentInfoField {
+                    label: "Model".to_string(),
+                    value: toml_value(line),
+                });
+            } else if line.starts_with("personality ") {
+                fields.push(AgentInfoField {
+                    label: "Personality".to_string(),
+                    value: toml_value(line),
+                });
+            } else if line.starts_with("model_reasoning_effort ") {
+                fields.push(AgentInfoField {
+                    label: "Reasoning effort".to_string(),
+                    value: toml_value(line),
+                });
+            }
+        }
+    }
+    fields
+}
+
+fn opencode_account_fields() -> Vec<AgentInfoField> {
+    let mut fields = Vec::new();
+    let config_dir = home_path(&[".config", "opencode"]);
+    fields.push(AgentInfoField {
+        label: "Config dir".to_string(),
+        value: if config_dir.is_dir() {
+            "present".to_string()
+        } else {
+            "missing".to_string()
+        },
+    });
+    fields
+}
+
+fn read_json_file(path: &Path) -> Result<Value, String> {
+    let contents =
+        std::fs::read_to_string(path).map_err(|error| format!("{}: {error}", path.display()))?;
+    serde_json::from_str(&contents).map_err(|error| error.to_string())
+}
+
+fn push_json_string(fields: &mut Vec<AgentInfoField>, label: &str, value: &Value, path: &[&str]) {
+    let Some(raw) = json_path(value, path) else {
+        return;
+    };
+    let Some(text) = value_to_string(raw) else {
+        return;
+    };
+    fields.push(AgentInfoField {
+        label: label.to_string(),
+        value: text,
+    });
+}
+
+fn push_json_u64(fields: &mut Vec<AgentInfoField>, label: &str, value: &Value, path: &[&str]) {
+    let Some(raw) = json_path(value, path) else {
+        return;
+    };
+    let Some(number) = raw.as_u64() else {
+        return;
+    };
+    fields.push(AgentInfoField {
+        label: label.to_string(),
+        value: number.to_string(),
+    });
+}
+
+fn push_json_bool(fields: &mut Vec<AgentInfoField>, label: &str, value: &Value, path: &[&str]) {
+    let Some(raw) = json_path(value, path) else {
+        return;
+    };
+    let Some(flag) = raw.as_bool() else {
+        return;
+    };
+    fields.push(AgentInfoField {
+        label: label.to_string(),
+        value: if flag { "yes" } else { "no" }.to_string(),
+    });
+}
+
+fn json_path<'a>(value: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    Some(current)
+}
+
+fn value_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.clone()),
+        Value::Number(number) => Some(number.to_string()),
+        Value::Bool(flag) => Some(if *flag { "yes" } else { "no" }.to_string()),
+        _ => None,
+    }
+}
+
+fn claude_total_cost_usd(value: &Value) -> Option<f64> {
+    let usage = value.get("modelUsage")?.as_object()?;
+    let mut total = 0.0;
+    for model in usage.values() {
+        if let Some(cost) = model.get("costUSD").and_then(Value::as_f64) {
+            total += cost;
+        }
+    }
+    (total > 0.0).then_some(total)
+}
+
+fn toml_value(line: &str) -> String {
+    line.split_once('=')
+        .map(|(_, value)| value.trim().trim_matches('"').to_string())
+        .unwrap_or_else(|| line.to_string())
+}
+
+fn program_name(kind: ManagedAgentKind) -> &'static str {
+    match kind {
+        ManagedAgentKind::Claude => "claude",
+        ManagedAgentKind::Codex => "codex",
+        ManagedAgentKind::OpenCode => "opencode",
+    }
+}
+
+pub fn kind_slug(kind: ManagedAgentKind) -> &'static str {
+    match kind {
+        ManagedAgentKind::Claude => "claude",
+        ManagedAgentKind::Codex => "codex",
+        ManagedAgentKind::OpenCode => "opencode",
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || "_@%+=:,./-".contains(ch))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cli(version: &str) -> AgentCliSummary {
+        AgentCliSummary {
+            available: true,
+            version: Some(version.to_string()),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn session_title_defaults_to_unknown_without_provider_title() {
+        assert_eq!(session_title(None).as_deref(), Some("Unknown"));
+        assert_eq!(
+            session_title(Some("Fix terminal paste".into())).as_deref(),
+            Some("Fix terminal paste")
+        );
+    }
+
+    #[test]
+    fn opencode_json_maps_safe_summary_fields() {
+        let json = br#"[
+          {
+            "id": "ses_123",
+            "title": "Fix terminal paste",
+            "updated": 1777805877635,
+            "created": 1777805707332,
+            "projectId": "project-hash",
+            "directory": "/repo"
+          }
+        ]"#;
+
+        let sessions = opencode_sessions_from_json(
+            Path::new("/repo"),
+            json,
+            &cli("1.14.33"),
+            "opencode sqlite",
+        )
+        .expect("parse opencode sessions");
+
+        assert_eq!(sessions.len(), 1);
+        let session = &sessions[0];
+        assert_eq!(session.kind, ManagedAgentKind::OpenCode);
+        assert_eq!(session.session_id, "ses_123");
+        assert_eq!(session.title.as_deref(), Some("Fix terminal paste"));
+        assert_eq!(
+            session.provider.native_project_id.as_deref(),
+            Some("project-hash")
+        );
+        assert_eq!(session.provider.cli_version.as_deref(), Some("1.14.33"));
+        assert!(session.resume.available);
+        assert_eq!(
+            session.resume.action_id.as_deref(),
+            Some("opencode:ses_123")
+        );
+    }
+
+    #[test]
+    fn opencode_workdir_matches_linked_git_worktree_via_common_dir() {
+        let workdir = Path::new("/Users/me/projects/zedra-main");
+        let linked = Path::new("/Users/me/projects/zedra");
+        let common = PathBuf::from("/Users/me/projects/zedra/.git");
+        let session = OpenCodeSessionJson {
+            id: "ses_linked".into(),
+            title: Some("Linked worktree session".into()),
+            updated: Some(1777805877635),
+            created: Some(1777805707332),
+            project_id: Some("project-hash".into()),
+            directory: Some(linked.display().to_string()),
+            worktree: Some(linked.display().to_string()),
+        };
+
+        let mut git_cache = HashMap::new();
+        git_cache.insert(normalize_path(workdir), Some(common.clone()));
+        git_cache.insert(normalize_path(linked), Some(common));
+
+        assert!(opencode_workdir_matches(workdir, &session, &mut git_cache));
+    }
+
+    #[test]
+    fn opencode_db_json_parses_sqlite_shape() {
+        let json = br#"[
+          {
+            "id": "ses_db",
+            "title": "From sqlite",
+            "directory": "/repo",
+            "created": 1777805707332,
+            "updated": 1777805877635,
+            "projectId": "project-hash",
+            "worktree": "/repo"
+          }
+        ]"#;
+        let sessions = opencode_sessions_from_json(
+            Path::new("/repo"),
+            json,
+            &cli("1.14.33"),
+            "opencode sqlite",
+        )
+        .expect("parse");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].title.as_deref(), Some("From sqlite"));
+    }
+
+    #[test]
+    fn codex_thread_db_json_parses_sqlite_shape() {
+        let json = br#"[
+          {
+            "id": "019e251d-03ed-76a1-87f6-eecda6eb88a8",
+            "cwd": "/repo",
+            "title": "Research live activity ios",
+            "rollout_path": "/home/.codex/sessions/2026/05/14/rollout.jsonl",
+            "source": "vscode",
+            "model_provider": "openai",
+            "cli_version": "0.130.0",
+            "created_at_ms": 1778746700000,
+            "updated_at_ms": 1778746704000,
+            "first_user_message": "research live activity",
+            "agent_nickname": null,
+            "agent_role": null,
+            "git_branch": "main",
+            "git_sha": "abc",
+            "git_origin_url": "https://example.com/repo.git",
+            "approval_mode": "on-request",
+            "model": "gpt-5.3-codex"
+          }
+        ]"#;
+        let threads: Vec<CodexThreadRow> = serde_json::from_slice(json).expect("parse");
+        assert_eq!(threads.len(), 1);
+        let summary = codex_session_summary_from_thread(&threads[0], &cli("0.130.0"));
+        assert_eq!(summary.session_id, "019e251d-03ed-76a1-87f6-eecda6eb88a8");
+        assert_eq!(summary.title.as_deref(), Some("Research live activity ios"));
+        assert_eq!(summary.provider.source.as_deref(), Some("vscode"));
+    }
+
+    #[test]
+    fn codex_thread_matches_exact_workdir_only() {
+        let workdir = PathBuf::from("/Users/me/projects/zedra-main");
+        let matching = CodexThreadRow {
+            id: "019e".into(),
+            cwd: "/Users/me/projects/zedra-main".into(),
+            title: "Main session".into(),
+            rollout_path: "/home/.codex/sessions/rollout.jsonl".into(),
+            source: "vscode".into(),
+            model_provider: "openai".into(),
+            cli_version: String::new(),
+            created_at_ms: None,
+            updated_at_ms: None,
+            first_user_message: String::new(),
+            preview: String::new(),
+            agent_nickname: None,
+            agent_role: None,
+            git_branch: None,
+            git_sha: None,
+            git_origin_url: None,
+            approval_mode: String::new(),
+            model: None,
+        };
+        let sibling = CodexThreadRow {
+            id: "019f".into(),
+            cwd: "/Users/me/projects/zedra".into(),
+            title: "Sibling session".into(),
+            rollout_path: "/home/.codex/sessions/rollout.jsonl".into(),
+            source: "vscode".into(),
+            model_provider: "openai".into(),
+            cli_version: String::new(),
+            created_at_ms: None,
+            updated_at_ms: None,
+            first_user_message: String::new(),
+            preview: String::new(),
+            agent_nickname: None,
+            agent_role: None,
+            git_branch: None,
+            git_sha: None,
+            git_origin_url: None,
+            approval_mode: String::new(),
+            model: None,
+        };
+        assert!(paths_equal(&workdir, Path::new(&matching.cwd)));
+        assert!(!paths_equal(&workdir, Path::new(&sibling.cwd)));
+    }
+
+    #[test]
+    fn codex_title_from_thread_prefers_db_title() {
+        let thread = CodexThreadRow {
+            id: "019e".into(),
+            cwd: "/repo".into(),
+            title: "Final title".into(),
+            rollout_path: "/home/.codex/sessions/rollout.jsonl".into(),
+            source: "vscode".into(),
+            model_provider: "openai".into(),
+            cli_version: String::new(),
+            created_at_ms: None,
+            updated_at_ms: None,
+            first_user_message: "initial prompt".into(),
+            preview: String::new(),
+            agent_nickname: None,
+            agent_role: None,
+            git_branch: None,
+            git_sha: None,
+            git_origin_url: None,
+            approval_mode: String::new(),
+            model: None,
+        };
+        assert_eq!(
+            codex_title_from_thread(&thread).as_deref(),
+            Some("Final title")
+        );
+    }
+
+    #[test]
+    fn codex_title_from_thread_prefers_db_title_over_cwd_message() {
+        let thread = CodexThreadRow {
+            id: "019e".into(),
+            cwd: "/Users/me/projects/zedra-main".into(),
+            title: "Research Gemini CLI integration".into(),
+            rollout_path: "/home/.codex/sessions/rollout.jsonl".into(),
+            source: "vscode".into(),
+            model_provider: "openai".into(),
+            cli_version: String::new(),
+            created_at_ms: None,
+            updated_at_ms: None,
+            first_user_message:
+                "CWD: /Users/me/projects/zedra-main. Research Gemini CLI integration opportunities"
+                    .into(),
+            preview: String::new(),
+            agent_nickname: None,
+            agent_role: None,
+            git_branch: None,
+            git_sha: None,
+            git_origin_url: None,
+            approval_mode: String::new(),
+            model: None,
+        };
+        assert_eq!(
+            codex_title_from_thread(&thread).as_deref(),
+            Some("Research Gemini CLI integration")
+        );
+    }
+
+    #[test]
+    fn codex_title_from_thread_falls_back_to_preview_before_first_user_message() {
+        let thread = CodexThreadRow {
+            id: "019e".into(),
+            cwd: "/repo".into(),
+            title: String::new(),
+            rollout_path: "/home/.codex/sessions/rollout.jsonl".into(),
+            source: "vscode".into(),
+            model_provider: "openai".into(),
+            cli_version: String::new(),
+            created_at_ms: None,
+            updated_at_ms: None,
+            preview: "Preview title".into(),
+            first_user_message: "CWD: /repo. Raw prompt body".into(),
+            agent_nickname: None,
+            agent_role: None,
+            git_branch: None,
+            git_sha: None,
+            git_origin_url: None,
+            approval_mode: String::new(),
+            model: None,
+        };
+        assert_eq!(
+            codex_title_from_thread(&thread).as_deref(),
+            Some("Preview title")
+        );
+    }
+
+    #[test]
+    fn codex_title_from_thread_falls_back_to_first_user_message() {
+        let thread = CodexThreadRow {
+            id: "019e".into(),
+            cwd: "/repo".into(),
+            title: String::new(),
+            rollout_path: "/home/.codex/sessions/rollout.jsonl".into(),
+            source: "vscode".into(),
+            model_provider: "openai".into(),
+            cli_version: String::new(),
+            created_at_ms: None,
+            updated_at_ms: None,
+            first_user_message: "research how to implement live activity ios for Zedra\n".into(),
+            preview: String::new(),
+            agent_nickname: None,
+            agent_role: None,
+            git_branch: None,
+            git_sha: None,
+            git_origin_url: None,
+            approval_mode: String::new(),
+            model: None,
+        };
+        assert_eq!(
+            codex_title_from_thread(&thread).as_deref(),
+            Some("research how to implement live activity ios for Zedra")
+        );
+    }
+
+    #[test]
+    fn sanitize_codex_prompt_fallback_strips_subagent_cwd_prefix() {
+        assert_eq!(
+            sanitize_codex_prompt_fallback(
+                "CWD: /repo. Research Gemini CLI integration opportunities for Zedra"
+            )
+            .as_deref(),
+            Some("Research Gemini CLI integration opportunities for Zedra")
+        );
+    }
+
+    #[test]
+    fn sanitize_codex_title_field_keeps_db_title_without_cwd_strip() {
+        assert_eq!(
+            sanitize_codex_title_field("Research Gemini CLI integration").as_deref(),
+            Some("Research Gemini CLI integration")
+        );
+    }
+
+    #[test]
+    fn codex_title_from_thread_sanitizes_continue_path_db_titles() {
+        let thread = CodexThreadRow {
+            id: "019e".into(),
+            cwd: "/Users/me/projects/zedra-main".into(),
+            title: "continue /Users/me/projects/zedra-main/docs/CLAUDE_HOST_INTEGRATION_PLAN.md"
+                .into(),
+            rollout_path: "/home/.codex/sessions/rollout.jsonl".into(),
+            source: "vscode".into(),
+            model_provider: "openai".into(),
+            cli_version: String::new(),
+            created_at_ms: None,
+            updated_at_ms: None,
+            first_user_message:
+                "continue /Users/me/projects/zedra-main/docs/CLAUDE_HOST_INTEGRATION_PLAN.md".into(),
+            preview: String::new(),
+            agent_nickname: None,
+            agent_role: None,
+            git_branch: None,
+            git_sha: None,
+            git_origin_url: None,
+            approval_mode: String::new(),
+            model: None,
+        };
+        assert_eq!(
+            codex_title_from_thread(&thread).as_deref(),
+            Some("CLAUDE_HOST_INTEGRATION_PLAN")
+        );
+    }
+
+    #[test]
+    fn codex_title_from_agent_identity_formats_role() {
+        assert_eq!(
+            codex_title_from_agent_identity(Some("Aquinas"), Some("explorer")).as_deref(),
+            Some("Aquinas (explorer)")
+        );
+    }
+
+    #[test]
+    fn resume_launch_commands_are_host_owned() {
+        assert_eq!(
+            resume_launch_command(ManagedAgentKind::Claude, "abc").as_deref(),
+            Some("claude --resume abc")
+        );
+        assert_eq!(
+            resume_launch_command(ManagedAgentKind::Codex, "019e").as_deref(),
+            Some("codex resume 019e")
+        );
+        assert_eq!(
+            resume_launch_command(ManagedAgentKind::OpenCode, "ses_123").as_deref(),
+            Some("opencode --session ses_123")
+        );
+    }
+
+    #[test]
+    fn claude_plugin_status_reads_installed_plugins_file() {
+        let json = r#"{
+          "version": 2,
+          "plugins": {
+            "zedra@zedra": [
+              {
+                "installPath": "/tmp/zedra-plugin"
+              }
+            ]
+          }
+        }"#;
+        let status = claude_plugin_status_from_installed_plugins(json);
+        assert!(status.plugin_installed);
+        assert!(!status.hooks_installed);
+        assert!(status.error.is_none());
+    }
+
+    #[test]
+    fn normalizes_supported_hook_events() {
+        assert_eq!(
+            normalize_event(ManagedAgentKind::Claude, "PermissionRequest"),
+            Some((
+                AgentEventKind::PermissionRequested,
+                AgentLifecycleStatus::WaitingForPermission
+            ))
+        );
+        assert_eq!(
+            normalize_event(ManagedAgentKind::Claude, "UserPromptSubmit"),
+            Some((AgentEventKind::TurnStarted, AgentLifecycleStatus::Running))
+        );
+        assert_eq!(
+            normalize_event(ManagedAgentKind::Claude, "PreToolUse"),
+            Some((AgentEventKind::ToolStarted, AgentLifecycleStatus::Running))
+        );
+        assert_eq!(
+            normalize_event(ManagedAgentKind::Claude, "SessionEnd"),
+            Some((AgentEventKind::SessionUpdated, AgentLifecycleStatus::Idle))
+        );
+        assert_eq!(
+            normalize_event(ManagedAgentKind::Codex, "PostToolUse"),
+            Some((AgentEventKind::ToolCompleted, AgentLifecycleStatus::Running))
+        );
+        assert_eq!(
+            normalize_event(ManagedAgentKind::OpenCode, "session.error"),
+            Some((AgentEventKind::TurnFailed, AgentLifecycleStatus::Failed))
+        );
+    }
+}

--- a/crates/zedra-host/src/agent_cache.rs
+++ b/crates/zedra-host/src/agent_cache.rs
@@ -1,0 +1,243 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use zedra_rpc::proto::*;
+
+use crate::agent;
+use crate::session_registry::ServerSession;
+
+/// Cached session scan for one agent kind. `limit` is the effective (clamped)
+/// limit the scan was run with, so a later request for a larger limit can
+/// detect that the cache is too small and re-scan.
+struct CachedSessions {
+    limit: u32,
+    result: AgentSessionsResult,
+}
+
+#[derive(Default)]
+struct CachedAgentData {
+    workdir: Option<PathBuf>,
+    installed: Option<AgentInstalledListResult>,
+    agents: Option<AgentListResult>,
+    sessions: HashMap<ManagedAgentKind, CachedSessions>,
+}
+
+pub struct AgentCache {
+    inner: Mutex<CachedAgentData>,
+}
+
+impl AgentCache {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(CachedAgentData::default()),
+        })
+    }
+
+    pub async fn preload(self: &Arc<Self>, workdir: PathBuf) {
+        let cache = Arc::clone(self);
+        let result = tokio::task::spawn_blocking(move || cache.refresh_all(&workdir)).await;
+        if let Err(error) = result {
+            tracing::warn!("agent cache preload task failed: {error}");
+        }
+    }
+
+    pub async fn installed(&self, refresh: bool) -> AgentInstalledListResult {
+        if refresh {
+            self.refresh_installed().await;
+        } else if self.ensure_installed().await {
+            if let Some(result) = self.inner.lock().await.installed.clone() {
+                return result;
+            }
+        }
+        AgentInstalledListResult {
+            agents: Vec::new(),
+            error: Some("agent cache not ready".into()),
+        }
+    }
+
+    pub async fn agents(
+        &self,
+        workdir: &Path,
+        session: Option<&Arc<ServerSession>>,
+        refresh: bool,
+    ) -> AgentListResult {
+        if refresh {
+            self.refresh_agents(workdir).await;
+        } else if self.ensure_agents(workdir).await {
+            if let Some(mut result) = self.inner.lock().await.agents.clone() {
+                agent::merge_live_into_agent_list(&mut result.agents, session).await;
+                return result;
+            }
+        }
+        AgentListResult {
+            agents: Vec::new(),
+            error: Some("agent cache not ready".into()),
+        }
+    }
+
+    pub async fn sessions(
+        &self,
+        kind: ManagedAgentKind,
+        workdir: &Path,
+        session: Option<&Arc<ServerSession>>,
+        limit: u32,
+        refresh: bool,
+    ) -> AgentSessionsResult {
+        if refresh {
+            self.refresh_sessions(kind, workdir, limit).await;
+        } else if self.ensure_sessions(kind, workdir, limit).await {
+            if let Some(mut result) = self
+                .inner
+                .lock()
+                .await
+                .sessions
+                .get(&kind)
+                .map(|cached| cached.result.clone())
+            {
+                agent::merge_live_into_sessions(&mut result.sessions, kind, session).await;
+                return result;
+            }
+        }
+        AgentSessionsResult {
+            sessions: Vec::new(),
+            total: 0,
+            error: Some("agent cache not ready".into()),
+        }
+    }
+
+    fn refresh_all(&self, workdir: &Path) {
+        let installed = agent::scan_installed_agents();
+        let agents = agent::scan_agent_list(workdir);
+        let limit = agent::default_agent_session_limit() as u32;
+        let mut sessions = HashMap::new();
+        for kind in [
+            ManagedAgentKind::Claude,
+            ManagedAgentKind::Codex,
+            ManagedAgentKind::OpenCode,
+        ] {
+            sessions.insert(
+                kind,
+                CachedSessions {
+                    limit,
+                    result: agent::scan_agent_sessions(kind, workdir, limit),
+                },
+            );
+        }
+
+        let mut inner = self.inner.blocking_lock();
+        inner.workdir = Some(workdir.to_path_buf());
+        inner.installed = Some(installed);
+        inner.agents = Some(agents);
+        inner.sessions = sessions;
+    }
+
+    async fn refresh_installed(&self) {
+        let installed = tokio::task::spawn_blocking(agent::scan_installed_agents)
+            .await
+            .unwrap_or_else(|error| AgentInstalledListResult {
+                agents: Vec::new(),
+                error: Some(error.to_string()),
+            });
+        self.inner.lock().await.installed = Some(installed);
+    }
+
+    async fn refresh_agents(&self, workdir: &Path) {
+        let workdir = workdir.to_path_buf();
+        let scan_workdir = workdir.clone();
+        let agents = tokio::task::spawn_blocking(move || agent::scan_agent_list(&scan_workdir))
+            .await
+            .unwrap_or_else(|error| AgentListResult {
+                agents: Vec::new(),
+                error: Some(error.to_string()),
+            });
+        let mut inner = self.inner.lock().await;
+        inner.invalidate_if_workdir_changed(&workdir);
+        inner.workdir = Some(workdir);
+        inner.agents = Some(agents);
+    }
+
+    async fn refresh_sessions(&self, kind: ManagedAgentKind, workdir: &Path, limit: u32) {
+        let effective_limit = agent::agent_session_limit(limit) as u32;
+        let workdir = workdir.to_path_buf();
+        let scan_workdir = workdir.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            agent::scan_agent_sessions(kind, &scan_workdir, limit)
+        })
+        .await
+        .unwrap_or_else(|error| AgentSessionsResult {
+            sessions: Vec::new(),
+            total: 0,
+            error: Some(error.to_string()),
+        });
+        let mut inner = self.inner.lock().await;
+        inner.invalidate_if_workdir_changed(&workdir);
+        inner.workdir = Some(workdir);
+        inner.sessions.insert(
+            kind,
+            CachedSessions {
+                limit: effective_limit,
+                result,
+            },
+        );
+    }
+
+    async fn ensure_installed(&self) -> bool {
+        if self.inner.lock().await.installed.is_some() {
+            return true;
+        }
+        self.refresh_installed().await;
+        self.inner.lock().await.installed.is_some()
+    }
+
+    async fn ensure_agents(&self, workdir: &Path) -> bool {
+        {
+            let inner = self.inner.lock().await;
+            if inner
+                .workdir
+                .as_deref()
+                .is_some_and(|cached| cached == workdir)
+                && inner.agents.is_some()
+            {
+                return true;
+            }
+        }
+        self.refresh_agents(workdir).await;
+        self.inner.lock().await.agents.is_some()
+    }
+
+    async fn ensure_sessions(&self, kind: ManagedAgentKind, workdir: &Path, limit: u32) -> bool {
+        // A cache hit must cover the requested limit: a scan run at a smaller
+        // limit would silently truncate the result for a larger request.
+        let needed = agent::agent_session_limit(limit) as u32;
+        {
+            let inner = self.inner.lock().await;
+            if inner
+                .workdir
+                .as_deref()
+                .is_some_and(|cached| cached == workdir)
+            {
+                if let Some(cached) = inner.sessions.get(&kind) {
+                    if cached.limit >= needed {
+                        return true;
+                    }
+                }
+            }
+        }
+        self.refresh_sessions(kind, workdir, limit).await;
+        self.inner.lock().await.sessions.contains_key(&kind)
+    }
+}
+
+impl CachedAgentData {
+    /// Workdir-scoped caches (`agents`, `sessions`) are keyed only by agent
+    /// kind, so when the workdir changes they must be dropped or a later
+    /// lookup would serve results from the previous workdir.
+    fn invalidate_if_workdir_changed(&mut self, workdir: &Path) {
+        if self.workdir.as_deref() != Some(workdir) {
+            self.agents = None;
+            self.sessions.clear();
+        }
+    }
+}

--- a/crates/zedra-host/src/agent_cli.rs
+++ b/crates/zedra-host/src/agent_cli.rs
@@ -1,0 +1,1478 @@
+use anyhow::{bail, Context, Result};
+use chrono::{DateTime, Utc};
+use clap::{Args, Subcommand, ValueEnum};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::io::{stderr, Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use zedra_host::{agent, identity, utils};
+use zedra_rpc::proto::{
+    AgentInstalledListResult, AgentListResult, AgentResumeResult, AgentSessionSummary,
+    AgentSessionsResult, AgentSummary, InstalledAgentEntry, ManagedAgentKind,
+};
+
+#[derive(Debug, Subcommand)]
+pub enum AgentCommand {
+    /// List managed-agent summaries for this workspace
+    List(AgentListArgs),
+    /// List sessions for one managed agent
+    Sessions(AgentSessionsArgs),
+    /// Resume an agent session in a new phone terminal
+    Resume(AgentResumeArgs),
+    /// Listen for hook events bound to one terminal id
+    Listen(AgentListenArgs),
+    /// Run local host filesystem/CLI scans (benchmark and raw preview)
+    Scan {
+        #[command(subcommand)]
+        command: AgentScanCommand,
+    },
+    /// Install or test local agent hook integration
+    Hook {
+        #[command(subcommand)]
+        command: AgentHookCommand,
+    },
+}
+
+#[derive(Debug, Args)]
+pub struct AgentListArgs {
+    /// Working directory of the running daemon
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Print the raw JSON response
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct AgentSessionsArgs {
+    /// Agent provider to inspect
+    #[arg(value_enum)]
+    kind: CliManagedAgentKind,
+    /// Working directory of the running daemon
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Print the raw JSON response
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AgentScanCommand {
+    /// Probe installed terminal agent CLIs on PATH
+    Installed(AgentScanCommonArgs),
+    /// Scan managed-agent summaries for a workspace
+    List(AgentScanWorkdirArgs),
+    /// Scan sessions for one managed agent
+    Sessions(AgentScanSessionsArgs),
+    /// Run all local scans and print benchmark timings
+    Bench(AgentScanBenchArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct AgentScanCommonArgs {
+    /// Print JSON output
+    #[arg(long)]
+    json: bool,
+    /// Suppress elapsed timing on stderr
+    #[arg(long)]
+    quiet: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct AgentScanWorkdirArgs {
+    /// Workspace directory to scan
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Print JSON output
+    #[arg(long)]
+    json: bool,
+    /// Suppress elapsed timing on stderr
+    #[arg(long)]
+    quiet: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct AgentScanSessionsArgs {
+    /// Agent provider to inspect
+    #[arg(value_enum)]
+    kind: CliManagedAgentKind,
+    /// Workspace directory to scan
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Maximum sessions to return (`0` uses host default)
+    #[arg(short, long, default_value_t = 0)]
+    limit: u32,
+    /// Print JSON output
+    #[arg(long)]
+    json: bool,
+    /// Suppress elapsed timing on stderr
+    #[arg(long)]
+    quiet: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct AgentScanBenchArgs {
+    /// Workspace directory to scan
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Maximum sessions per agent (`0` uses host default)
+    #[arg(short, long, default_value_t = 0)]
+    limit: u32,
+    /// Print JSON benchmark report
+    #[arg(long)]
+    json: bool,
+    /// Suppress elapsed timing on stderr
+    #[arg(long)]
+    quiet: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct AgentResumeArgs {
+    /// Agent provider to resume
+    #[arg(value_enum)]
+    kind: CliManagedAgentKind,
+    /// Provider session id to resume
+    session_id: String,
+    /// Working directory of the running daemon
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Initial terminal columns
+    #[arg(long, default_value_t = 220)]
+    cols: u16,
+    /// Initial terminal rows
+    #[arg(long, default_value_t = 50)]
+    rows: u16,
+    /// Print the raw JSON response
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct AgentListenArgs {
+    /// Zedra terminal id to listen on
+    #[arg(long = "tid", alias = "terminal-id")]
+    terminal_id: String,
+    /// Working directory of the running daemon
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Read the current buffered events and exit
+    #[arg(long)]
+    once: bool,
+    /// Poll interval while following events
+    #[arg(long, default_value_t = 1)]
+    interval_secs: u64,
+    /// Print one JSON object per event
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AgentHookCommand {
+    /// Write project-local hook config files for this workspace
+    Install(AgentHookInstallArgs),
+    /// Receive one hook payload on stdin and forward it to the daemon
+    Receive(AgentHookReceiveArgs),
+    /// Send a synthetic hook payload to the daemon
+    Test(AgentHookTestArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct AgentHookInstallArgs {
+    /// Working directory to write local hook files into
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Provider to install. Repeat for multiple providers. Defaults to all.
+    #[arg(long = "provider", value_enum)]
+    providers: Vec<CliManagedAgentKind>,
+    /// Overwrite existing generated hook config files
+    #[arg(long)]
+    force: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct AgentHookReceiveArgs {
+    /// Agent provider that emitted the hook
+    #[arg(long, value_enum)]
+    kind: CliManagedAgentKind,
+    /// Provider event name. If omitted, zedra tries to infer it from stdin JSON.
+    #[arg(long)]
+    event: Option<String>,
+    /// Working directory of the running daemon
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Override the Zedra terminal id. Defaults to ZEDRA_TERMINAL_ID.
+    #[arg(long)]
+    terminal_id: Option<String>,
+    /// Provider session id, when the hook exposes it
+    #[arg(long)]
+    session_id: Option<String>,
+    /// Provider turn id, when the hook exposes it
+    #[arg(long)]
+    turn_id: Option<String>,
+    /// Tool name, when the hook exposes it
+    #[arg(long)]
+    tool_name: Option<String>,
+    /// Do not print the daemon response. Useful for provider hooks.
+    #[arg(long)]
+    quiet: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct AgentHookTestArgs {
+    /// Agent provider to simulate
+    #[arg(value_enum)]
+    kind: CliManagedAgentKind,
+    /// Provider event name to simulate
+    event: String,
+    /// Working directory of the running daemon
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Bind the synthetic hook to a known Zedra terminal id
+    #[arg(long)]
+    terminal_id: Option<String>,
+    /// Print the raw JSON response
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum CliManagedAgentKind {
+    Claude,
+    Codex,
+    #[value(name = "opencode", alias = "open-code", alias = "open_code")]
+    OpenCode,
+}
+
+impl CliManagedAgentKind {
+    fn slug(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::OpenCode => "opencode",
+        }
+    }
+}
+
+impl From<CliManagedAgentKind> for ManagedAgentKind {
+    fn from(value: CliManagedAgentKind) -> Self {
+        match value {
+            CliManagedAgentKind::Claude => ManagedAgentKind::Claude,
+            CliManagedAgentKind::Codex => ManagedAgentKind::Codex,
+            CliManagedAgentKind::OpenCode => ManagedAgentKind::OpenCode,
+        }
+    }
+}
+
+pub async fn run(command: AgentCommand) -> Result<()> {
+    match command {
+        AgentCommand::List(args) => list_agents(args).await,
+        AgentCommand::Sessions(args) => list_sessions(args).await,
+        AgentCommand::Resume(args) => resume_session(args).await,
+        AgentCommand::Listen(args) => listen_events(args).await,
+        AgentCommand::Scan { command } => run_scan(command),
+        AgentCommand::Hook { command } => run_hook(command).await,
+    }
+}
+
+async fn list_agents(args: AgentListArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let result: AgentListResult = api_get(&workdir, "/api/agents").await?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!("{}", render_agent_list(&result));
+    }
+    Ok(())
+}
+
+async fn list_sessions(args: AgentSessionsArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let path = format!("/api/agents/{}/sessions", args.kind.slug());
+    let result: AgentSessionsResult = api_get(&workdir, &path).await?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!("{}", render_agent_sessions(args.kind.into(), &result));
+    }
+    Ok(())
+}
+
+fn run_scan(command: AgentScanCommand) -> Result<()> {
+    match command {
+        AgentScanCommand::Installed(args) => scan_installed(args),
+        AgentScanCommand::List(args) => scan_list(args),
+        AgentScanCommand::Sessions(args) => scan_sessions(args),
+        AgentScanCommand::Bench(args) => scan_bench(args),
+    }
+}
+
+fn scan_installed(args: AgentScanCommonArgs) -> Result<()> {
+    let started = Instant::now();
+    let result = agent::scan_installed_agents();
+    emit_scan(
+        ScanEmit {
+            scan: "installed",
+            workdir: None,
+            limit: None,
+            elapsed: started.elapsed(),
+            json: args.json,
+            quiet: args.quiet,
+        },
+        &result,
+        render_installed_agents,
+    )
+}
+
+fn scan_list(args: AgentScanWorkdirArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let started = Instant::now();
+    let result = agent::scan_agent_list(&workdir);
+    emit_scan(
+        ScanEmit {
+            scan: "list",
+            workdir: Some(workdir),
+            limit: None,
+            elapsed: started.elapsed(),
+            json: args.json,
+            quiet: args.quiet,
+        },
+        &result,
+        render_agent_list,
+    )
+}
+
+fn scan_sessions(args: AgentScanSessionsArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let kind: ManagedAgentKind = args.kind.into();
+    let started = Instant::now();
+    let result = agent::scan_agent_sessions(kind, &workdir, args.limit);
+    emit_scan(
+        ScanEmit {
+            scan: "sessions",
+            workdir: Some(workdir),
+            limit: Some(args.limit),
+            elapsed: started.elapsed(),
+            json: args.json,
+            quiet: args.quiet,
+        },
+        &result,
+        |value| render_agent_sessions(kind, value),
+    )
+}
+
+#[derive(Serialize)]
+struct ScanStepTiming {
+    scan: String,
+    elapsed_ms: u128,
+}
+
+#[derive(Serialize)]
+struct ScanBenchReport {
+    workdir: String,
+    limit: u32,
+    effective_limit: u32,
+    total_elapsed_ms: u128,
+    steps: Vec<ScanStepTiming>,
+    installed: AgentInstalledListResult,
+    list: AgentListResult,
+    sessions: std::collections::HashMap<String, AgentSessionsResult>,
+}
+
+fn scan_bench(args: AgentScanBenchArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let effective_limit = agent::agent_session_limit(args.limit) as u32;
+    let bench_started = Instant::now();
+    let mut steps = Vec::new();
+
+    let started = Instant::now();
+    let installed = agent::scan_installed_agents();
+    steps.push(ScanStepTiming {
+        scan: "installed".to_string(),
+        elapsed_ms: started.elapsed().as_millis(),
+    });
+
+    let started = Instant::now();
+    let list = agent::scan_agent_list(&workdir);
+    steps.push(ScanStepTiming {
+        scan: "list".to_string(),
+        elapsed_ms: started.elapsed().as_millis(),
+    });
+
+    let mut sessions = std::collections::HashMap::new();
+    for kind in [
+        ManagedAgentKind::Claude,
+        ManagedAgentKind::Codex,
+        ManagedAgentKind::OpenCode,
+    ] {
+        let started = Instant::now();
+        let result = agent::scan_agent_sessions(kind, &workdir, args.limit);
+        steps.push(ScanStepTiming {
+            scan: format!("sessions:{kind:?}"),
+            elapsed_ms: started.elapsed().as_millis(),
+        });
+        sessions.insert(format!("{kind:?}"), result);
+    }
+
+    let total_elapsed = bench_started.elapsed();
+    if !args.quiet {
+        writeln!(
+            stderr(),
+            "scan bench completed in {}ms",
+            total_elapsed.as_millis()
+        )?;
+    }
+
+    if args.json {
+        let report = ScanBenchReport {
+            workdir: workdir.display().to_string(),
+            limit: args.limit,
+            effective_limit,
+            total_elapsed_ms: total_elapsed.as_millis(),
+            steps,
+            installed,
+            list,
+            sessions,
+        };
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    println!("Agent Scan Benchmark\n");
+    println!(
+        "{}",
+        utils::render_key_values(&[
+            ("Workdir", workdir.display().to_string()),
+            (
+                "Limit",
+                if args.limit == 0 {
+                    format!("default ({effective_limit})")
+                } else {
+                    args.limit.to_string()
+                },
+            ),
+        ])
+    );
+    println!();
+    println!(
+        "{}",
+        utils::render_table(
+            &["SCAN", "ELAPSED"],
+            &steps
+                .iter()
+                .map(|step| vec![step.scan.clone(), format!("{}ms", step.elapsed_ms)])
+                .collect::<Vec<_>>(),
+        )
+    );
+    println!();
+    println!("Total: {}ms", total_elapsed.as_millis());
+    println!();
+    println!("{}", render_installed_agents(&installed));
+    println!();
+    println!("{}", render_agent_list(&list));
+    for kind in [
+        ManagedAgentKind::Claude,
+        ManagedAgentKind::Codex,
+        ManagedAgentKind::OpenCode,
+    ] {
+        println!();
+        if let Some(result) = sessions.get(&format!("{kind:?}")) {
+            println!("{}", render_agent_sessions(kind, result));
+        }
+    }
+    Ok(())
+}
+
+struct ScanEmit {
+    scan: &'static str,
+    workdir: Option<PathBuf>,
+    limit: Option<u32>,
+    elapsed: Duration,
+    json: bool,
+    quiet: bool,
+}
+
+#[derive(Serialize)]
+struct ScanEnvelope<'a, T: Serialize + 'a> {
+    scan: &'static str,
+    elapsed_ms: u128,
+    workdir: Option<String>,
+    limit: Option<u32>,
+    effective_limit: Option<u32>,
+    result: &'a T,
+}
+
+fn emit_scan<T: Serialize>(
+    meta: ScanEmit,
+    result: &T,
+    render: impl FnOnce(&T) -> String,
+) -> Result<()> {
+    if !meta.quiet {
+        writeln!(
+            stderr(),
+            "scan {}{} completed in {}ms",
+            meta.scan,
+            meta.workdir
+                .as_ref()
+                .map(|workdir| format!(" {}", workdir.display()))
+                .unwrap_or_default(),
+            meta.elapsed.as_millis()
+        )?;
+    }
+
+    if meta.json {
+        let envelope = ScanEnvelope {
+            scan: meta.scan,
+            elapsed_ms: meta.elapsed.as_millis(),
+            workdir: meta
+                .workdir
+                .as_ref()
+                .map(|workdir| workdir.display().to_string()),
+            limit: meta.limit,
+            effective_limit: meta
+                .limit
+                .map(|limit| agent::agent_session_limit(limit) as u32),
+            result,
+        };
+        println!("{}", serde_json::to_string_pretty(&envelope)?);
+    } else {
+        println!("{}", render(result));
+    }
+    Ok(())
+}
+
+async fn resume_session(args: AgentResumeArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let path = format!("/api/agents/{}/resume", args.kind.slug());
+    let body = serde_json::json!({
+        "session_id": args.session_id,
+        "cols": args.cols,
+        "rows": args.rows,
+    });
+    let result: AgentResumeResult = api_post(&workdir, &path, &body).await?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else if let Some(error) = result.error {
+        bail!("failed to resume agent session: {error}");
+    } else {
+        println!(
+            "Agent Session Resumed\n\n{}",
+            utils::render_key_values(&[("Terminal", result.terminal_id)])
+        );
+    }
+    Ok(())
+}
+
+async fn listen_events(args: AgentListenArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let mut after = 0;
+    if !args.json && !args.once {
+        println!(
+            "Listening for agent hook events on terminal {}",
+            args.terminal_id
+        );
+    }
+
+    loop {
+        let path = format!(
+            "/api/agent-hooks/events?terminal_id={}&after={after}&limit=100",
+            query_encode(&args.terminal_id)
+        );
+        let response: serde_json::Value = api_get(&workdir, &path).await?;
+        let events = response["events"].as_array().cloned().unwrap_or_default();
+
+        for event in &events {
+            if let Some(seq) = event["seq"].as_u64() {
+                after = after.max(seq);
+            }
+            if args.json {
+                println!("{}", serde_json::to_string(event)?);
+            } else {
+                println!("{}", render_hook_event(event));
+            }
+        }
+
+        if args.once {
+            if events.is_empty() && !args.json {
+                println!(
+                    "No agent hook events buffered for terminal {}.",
+                    args.terminal_id
+                );
+            }
+            return Ok(());
+        }
+
+        tokio::time::sleep(Duration::from_secs(args.interval_secs.max(1))).await;
+    }
+}
+
+async fn run_hook(command: AgentHookCommand) -> Result<()> {
+    match command {
+        AgentHookCommand::Install(args) => install_hooks(args),
+        AgentHookCommand::Receive(args) => receive_hook(args).await,
+        AgentHookCommand::Test(args) => test_hook(args).await,
+    }
+}
+
+async fn receive_hook(args: AgentHookReceiveArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let mut stdin = String::new();
+    std::io::stdin()
+        .read_to_string(&mut stdin)
+        .context("failed to read hook payload from stdin")?;
+    let payload = parse_hook_payload(&stdin);
+    let body = AgentHookForwardReq {
+        event_name: args.event,
+        terminal_id: args
+            .terminal_id
+            .or_else(|| std::env::var("ZEDRA_TERMINAL_ID").ok()),
+        session_id: args.session_id,
+        turn_id: args.turn_id,
+        tool_name: args.tool_name,
+        payload,
+    };
+    let path = format!("/api/agent-hooks/{}", args.kind.slug());
+    let response: serde_json::Value = api_post(&workdir, &path, &body).await?;
+    if !args.quiet {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    }
+    Ok(())
+}
+
+async fn test_hook(args: AgentHookTestArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let payload = synthetic_hook_payload(args.kind, &args.event, &workdir);
+    let body = AgentHookForwardReq {
+        event_name: Some(args.event),
+        terminal_id: args.terminal_id,
+        session_id: None,
+        turn_id: None,
+        tool_name: Some("Bash".to_string()),
+        payload,
+    };
+    let path = format!("/api/agent-hooks/{}", args.kind.slug());
+    let response: serde_json::Value = api_post(&workdir, &path, &body).await?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("{}", render_hook_response(&response));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct AgentHookForwardReq {
+    event_name: Option<String>,
+    terminal_id: Option<String>,
+    session_id: Option<String>,
+    turn_id: Option<String>,
+    tool_name: Option<String>,
+    payload: serde_json::Value,
+}
+
+fn install_hooks(args: AgentHookInstallArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let providers = if args.providers.is_empty() {
+        vec![
+            CliManagedAgentKind::Claude,
+            CliManagedAgentKind::Codex,
+            CliManagedAgentKind::OpenCode,
+        ]
+    } else {
+        args.providers
+    };
+    let script_path = write_hook_script(&workdir, args.force)?;
+    let mut written = vec![script_path.clone()];
+    for provider in providers {
+        match provider {
+            CliManagedAgentKind::Claude => written.push(write_claude_hook_config(
+                &workdir,
+                &script_path,
+                args.force,
+            )?),
+            CliManagedAgentKind::Codex => {
+                written.push(write_codex_hook_config(&workdir, &script_path, args.force)?)
+            }
+            CliManagedAgentKind::OpenCode => written.push(write_opencode_hook_config(
+                &workdir,
+                &script_path,
+                args.force,
+            )?),
+        }
+    }
+
+    println!("Local Agent Hooks Prepared\n");
+    println!(
+        "{}",
+        utils::render_key_values(&[
+            ("Workdir", workdir.display().to_string()),
+            ("Hook Script", script_path.display().to_string()),
+        ])
+    );
+    println!();
+    println!("Files");
+    for path in written {
+        println!("  {}", path.display());
+    }
+    Ok(())
+}
+
+fn write_hook_script(workdir: &Path, force: bool) -> Result<PathBuf> {
+    let path = workdir.join(".zedra/agent-hooks/zedra-agent-hook.sh");
+    write_file_checked(
+        &path,
+        &hook_script_contents(workdir)?,
+        force,
+        "agent hook script",
+    )?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&path)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&path, permissions)?;
+    }
+    Ok(path)
+}
+
+fn write_claude_hook_config(workdir: &Path, script_path: &Path, force: bool) -> Result<PathBuf> {
+    let path = workdir.join(".claude/settings.local.json");
+    let value = claude_hook_config(script_path);
+    write_json_file_checked(&path, &value, force, "Claude local hook config")?;
+    Ok(path)
+}
+
+fn claude_hook_config(script_path: &Path) -> serde_json::Value {
+    serde_json::json!({
+        "hooks": {
+            "Setup": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "Setup", Some("*")),
+            "SessionStart": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "SessionStart", None),
+            "InstructionsLoaded": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "InstructionsLoaded", Some("*")),
+            "UserPromptSubmit": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "UserPromptSubmit", None),
+            "UserPromptExpansion": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "UserPromptExpansion", Some("*")),
+            "PreToolUse": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "PreToolUse", Some("*")),
+            "PermissionRequest": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "PermissionRequest", Some("*")),
+            "PermissionDenied": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "PermissionDenied", Some("*")),
+            "PostToolUse": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "PostToolUse", Some("*")),
+            "PostToolUseFailure": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "PostToolUseFailure", Some("*")),
+            "PostToolBatch": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "PostToolBatch", None),
+            "SubagentStart": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "SubagentStart", Some("*")),
+            "SubagentStop": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "SubagentStop", Some("*")),
+            "TaskCreated": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "TaskCreated", None),
+            "TaskCompleted": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "TaskCompleted", None),
+            "Stop": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "Stop", None),
+            "StopFailure": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "StopFailure", None),
+            "TeammateIdle": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "TeammateIdle", None),
+            "ConfigChange": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "ConfigChange", Some("*")),
+            "CwdChanged": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "CwdChanged", None),
+            "WorktreeCreate": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "WorktreeCreate", None),
+            "WorktreeRemove": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "WorktreeRemove", None),
+            "PreCompact": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "PreCompact", Some("*")),
+            "PostCompact": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "PostCompact", Some("*")),
+            "Elicitation": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "Elicitation", Some("*")),
+            "ElicitationResult": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "ElicitationResult", Some("*")),
+            "SessionEnd": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "SessionEnd", Some("*")),
+            "Notification": hook_groups_for_event(script_path, CliManagedAgentKind::Claude, "Notification", Some("*"))
+        }
+    })
+}
+
+fn write_codex_hook_config(workdir: &Path, script_path: &Path, force: bool) -> Result<PathBuf> {
+    let path = workdir.join(".codex/hooks.json");
+    let value = serde_json::json!({
+        "hooks": {
+            "SessionStart": hook_groups_for_event(script_path, CliManagedAgentKind::Codex, "SessionStart", None),
+            "PermissionRequest": hook_groups_for_event(script_path, CliManagedAgentKind::Codex, "PermissionRequest", Some("*")),
+            "PostToolUse": hook_groups_for_event(script_path, CliManagedAgentKind::Codex, "PostToolUse", Some("*")),
+            "Stop": hook_groups_for_event(script_path, CliManagedAgentKind::Codex, "Stop", None)
+        }
+    });
+    write_json_file_checked(&path, &value, force, "Codex local hook config")?;
+    Ok(path)
+}
+
+fn write_opencode_hook_config(workdir: &Path, script_path: &Path, force: bool) -> Result<PathBuf> {
+    let path = workdir.join(".opencode/plugins/zedra.js");
+    let contents = format!(
+        r#"const hookScript = {script};
+
+async function send(event, payload = {{}}) {{
+  const proc = Bun.spawn([hookScript], {{
+    stdin: "pipe",
+    stdout: "ignore",
+    stderr: "ignore",
+    env: {{
+      ...process.env,
+      ZEDRA_AGENT_KIND: "opencode",
+      ZEDRA_AGENT_EVENT: event,
+    }},
+  }});
+  proc.stdin.write(JSON.stringify({{ type: event, ...payload }}));
+  proc.stdin.end();
+  await proc.exited;
+}}
+
+export const ZedraPlugin = async () => ({{
+  event: async (input) => {{
+    await send(input.event?.type ?? "unknown", input.event ?? input);
+  }},
+  "tool.execute.before": async (input, output) => {{
+    await send("tool.execute.before", {{ input, output }});
+  }},
+  "tool.execute.after": async (input, output) => {{
+    await send("tool.execute.after", {{ input, output }});
+  }},
+  "shell.env": async (input, output) => {{
+    output.env.ZEDRA_AGENT_KIND = "opencode";
+    await send("shell.env", {{ input }});
+  }},
+}});
+"#,
+        script = serde_json::to_string(&script_path.display().to_string())?
+    );
+    write_file_checked(&path, &contents, force, "OpenCode local plugin")?;
+    Ok(path)
+}
+
+fn hook_groups(command: &str, matcher: Option<&str>) -> serde_json::Value {
+    let mut group = serde_json::json!({
+        "hooks": [{
+            "type": "command",
+            "command": command,
+            "timeout": 5
+        }]
+    });
+    if let Some(matcher) = matcher {
+        group["matcher"] = serde_json::Value::String(matcher.to_string());
+    }
+    serde_json::Value::Array(vec![group])
+}
+
+fn hook_groups_for_event(
+    script_path: &Path,
+    kind: CliManagedAgentKind,
+    event_name: &str,
+    matcher: Option<&str>,
+) -> serde_json::Value {
+    hook_groups(&hook_command(script_path, kind, event_name), matcher)
+}
+
+fn hook_command(script_path: &Path, kind: CliManagedAgentKind, event_expr: &str) -> String {
+    format!(
+        "ZEDRA_AGENT_KIND={} ZEDRA_AGENT_EVENT={} {}",
+        kind.slug(),
+        event_expr,
+        utils::shell_arg_path(script_path)
+    )
+}
+
+fn hook_script_contents(workdir: &Path) -> Result<String> {
+    let cli = std::env::current_exe().context("failed to resolve current zedra binary")?;
+    Ok(format!(
+        r#"#!/bin/sh
+set -eu
+
+WORKDIR={workdir}
+KIND="${{ZEDRA_AGENT_KIND:-}}"
+EVENT="${{ZEDRA_AGENT_EVENT:-}}"
+CLI="${{ZEDRA_CLI:-{cli}}}"
+
+if [ -z "$KIND" ]; then
+  echo "ZEDRA_AGENT_KIND is required" >&2
+  exit 0
+fi
+
+if [ ! -x "$CLI" ]; then
+  CLI="zedra"
+fi
+
+if [ -n "$EVENT" ]; then
+  exec "$CLI" agent hook receive --workdir "$WORKDIR" --kind "$KIND" --event "$EVENT" --quiet
+fi
+
+exec "$CLI" agent hook receive --workdir "$WORKDIR" --kind "$KIND" --quiet
+"#,
+        workdir = utils::shell_arg_path(workdir),
+        cli = utils::shell_arg_path(&cli),
+    ))
+}
+
+fn write_json_file_checked(
+    path: &Path,
+    value: &serde_json::Value,
+    force: bool,
+    label: &str,
+) -> Result<()> {
+    let mut contents = serde_json::to_string_pretty(value)?;
+    contents.push('\n');
+    write_file_checked(path, &contents, force, label)
+}
+
+fn write_file_checked(path: &Path, contents: &str, force: bool, label: &str) -> Result<()> {
+    if path.exists() && !force {
+        bail!(
+            "{label} already exists at {}. Re-run with --force to overwrite it.",
+            path.display()
+        );
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    std::fs::write(path, contents)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+fn synthetic_hook_payload(
+    kind: CliManagedAgentKind,
+    event_name: &str,
+    workdir: &Path,
+) -> serde_json::Value {
+    match kind {
+        CliManagedAgentKind::Claude => {
+            let cwd = workdir.to_string_lossy();
+            serde_json::json!({
+                "hook_event_name": event_name,
+                "session_id": "zedra-test-session",
+                "transcript_path": "/tmp/zedra-test-session.jsonl",
+                "cwd": cwd,
+                "tool_name": "Bash",
+                "tool_use_id": "toolu_zedra_test"
+            })
+        }
+        CliManagedAgentKind::Codex => {
+            let cwd = workdir.to_string_lossy();
+            serde_json::json!({
+                "hook_event_name": event_name,
+                "session_id": "zedra-test-session",
+                "cwd": cwd,
+                "tool_name": "Bash"
+            })
+        }
+        CliManagedAgentKind::OpenCode => {
+            let cwd = workdir.to_string_lossy();
+            serde_json::json!({
+                "type": event_name,
+                "sessionID": "zedra-test-session",
+                "cwd": cwd,
+                "tool": "bash"
+            })
+        }
+    }
+}
+
+fn parse_hook_payload(stdin: &str) -> serde_json::Value {
+    let trimmed = stdin.trim();
+    if trimmed.is_empty() {
+        serde_json::Value::Object(Default::default())
+    } else {
+        serde_json::from_str(trimmed).unwrap_or_else(|_| {
+            serde_json::json!({
+                "raw": trimmed
+            })
+        })
+    }
+}
+
+async fn api_get<T: DeserializeOwned>(workdir: &Path, path: &str) -> Result<T> {
+    let (addr, token) = daemon_api(workdir)?;
+    let url = format!("http://{}{}", addr.trim(), path);
+    let response = reqwest::Client::new()
+        .get(url)
+        .bearer_auth(token.trim())
+        .send()
+        .await
+        .context("failed to reach daemon")?;
+    decode_response(response).await
+}
+
+async fn api_post<T: DeserializeOwned, B: Serialize>(
+    workdir: &Path,
+    path: &str,
+    body: &B,
+) -> Result<T> {
+    let (addr, token) = daemon_api(workdir)?;
+    let url = format!("http://{}{}", addr.trim(), path);
+    let response = reqwest::Client::new()
+        .post(url)
+        .bearer_auth(token.trim())
+        .json(body)
+        .send()
+        .await
+        .context("failed to reach daemon")?;
+    decode_response(response).await
+}
+
+async fn decode_response<T: DeserializeOwned>(response: reqwest::Response) -> Result<T> {
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!("daemon returned HTTP {status}: {text}");
+    }
+    serde_json::from_str(&text).with_context(|| format!("failed to decode daemon response: {text}"))
+}
+
+fn daemon_api(workdir: &Path) -> Result<(String, String)> {
+    let config_dir = identity::workspace_config_dir(workdir)?;
+    let addr = std::fs::read_to_string(config_dir.join("api-addr")).unwrap_or_default();
+    let token = std::fs::read_to_string(config_dir.join("api-token")).unwrap_or_default();
+    if addr.trim().is_empty() {
+        bail!("No running daemon found for: {}", workdir.display());
+    }
+    Ok((addr, token))
+}
+
+fn resolve_workdir(raw: &str) -> PathBuf {
+    PathBuf::from(raw)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(raw))
+}
+
+fn render_installed_agents(result: &AgentInstalledListResult) -> String {
+    let rows = result
+        .agents
+        .iter()
+        .map(installed_agent_row)
+        .collect::<Vec<_>>();
+    let mut sections = vec!["Installed Agents".to_string(), String::new()];
+    if rows.is_empty() {
+        sections.push("No installed agents found.".to_string());
+    } else {
+        sections.push(utils::render_table(
+            &["SLUG", "NAME", "AVAILABLE", "VERSION", "LAUNCH"],
+            &rows,
+        ));
+    }
+    if let Some(error) = &result.error {
+        sections.push(String::new());
+        sections.push(format!("Error: {error}"));
+    }
+    sections.join("\n")
+}
+
+fn installed_agent_row(agent: &InstalledAgentEntry) -> Vec<String> {
+    vec![
+        agent.slug.clone(),
+        agent.display_name.clone(),
+        agent.available.to_string(),
+        agent.version.clone().unwrap_or_else(|| "-".to_string()),
+        agent.launch_cmd.clone().unwrap_or_else(|| "-".to_string()),
+    ]
+}
+
+fn render_agent_list(result: &AgentListResult) -> String {
+    let rows = result
+        .agents
+        .iter()
+        .map(agent_summary_row)
+        .collect::<Vec<_>>();
+    let mut sections = vec![
+        "Managed Agents".to_string(),
+        String::new(),
+        utils::render_table(
+            &[
+                "KIND", "CLI", "SETUP", "SESSIONS", "LIVE", "LATEST", "WARNINGS",
+            ],
+            &rows,
+        ),
+    ];
+    if let Some(error) = &result.error {
+        sections.push(String::new());
+        sections.push(format!("Error: {error}"));
+    }
+    sections.join("\n")
+}
+
+fn agent_summary_row(agent: &AgentSummary) -> Vec<String> {
+    vec![
+        agent.display_name.clone(),
+        if agent.cli.available {
+            agent
+                .cli
+                .version
+                .clone()
+                .unwrap_or_else(|| "available".to_string())
+        } else {
+            format!("missing{}", suffix(agent.cli.error.as_deref()))
+        },
+        format!("{:?}", agent.setup.state),
+        format!("{}/{}", agent.sessions.resumable, agent.sessions.total),
+        format!(
+            "{} term, {} pending",
+            agent.live.active_terminal_ids.len(),
+            agent.live.pending_action_count
+        ),
+        agent
+            .sessions
+            .latest_session_title
+            .clone()
+            .or_else(|| agent.sessions.latest_session_id.clone())
+            .unwrap_or_else(|| "-".to_string()),
+        if agent.warnings.is_empty() {
+            "-".to_string()
+        } else {
+            agent
+                .warnings
+                .iter()
+                .map(|warning| warning.code.clone())
+                .collect::<Vec<_>>()
+                .join(",")
+        },
+    ]
+}
+
+fn render_agent_sessions(kind: ManagedAgentKind, result: &AgentSessionsResult) -> String {
+    let rows = result
+        .sessions
+        .iter()
+        .map(agent_session_row)
+        .collect::<Vec<_>>();
+    let mut sections = vec![format!("{kind:?} Sessions"), String::new()];
+    sections.push(format!(
+        "Showing {} of {} workspace sessions",
+        result.sessions.len(),
+        result.total
+    ));
+    sections.push(String::new());
+    if rows.is_empty() {
+        sections.push("No sessions found for this workspace.".to_string());
+    } else {
+        sections.push(utils::render_table(
+            &["ID", "TITLE", "CWD", "UPDATED", "RESUME"],
+            &rows,
+        ));
+    }
+    if let Some(error) = &result.error {
+        sections.push(String::new());
+        sections.push(format!("Error: {error}"));
+    }
+    sections.join("\n")
+}
+
+fn agent_session_row(session: &AgentSessionSummary) -> Vec<String> {
+    vec![
+        short_id(&session.session_id),
+        utils::truncate_chars(
+            session.title.as_deref().unwrap_or("-"),
+            SESSION_TITLE_MAX_LEN,
+        ),
+        strip_home_path(session.cwd.as_deref().unwrap_or("-")),
+        session
+            .last_activity_at
+            .map(format_session_time)
+            .unwrap_or_else(|| "-".to_string()),
+        if session.resume.available {
+            session
+                .resume
+                .action_id
+                .as_deref()
+                .unwrap_or("available")
+                .to_string()
+        } else {
+            session
+                .resume
+                .unavailable_reason
+                .as_deref()
+                .unwrap_or("no")
+                .to_string()
+        },
+    ]
+}
+
+const SESSION_TITLE_MAX_LEN: usize = 60;
+
+fn format_session_time(time: DateTime<Utc>) -> String {
+    time.format("%Y-%m-%d %H:%M").to_string()
+}
+
+fn strip_home_path(path: &str) -> String {
+    let Some(home) = std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+    else {
+        return path.to_string();
+    };
+    let home = home.to_string_lossy();
+    if path == home.as_ref() {
+        return "~".to_string();
+    }
+    let prefix = format!("{home}/");
+    if let Some(rest) = path.strip_prefix(&prefix) {
+        return format!("~/{rest}");
+    }
+    path.to_string()
+}
+
+fn render_hook_response(response: &serde_json::Value) -> String {
+    let normalized = response
+        .get("normalized")
+        .and_then(|value| value.get("kind"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("-");
+    let status = response
+        .get("normalized")
+        .and_then(|value| value.get("status"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("-");
+    let rows = vec![
+        (
+            "Seq",
+            response["seq"]
+                .as_u64()
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+        ),
+        (
+            "Provider",
+            response["kind"].as_str().unwrap_or("-").to_string(),
+        ),
+        (
+            "Event",
+            response["provider_event_name"]
+                .as_str()
+                .unwrap_or("-")
+                .to_string(),
+        ),
+        (
+            "Provider IDs",
+            render_provider_ids(&response["provider_ids"]),
+        ),
+        ("Normalized", normalized.to_string()),
+        ("Status", status.to_string()),
+        (
+            "Terminal Bound",
+            response["terminal_bound"]
+                .as_bool()
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+        ),
+        (
+            "Warning",
+            response["warning"].as_str().unwrap_or("-").to_string(),
+        ),
+    ];
+    format!("Agent Hook Received\n\n{}", utils::render_key_values(&rows))
+}
+
+fn render_hook_event(event: &serde_json::Value) -> String {
+    let normalized = event.get("normalized");
+    let kind = normalized
+        .and_then(|value| value.get("kind"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("-");
+    let status = normalized
+        .and_then(|value| value.get("status"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("-");
+    let session = normalized
+        .and_then(|value| value.get("session_id"))
+        .and_then(serde_json::Value::as_str);
+    let turn = normalized
+        .and_then(|value| value.get("turn_id"))
+        .and_then(serde_json::Value::as_str);
+    let tool = normalized
+        .and_then(|value| value.get("tool_name"))
+        .and_then(serde_json::Value::as_str);
+    let provider_ids = render_provider_ids(&event["provider_ids"]);
+    let warning = event["warning"].as_str();
+    let mut suffix = Vec::new();
+    push_label(&mut suffix, "session", session);
+    push_label(&mut suffix, "turn", turn);
+    push_label(&mut suffix, "tool", tool);
+    if provider_ids != "-" {
+        suffix.push(format!("ids={provider_ids}"));
+    }
+    push_label(&mut suffix, "warning", warning);
+
+    let base = format!(
+        "[{}] {} {} -> {} ({})",
+        event["seq"]
+            .as_u64()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        event["kind"].as_str().unwrap_or("-"),
+        event["provider_event_name"].as_str().unwrap_or("-"),
+        kind,
+        status
+    );
+    if suffix.is_empty() {
+        base
+    } else {
+        format!("{base} {}", suffix.join(" "))
+    }
+}
+
+fn push_label(parts: &mut Vec<String>, label: &str, value: Option<&str>) {
+    if let Some(value) = value.filter(|value| !value.is_empty()) {
+        parts.push(format!("{label}={value}"));
+    }
+}
+
+fn render_provider_ids(provider_ids: &serde_json::Value) -> String {
+    let Some(provider_ids) = provider_ids.as_object() else {
+        return "-".to_string();
+    };
+    let mut parts = Vec::new();
+    for (key, label) in [
+        ("turn_id", "turn"),
+        ("tool_use_id", "tool_use"),
+        ("task_id", "task"),
+        ("agent_id", "agent"),
+        ("elicitation_id", "elicitation"),
+        ("transcript_id", "transcript"),
+    ] {
+        if let Some(value) = provider_ids
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty())
+        {
+            parts.push(format!("{label}={value}"));
+        }
+    }
+    if let Some(values) = provider_ids
+        .get("batch_tool_use_ids")
+        .and_then(serde_json::Value::as_array)
+    {
+        let values = values
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty())
+            .collect::<Vec<_>>();
+        if !values.is_empty() {
+            parts.push(format!("batch_tools={}", values.join(",")));
+        }
+    }
+
+    if parts.is_empty() {
+        "-".to_string()
+    } else {
+        parts.join(" ")
+    }
+}
+
+fn query_encode(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char)
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+fn suffix(value: Option<&str>) -> String {
+    value
+        .filter(|value| !value.is_empty())
+        .map(|value| format!(" ({value})"))
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_empty_hook_payload() {
+        assert_eq!(parse_hook_payload(""), serde_json::json!({}));
+    }
+
+    #[test]
+    fn parses_json_hook_payload() {
+        assert_eq!(
+            parse_hook_payload(r#"{"hook_event_name":"Stop"}"#),
+            serde_json::json!({"hook_event_name": "Stop"})
+        );
+    }
+
+    #[test]
+    fn hook_command_uses_provider_env() {
+        let command = hook_command(
+            Path::new("/tmp/zedra hook.sh"),
+            CliManagedAgentKind::Claude,
+            "Stop",
+        );
+        assert!(command.contains("ZEDRA_AGENT_KIND=claude"));
+        assert!(command.contains("ZEDRA_AGENT_EVENT=Stop"));
+        assert!(command.contains("'/tmp/zedra hook.sh'"));
+    }
+
+    #[test]
+    fn claude_hook_config_includes_turn_tool_and_session_events() {
+        let config = claude_hook_config(Path::new("/tmp/zedra-hook.sh"));
+        let hooks = config["hooks"].as_object().unwrap();
+
+        for event in [
+            "UserPromptSubmit",
+            "PreToolUse",
+            "PostToolBatch",
+            "PermissionDenied",
+            "SubagentStart",
+            "SessionEnd",
+        ] {
+            assert!(hooks.contains_key(event), "missing {event}");
+        }
+    }
+
+    #[test]
+    fn strip_home_path_replaces_home_prefix_with_tilde() {
+        let home = std::env::var("HOME").expect("HOME");
+        assert_eq!(strip_home_path(&home), "~");
+        assert_eq!(
+            strip_home_path(&format!("{home}/projects/zedra-main")),
+            "~/projects/zedra-main"
+        );
+        assert_eq!(strip_home_path("/other/path"), "/other/path");
+    }
+
+    #[test]
+    fn truncate_session_title_caps_display_width() {
+        let title = "A".repeat(SESSION_TITLE_MAX_LEN + 10);
+        let truncated = utils::truncate_chars(&title, SESSION_TITLE_MAX_LEN);
+        assert!(truncated.ends_with('…'));
+        assert_eq!(truncated.chars().count(), SESSION_TITLE_MAX_LEN + 1);
+    }
+
+    #[test]
+    fn format_session_time_uses_compact_local_table_format() {
+        let time = DateTime::parse_from_rfc3339("2026-05-21T08:07:35+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(format_session_time(time), "2026-05-21 08:07");
+    }
+
+    #[test]
+    fn hook_event_output_includes_terminal_bound_event_fields() {
+        let event = serde_json::json!({
+            "seq": 9,
+            "kind": "Claude",
+            "provider_event_name": "TaskCompleted",
+            "normalized": {
+                "kind": "TaskCompleted",
+                "status": "Completed",
+                "session_id": "session-1",
+                "turn_id": "turn-1",
+                "tool_name": "Bash"
+            },
+            "provider_ids": {
+                "task_id": "task-1",
+                "batch_tool_use_ids": []
+            },
+            "warning": null
+        });
+
+        let output = render_hook_event(&event);
+        assert!(output.contains("[9] Claude TaskCompleted -> TaskCompleted (Completed)"));
+        assert!(output.contains("session=session-1"));
+        assert!(output.contains("ids=task=task-1"));
+        assert!(!output.contains("corr="));
+        assert!(!output.contains("warning=-"));
+    }
+}

--- a/crates/zedra-host/src/api.rs
+++ b/crates/zedra-host/src/api.rs
@@ -10,13 +10,18 @@
 //   POST /api/qr                  — create and return a fresh one-time pairing QR
 //   POST /api/qr/static           — create and return a static pairing QR
 //   POST /api/terminal            — create a terminal in the active session
+//   GET  /api/agents              — list supported managed agents
+//   GET  /api/agents/:kind/sessions
+//   POST /api/agents/:kind/resume — resume an agent session in a new terminal
+//   GET  /api/agent-hooks/events — list recent hook events for CLI testing
+//   POST /api/agent-hooks/:kind   — ingest a local agent hook event
 //
 // Auth: every request must carry  Authorization: Bearer <token>
 //       where <token> is the contents of  <config_dir>/api-token
 
 use std::sync::Arc;
 
-use axum::extract::State;
+use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
@@ -24,12 +29,14 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 
+use crate::agent;
 use crate::metrics;
 use crate::pty::SpawnOptions;
 use crate::qr;
-use crate::rpc_daemon::{create_terminal, DaemonState};
-use crate::session_registry::{PairingSlotMode, SessionRegistry};
-use zedra_rpc::proto::HostEvent;
+use crate::rpc_daemon::{create_terminal, AgentHookEventRecord, AgentHookProviderIds, DaemonState};
+use crate::session_registry::{PairingSlotMode, ServerSession, SessionRegistry};
+use chrono::Utc;
+use zedra_rpc::proto::{AgentEventSummary, AgentResumeResult, HostEvent, ManagedAgentKind};
 use zedra_rpc::ZedraPairingTicket;
 use zedra_telemetry::Event;
 
@@ -69,6 +76,8 @@ struct StatusTerminal {
     session_id: String,
     session_name: Option<String>,
     title: Option<String>,
+    cwd: Option<String>,
+    icon_name: Option<String>,
     created_at_unix_secs: u64,
     created_at_elapsed_secs: u64,
     uptime_secs: u64,
@@ -126,6 +135,8 @@ async fn status(State(s): State<ApiState>, headers: HeaderMap) -> impl IntoRespo
                 session_id: session_info.id.clone(),
                 session_name: session_info.name.clone(),
                 title: terminal.title,
+                cwd: terminal.cwd,
+                icon_name: terminal.icon_name,
                 created_at_unix_secs: terminal.created_at_unix_secs,
                 created_at_elapsed_secs: terminal.created_at_elapsed_secs,
                 uptime_secs: terminal.uptime_secs,
@@ -185,7 +196,7 @@ async fn create_pairing_qr_response(
             .into_response();
     }
 
-    let Some(session) = s.registry.first_session().await else {
+    let Some(session) = s.registry.most_recent_session().await else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(serde_json::json!({"error": "no session available"})),
@@ -254,11 +265,11 @@ async fn create_terminal_handler(
             .into_response();
     }
 
-    // Resolve session: explicit ID → first active session → any session.
+    // Resolve session: explicit ID → most recently active session.
     let session = if let Some(id) = &req.session_id {
         s.registry.get(id).await
     } else {
-        s.registry.first_session().await
+        s.registry.most_recent_session().await
     };
 
     let Some(session) = session else {
@@ -277,6 +288,7 @@ async fn create_terminal_handler(
     let opts = SpawnOptions {
         workdir,
         launch_cmd: launch_cmd.clone(),
+        env: Vec::new(),
     };
 
     match create_terminal(&session, req.cols, req.rows, opts).await {
@@ -316,6 +328,389 @@ async fn create_terminal_handler(
     }
 }
 
+fn unauthorized() -> axum::response::Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({"error": "unauthorized"})),
+    )
+        .into_response()
+}
+
+fn invalid_agent(kind: &str) -> axum::response::Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({"error": format!("unsupported managed agent: {kind}")})),
+    )
+        .into_response()
+}
+
+async fn agent_session_context(s: &ApiState) -> Option<(Arc<ServerSession>, std::path::PathBuf)> {
+    let session = s.registry.most_recent_session().await?;
+    let workdir = session
+        .workdir
+        .clone()
+        .unwrap_or_else(|| s.daemon_state.workdir.clone());
+    Some((session, workdir))
+}
+
+async fn list_agents_handler(State(s): State<ApiState>, headers: HeaderMap) -> impl IntoResponse {
+    if !verify_token(&headers, &s.token) {
+        return unauthorized();
+    }
+
+    let Some((session, workdir)) = agent_session_context(&s).await else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"error": "no session available"})),
+        )
+            .into_response();
+    };
+    Json(agent::list_agents(&s.daemon_state.agent_cache, &workdir, Some(&session), true).await)
+        .into_response()
+}
+
+async fn list_agent_sessions_handler(
+    State(s): State<ApiState>,
+    headers: HeaderMap,
+    AxumPath(kind): AxumPath<String>,
+) -> impl IntoResponse {
+    if !verify_token(&headers, &s.token) {
+        return unauthorized();
+    }
+    let Some(kind) = agent::managed_kind_from_slug(&kind) else {
+        return invalid_agent(&kind);
+    };
+
+    let Some((session, workdir)) = agent_session_context(&s).await else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"error": "no session available"})),
+        )
+            .into_response();
+    };
+    Json(
+        agent::list_agent_sessions(
+            &s.daemon_state.agent_cache,
+            kind,
+            &workdir,
+            Some(&session),
+            0,
+            true,
+        )
+        .await,
+    )
+    .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResumeAgentReq {
+    pub session_id: String,
+    #[serde(default = "default_cols")]
+    pub cols: u16,
+    #[serde(default = "default_rows")]
+    pub rows: u16,
+}
+
+async fn resume_agent_handler(
+    State(s): State<ApiState>,
+    headers: HeaderMap,
+    AxumPath(kind): AxumPath<String>,
+    Json(req): Json<ResumeAgentReq>,
+) -> impl IntoResponse {
+    if !verify_token(&headers, &s.token) {
+        return unauthorized();
+    }
+    let Some(kind) = agent::managed_kind_from_slug(&kind) else {
+        return invalid_agent(&kind);
+    };
+    let Some((session, workdir)) = agent_session_context(&s).await else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"error": "no session available"})),
+        )
+            .into_response();
+    };
+    let Some(launch_cmd) = agent::resume_launch_command(kind, &req.session_id) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "missing session id"})),
+        )
+            .into_response();
+    };
+
+    match create_terminal(
+        &session,
+        req.cols,
+        req.rows,
+        SpawnOptions {
+            workdir: Some(workdir),
+            launch_cmd: Some(launch_cmd.clone()),
+            env: Vec::new(),
+        },
+    )
+    .await
+    {
+        Ok(terminal_id) => {
+            zedra_telemetry::send(Event::HostTerminalOpen {
+                has_launch_cmd: true,
+            });
+            let terminal_count = session.terminals.lock().await.len();
+            if let Err(e) =
+                metrics::record_terminal_created(&s.daemon_state.workdir, terminal_count)
+            {
+                tracing::warn!("Failed to record terminal metrics: {}", e);
+            }
+            session
+                .push_event(HostEvent::TerminalCreated {
+                    id: terminal_id.clone(),
+                    launch_cmd: Some(launch_cmd),
+                })
+                .await;
+            Json(AgentResumeResult {
+                terminal_id,
+                error: None,
+            })
+            .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AgentHookReq {
+    pub event_name: Option<String>,
+    pub terminal_id: Option<String>,
+    pub session_id: Option<String>,
+    pub turn_id: Option<String>,
+    pub tool_name: Option<String>,
+    #[serde(default)]
+    pub payload: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+struct AgentHookResp {
+    ok: bool,
+    seq: u64,
+    kind: ManagedAgentKind,
+    provider_event_name: String,
+    provider_ids: AgentHookProviderIds,
+    normalized: Option<AgentEventSummary>,
+    terminal_bound: bool,
+    warning: Option<String>,
+}
+
+async fn receive_agent_hook_handler(
+    State(s): State<ApiState>,
+    headers: HeaderMap,
+    AxumPath(kind): AxumPath<String>,
+    Json(req): Json<AgentHookReq>,
+) -> impl IntoResponse {
+    if !verify_token(&headers, &s.token) {
+        return unauthorized();
+    }
+    let Some(kind) = agent::managed_kind_from_slug(&kind) else {
+        return invalid_agent(&kind);
+    };
+
+    let event_name = req
+        .event_name
+        .clone()
+        .or_else(|| payload_string(&req.payload, "hook_event_name"))
+        .or_else(|| payload_string(&req.payload, "event_name"))
+        .or_else(|| payload_string(&req.payload, "type"))
+        .or_else(|| {
+            req.payload
+                .get("event")
+                .and_then(|event| payload_string(event, "type"))
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let terminal_id = req
+        .terminal_id
+        .clone()
+        .or_else(|| payload_string(&req.payload, "terminal_id"));
+    let provider_ids = extract_provider_ids(&req);
+    let terminal_bound = match terminal_id.as_deref() {
+        Some(id) if !id.is_empty() => terminal_exists(&s.registry, id).await,
+        _ => false,
+    };
+    let warning = if terminal_id.as_deref().filter(|id| !id.is_empty()).is_none() {
+        Some("hook did not include ZEDRA_TERMINAL_ID".to_string())
+    } else if !terminal_bound {
+        Some("hook terminal id is not active in this daemon".to_string())
+    } else {
+        None
+    };
+
+    let normalized =
+        agent::normalize_event(kind, &event_name).map(|(event_kind, status)| AgentEventSummary {
+            kind: event_kind,
+            status,
+            at: Some(Utc::now()),
+            terminal_id: terminal_id.clone(),
+            session_id: req
+                .session_id
+                .clone()
+                .or_else(|| provider_ids.session_id.clone())
+                .or_else(|| payload_string(&req.payload, "session_id"))
+                .or_else(|| payload_string(&req.payload, "sessionID")),
+            turn_id: req
+                .turn_id
+                .clone()
+                .or_else(|| provider_ids.turn_id.clone())
+                .or_else(|| payload_string(&req.payload, "turn_id"))
+                .or_else(|| payload_string(&req.payload, "turnID")),
+            tool_name: req
+                .tool_name
+                .clone()
+                .or_else(|| payload_string(&req.payload, "tool_name"))
+                .or_else(|| payload_string(&req.payload, "tool")),
+        });
+    let record = AgentHookEventRecord {
+        seq: 0,
+        kind,
+        provider_event_name: event_name.clone(),
+        provider_ids: provider_ids.clone(),
+        terminal_id: terminal_id.clone(),
+        normalized: normalized.clone(),
+        terminal_bound,
+        warning: warning.clone(),
+    };
+    let seq = s.daemon_state.record_agent_hook_event(record).await;
+
+    tracing::info!(
+        ?kind,
+        provider_event_name = %event_name,
+        terminal_bound,
+        normalized = ?normalized.as_ref().map(|event| event.kind),
+        "agent hook received"
+    );
+
+    Json(AgentHookResp {
+        ok: normalized.is_some(),
+        seq,
+        kind,
+        provider_event_name: event_name,
+        provider_ids,
+        normalized,
+        terminal_bound,
+        warning,
+    })
+    .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AgentHookEventsQuery {
+    pub terminal_id: Option<String>,
+    #[serde(default)]
+    pub after: u64,
+    #[serde(default = "default_hook_event_limit")]
+    pub limit: usize,
+}
+
+fn default_hook_event_limit() -> usize {
+    100
+}
+
+#[derive(Debug, Serialize)]
+struct AgentHookEventsResp {
+    events: Vec<AgentHookEventRecord>,
+}
+
+async fn list_agent_hook_events_handler(
+    State(s): State<ApiState>,
+    headers: HeaderMap,
+    Query(query): Query<AgentHookEventsQuery>,
+) -> impl IntoResponse {
+    if !verify_token(&headers, &s.token) {
+        return unauthorized();
+    }
+    let events = s
+        .daemon_state
+        .list_agent_hook_events(query.terminal_id.as_deref(), query.after, query.limit)
+        .await;
+    Json(AgentHookEventsResp { events }).into_response()
+}
+
+fn payload_string(payload: &serde_json::Value, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn extract_provider_ids(req: &AgentHookReq) -> AgentHookProviderIds {
+    let mut ids = AgentHookProviderIds {
+        session_id: req
+            .session_id
+            .clone()
+            .or_else(|| payload_string(&req.payload, "session_id"))
+            .or_else(|| payload_string(&req.payload, "sessionID")),
+        turn_id: req
+            .turn_id
+            .clone()
+            .or_else(|| payload_string(&req.payload, "turn_id"))
+            .or_else(|| payload_string(&req.payload, "turnID")),
+        tool_use_id: payload_string(&req.payload, "tool_use_id")
+            .or_else(|| payload_string(&req.payload, "toolUseID"))
+            .or_else(|| payload_string(&req.payload, "toolUseId")),
+        task_id: payload_string(&req.payload, "task_id")
+            .or_else(|| payload_string(&req.payload, "taskID"))
+            .or_else(|| payload_string(&req.payload, "taskId")),
+        agent_id: payload_string(&req.payload, "agent_id")
+            .or_else(|| payload_string(&req.payload, "agentID"))
+            .or_else(|| payload_string(&req.payload, "agentId")),
+        elicitation_id: payload_string(&req.payload, "elicitation_id")
+            .or_else(|| payload_string(&req.payload, "elicitationID"))
+            .or_else(|| payload_string(&req.payload, "elicitationId")),
+        transcript_id: payload_string(&req.payload, "transcript_path")
+            .and_then(|path| transcript_id_from_path(&path)),
+        batch_tool_use_ids: Vec::new(),
+    };
+    ids.batch_tool_use_ids = req
+        .payload
+        .get("tool_calls")
+        .and_then(serde_json::Value::as_array)
+        .map(|tool_calls| {
+            tool_calls
+                .iter()
+                .filter_map(|tool_call| payload_string(tool_call, "tool_use_id"))
+                .collect()
+        })
+        .unwrap_or_default();
+    ids
+}
+
+fn transcript_id_from_path(path: &str) -> Option<String> {
+    std::path::Path::new(path)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .map(str::to_string)
+}
+
+async fn terminal_exists(registry: &SessionRegistry, terminal_id: &str) -> bool {
+    for session in registry.list_sessions().await {
+        let Some(session) = registry.get(&session.id).await else {
+            continue;
+        };
+        if session
+            .terminal_infos()
+            .await
+            .iter()
+            .any(|terminal| terminal.id == terminal_id)
+        {
+            return true;
+        }
+    }
+    false
+}
+
 // ---------------------------------------------------------------------------
 // Server startup
 // ---------------------------------------------------------------------------
@@ -330,6 +725,17 @@ pub async fn start(state: ApiState) -> anyhow::Result<std::net::SocketAddr> {
         .route("/api/qr", post(create_pairing_qr_handler))
         .route("/api/qr/static", post(create_static_pairing_qr_handler))
         .route("/api/terminal", post(create_terminal_handler))
+        .route("/api/agents", get(list_agents_handler))
+        .route(
+            "/api/agents/:kind/sessions",
+            get(list_agent_sessions_handler),
+        )
+        .route("/api/agents/:kind/resume", post(resume_agent_handler))
+        .route(
+            "/api/agent-hooks/events",
+            get(list_agent_hook_events_handler),
+        )
+        .route("/api/agent-hooks/:kind", post(receive_agent_hook_handler))
         .with_state(state);
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -436,5 +842,48 @@ mod tests {
         }
 
         endpoint.close().await;
+    }
+
+    #[test]
+    fn extracts_safe_provider_ids_from_claude_tool_payload() {
+        let req = AgentHookReq {
+            event_name: Some("PreToolUse".to_string()),
+            terminal_id: None,
+            session_id: None,
+            turn_id: None,
+            tool_name: None,
+            payload: serde_json::json!({
+                "session_id": "claude-session",
+                "transcript_path": "/Users/me/.claude/projects/repo/claude-session.jsonl",
+                "tool_use_id": "toolu_123",
+                "tool_input": {"command": "secret command should not be copied"}
+            }),
+        };
+
+        let ids = extract_provider_ids(&req);
+        assert_eq!(ids.session_id.as_deref(), Some("claude-session"));
+        assert_eq!(ids.tool_use_id.as_deref(), Some("toolu_123"));
+        assert_eq!(ids.transcript_id.as_deref(), Some("claude-session"));
+    }
+
+    #[test]
+    fn extracts_batch_tool_ids_without_tool_outputs() {
+        let req = AgentHookReq {
+            event_name: Some("PostToolBatch".to_string()),
+            terminal_id: None,
+            session_id: None,
+            turn_id: None,
+            tool_name: None,
+            payload: serde_json::json!({
+                "session_id": "claude-session",
+                "tool_calls": [
+                    {"tool_use_id": "toolu_1", "tool_response": "large output"},
+                    {"tool_use_id": "toolu_2", "tool_input": {"file_path": "/tmp/a"}}
+                ]
+            }),
+        };
+
+        let ids = extract_provider_ids(&req);
+        assert_eq!(ids.batch_tool_use_ids, vec!["toolu_1", "toolu_2"]);
     }
 }

--- a/crates/zedra-host/src/claude.rs
+++ b/crates/zedra-host/src/claude.rs
@@ -1,0 +1,784 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::Value;
+
+const LIST_HEAD_SCAN_MAX_LINES: usize = 64;
+const LIST_HEAD_SCAN_MAX_BYTES: usize = 32 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TranscriptScanMode {
+    Full,
+    List,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaudeSessionList {
+    pub workdir: PathBuf,
+    pub claude_config_dir: PathBuf,
+    pub project_dir: PathBuf,
+    pub total: usize,
+    pub sessions: Vec<ClaudeSessionMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaudeSessionMetadata {
+    pub session_id: String,
+    pub title: Option<String>,
+    pub cwd: Option<String>,
+    pub git_branch: Option<String>,
+    pub worktree: Option<String>,
+    pub created_at: Option<String>,
+    pub last_activity_at: Option<String>,
+    pub message_count: usize,
+    pub malformed_line_count: usize,
+    pub claude_version: Option<String>,
+    pub entrypoint: Option<String>,
+    pub user_type: Option<String>,
+    pub permission_mode: Option<String>,
+    pub hook_success_count: usize,
+    pub hook_failure_count: usize,
+    pub task_created_count: usize,
+    pub task_completed_count: usize,
+    pub task_failed_count: usize,
+    pub pr_links: Vec<ClaudePrLink>,
+    pub is_sidechain: bool,
+    pub transcript_path: PathBuf,
+    #[serde(skip_serializing)]
+    sort_mtime_unix_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ClaudePrLink {
+    pub number: Option<u64>,
+    pub url: Option<String>,
+    pub repository: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TranscriptCandidate {
+    path: PathBuf,
+    worktree: Option<String>,
+    sort_mtime_unix_secs: Option<u64>,
+}
+
+pub fn list_sessions_limited(workdir: &Path, limit: usize) -> Result<ClaudeSessionList> {
+    let config_dir = claude_config_dir()?;
+    list_sessions_in_config_with_mode(workdir, &config_dir, Some(limit), TranscriptScanMode::List)
+}
+
+pub fn session_count_summary(workdir: &Path) -> Result<(usize, Option<ClaudeSessionMetadata>)> {
+    let config_dir = claude_config_dir()?;
+    session_count_summary_in_config(workdir, &config_dir)
+}
+
+fn sorted_transcript_candidates(
+    claude_config_dir: &Path,
+    workdir: &Path,
+) -> Result<Vec<TranscriptCandidate>> {
+    let project_dirs = project_dirs_for_workdir(claude_config_dir, workdir);
+    let mut candidates = collect_transcript_candidates(&project_dirs)?;
+    candidates.sort_by(|a, b| {
+        b.sort_mtime_unix_secs
+            .cmp(&a.sort_mtime_unix_secs)
+            .then_with(|| b.path.cmp(&a.path))
+    });
+    Ok(candidates)
+}
+
+fn session_count_summary_in_config(
+    workdir: &Path,
+    claude_config_dir: &Path,
+) -> Result<(usize, Option<ClaudeSessionMetadata>)> {
+    let candidates = sorted_transcript_candidates(claude_config_dir, workdir)?;
+    let total = candidates.len();
+    let latest = candidates
+        .first()
+        .map(|candidate| {
+            read_transcript_list_metadata(
+                &candidate.path,
+                candidate.worktree.as_deref(),
+                TranscriptScanMode::List,
+            )
+        })
+        .transpose()?;
+    Ok((total, latest))
+}
+
+fn list_sessions_in_config_with_mode(
+    workdir: &Path,
+    claude_config_dir: &Path,
+    limit: Option<usize>,
+    scan_mode: TranscriptScanMode,
+) -> Result<ClaudeSessionList> {
+    let project_dir = project_dir_for_workdir(claude_config_dir, workdir);
+    let candidates = sorted_transcript_candidates(claude_config_dir, workdir)?;
+    let total = candidates.len();
+
+    let read_limit = limit.unwrap_or(total);
+    let mut sessions = candidates
+        .into_iter()
+        .take(read_limit)
+        .map(|candidate| {
+            read_transcript_list_metadata(&candidate.path, candidate.worktree.as_deref(), scan_mode)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    sessions.sort_by(|a, b| {
+        b.last_activity_at
+            .cmp(&a.last_activity_at)
+            .then_with(|| b.sort_mtime_unix_secs.cmp(&a.sort_mtime_unix_secs))
+            .then_with(|| b.transcript_path.cmp(&a.transcript_path))
+    });
+
+    Ok(ClaudeSessionList {
+        workdir: workdir.to_path_buf(),
+        claude_config_dir: claude_config_dir.to_path_buf(),
+        project_dir,
+        total,
+        sessions,
+    })
+}
+
+pub fn project_dir_for_workdir(claude_config_dir: &Path, workdir: &Path) -> PathBuf {
+    claude_config_dir
+        .join("projects")
+        .join(encoded_project_name(workdir))
+}
+
+pub fn project_dirs_for_workdir(claude_config_dir: &Path, workdir: &Path) -> Vec<PathBuf> {
+    let projects_root = claude_config_dir.join("projects");
+    let mut dirs = Vec::new();
+    let project_dir = project_dir_for_workdir(claude_config_dir, workdir);
+    if project_dir.is_dir() {
+        dirs.push(project_dir);
+    }
+
+    let claude_worktree_prefix = format!("{}--claude-worktrees-", encoded_project_name(workdir));
+    let Ok(entries) = std::fs::read_dir(&projects_root) else {
+        return dirs;
+    };
+    for entry in entries.flatten() {
+        let claude_worktree_dir = entry.path();
+        if !claude_worktree_dir.is_dir() {
+            continue;
+        }
+        let Some(name) = claude_worktree_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+        else {
+            continue;
+        };
+        if name.starts_with(&claude_worktree_prefix) {
+            dirs.push(claude_worktree_dir);
+        }
+    }
+
+    dirs
+}
+
+fn collect_transcript_candidates(project_dirs: &[PathBuf]) -> Result<Vec<TranscriptCandidate>> {
+    let mut candidates = Vec::new();
+    for project_dir in project_dirs {
+        let worktree = worktree_from_project_dir(project_dir);
+        let entries = match std::fs::read_dir(project_dir) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!(
+                        "failed to read Claude project dir {}",
+                        project_dir.display()
+                    )
+                });
+            }
+        };
+
+        for entry in entries {
+            let entry = entry.with_context(|| {
+                format!(
+                    "failed to read an entry in Claude project dir {}",
+                    project_dir.display()
+                )
+            })?;
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+                continue;
+            }
+            if is_subagent_transcript(&path) {
+                continue;
+            }
+            candidates.push(TranscriptCandidate {
+                path,
+                worktree: worktree.clone(),
+                sort_mtime_unix_secs: transcript_mtime_unix_secs(&entry.path()),
+            });
+        }
+    }
+    Ok(candidates)
+}
+
+fn claude_config_dir() -> Result<PathBuf> {
+    if let Some(value) = std::env::var_os("CLAUDE_CONFIG_DIR").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(value));
+    }
+
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+    Ok(home.join(".claude"))
+}
+
+fn encoded_project_name(workdir: &Path) -> String {
+    workdir
+        .to_string_lossy()
+        .chars()
+        .map(|ch| match ch {
+            '/' | '\\' => '-',
+            _ => ch,
+        })
+        .collect()
+}
+
+fn worktree_from_project_dir(project_dir: &Path) -> Option<String> {
+    let name = project_dir.file_name()?.to_str()?;
+    let marker = "--claude-worktrees-";
+    name.find(marker)
+        .map(|index| name[index + marker.len()..].to_string())
+}
+
+pub fn is_subagent_transcript(path: &Path) -> bool {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem.starts_with("agent-"))
+}
+
+fn read_transcript_list_metadata(
+    path: &Path,
+    worktree: Option<&str>,
+    scan_mode: TranscriptScanMode,
+) -> Result<ClaudeSessionMetadata> {
+    let file = File::open(path)
+        .with_context(|| format!("failed to read transcript {}", path.display()))?;
+    let sort_mtime_unix_secs = transcript_mtime_unix_secs(path);
+    let mut metadata = ClaudeSessionMetadata {
+        session_id: String::new(),
+        title: None,
+        cwd: None,
+        git_branch: None,
+        worktree: worktree.map(str::to_string),
+        created_at: None,
+        last_activity_at: None,
+        message_count: 0,
+        malformed_line_count: 0,
+        claude_version: None,
+        entrypoint: None,
+        user_type: None,
+        permission_mode: None,
+        hook_success_count: 0,
+        hook_failure_count: 0,
+        task_created_count: 0,
+        task_completed_count: 0,
+        task_failed_count: 0,
+        pr_links: Vec::new(),
+        is_sidechain: false,
+        transcript_path: path.to_path_buf(),
+        sort_mtime_unix_secs,
+    };
+
+    let mut scanned_lines = 0usize;
+    let mut scanned_bytes = 0usize;
+    for line in BufReader::new(file).lines() {
+        let line =
+            line.with_context(|| format!("failed to read transcript line in {}", path.display()))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        if scan_mode == TranscriptScanMode::List {
+            scanned_lines += 1;
+            scanned_bytes += line.len() + 1;
+        }
+
+        let record = match serde_json::from_str::<Value>(&line) {
+            Ok(Value::Object(record)) => Value::Object(record),
+            Ok(_) | Err(_) => {
+                metadata.malformed_line_count += 1;
+                continue;
+            }
+        };
+
+        if scan_mode == TranscriptScanMode::Full {
+            metadata.message_count += 1;
+        }
+        if metadata.session_id.is_empty() {
+            if let Some(session_id) = string_field(&record, &["sessionId", "session_id"]) {
+                metadata.session_id = session_id.to_string();
+            }
+        }
+        set_latest_string(&mut metadata.cwd, string_field(&record, &["cwd"]));
+        set_latest_string(
+            &mut metadata.git_branch,
+            string_field(&record, &["gitBranch", "git_branch"]),
+        );
+        set_latest_string(
+            &mut metadata.claude_version,
+            string_field(&record, &["version", "claudeVersion", "claude_version"]),
+        );
+        set_latest_string(
+            &mut metadata.entrypoint,
+            string_field(&record, &["entrypoint", "entryPoint"]),
+        );
+        set_latest_string(
+            &mut metadata.user_type,
+            string_field(&record, &["userType", "user_type"]),
+        );
+        set_latest_string(
+            &mut metadata.permission_mode,
+            string_field(&record, &["permissionMode", "permission_mode"]),
+        );
+        if scan_mode == TranscriptScanMode::Full {
+            if let Some(timestamp) =
+                string_field(&record, &["timestamp", "createdAt", "created_at"])
+            {
+                observe_timestamp(&mut metadata, timestamp);
+            }
+        } else if metadata.created_at.is_none() {
+            if let Some(timestamp) =
+                string_field(&record, &["timestamp", "createdAt", "created_at"])
+            {
+                metadata.created_at = Some(timestamp.to_string());
+            }
+        }
+        if bool_field(&record, &["isSidechain", "is_sidechain"]).unwrap_or(false) {
+            metadata.is_sidechain = true;
+        }
+        if scan_mode == TranscriptScanMode::Full {
+            observe_pr_link(&mut metadata, &record);
+            observe_hook_or_task_event(&mut metadata, &record);
+        }
+        if let Some(title) = string_field(&record, &["aiTitle", "ai_title"]) {
+            metadata.title = Some(title.to_string());
+        }
+        // The head-scan cap is enforced after parsing the current record, not
+        // before, so a single oversized head line (e.g. a large system prompt)
+        // still contributes its sessionId/cwd/title before the scan stops.
+        if scan_mode == TranscriptScanMode::List
+            && (list_head_scan_complete(&metadata, scanned_lines)
+                || scanned_lines >= LIST_HEAD_SCAN_MAX_LINES
+                || scanned_bytes >= LIST_HEAD_SCAN_MAX_BYTES)
+        {
+            break;
+        }
+    }
+
+    if metadata.session_id.is_empty() {
+        metadata.session_id = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+    }
+    if scan_mode == TranscriptScanMode::List || metadata.last_activity_at.is_none() {
+        metadata.last_activity_at = sort_mtime_unix_secs.and_then(|secs| {
+            DateTime::<Utc>::from_timestamp(secs as i64, 0).map(|dt| dt.to_rfc3339())
+        });
+    }
+
+    Ok(metadata)
+}
+
+fn string_field<'a>(record: &'a Value, names: &[&str]) -> Option<&'a str> {
+    names
+        .iter()
+        .find_map(|name| record.get(*name)?.as_str())
+        .filter(|value| !value.is_empty())
+}
+
+fn nested_string_field<'a>(
+    record: &'a Value,
+    object_name: &str,
+    names: &[&str],
+) -> Option<&'a str> {
+    let nested = record.get(object_name)?;
+    string_field(nested, names)
+}
+
+fn u64_field(record: &Value, names: &[&str]) -> Option<u64> {
+    names.iter().find_map(|name| match record.get(*name)? {
+        Value::Number(number) => number.as_u64(),
+        Value::String(value) => value.parse().ok(),
+        _ => None,
+    })
+}
+
+fn bool_field(record: &Value, names: &[&str]) -> Option<bool> {
+    names.iter().find_map(|name| record.get(*name)?.as_bool())
+}
+
+fn set_latest_string(slot: &mut Option<String>, value: Option<&str>) {
+    if let Some(value) = value {
+        *slot = Some(value.to_string());
+    }
+}
+
+fn observe_timestamp(metadata: &mut ClaudeSessionMetadata, timestamp: &str) {
+    if metadata
+        .created_at
+        .as_deref()
+        .map(|created_at| timestamp < created_at)
+        .unwrap_or(true)
+    {
+        metadata.created_at = Some(timestamp.to_string());
+    }
+    if metadata
+        .last_activity_at
+        .as_deref()
+        .map(|last_activity_at| timestamp > last_activity_at)
+        .unwrap_or(true)
+    {
+        metadata.last_activity_at = Some(timestamp.to_string());
+    }
+}
+
+fn observe_pr_link(metadata: &mut ClaudeSessionMetadata, record: &Value) {
+    if string_field(record, &["type"]) != Some("pr-link") {
+        return;
+    }
+
+    let link = ClaudePrLink {
+        number: u64_field(record, &["prNumber", "pr_number"]),
+        url: string_field(record, &["prUrl", "pr_url"]).map(str::to_owned),
+        repository: string_field(record, &["prRepository", "pr_repository"]).map(str::to_owned),
+    };
+    if link.number.is_some() || link.url.is_some() || link.repository.is_some() {
+        metadata.pr_links.push(link);
+    }
+}
+
+fn observe_hook_or_task_event(metadata: &mut ClaudeSessionMetadata, record: &Value) {
+    let attachment_type = nested_string_field(record, "attachment", &["type"]);
+    match attachment_type {
+        Some("hook_success") => metadata.hook_success_count += 1,
+        Some("hook_failure") => metadata.hook_failure_count += 1,
+        _ => {}
+    }
+
+    let event = string_field(
+        record,
+        &[
+            "hookEvent",
+            "hook_event",
+            "hookEventName",
+            "hook_event_name",
+            "event",
+        ],
+    )
+    .or_else(|| {
+        nested_string_field(
+            record,
+            "attachment",
+            &[
+                "hookEvent",
+                "hook_event",
+                "hookEventName",
+                "hook_event_name",
+                "event",
+            ],
+        )
+    });
+    match event {
+        Some("TaskCreated") => metadata.task_created_count += 1,
+        Some("TaskCompleted") => metadata.task_completed_count += 1,
+        Some("TaskFailed") | Some("StopFailure") | Some("PostToolUseFailure") => {
+            metadata.task_failed_count += 1
+        }
+        _ => {}
+    }
+}
+
+fn transcript_mtime_unix_secs(path: &Path) -> Option<u64> {
+    std::fs::metadata(path)
+        .ok()?
+        .modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs())
+}
+
+fn list_head_scan_complete(metadata: &ClaudeSessionMetadata, scanned_lines: usize) -> bool {
+    let core_metadata =
+        !metadata.session_id.is_empty() && metadata.cwd.is_some() && metadata.created_at.is_some();
+    core_metadata && (metadata.title.is_some() || scanned_lines >= 8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_dir_uses_claude_path_encoding() {
+        assert_eq!(
+            project_dir_for_workdir(Path::new("/config"), Path::new("/Users/me/project")),
+            PathBuf::from("/config/projects/-Users-me-project")
+        );
+        assert_eq!(
+            encoded_project_name(Path::new(r"C:\Users\me\project")),
+            "C:-Users-me-project"
+        );
+    }
+
+    #[test]
+    fn list_sessions_reads_workspace_transcripts() {
+        let config = tempfile::tempdir().unwrap();
+        let workdir = Path::new("/Users/me/project");
+        let project_dir = project_dir_for_workdir(config.path(), workdir);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("older.jsonl"),
+            r#"{"sessionId":"older-session","cwd":"/Users/me/project","gitBranch":"main","version":"1.0.0","timestamp":"2026-05-09T10:00:00Z","isSidechain":false}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            project_dir.join("newer.jsonl"),
+            r#"not-json
+{"sessionId":"newer-session","cwd":"/Users/me/project","gitBranch":"feature","version":"1.0.1","timestamp":"2026-05-09T09:00:00Z","isSidechain":false}
+{"cwd":"/Users/me/project","gitBranch":"feature-2","version":"1.0.2","timestamp":"2026-05-09T11:00:00Z","isSidechain":true}
+"#,
+        )
+        .unwrap();
+
+        let list = list_sessions_in_config_with_mode(
+            workdir,
+            config.path(),
+            None,
+            TranscriptScanMode::Full,
+        )
+        .unwrap();
+
+        assert_eq!(list.sessions.len(), 2);
+        assert_eq!(list.sessions[0].session_id, "newer-session");
+        assert_eq!(list.sessions[0].git_branch.as_deref(), Some("feature-2"));
+        assert_eq!(list.sessions[0].claude_version.as_deref(), Some("1.0.2"));
+        assert!(list.sessions[0].is_sidechain);
+        assert_eq!(list.sessions[0].message_count, 2);
+        assert_eq!(list.sessions[0].malformed_line_count, 1);
+        assert_eq!(list.sessions[1].session_id, "older-session");
+    }
+
+    #[test]
+    fn list_sessions_reads_safe_enriched_metadata() {
+        let config = tempfile::tempdir().unwrap();
+        let workdir = Path::new("/Users/me/project");
+        let project_dir = project_dir_for_workdir(config.path(), workdir);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("session.jsonl"),
+            r#"{"sessionId":"session","cwd":"/Users/me/project","entrypoint":"cli","userType":"human","permissionMode":"default","timestamp":"2026-05-09T10:00:00Z","prompt":"SECRET"}
+{"type":"pr-link","sessionId":"session","prNumber":42,"prUrl":"https://example.com/pull/42","prRepository":"owner/repo","timestamp":"2026-05-09T10:01:00Z"}
+{"type":"attachment","sessionId":"session","attachment":{"type":"hook_success","hookEvent":"TaskCompleted"},"timestamp":"2026-05-09T10:02:00Z"}
+{"type":"attachment","sessionId":"session","attachment":{"type":"hook_failure","hookEvent":"StopFailure"},"timestamp":"2026-05-09T10:03:00Z"}
+"#,
+        )
+        .unwrap();
+
+        let session = read_transcript_list_metadata(
+            &project_dir.join("session.jsonl"),
+            None,
+            TranscriptScanMode::Full,
+        )
+        .unwrap();
+
+        assert_eq!(session.entrypoint.as_deref(), Some("cli"));
+        assert_eq!(session.user_type.as_deref(), Some("human"));
+        assert_eq!(session.permission_mode.as_deref(), Some("default"));
+        assert_eq!(session.hook_success_count, 1);
+        assert_eq!(session.hook_failure_count, 1);
+        assert_eq!(session.task_completed_count, 1);
+        assert_eq!(session.task_failed_count, 1);
+        assert_eq!(session.pr_links[0].number, Some(42));
+        assert_eq!(
+            session.pr_links[0].url.as_deref(),
+            Some("https://example.com/pull/42")
+        );
+
+        let serialized = serde_json::to_string(&session).unwrap();
+        assert!(!serialized.contains("SECRET"));
+    }
+
+    #[test]
+    fn list_sessions_falls_back_to_filename_session_id() {
+        let config = tempfile::tempdir().unwrap();
+        let workdir = Path::new("/Users/me/project");
+        let project_dir = project_dir_for_workdir(config.path(), workdir);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("session-from-file.jsonl"),
+            r#"{"cwd":"/Users/me/project","timestamp":"2026-05-09T10:00:00Z"}
+"#,
+        )
+        .unwrap();
+
+        let list = list_sessions_in_config_with_mode(
+            workdir,
+            config.path(),
+            None,
+            TranscriptScanMode::Full,
+        )
+        .unwrap();
+
+        assert_eq!(list.sessions[0].session_id, "session-from-file");
+    }
+
+    #[test]
+    fn worktree_from_project_dir_reads_marker_suffix() {
+        let dir = Path::new("/config/projects/-Users-me-project--claude-worktrees-feature-a");
+        assert_eq!(worktree_from_project_dir(dir).as_deref(), Some("feature-a"));
+    }
+
+    #[test]
+    fn project_dirs_exclude_sibling_workdir_project_dirs() {
+        let config = tempfile::tempdir().unwrap();
+        let workdir = Path::new("/Users/me/project-main");
+        let projects_root = config.path().join("projects");
+        std::fs::create_dir_all(projects_root.join("-Users-me-project-main")).unwrap();
+        std::fs::create_dir_all(projects_root.join("-Users-me-project")).unwrap();
+        std::fs::create_dir_all(projects_root.join("-Users-me-project-ios")).unwrap();
+        std::fs::create_dir_all(
+            projects_root.join("-Users-me-project--claude-worktrees-feature-a"),
+        )
+        .unwrap();
+
+        let dirs = project_dirs_for_workdir(config.path(), workdir);
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0], projects_root.join("-Users-me-project-main"));
+    }
+
+    #[test]
+    fn project_dirs_include_claude_worktree_suffix_dirs() {
+        let config = tempfile::tempdir().unwrap();
+        let workdir = Path::new("/Users/me/project");
+        let projects_root = config.path().join("projects");
+        std::fs::create_dir_all(projects_root.join("-Users-me-project")).unwrap();
+        std::fs::create_dir_all(
+            projects_root.join("-Users-me-project--claude-worktrees-feature-a"),
+        )
+        .unwrap();
+
+        let dirs = project_dirs_for_workdir(config.path(), workdir);
+        assert_eq!(dirs.len(), 2);
+        assert!(dirs.iter().any(|dir| {
+            dir.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains("--claude-worktrees-feature-a"))
+        }));
+    }
+
+    #[test]
+    fn list_sessions_reads_ai_title() {
+        let config = tempfile::tempdir().unwrap();
+        let workdir = Path::new("/Users/me/project");
+        let project_dir = project_dir_for_workdir(config.path(), workdir);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("session.jsonl"),
+            r#"{"type":"summary","aiTitle":"Review pending changes"}
+{"sessionId":"session","cwd":"/Users/me/project","timestamp":"2026-05-09T10:00:00Z"}
+"#,
+        )
+        .unwrap();
+
+        let list = list_sessions_in_config_with_mode(
+            workdir,
+            config.path(),
+            Some(10),
+            TranscriptScanMode::List,
+        )
+        .unwrap();
+        let session = &list.sessions[0];
+        assert_eq!(session.title.as_deref(), Some("Review pending changes"));
+    }
+
+    #[test]
+    fn list_mode_scans_only_transcript_head() {
+        let config = tempfile::tempdir().unwrap();
+        let workdir = Path::new("/Users/me/project");
+        let project_dir = project_dir_for_workdir(config.path(), workdir);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let mut contents = String::from(
+            r#"{"sessionId":"session","cwd":"/Users/me/project","timestamp":"2026-05-09T10:00:00Z"}"#,
+        );
+        for index in 0..200 {
+            contents.push('\n');
+            contents.push_str(&format!(
+                r#"{{"sessionId":"session","cwd":"/Users/me/project","timestamp":"2026-05-09T10:00:{index:02}Z"}}"#
+            ));
+        }
+        std::fs::write(project_dir.join("large.jsonl"), contents).unwrap();
+
+        let session = read_transcript_list_metadata(
+            &project_dir.join("large.jsonl"),
+            None,
+            TranscriptScanMode::List,
+        )
+        .unwrap();
+        assert_eq!(session.session_id, "session");
+        assert_eq!(session.message_count, 0);
+    }
+
+    #[test]
+    fn session_count_summary_reads_only_latest_transcript() {
+        let config = tempfile::tempdir().unwrap();
+        let workdir = Path::new("/Users/me/project-count");
+        let project_dir = project_dir_for_workdir(config.path(), workdir);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("older.jsonl"),
+            r#"{"sessionId":"older","cwd":"/Users/me/project-count","timestamp":"2026-05-09T10:00:00Z","aiTitle":"Older"}
+"#,
+        )
+        .unwrap();
+        let newer_path = project_dir.join("newer.jsonl");
+        std::fs::write(
+            &newer_path,
+            r#"{"sessionId":"newer","cwd":"/Users/me/project-count","timestamp":"2026-05-09T11:00:00Z","aiTitle":"Newer"}
+"#,
+        )
+        .unwrap();
+        filetime::set_file_mtime(
+            &project_dir.join("older.jsonl"),
+            filetime::FileTime::from_unix_time(1_700_000_000, 0),
+        )
+        .unwrap();
+        filetime::set_file_mtime(
+            &newer_path,
+            filetime::FileTime::from_unix_time(1_800_000_000, 0),
+        )
+        .unwrap();
+
+        let (total, latest) = session_count_summary_in_config(workdir, config.path()).unwrap();
+        assert_eq!(total, 2);
+        assert_eq!(latest.unwrap().session_id, "newer");
+    }
+
+    #[test]
+    fn missing_project_dir_returns_empty_list() {
+        let config = tempfile::tempdir().unwrap();
+        let list = list_sessions_in_config_with_mode(
+            Path::new("/Users/me/missing"),
+            config.path(),
+            None,
+            TranscriptScanMode::List,
+        )
+        .unwrap();
+
+        assert!(list.sessions.is_empty());
+    }
+}

--- a/crates/zedra-host/src/installed_agents.rs
+++ b/crates/zedra-host/src/installed_agents.rs
@@ -1,0 +1,225 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use zedra_rpc::proto::{AgentInstalledListResult, InstalledAgentEntry};
+
+struct InstalledAgentSpec {
+    slug: &'static str,
+    display_name: &'static str,
+    icon_name: &'static str,
+    programs: &'static [&'static str],
+}
+
+const INSTALLED_AGENT_SPECS: &[InstalledAgentSpec] = &[
+    InstalledAgentSpec {
+        slug: "claude",
+        display_name: "Claude Code",
+        icon_name: "AgentClaude",
+        programs: &["claude"],
+    },
+    InstalledAgentSpec {
+        slug: "codex",
+        display_name: "Codex",
+        icon_name: "AgentCodex",
+        programs: &["codex"],
+    },
+    InstalledAgentSpec {
+        slug: "opencode",
+        display_name: "OpenCode",
+        icon_name: "AgentOpenCode",
+        programs: &["opencode"],
+    },
+    InstalledAgentSpec {
+        slug: "amp",
+        display_name: "Amp",
+        icon_name: "AgentAmp",
+        programs: &["amp"],
+    },
+    InstalledAgentSpec {
+        slug: "cline",
+        display_name: "Cline",
+        icon_name: "AgentCline",
+        programs: &["cline"],
+    },
+    InstalledAgentSpec {
+        slug: "cursor",
+        display_name: "Cursor Agent",
+        icon_name: "AgentCursor",
+        programs: &["cursor-agent", "cursor"],
+    },
+    InstalledAgentSpec {
+        slug: "copilot",
+        display_name: "GitHub Copilot",
+        icon_name: "AgentCopilot",
+        programs: &["copilot", "github-copilot-cli"],
+    },
+    InstalledAgentSpec {
+        slug: "gemini",
+        display_name: "Gemini",
+        icon_name: "AgentGemini",
+        programs: &["gemini"],
+    },
+    InstalledAgentSpec {
+        slug: "goose",
+        display_name: "Goose",
+        icon_name: "AgentGoose",
+        programs: &["goose"],
+    },
+    InstalledAgentSpec {
+        slug: "hermes",
+        display_name: "Hermes Agent",
+        icon_name: "AgentHermes",
+        programs: &["hermes", "hermes-agent"],
+    },
+    InstalledAgentSpec {
+        slug: "junie",
+        display_name: "Junie",
+        icon_name: "AgentJunie",
+        programs: &["junie"],
+    },
+    InstalledAgentSpec {
+        slug: "kilocode",
+        display_name: "Kilo Code",
+        icon_name: "AgentKiloCode",
+        programs: &["kilocode"],
+    },
+    InstalledAgentSpec {
+        slug: "openclaw",
+        display_name: "OpenClaw",
+        icon_name: "AgentOpenClaw",
+        programs: &["openclaw"],
+    },
+    InstalledAgentSpec {
+        slug: "openhands",
+        display_name: "OpenHands",
+        icon_name: "AgentOpenHands",
+        programs: &["openhands"],
+    },
+    InstalledAgentSpec {
+        slug: "pi",
+        display_name: "Pi",
+        icon_name: "AgentPi",
+        programs: &["pi"],
+    },
+    InstalledAgentSpec {
+        slug: "qoder",
+        display_name: "Qoder",
+        icon_name: "AgentQoder",
+        programs: &["qoder"],
+    },
+    InstalledAgentSpec {
+        slug: "qwen",
+        display_name: "Qwen Code",
+        icon_name: "AgentQwen",
+        programs: &["qwen"],
+    },
+    InstalledAgentSpec {
+        slug: "trae",
+        display_name: "Trae Agent",
+        icon_name: "AgentTrae",
+        programs: &["trae"],
+    },
+    InstalledAgentSpec {
+        slug: "zencoder",
+        display_name: "Zencoder",
+        icon_name: "AgentZencoder",
+        programs: &["zencoder"],
+    },
+];
+
+pub fn list_installed_agents() -> AgentInstalledListResult {
+    let agents = Mutex::new(Vec::with_capacity(INSTALLED_AGENT_SPECS.len()));
+    std::thread::scope(|scope| {
+        for spec in INSTALLED_AGENT_SPECS {
+            let agents = &agents;
+            scope.spawn(move || {
+                let launch_cmd = resolve_program(spec.programs);
+                let entry = InstalledAgentEntry {
+                    slug: spec.slug.to_string(),
+                    display_name: spec.display_name.to_string(),
+                    icon_name: spec.icon_name.to_string(),
+                    available: launch_cmd.is_some(),
+                    version: None,
+                    launch_cmd,
+                };
+                agents
+                    .lock()
+                    .expect("installed agent probe lock")
+                    .push(entry);
+            });
+        }
+    });
+
+    let mut agents = agents.into_inner().expect("installed agent probe lock");
+    agents.sort_by_key(|entry| {
+        INSTALLED_AGENT_SPECS
+            .iter()
+            .position(|spec| spec.slug == entry.slug)
+            .unwrap_or(usize::MAX)
+    });
+
+    AgentInstalledListResult {
+        agents,
+        error: None,
+    }
+}
+
+fn resolve_program(programs: &[&str]) -> Option<String> {
+    programs
+        .iter()
+        .find(|program| program_on_path(program))
+        .map(|program| program.to_string())
+}
+
+fn program_on_path(program: &str) -> bool {
+    if program.contains('/') {
+        return is_executable_file(Path::new(program));
+    }
+    path_lookup(program).is_some()
+}
+
+fn path_lookup(program: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(program);
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// A PATH entry only counts as an installed agent CLI if it is an executable
+/// regular file; a non-executable file of the same name (a stray note, a
+/// partial download) must not mark the agent as available.
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn installed_agent_list_includes_all_supported_slugs() {
+        let result = list_installed_agents();
+        assert_eq!(result.agents.len(), INSTALLED_AGENT_SPECS.len());
+        assert!(result
+            .agents
+            .iter()
+            .any(|agent| agent.slug == "claude" && agent.icon_name == "AgentClaude"));
+    }
+}

--- a/crates/zedra-host/src/lib.rs
+++ b/crates/zedra-host/src/lib.rs
@@ -1,6 +1,9 @@
 // zedra-host library — re-exports for integration tests
 
+pub mod agent;
+pub mod agent_cache;
 pub mod api;
+pub mod claude;
 pub mod client;
 pub mod docs_tree;
 pub mod fs;
@@ -8,6 +11,7 @@ pub mod ga4;
 pub mod git;
 pub mod host_info;
 pub mod identity;
+pub mod installed_agents;
 pub mod iroh_listener;
 pub mod metrics;
 pub mod net_monitor;

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -23,7 +23,9 @@ use zedra_host::{
 use zedra_rpc::ZedraPairingTicket;
 use zedra_telemetry::Event;
 
+mod agent_cli;
 mod setup;
+mod terminal_cli;
 
 #[derive(Parser)]
 #[command(
@@ -171,15 +173,13 @@ enum Commands {
         lines: usize,
     },
 
-    /// Open a terminal on the connected phone
-    Terminal {
-        /// Working directory of the running daemon
-        #[arg(short, long, default_value = ".")]
-        workdir: String,
+    /// Open or list terminals on the connected phone
+    Terminal(terminal_cli::TerminalArgs),
 
-        /// Command to run in the terminal on startup (e.g. "claude --resume <id>")
-        #[arg(long)]
-        launch_cmd: Option<String>,
+    /// Inspect and test managed AI-agent integration
+    Agent {
+        #[command(subcommand)]
+        command: agent_cli::AgentCommand,
     },
 
     /// Install Zedra skills or plugins for an AI coding agent
@@ -702,6 +702,13 @@ async fn main() -> Result<()> {
                 workdir.clone(),
                 host_identity.clone(),
             ));
+            {
+                let cache = state.agent_cache.clone();
+                let preload_workdir = workdir.clone();
+                tokio::spawn(async move {
+                    cache.preload(preload_workdir).await;
+                });
+            }
 
             // 1. Bind iroh endpoint with configured relay URLs.
             let endpoint_relay_urls: Vec<String> = if relay_url.is_empty() {
@@ -910,7 +917,7 @@ async fn main() -> Result<()> {
                 });
             }
 
-            // 5. Run iroh accept loop until the endpoint closes or the process exits.
+            // 5. Run iroh accept loop (blocks main)
             iroh_listener::run_accept_loop(&endpoint, registry, state).await?;
         }
 
@@ -986,51 +993,12 @@ async fn main() -> Result<()> {
             }
         }
 
-        Commands::Terminal {
-            workdir,
-            launch_cmd,
-        } => {
-            let workdir = resolve_workdir(workdir);
-            let config_dir = identity::workspace_config_dir(&workdir)?;
-            let addr = std::fs::read_to_string(config_dir.join("api-addr")).unwrap_or_default();
-            let token = std::fs::read_to_string(config_dir.join("api-token")).unwrap_or_default();
-            if addr.trim().is_empty() {
-                utils::eprintln_error(format!(
-                    "No running daemon found for: {}",
-                    workdir.display()
-                ));
-                std::process::exit(1);
-            }
-            let url = format!("http://{}/api/terminal", addr.trim());
-            let body = serde_json::json!({ "launch_cmd": launch_cmd.as_deref() });
-            let client = reqwest::Client::new();
-            match client
-                .post(&url)
-                .bearer_auth(token.trim())
-                .json(&body)
-                .send()
-                .await
-            {
-                Ok(resp) => {
-                    let status = resp.status();
-                    let text = resp.text().await.unwrap_or_default();
-                    if !status.is_success() {
-                        utils::eprintln_error(format!(
-                            "Failed to open terminal: HTTP {} {}",
-                            status, text
-                        ));
-                        std::process::exit(1);
-                    }
-                    match render_terminal_created_output(&text, launch_cmd.as_deref()) {
-                        Some(output) => println!("{output}"),
-                        None => println!("{}", text),
-                    }
-                }
-                Err(e) => {
-                    utils::eprintln_error(format!("Failed to reach daemon: {}", e));
-                    std::process::exit(1);
-                }
-            }
+        Commands::Terminal(args) => {
+            terminal_cli::run(args).await?;
+        }
+
+        Commands::Agent { command } => {
+            agent_cli::run(command).await?;
         }
 
         Commands::Setup { yes, agent } => {
@@ -1231,8 +1199,7 @@ async fn main() -> Result<()> {
         Commands::Stop { workdir, grace } => {
             let workdir = resolve_workdir(&workdir);
 
-            let lock_info = workspace_lock::read_lock_info(&workdir)?;
-            match &lock_info {
+            match workspace_lock::read_lock_info(&workdir)? {
                 None => {
                     utils::eprintln_error(format!(
                         "No running Zedra daemon found for: {}",
@@ -1622,21 +1589,6 @@ fn terminal_status_row(terminal: &serde_json::Value) -> Vec<String> {
         .unwrap_or_else(|| "-".to_string());
 
     vec![id, title.to_string(), created, uptime, session]
-}
-
-fn render_terminal_created_output(body: &str, launch_cmd: Option<&str>) -> Option<String> {
-    let response = serde_json::from_str::<serde_json::Value>(body).ok()?;
-    let id = response["id"].as_str()?;
-    let session_id = response["session_id"].as_str()?;
-    let mut rows = vec![("ID", id.to_string()), ("Session", session_id.to_string())];
-    if let Some(launch_cmd) = launch_cmd.filter(|command| !command.is_empty()) {
-        rows.push(("Command", launch_cmd.to_string()));
-    }
-
-    Some(format!(
-        "Terminal Opened\n\n{}",
-        utils::render_key_values(&rows)
-    ))
 }
 
 fn non_empty_str(value: &serde_json::Value) -> Option<&str> {
@@ -2242,20 +2194,6 @@ mod tests {
         assert!(output.contains("  Daemon        not running"));
         assert!(output.contains("  Active Time   40s"));
         assert!(output.contains("  Active Now    0 connections"));
-    }
-
-    #[test]
-    fn terminal_created_output_summarizes_api_response() {
-        let output = render_terminal_created_output(
-            r#"{"id":"terminal-id","session_id":"session-id"}"#,
-            Some("claude"),
-        )
-        .unwrap();
-
-        assert!(output.contains("Terminal Opened"));
-        assert!(output.contains("  ID       terminal-id"));
-        assert!(output.contains("  Session  session-id"));
-        assert!(output.contains("  Command  claude"));
     }
 
     #[cfg(unix)]

--- a/crates/zedra-host/src/pty.rs
+++ b/crates/zedra-host/src/pty.rs
@@ -22,6 +22,8 @@ pub struct SpawnOptions {
     /// Shell command to run when the PTY starts.
     /// Example: `"claude --resume"` to drop straight into a Claude session.
     pub launch_cmd: Option<String>,
+    /// Extra environment variables set on the spawned shell after sanitization.
+    pub env: Vec<(String, String)>,
 }
 
 fn launch_script(launch_cmd: &str) -> String {
@@ -65,6 +67,9 @@ impl ShellSession {
         // Always set a known-good TERM; override any inherited value.
         cmd.env("TERM", "xterm-256color");
         cmd.env("COLORTERM", "truecolor");
+        for (key, val) in &opts.env {
+            cmd.env(key, val);
+        }
 
         // Spawn the shell process
         let child = pair
@@ -423,6 +428,7 @@ mod tests {
             SpawnOptions {
                 workdir: None,
                 launch_cmd: Some("printf 'ZEDRA_LAUNCH_OK\\n'; exit".to_string()),
+                env: Vec::new(),
             },
         )
         .unwrap();

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -6,6 +6,8 @@
 //   PKI reconnect:  Connect(None) → Challenge → AuthProve → Ok(SyncSessionResult) → (RPC calls)
 //   Health:         Ping (every 2s, foreground only, 5 misses = client reconnects)
 
+use crate::agent;
+use crate::agent_cache;
 use crate::docs_tree::{
     build_snapshot, docs_tree_cache_key, docs_tree_limit, snapshot_page_result,
     validate_docs_tree_offset,
@@ -24,11 +26,11 @@ use crate::session_registry::{
 };
 use crate::utils;
 use anyhow::Result;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zedra_rpc::proto::*;
@@ -235,6 +237,7 @@ mod terminal_meta_preamble_tests {
         let opts = SpawnOptions {
             workdir: Some(PathBuf::from("/repo/project")),
             launch_cmd: Some("claude --resume session".to_owned()),
+            env: Vec::new(),
         };
 
         assert_eq!(
@@ -490,6 +493,9 @@ pub struct DaemonState {
     pub identity: SharedIdentity,
     /// When the daemon started; used to compute uptime.
     pub started_at: std::time::Instant,
+    pub agent_hook_events: tokio::sync::Mutex<VecDeque<AgentHookEventRecord>>,
+    pub agent_cache: Arc<agent_cache::AgentCache>,
+    next_agent_hook_event_seq: AtomicU64,
 }
 
 impl std::fmt::Debug for DaemonState {
@@ -507,8 +513,72 @@ impl DaemonState {
             workdir,
             identity,
             started_at: std::time::Instant::now(),
+            agent_hook_events: tokio::sync::Mutex::new(VecDeque::new()),
+            agent_cache: agent_cache::AgentCache::new(),
+            next_agent_hook_event_seq: AtomicU64::new(1),
         }
     }
+
+    pub async fn record_agent_hook_event(&self, mut event: AgentHookEventRecord) -> u64 {
+        let seq = self
+            .next_agent_hook_event_seq
+            .fetch_add(1, Ordering::Relaxed);
+        event.seq = seq;
+        let mut events = self.agent_hook_events.lock().await;
+        events.push_back(event);
+        while events.len() > MAX_AGENT_HOOK_EVENTS {
+            events.pop_front();
+        }
+        seq
+    }
+
+    pub async fn list_agent_hook_events(
+        &self,
+        terminal_id: Option<&str>,
+        after_seq: u64,
+        limit: usize,
+    ) -> Vec<AgentHookEventRecord> {
+        let limit = limit.clamp(1, MAX_AGENT_HOOK_EVENTS);
+        self.agent_hook_events
+            .lock()
+            .await
+            .iter()
+            .filter(|event| event.seq > after_seq)
+            .filter(|event| {
+                terminal_id
+                    .map(|terminal_id| event.terminal_id.as_deref() == Some(terminal_id))
+                    .unwrap_or(true)
+            })
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+}
+
+const MAX_AGENT_HOOK_EVENTS: usize = 512;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentHookEventRecord {
+    pub seq: u64,
+    pub kind: ManagedAgentKind,
+    pub provider_event_name: String,
+    pub provider_ids: AgentHookProviderIds,
+    pub normalized: Option<AgentEventSummary>,
+    pub terminal_id: Option<String>,
+    pub terminal_bound: bool,
+    pub warning: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct AgentHookProviderIds {
+    pub session_id: Option<String>,
+    pub turn_id: Option<String>,
+    pub tool_use_id: Option<String>,
+    pub task_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub elicitation_id: Option<String>,
+    pub transcript_id: Option<String>,
+    pub batch_tool_use_ids: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -969,6 +1039,23 @@ async fn handle_register(
             RegisterResult::Ok
         }
         ConsumeSlotResult::Consumed => {
+            // The slot may have been consumed by THIS client on an earlier
+            // connection that dropped before the client observed the result.
+            // Re-registration from a pubkey already in the ACL is idempotent:
+            // report success instead of a fatal HandshakeConsumed. A pubkey
+            // not in the ACL (e.g. the slot was burned by a bad-HMAC attempt)
+            // still gets HandshakeConsumed.
+            if registry
+                .is_in_session_acl(&msg.session_id, &msg.client_pubkey)
+                .await
+            {
+                tracing::info!(
+                    "Register: client {:?}... already registered to session {}; idempotent ok",
+                    &msg.client_pubkey[..4],
+                    msg.session_id,
+                );
+                return RegisterResult::Ok;
+            }
             tracing::warn!("Register: slot for {} already consumed", msg.session_id);
             utils::eprintln_warn(
                 "QR already used. Run `zedra qr` from the workspace, or add `--workdir <path>` from another directory.",
@@ -1145,7 +1232,7 @@ pub async fn create_terminal(
     session: &Arc<ServerSession>,
     cols: u16,
     rows: u16,
-    opts: SpawnOptions,
+    mut opts: SpawnOptions,
 ) -> Result<String> {
     if session.terminals.lock().await.len() >= MAX_TERMINALS_PER_SESSION {
         anyhow::bail!(
@@ -1156,10 +1243,18 @@ pub async fn create_terminal(
         );
     }
 
+    let id = session.next_terminal_id().await;
+    opts.env.push(("ZEDRA_TERMINAL_ID".to_string(), id.clone()));
+    if let Some(workdir) = &opts.workdir {
+        opts.env.push((
+            "ZEDRA_WORKDIR".to_string(),
+            workdir.to_string_lossy().into_owned(),
+        ));
+    }
+
     let initial_meta = initial_host_meta(&opts);
     let shell = ShellSession::spawn(cols, rows, opts)?;
     let (pty_reader, pty_writer, master, child) = shell.take_reader();
-    let id = session.next_terminal_id().await;
 
     tracing::info!(
         "create_terminal: id={} cols={} rows={} session={}",
@@ -1909,6 +2004,7 @@ async fn dispatch(
                 SpawnOptions {
                     workdir,
                     launch_cmd,
+                    env: Vec::new(),
                 },
             )
             .await
@@ -2412,6 +2508,94 @@ async fn dispatch(
                 response_bytes: text.len(),
             });
             let _ = msg.tx.send(AiPromptResult { text, done }).await;
+        }
+
+        ZedraMessage::AgentList(msg) => {
+            session.touch().await;
+            let workdir = session.workdir.as_ref().unwrap_or(&state.workdir);
+            let result =
+                agent::list_agents(&state.agent_cache, workdir, Some(&session), msg.refresh).await;
+            let _ = msg.tx.send(result).await;
+        }
+
+        ZedraMessage::AgentSessions(msg) => {
+            session.touch().await;
+            let workdir = session.workdir.as_ref().unwrap_or(&state.workdir);
+            let result = agent::list_agent_sessions(
+                &state.agent_cache,
+                msg.kind,
+                workdir,
+                Some(&session),
+                msg.limit,
+                msg.refresh,
+            )
+            .await;
+            let _ = msg.tx.send(result).await;
+        }
+
+        ZedraMessage::AgentInstalledList(msg) => {
+            session.touch().await;
+            let result = agent::list_installed_agents(&state.agent_cache, msg.refresh).await;
+            let _ = msg.tx.send(result).await;
+        }
+
+        ZedraMessage::AgentResume(msg) => {
+            session.touch().await;
+            let workdir = session
+                .workdir
+                .clone()
+                .or_else(|| Some(state.workdir.clone()));
+            let launch_cmd = agent::resume_launch_command(msg.kind, &msg.session_id);
+            let Some(launch_cmd) = launch_cmd else {
+                let _ = msg
+                    .tx
+                    .send(AgentResumeResult {
+                        terminal_id: String::new(),
+                        error: Some("missing session id".to_string()),
+                    })
+                    .await;
+                return Ok(());
+            };
+            match create_terminal(
+                &session,
+                msg.cols,
+                msg.rows,
+                SpawnOptions {
+                    workdir,
+                    launch_cmd: Some(launch_cmd),
+                    env: Vec::new(),
+                },
+            )
+            .await
+            {
+                Ok(terminal_id) => {
+                    zedra_telemetry::send(Event::HostTerminalOpen {
+                        has_launch_cmd: true,
+                    });
+                    let terminal_count = session.terminals.lock().await.len();
+                    if let Err(e) = metrics::record_terminal_created(&state.workdir, terminal_count)
+                    {
+                        tracing::warn!("Failed to record terminal metrics: {}", e);
+                    }
+                    let _ = msg
+                        .tx
+                        .send(AgentResumeResult {
+                            terminal_id,
+                            error: None,
+                        })
+                        .await;
+                }
+                Err(e) => {
+                    tracing::warn!("AgentResume failed: {}", e);
+                    let _ = msg
+                        .tx
+                        .send(AgentResumeResult {
+                            terminal_id: String::new(),
+                            error: Some(e.to_string()),
+                        })
+                        .await;
+                }
+            }
         }
 
         // -- LSP --

--- a/crates/zedra-host/src/session_registry.rs
+++ b/crates/zedra-host/src/session_registry.rs
@@ -553,6 +553,8 @@ pub struct SessionInfo {
 pub struct TerminalInfo {
     pub id: String,
     pub title: Option<String>,
+    pub cwd: Option<String>,
+    pub icon_name: Option<String>,
     pub created_at_unix_secs: u64,
     pub created_at_elapsed_secs: u64,
     pub uptime_secs: u64,
@@ -838,10 +840,20 @@ impl SessionRegistry {
         self.sessions.lock().await.len()
     }
 
-    /// Return the first session (arbitrary order), if any.
-    /// Used by the REST API when no session_id is specified.
-    pub async fn first_session(&self) -> Option<Arc<ServerSession>> {
-        self.sessions.lock().await.values().next().cloned()
+    /// Return the most recently active session, if any.
+    /// Used by the REST API when no session_id is specified, so the request
+    /// targets the session a user is actually working in rather than an
+    /// arbitrary entry in `HashMap` iteration order.
+    pub async fn most_recent_session(&self) -> Option<Arc<ServerSession>> {
+        let sessions = self.sessions.lock().await;
+        let mut best: Option<(Instant, &Arc<ServerSession>)> = None;
+        for session in sessions.values() {
+            let last = *session.last_activity.lock().await;
+            if best.map(|(t, _)| last > t).unwrap_or(true) {
+                best = Some((last, session));
+            }
+        }
+        best.map(|(_, session)| Arc::clone(session))
     }
 
     /// List all active sessions with summary info.
@@ -927,6 +939,15 @@ impl SessionRegistry {
     /// Check if a client pubkey is in the global authorized list.
     pub async fn is_globally_authorized(&self, client_pubkey: &[u8; 32]) -> bool {
         self.authorized_clients.lock().await.contains(client_pubkey)
+    }
+
+    /// Check if a client pubkey is already in a session's ACL.
+    pub async fn is_in_session_acl(&self, session_id: &str, client_pubkey: &[u8; 32]) -> bool {
+        let sessions = self.sessions.lock().await;
+        match sessions.get(session_id) {
+            Some(session) => session.acl.lock().await.contains(client_pubkey),
+            None => false,
+        }
     }
 
     /// Add a client pubkey to the global authorized list and the session ACL.
@@ -1306,11 +1327,12 @@ impl ServerSession {
             let Some(term) = terms.get(&id) else {
                 continue;
             };
-            let title = term
+            let (title, cwd, icon_name) = term
                 .host_meta
                 .lock()
                 .ok()
-                .and_then(|meta| meta.title.clone());
+                .map(|meta| (meta.title.clone(), meta.cwd.clone(), meta.icon_name.clone()))
+                .unwrap_or((None, None, None));
             let created_at_unix_secs = term
                 .created_at
                 .duration_since(UNIX_EPOCH)
@@ -1320,6 +1342,8 @@ impl ServerSession {
             entries.push(TerminalInfo {
                 id,
                 title,
+                cwd,
+                icon_name,
                 created_at_unix_secs,
                 created_at_elapsed_secs: uptime_secs,
                 uptime_secs,

--- a/crates/zedra-host/src/setup.rs
+++ b/crates/zedra-host/src/setup.rs
@@ -9,7 +9,6 @@ use zedra_host::utils;
 const PLUGIN_REPO: &str = "tanlethanh/zedra-plugin";
 const CLAUDE_MARKETPLACE: &str = "zedra";
 const CLAUDE_PLUGIN: &str = "zedra@zedra";
-const PLUGIN_GIT_URL: &str = "https://github.com/tanlethanh/zedra-plugin.git";
 const PLUGIN_RAW_BASE: &str = "https://raw.githubusercontent.com/tanlethanh/zedra-plugin/main";
 const SKILL_NAMES: &[&str] = &[
     "zedra-start",

--- a/crates/zedra-host/src/terminal_cli.rs
+++ b/crates/zedra-host/src/terminal_cli.rs
@@ -1,0 +1,317 @@
+use anyhow::{bail, Context, Result};
+use clap::{Args, Subcommand};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use zedra_host::{identity, utils};
+
+#[derive(Debug, Args)]
+pub struct TerminalArgs {
+    #[command(subcommand)]
+    pub command: Option<TerminalCommand>,
+    #[command(flatten)]
+    pub open: TerminalOpenArgs,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum TerminalCommand {
+    /// List active terminals for this workspace
+    List(TerminalListArgs),
+    /// Show details for one active terminal
+    #[command(alias = "detail")]
+    Details(TerminalDetailsArgs),
+    /// Open a terminal on the connected phone
+    Open(TerminalOpenArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct TerminalOpenArgs {
+    /// Working directory of the running daemon
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+
+    /// Command to run in the terminal on startup (e.g. "claude --resume <id>")
+    #[arg(long)]
+    launch_cmd: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct TerminalListArgs {
+    /// Working directory of the running daemon
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Print terminal list JSON
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct TerminalDetailsArgs {
+    /// Zedra terminal id to inspect
+    #[arg(long = "tid", alias = "terminal-id")]
+    terminal_id: String,
+    /// Working directory of the running daemon
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Print terminal detail JSON
+    #[arg(long)]
+    json: bool,
+}
+
+pub async fn run(args: TerminalArgs) -> Result<()> {
+    match args.command {
+        Some(TerminalCommand::List(args)) => list(args).await,
+        Some(TerminalCommand::Details(args)) => details(args).await,
+        Some(TerminalCommand::Open(args)) => open(args).await,
+        None => open(args.open).await,
+    }
+}
+
+async fn list(args: TerminalListArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let status: serde_json::Value = api_get(&workdir, "/api/status").await?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(terminal_values(&status))?
+        );
+    } else {
+        println!("{}", render_terminal_list(&status));
+    }
+    Ok(())
+}
+
+async fn details(args: TerminalDetailsArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let status: serde_json::Value = api_get(&workdir, "/api/status").await?;
+    let terminal = find_terminal(&status, &args.terminal_id)
+        .with_context(|| format!("terminal id not found: {}", args.terminal_id))?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(terminal)?);
+    } else {
+        println!("{}", render_terminal_details(terminal));
+    }
+    Ok(())
+}
+
+async fn open(args: TerminalOpenArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let body = serde_json::json!({ "launch_cmd": args.launch_cmd.as_deref() });
+    let response: serde_json::Value = api_post(&workdir, "/api/terminal", &body).await?;
+    println!(
+        "{}",
+        render_terminal_created_output(&response, args.launch_cmd.as_deref())
+    );
+    Ok(())
+}
+
+fn render_terminal_list(status: &serde_json::Value) -> String {
+    let terminals = terminal_values(status);
+    let mut sections = vec!["Active Terminals".to_string(), String::new()];
+    if terminals.is_empty() {
+        sections.push("No active terminals.".to_string());
+        return sections.join("\n");
+    }
+
+    let rows = terminals.iter().map(terminal_row).collect::<Vec<_>>();
+    sections.push(utils::render_table(
+        &["ID", "TITLE", "CWD", "UPTIME"],
+        &rows,
+    ));
+    sections.join("\n")
+}
+
+fn terminal_row(terminal: &serde_json::Value) -> Vec<String> {
+    vec![
+        terminal["id"].as_str().unwrap_or("-").to_string(),
+        non_empty_str(&terminal["title"])
+            .unwrap_or("(untitled)")
+            .to_string(),
+        non_empty_str(&terminal["cwd"]).unwrap_or("-").to_string(),
+        terminal["uptime_secs"]
+            .as_u64()
+            .map(utils::format_duration)
+            .unwrap_or_else(|| "-".to_string()),
+    ]
+}
+
+fn render_terminal_details(terminal: &serde_json::Value) -> String {
+    let session = non_empty_str(&terminal["session_name"]).unwrap_or("-");
+    let rows = vec![
+        ("ID", terminal["id"].as_str().unwrap_or("-").to_string()),
+        (
+            "Title",
+            non_empty_str(&terminal["title"])
+                .unwrap_or("(untitled)")
+                .to_string(),
+        ),
+        (
+            "CWD",
+            non_empty_str(&terminal["cwd"]).unwrap_or("-").to_string(),
+        ),
+        (
+            "Uptime",
+            terminal["uptime_secs"]
+                .as_u64()
+                .map(utils::format_duration)
+                .unwrap_or_else(|| "-".to_string()),
+        ),
+        (
+            "Created",
+            terminal["created_at_elapsed_secs"]
+                .as_u64()
+                .map(|secs| format!("{} ago", utils::format_duration(secs)))
+                .unwrap_or_else(|| "-".to_string()),
+        ),
+        ("Session", session.to_string()),
+        (
+            "Session ID",
+            terminal["session_id"].as_str().unwrap_or("-").to_string(),
+        ),
+        (
+            "Icon",
+            non_empty_str(&terminal["icon_name"])
+                .unwrap_or("-")
+                .to_string(),
+        ),
+    ];
+
+    format!("Terminal Details\n\n{}", utils::render_key_values(&rows))
+}
+
+fn render_terminal_created_output(
+    response: &serde_json::Value,
+    launch_cmd: Option<&str>,
+) -> String {
+    let id = response["id"].as_str().unwrap_or("-");
+    let session_id = response["session_id"].as_str().unwrap_or("-");
+    let mut rows = vec![("ID", id.to_string()), ("Session", session_id.to_string())];
+    if let Some(launch_cmd) = launch_cmd.filter(|command| !command.is_empty()) {
+        rows.push(("Command", launch_cmd.to_string()));
+    }
+
+    format!("Terminal Opened\n\n{}", utils::render_key_values(&rows))
+}
+
+async fn api_get<T: DeserializeOwned>(workdir: &Path, path: &str) -> Result<T> {
+    let (addr, token) = daemon_api(workdir)?;
+    let url = format!("http://{}{}", addr.trim(), path);
+    let response = reqwest::Client::new()
+        .get(url)
+        .bearer_auth(token.trim())
+        .send()
+        .await
+        .context("failed to reach daemon")?;
+    decode_response(response).await
+}
+
+async fn api_post<T: DeserializeOwned, B: Serialize>(
+    workdir: &Path,
+    path: &str,
+    body: &B,
+) -> Result<T> {
+    let (addr, token) = daemon_api(workdir)?;
+    let url = format!("http://{}{}", addr.trim(), path);
+    let response = reqwest::Client::new()
+        .post(url)
+        .bearer_auth(token.trim())
+        .json(body)
+        .send()
+        .await
+        .context("failed to reach daemon")?;
+    decode_response(response).await
+}
+
+async fn decode_response<T: DeserializeOwned>(response: reqwest::Response) -> Result<T> {
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!("daemon returned HTTP {status}: {text}");
+    }
+    serde_json::from_str(&text).with_context(|| format!("failed to decode daemon response: {text}"))
+}
+
+fn daemon_api(workdir: &Path) -> Result<(String, String)> {
+    let config_dir = identity::workspace_config_dir(workdir)?;
+    let addr = std::fs::read_to_string(config_dir.join("api-addr")).unwrap_or_default();
+    let token = std::fs::read_to_string(config_dir.join("api-token")).unwrap_or_default();
+    if addr.trim().is_empty() {
+        bail!("No running daemon found for: {}", workdir.display());
+    }
+    Ok((addr, token))
+}
+
+fn resolve_workdir(raw: &str) -> PathBuf {
+    PathBuf::from(raw)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(raw))
+}
+
+fn non_empty_str(value: &serde_json::Value) -> Option<&str> {
+    value.as_str().filter(|value| !value.is_empty())
+}
+
+fn terminal_values(status: &serde_json::Value) -> &[serde_json::Value] {
+    status["terminals"]
+        .as_array()
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+}
+
+fn find_terminal<'a>(
+    status: &'a serde_json::Value,
+    terminal_id: &str,
+) -> Option<&'a serde_json::Value> {
+    terminal_values(status)
+        .iter()
+        .find(|terminal| terminal["id"].as_str() == Some(terminal_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_list_renders_full_ids() {
+        let status = serde_json::json!({
+            "terminals": [{
+                "id": "terminal-full-id",
+                "title": "claude",
+                "cwd": "/repo",
+                "uptime_secs": 5,
+                "session_name": "zedra-main",
+                "icon_name": "claude"
+            }]
+        });
+
+        let output = render_terminal_list(&status);
+        assert!(output.contains("terminal-full-id"));
+        assert!(output.contains("/repo"));
+        assert!(output.contains("ID"));
+        assert!(output.contains("TITLE"));
+        assert!(output.contains("CWD"));
+        assert!(output.contains("UPTIME"));
+        assert!(!output.contains("SESSION"));
+        assert!(!output.contains("ICON"));
+    }
+
+    #[test]
+    fn terminal_details_renders_extra_fields_for_one_terminal() {
+        let terminal = serde_json::json!({
+            "id": "terminal-full-id",
+            "title": "claude",
+            "cwd": "/repo",
+            "uptime_secs": 65,
+            "created_at_elapsed_secs": 70,
+            "session_id": "session-full-id",
+            "session_name": "zedra-main",
+            "icon_name": "claude"
+        });
+
+        let output = render_terminal_details(&terminal);
+        assert!(output.contains("Terminal Details"));
+        assert!(output.contains("terminal-full-id"));
+        assert!(output.contains("1m5s"));
+        assert!(output.contains("session-full-id"));
+    }
+}

--- a/crates/zedra-host/src/utils.rs
+++ b/crates/zedra-host/src/utils.rs
@@ -184,6 +184,17 @@ pub fn format_duration(secs: u64) -> String {
     }
 }
 
+pub fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let mut end = max_chars;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &text[..end])
+}
+
 pub fn shell_arg_path(path: &Path) -> String {
     shell_arg(&path.display().to_string())
 }
@@ -263,5 +274,11 @@ mod tests {
         assert_eq!(format_duration(59), "59s");
         assert_eq!(format_duration(65), "1m5s");
         assert_eq!(format_duration(3661), "1h1m");
+    }
+
+    #[test]
+    fn truncate_chars_respects_char_boundary() {
+        assert_eq!(truncate_chars("hello", 10), "hello");
+        assert_eq!(truncate_chars("abcdef", 3), "abc…");
     }
 }

--- a/crates/zedra-rpc/Cargo.toml
+++ b/crates/zedra-rpc/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 serde.workspace = true
+chrono.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 iroh.workspace = true

--- a/crates/zedra-rpc/src/proto.rs
+++ b/crates/zedra-rpc/src/proto.rs
@@ -8,6 +8,7 @@
 //   PKI reconnect:   Connect(None) → Challenge → AuthProve → Ok(SyncSessionResult) → (RPC calls)
 //   Health:          Ping → Pong (every 2s, foreground only)
 
+use chrono::{DateTime, Utc};
 use irpc::channel::{mpsc, oneshot};
 use irpc::rpc_requests;
 use serde::{Deserialize, Serialize};
@@ -163,6 +164,26 @@ pub enum ZedraProto {
     /// Kept at enum tail because protocol variants are append-only.
     #[rpc(tx = oneshot::Sender<FsDocsTreeResult>)]
     FsDocsTree(FsDocsTreeReq),
+
+    /// List supported managed AI agents for the active workspace.
+    /// Kept at enum tail because protocol variants are append-only.
+    #[rpc(tx = oneshot::Sender<AgentListResult>)]
+    AgentList(AgentListReq),
+
+    /// List known sessions for one managed AI agent.
+    /// Kept at enum tail because protocol variants are append-only.
+    #[rpc(tx = oneshot::Sender<AgentSessionsResult>)]
+    AgentSessions(AgentSessionsReq),
+
+    /// Resume a managed-agent session by creating a new terminal.
+    /// Kept at enum tail because protocol variants are append-only.
+    #[rpc(tx = oneshot::Sender<AgentResumeResult>)]
+    AgentResume(AgentResumeReq),
+
+    /// List installed terminal AI agents with host-owned launch commands.
+    /// Kept at enum tail because protocol variants are append-only.
+    #[rpc(tx = oneshot::Sender<AgentInstalledListResult>)]
+    AgentInstalledList(AgentInstalledListReq),
 }
 
 // ---------------------------------------------------------------------------
@@ -915,6 +936,327 @@ pub struct AiPromptResult {
 }
 
 // ---------------------------------------------------------------------------
+// Managed AI agent types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum ManagedAgentKind {
+    Claude,
+    Codex,
+    OpenCode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentListReq {
+    #[serde(default)]
+    pub refresh: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentListResult {
+    pub agents: Vec<AgentSummary>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentSessionsReq {
+    pub kind: ManagedAgentKind,
+    /// When false, return the host cache populated at daemon start unless missing.
+    #[serde(default)]
+    pub refresh: bool,
+    /// Maximum sessions to return. `0` uses the host default (`50`).
+    #[serde(default)]
+    pub limit: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentSessionsResult {
+    pub sessions: Vec<AgentSessionSummary>,
+    /// Total workspace-matching sessions before applying `limit`.
+    pub total: u32,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentResumeReq {
+    pub kind: ManagedAgentKind,
+    pub session_id: String,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentResumeResult {
+    pub terminal_id: String,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentInstalledListReq {
+    #[serde(default)]
+    pub refresh: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentInstalledListResult {
+    pub agents: Vec<InstalledAgentEntry>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InstalledAgentEntry {
+    pub slug: String,
+    pub display_name: String,
+    pub icon_name: String,
+    pub available: bool,
+    pub version: Option<String>,
+    pub launch_cmd: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentSummary {
+    pub kind: ManagedAgentKind,
+    pub display_name: String,
+    pub cli: AgentCliSummary,
+    pub setup: AgentSetupSummary,
+    pub capabilities: AgentCapabilities,
+    pub workspace: AgentWorkspaceSummary,
+    pub sessions: AgentSessionCounts,
+    pub live: AgentLiveSummary,
+    pub last_activity_at: Option<DateTime<Utc>>,
+    pub updated_at: DateTime<Utc>,
+    pub data_sources: Vec<AgentDataSource>,
+    pub warnings: Vec<AgentWarning>,
+    pub account: AgentAccountSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct AgentAccountSummary {
+    pub fields: Vec<AgentInfoField>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentInfoField {
+    pub label: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentCliSummary {
+    pub available: bool,
+    pub version: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentSetupSummary {
+    pub state: AgentSetupState,
+    pub skills_installed: bool,
+    pub plugin_installed: bool,
+    pub hooks_installed: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AgentSetupState {
+    MissingCli,
+    NotConfigured,
+    SkillsOnly,
+    HooksReady,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentCapabilities {
+    pub list_sessions: bool,
+    pub resume_session: bool,
+    pub live_binding: bool,
+    pub confirm_action: bool,
+    pub select_action: bool,
+    pub lifecycle_events: bool,
+    pub usage_snapshot: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentWorkspaceSummary {
+    pub workdir: String,
+    pub provider_project_id: Option<String>,
+    pub provider_project_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentSessionCounts {
+    pub total: usize,
+    pub resumable: usize,
+    pub active_live: usize,
+    pub latest_session_id: Option<String>,
+    pub latest_session_title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentLiveSummary {
+    pub active_terminal_ids: Vec<String>,
+    pub pending_action_count: usize,
+    pub latest_event: Option<AgentEventSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentSessionSummary {
+    pub kind: ManagedAgentKind,
+    pub session_id: String,
+    pub title: Option<String>,
+    pub cwd: Option<String>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub last_activity_at: Option<DateTime<Utc>>,
+    pub resume: AgentResumeSummary,
+    pub live: AgentSessionLiveSummary,
+    pub provider: AgentProviderSessionInfo,
+    pub git: Option<AgentGitSummary>,
+    pub usage: Option<AgentUsageSnapshot>,
+    pub counters: AgentSessionCounters,
+    pub flags: AgentSessionFlags,
+    pub data_sources: Vec<AgentDataSource>,
+    pub warnings: Vec<AgentWarning>,
+    pub transcript_size_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentResumeSummary {
+    pub available: bool,
+    pub unavailable_reason: Option<String>,
+    pub action_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentSessionLiveSummary {
+    pub terminal_id: Option<String>,
+    pub status: AgentLifecycleStatus,
+    pub pending_action_count: usize,
+    pub current_turn_id: Option<String>,
+    pub latest_event: Option<AgentEventSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentProviderSessionInfo {
+    pub model: Option<String>,
+    pub permission_mode: Option<String>,
+    pub cli_version: Option<String>,
+    pub origin: Option<String>,
+    pub source: Option<String>,
+    pub entrypoint: Option<String>,
+    pub native_project_id: Option<String>,
+    pub model_provider: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentGitSummary {
+    pub branch: Option<String>,
+    pub worktree: Option<String>,
+    pub commit_hash: Option<String>,
+    pub repository_url: Option<String>,
+    pub pr_number: Option<u64>,
+    pub pr_url: Option<String>,
+    pub pr_repository: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentUsageSnapshot {
+    pub context_used_percent: Option<f32>,
+    pub total_cost_usd: Option<f64>,
+    pub total_duration_ms: Option<u64>,
+    pub total_api_duration_ms: Option<u64>,
+    pub lines_added: Option<i64>,
+    pub lines_removed: Option<i64>,
+    pub rate_limit_five_hour_used_percent: Option<f32>,
+    pub rate_limit_seven_day_used_percent: Option<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentSessionCounters {
+    pub record_count: u64,
+    pub message_count: u64,
+    pub turn_count: u64,
+    pub tool_count: u64,
+    pub tool_failure_count: u64,
+    pub hook_success_count: u64,
+    pub hook_failure_count: u64,
+    pub malformed_record_count: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentSessionFlags {
+    pub is_sidechain: bool,
+    pub is_subagent: bool,
+    pub is_archived: bool,
+    pub historical_only: bool,
+    pub live_bound: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentEventSummary {
+    pub kind: AgentEventKind,
+    pub status: AgentLifecycleStatus,
+    pub at: Option<DateTime<Utc>>,
+    pub terminal_id: Option<String>,
+    pub session_id: Option<String>,
+    pub turn_id: Option<String>,
+    pub tool_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AgentLifecycleStatus {
+    Unknown,
+    Starting,
+    Running,
+    WaitingForUser,
+    WaitingForPermission,
+    Idle,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AgentEventKind {
+    SessionStarted,
+    SessionUpdated,
+    TurnStarted,
+    TurnCompleted,
+    TurnFailed,
+    TaskCreated,
+    TaskCompleted,
+    TaskFailed,
+    ToolStarted,
+    ToolCompleted,
+    ToolFailed,
+    PermissionRequested,
+    PermissionResolved,
+    Notification,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AgentActionKind {
+    Confirm,
+    Select,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AgentDataSource {
+    Cli,
+    Setup,
+    HistoricalScan,
+    TerminalMetadata,
+    HookState,
+    StatusLine,
+    ProviderCli,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentWarning {
+    pub code: String,
+    pub message: String,
+}
+
+// ---------------------------------------------------------------------------
 // LSP types
 // ---------------------------------------------------------------------------
 
@@ -1115,5 +1457,153 @@ mod tests {
         let encoded = postcard::to_allocvec(&snapshot).unwrap();
         let decoded: HostInfoSnapshot = postcard::from_bytes(&encoded).unwrap();
         assert_eq!(decoded, snapshot);
+    }
+
+    #[test]
+    fn agent_summary_roundtrip() {
+        let now = Utc::now();
+        let result = AgentListResult {
+            agents: vec![AgentSummary {
+                kind: ManagedAgentKind::Claude,
+                display_name: "Claude".into(),
+                cli: AgentCliSummary {
+                    available: true,
+                    version: Some("2.1.138".into()),
+                    error: None,
+                },
+                setup: AgentSetupSummary {
+                    state: AgentSetupState::HooksReady,
+                    skills_installed: false,
+                    plugin_installed: true,
+                    hooks_installed: true,
+                    error: None,
+                },
+                capabilities: AgentCapabilities {
+                    list_sessions: true,
+                    resume_session: true,
+                    live_binding: true,
+                    confirm_action: true,
+                    select_action: true,
+                    lifecycle_events: true,
+                    usage_snapshot: true,
+                },
+                workspace: AgentWorkspaceSummary {
+                    workdir: "/repo".into(),
+                    provider_project_id: None,
+                    provider_project_key: None,
+                },
+                sessions: AgentSessionCounts {
+                    total: 1,
+                    resumable: 1,
+                    active_live: 0,
+                    latest_session_id: Some("session".into()),
+                    latest_session_title: None,
+                },
+                live: AgentLiveSummary {
+                    active_terminal_ids: vec!["term".into()],
+                    pending_action_count: 1,
+                    latest_event: Some(AgentEventSummary {
+                        kind: AgentEventKind::PermissionRequested,
+                        status: AgentLifecycleStatus::WaitingForPermission,
+                        at: Some(now),
+                        terminal_id: Some("term".into()),
+                        session_id: Some("session".into()),
+                        turn_id: Some("turn".into()),
+                        tool_name: Some("Bash".into()),
+                    }),
+                },
+                last_activity_at: Some(now),
+                updated_at: now,
+                data_sources: vec![AgentDataSource::HistoricalScan],
+                warnings: vec![AgentWarning {
+                    code: "fixture".into(),
+                    message: "fixture warning".into(),
+                }],
+                account: AgentAccountSummary::default(),
+            }],
+            error: None,
+        };
+
+        let encoded = postcard::to_allocvec(&result).unwrap();
+        let decoded: AgentListResult = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(decoded, result);
+    }
+
+    #[test]
+    fn agent_session_summary_roundtrip() {
+        let now = Utc::now();
+        let session = AgentSessionSummary {
+            kind: ManagedAgentKind::Codex,
+            session_id: "019e".into(),
+            title: Some("Work session".into()),
+            cwd: Some("/repo".into()),
+            created_at: Some(now),
+            last_activity_at: Some(now),
+            resume: AgentResumeSummary {
+                available: true,
+                unavailable_reason: None,
+                action_id: Some("codex:019e".into()),
+            },
+            live: AgentSessionLiveSummary {
+                terminal_id: Some("term".into()),
+                status: AgentLifecycleStatus::Running,
+                pending_action_count: 0,
+                current_turn_id: Some("turn".into()),
+                latest_event: None,
+            },
+            provider: AgentProviderSessionInfo {
+                model: Some("gpt-5.3-codex".into()),
+                permission_mode: Some("on-request".into()),
+                cli_version: Some("0.130.0".into()),
+                origin: Some("codex_cli".into()),
+                source: Some("cli".into()),
+                entrypoint: None,
+                native_project_id: None,
+                model_provider: Some("openai".into()),
+            },
+            git: Some(AgentGitSummary {
+                branch: Some("main".into()),
+                worktree: None,
+                commit_hash: Some("abc".into()),
+                repository_url: Some("https://example.com/repo.git".into()),
+                pr_number: None,
+                pr_url: None,
+                pr_repository: None,
+            }),
+            usage: Some(AgentUsageSnapshot {
+                context_used_percent: Some(50.0),
+                total_cost_usd: Some(0.1),
+                total_duration_ms: Some(1000),
+                total_api_duration_ms: Some(900),
+                lines_added: Some(3),
+                lines_removed: Some(1),
+                rate_limit_five_hour_used_percent: None,
+                rate_limit_seven_day_used_percent: None,
+            }),
+            counters: AgentSessionCounters {
+                record_count: 3,
+                message_count: 0,
+                turn_count: 1,
+                tool_count: 0,
+                tool_failure_count: 0,
+                hook_success_count: 0,
+                hook_failure_count: 0,
+                malformed_record_count: 0,
+            },
+            flags: AgentSessionFlags {
+                is_sidechain: false,
+                is_subagent: false,
+                is_archived: false,
+                historical_only: true,
+                live_bound: false,
+            },
+            data_sources: vec![AgentDataSource::HistoricalScan],
+            warnings: vec![],
+            transcript_size_bytes: Some(4096),
+        };
+
+        let encoded = postcard::to_allocvec(&session).unwrap();
+        let decoded: AgentSessionSummary = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(decoded, session);
     }
 }

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -545,6 +545,75 @@ impl SessionHandle {
         }
     }
 
+    pub async fn agent_installed_list(&self, refresh: bool) -> Result<Vec<InstalledAgentEntry>> {
+        let result: AgentInstalledListResult = self
+            .client()?
+            .rpc(AgentInstalledListReq { refresh })
+            .await?;
+        if let Some(e) = result.error {
+            return Err(anyhow::anyhow!(e));
+        }
+        Ok(result.agents)
+    }
+
+    pub async fn agent_list(&self, refresh: bool) -> Result<Vec<AgentSummary>> {
+        let result: AgentListResult = self.client()?.rpc(AgentListReq { refresh }).await?;
+        if let Some(e) = result.error {
+            return Err(anyhow::anyhow!(e));
+        }
+        Ok(result.agents)
+    }
+
+    pub async fn agent_sessions(
+        &self,
+        kind: ManagedAgentKind,
+        refresh: bool,
+        limit: u32,
+    ) -> Result<Vec<AgentSessionSummary>> {
+        let result: AgentSessionsResult = self
+            .client()?
+            .rpc(AgentSessionsReq {
+                kind,
+                refresh,
+                limit,
+            })
+            .await?;
+        if let Some(e) = result.error {
+            return Err(anyhow::anyhow!(e));
+        }
+        Ok(result.sessions)
+    }
+
+    pub async fn agent_resume_session(
+        &self,
+        kind: ManagedAgentKind,
+        session_id: String,
+        cols: u16,
+        rows: u16,
+    ) -> Result<String> {
+        let client = self.client()?;
+        let result: AgentResumeResult = client
+            .rpc(AgentResumeReq {
+                kind,
+                session_id,
+                cols,
+                rows,
+            })
+            .await?;
+        if let Some(e) = result.error {
+            return Err(anyhow::anyhow!(e));
+        }
+
+        let terminal = RemoteTerminal::new(result.terminal_id.clone());
+        if terminal.attach_remote(&client).await.is_ok() {
+            self.add_terminal(terminal);
+            tracing::info!("Agent session resumed in terminal: {}", result.terminal_id);
+            Ok(result.terminal_id)
+        } else {
+            Err(anyhow::anyhow!("Failed to attach resumed agent terminal"))
+        }
+    }
+
     pub async fn terminal_resize(&self, id: &str, cols: u16, rows: u16) -> Result<()> {
         let _: TermResizeResult = self
             .client()?

--- a/crates/zedra-session/src/state.rs
+++ b/crates/zedra-session/src/state.rs
@@ -250,6 +250,11 @@ pub struct ConnectSnapshot {
     pub hole_punch_ms: Option<u64>,
     pub rpc_ms: Option<u64>,
     pub register_ms: Option<u64>,
+    /// Set once a Register handshake has been attempted this process. Sticky
+    /// across reconnects: a one-time pairing ticket must not be resent after
+    /// registration was attempted, even if `register_ms` is missing because
+    /// the connection dropped before `RegisterComplete` was observed.
+    pub register_attempted: bool,
     pub auth_ms: Option<u64>,
     pub sync_ms: Option<u64>,
     pub resume_ms: Option<u64>,
@@ -383,6 +388,7 @@ impl SessionState {
                 self.phase = ConnectPhase::Registering;
                 snap.session_id = Some(session_id);
                 snap.is_first_pairing = true;
+                snap.register_attempted = true;
             }
             ConnectEvent::RegisterComplete { register_ms } => {
                 snap.register_ms = Some(register_ms);
@@ -596,6 +602,8 @@ fn classify_ip(ip: std::net::IpAddr) -> NetworkHint {
     }
 }
 
+/// Last path component of a workdir. Splits on both `/` and `\` so a Windows
+/// host workdir yields the project folder, and trims trailing separators.
 fn project_name_from_workdir(workdir: &str) -> String {
     workdir
         .trim_end_matches(['/', '\\'])

--- a/crates/zedra/Cargo.toml
+++ b/crates/zedra/Cargo.toml
@@ -57,6 +57,7 @@ iroh.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
 rust-embed = { workspace = true, features = ["debug-embed"] }
+chrono.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies]
 gpui_android = { path = "../../vendor/zed/crates/gpui_android" }

--- a/crates/zedra/Cargo.toml
+++ b/crates/zedra/Cargo.toml
@@ -27,6 +27,7 @@ futures.workspace = true
 tokio.workspace = true
 once_cell = "1.19"
 pulldown-cmark = "0.13"
+mermaid-rs-renderer = { version = "0.2.2", default-features = false }
 
 # Syntax highlighting
 tree-sitter = "0.26"

--- a/crates/zedra/src/agent_manage_view.rs
+++ b/crates/zedra/src/agent_manage_view.rs
@@ -1,0 +1,477 @@
+use gpui::*;
+use tracing::error;
+use zedra_rpc::proto::{AgentSetupState, AgentSummary, ManagedAgentKind};
+use zedra_session::SessionHandle;
+
+use crate::agent_session_list::{
+    AgentSessionListProps, agent_icon, kind_slug, managed_agent_name, render_agent_session_list,
+};
+use crate::platform_bridge::{self, HapticFeedback};
+use crate::theme;
+
+#[derive(Clone, Debug)]
+enum LoadState {
+    Loading,
+    Ready,
+    Error(String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Screen {
+    List,
+    Detail(ManagedAgentKind),
+}
+
+pub struct AgentManageView {
+    session_handle: SessionHandle,
+    agents: Vec<AgentSummary>,
+    sessions: Vec<zedra_rpc::proto::AgentSessionSummary>,
+    screen: Screen,
+    agent_state: LoadState,
+    session_state: LoadState,
+    loading_epoch: u64,
+    _tasks: Vec<Task<()>>,
+}
+
+impl AgentManageView {
+    pub fn new(session_handle: SessionHandle, cx: &mut Context<Self>) -> Self {
+        let mut view = Self {
+            session_handle,
+            agents: Vec::new(),
+            sessions: Vec::new(),
+            screen: Screen::List,
+            agent_state: LoadState::Loading,
+            session_state: LoadState::Ready,
+            loading_epoch: 0,
+            _tasks: Vec::new(),
+        };
+        view.load_agents(false, cx);
+        view
+    }
+
+    fn load_agents(&mut self, refresh: bool, cx: &mut Context<Self>) {
+        self.loading_epoch = self.loading_epoch.wrapping_add(1);
+        let epoch = self.loading_epoch;
+        self.agent_state = LoadState::Loading;
+        self.session_state = LoadState::Ready;
+        cx.notify();
+
+        let handle = self.session_handle.clone();
+        let task = cx.spawn(
+            async move |this, cx| match handle.agent_list(refresh).await {
+                Ok(agents) => {
+                    let _ = this.update(cx, |this, cx| {
+                        if this.loading_epoch != epoch {
+                            return;
+                        }
+                        this.agents = agents;
+                        this.agent_state = LoadState::Ready;
+                        if let Screen::Detail(kind) = this.screen {
+                            if this.agents.iter().any(|agent| agent.kind == kind) {
+                                this.fetch_sessions(kind, refresh, cx);
+                            } else {
+                                this.screen = Screen::List;
+                                this.sessions.clear();
+                            }
+                        }
+                        cx.notify();
+                    });
+                }
+                Err(err) => {
+                    error!("agent list failed: {}", err);
+                    let _ = this.update(cx, |this, cx| {
+                        if this.loading_epoch != epoch {
+                            return;
+                        }
+                        this.agent_state = LoadState::Error(err.to_string());
+                        this.sessions.clear();
+                        cx.notify();
+                    });
+                }
+            },
+        );
+        self._tasks.push(task);
+    }
+
+    fn open_agent(&mut self, kind: ManagedAgentKind, cx: &mut Context<Self>) {
+        self.screen = Screen::Detail(kind);
+        self.fetch_sessions(kind, false, cx);
+        cx.notify();
+    }
+
+    fn back_to_list(&mut self, cx: &mut Context<Self>) {
+        self.screen = Screen::List;
+        self.sessions.clear();
+        self.session_state = LoadState::Ready;
+        cx.notify();
+    }
+
+    fn fetch_sessions(&mut self, kind: ManagedAgentKind, refresh: bool, cx: &mut Context<Self>) {
+        self.loading_epoch = self.loading_epoch.wrapping_add(1);
+        let epoch = self.loading_epoch;
+        self.sessions.clear();
+        self.session_state = LoadState::Loading;
+        cx.notify();
+
+        let handle = self.session_handle.clone();
+        let task =
+            cx.spawn(
+                async move |this, cx| match handle.agent_sessions(kind, refresh, 0).await {
+                    Ok(sessions) => {
+                        let _ = this.update(cx, |this, cx| {
+                            if this.loading_epoch != epoch {
+                                return;
+                            }
+                            if this.screen != Screen::Detail(kind) {
+                                return;
+                            }
+                            this.sessions = sessions;
+                            this.session_state = LoadState::Ready;
+                            cx.notify();
+                        });
+                    }
+                    Err(err) => {
+                        error!(?kind, "agent sessions failed: {}", err);
+                        let _ = this.update(cx, |this, cx| {
+                            if this.loading_epoch != epoch || this.screen != Screen::Detail(kind) {
+                                return;
+                            }
+                            this.sessions.clear();
+                            this.session_state = LoadState::Error(err.to_string());
+                            cx.notify();
+                        });
+                    }
+                },
+            );
+        self._tasks.push(task);
+    }
+
+    fn selected_agent(&self) -> Option<&AgentSummary> {
+        let Screen::Detail(kind) = self.screen else {
+            return None;
+        };
+        self.agents.iter().find(|agent| agent.kind == kind)
+    }
+
+    fn render_list(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let mut list = div()
+            .id("agent-manage-list")
+            .flex_1()
+            .min_h_0()
+            .overflow_y_scroll()
+            .px(px(theme::SPACING_MD))
+            .pb(px(theme::SPACING_MD))
+            .flex()
+            .flex_col()
+            .gap(px(theme::SPACING_SM));
+
+        for agent in self.agents.clone() {
+            let kind = agent.kind;
+            list = list.child(
+                div()
+                    .id(SharedString::from(format!(
+                        "agent-manage-row-{}",
+                        kind_slug(kind)
+                    )))
+                    .px(px(theme::SPACING_MD))
+                    .py(px(theme::SPACING_SM))
+                    .rounded(px(6.0))
+                    .border_1()
+                    .border_color(rgb(theme::BORDER_SUBTLE))
+                    .bg(rgb(theme::BG_CARD))
+                    .cursor_pointer()
+                    .on_press(cx.listener(move |this, _event, _window, cx| {
+                        platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
+                        this.open_agent(kind, cx);
+                    }))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap(px(8.0))
+                            .child(
+                                svg()
+                                    .path(agent_icon(kind))
+                                    .size(px(theme::ICON_SM))
+                                    .text_color(rgb(theme::TEXT_MUTED)),
+                            )
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .child(
+                                        div()
+                                            .truncate()
+                                            .text_size(px(theme::FONT_BODY))
+                                            .text_color(rgb(theme::TEXT_PRIMARY))
+                                            .child(agent.display_name.clone()),
+                                    )
+                                    .child(
+                                        div()
+                                            .truncate()
+                                            .text_size(px(theme::FONT_DETAIL))
+                                            .text_color(rgb(theme::TEXT_MUTED))
+                                            .child(format!(
+                                                "{} · {} sessions",
+                                                setup_label(agent.setup.state),
+                                                agent.sessions.resumable.max(agent.sessions.total)
+                                            )),
+                                    ),
+                            ),
+                    ),
+            );
+        }
+        list
+    }
+
+    fn render_detail(&self, cx: &mut Context<Self>) -> Div {
+        let Some(agent) = self.selected_agent() else {
+            return empty_text("No agent selected.");
+        };
+        let kind = agent.kind;
+
+        div()
+            .flex_1()
+            .min_h_0()
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .px(px(theme::SPACING_MD))
+                    .pt(px(theme::SPACING_SM))
+                    .pb(px(theme::SPACING_SM))
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap(px(theme::SPACING_SM))
+                    .child(back_button(cx))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .child(
+                                div()
+                                    .truncate()
+                                    .text_size(px(theme::FONT_BODY))
+                                    .text_color(rgb(theme::TEXT_PRIMARY))
+                                    .child(agent.display_name.clone()),
+                            )
+                            .child(
+                                div()
+                                    .truncate()
+                                    .text_size(px(theme::FONT_DETAIL))
+                                    .text_color(rgb(theme::TEXT_MUTED))
+                                    .child(managed_agent_name(kind)),
+                            ),
+                    )
+                    .child(refresh_button(cx)),
+            )
+            .child(render_detail_summary(agent))
+            .child(section_header("Sessions"))
+            .child(render_agent_session_list(
+                AgentSessionListProps {
+                    sections: crate::agent_session_list::group_sessions_by_day(
+                        self.sessions.clone(),
+                    ),
+                    loading: matches!(self.session_state, LoadState::Loading),
+                    error: match &self.session_state {
+                        LoadState::Error(message) => Some(message.clone()),
+                        _ => None,
+                    },
+                    empty_message: "No sessions found for this agent.",
+                    resume_on_tap: true,
+                },
+                cx,
+            ))
+    }
+}
+
+impl Render for AgentManageView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let mut root = div()
+            .id("agent-manage-view")
+            .size_full()
+            .min_h_0()
+            .bg(rgb(theme::BG_PRIMARY))
+            .flex()
+            .flex_col();
+
+        match &self.agent_state {
+            LoadState::Loading => {
+                root = root.child(empty_text("Loading managed agents..."));
+            }
+            LoadState::Error(message) => {
+                root = root
+                    .child(empty_text(format!(
+                        "Failed to load managed agents: {message}"
+                    )))
+                    .child(refresh_button(cx));
+            }
+            LoadState::Ready => {
+                root = match self.screen {
+                    Screen::List => root.child(self.render_list(cx)),
+                    Screen::Detail(_) => root.child(self.render_detail(cx)),
+                };
+            }
+        }
+        root
+    }
+}
+
+fn render_detail_summary(agent: &AgentSummary) -> Div {
+    let mut summary = div()
+        .mx(px(theme::SPACING_MD))
+        .mb(px(theme::SPACING_SM))
+        .px(px(theme::SPACING_MD))
+        .py(px(theme::SPACING_SM))
+        .rounded(px(6.0))
+        .border_1()
+        .border_color(rgb(theme::BORDER_SUBTLE))
+        .bg(rgb(theme::BG_CARD))
+        .flex()
+        .flex_col()
+        .gap(px(4.0));
+
+    let cli = if agent.cli.available {
+        agent
+            .cli
+            .version
+            .clone()
+            .unwrap_or_else(|| "available".to_string())
+    } else {
+        agent
+            .cli
+            .error
+            .clone()
+            .unwrap_or_else(|| "missing".to_string())
+    };
+
+    summary = summary
+        .child(summary_line("CLI", cli))
+        .child(summary_line(
+            "Setup",
+            setup_label(agent.setup.state).to_string(),
+        ))
+        .child(summary_line(
+            "Sessions",
+            format!(
+                "{} resumable / {} total",
+                agent.sessions.resumable, agent.sessions.total
+            ),
+        ));
+
+    for field in &agent.account.fields {
+        summary = summary.child(summary_line(&field.label, field.value.clone()));
+    }
+
+    if !agent.warnings.is_empty() {
+        summary = summary.child(summary_line(
+            "Warnings",
+            agent
+                .warnings
+                .iter()
+                .map(|warning| warning.code.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+        ));
+    }
+    summary
+}
+
+fn back_button(cx: &mut Context<AgentManageView>) -> Stateful<Div> {
+    div()
+        .id("agent-manage-back-btn")
+        .px(px(8.0))
+        .py(px(6.0))
+        .rounded(px(6.0))
+        .border_1()
+        .border_color(rgb(theme::BORDER_SUBTLE))
+        .cursor_pointer()
+        .on_press(cx.listener(|this, _event, _window, cx| {
+            platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
+            this.back_to_list(cx);
+        }))
+        .child(
+            svg()
+                .path("icons/chevron-left.svg")
+                .size(px(theme::ICON_SM))
+                .text_color(rgb(theme::TEXT_SECONDARY)),
+        )
+}
+
+fn refresh_button(cx: &mut Context<AgentManageView>) -> Stateful<Div> {
+    div()
+        .id("agent-manage-refresh-btn")
+        .px(px(10.0))
+        .py(px(6.0))
+        .rounded(px(6.0))
+        .border_1()
+        .border_color(rgb(theme::BORDER_SUBTLE))
+        .cursor_pointer()
+        .on_press(cx.listener(|this, _event, _window, cx| {
+            this.load_agents(true, cx);
+        }))
+        .child(
+            div()
+                .text_size(px(theme::FONT_DETAIL))
+                .text_color(rgb(theme::TEXT_SECONDARY))
+                .child("Refresh"),
+        )
+}
+
+fn section_header(label: &'static str) -> Div {
+    div()
+        .px(px(theme::SPACING_MD))
+        .pt(px(theme::SPACING_SM))
+        .pb(px(4.0))
+        .text_size(px(theme::FONT_DETAIL))
+        .text_color(rgb(theme::TEXT_MUTED))
+        .child(label)
+}
+
+fn summary_line(label: &str, value: String) -> Div {
+    div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap(px(theme::SPACING_SM))
+        .child(
+            div()
+                .w(px(120.0))
+                .flex_shrink_0()
+                .text_size(px(theme::FONT_DETAIL))
+                .text_color(rgb(theme::TEXT_MUTED))
+                .child(label.to_string()),
+        )
+        .child(
+            div()
+                .min_w_0()
+                .truncate()
+                .text_size(px(theme::FONT_DETAIL))
+                .text_color(rgb(theme::TEXT_SECONDARY))
+                .child(value),
+        )
+}
+
+fn empty_text(text: impl Into<SharedString>) -> Div {
+    div()
+        .flex()
+        .flex_1()
+        .items_center()
+        .justify_center()
+        .px(px(theme::SPACING_MD))
+        .text_size(px(theme::FONT_BODY))
+        .text_color(rgb(theme::TEXT_MUTED))
+        .child(text.into())
+}
+
+fn setup_label(state: AgentSetupState) -> &'static str {
+    match state {
+        AgentSetupState::MissingCli => "Missing CLI",
+        AgentSetupState::NotConfigured => "Not configured",
+        AgentSetupState::SkillsOnly => "Skills only",
+        AgentSetupState::HooksReady => "Hooks ready",
+        AgentSetupState::Error => "Error",
+    }
+}

--- a/crates/zedra/src/agent_session_list.rs
+++ b/crates/zedra/src/agent_session_list.rs
@@ -1,0 +1,294 @@
+use chrono::{DateTime, Utc};
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use zedra_rpc::proto::{AgentSessionSummary, ManagedAgentKind};
+
+use crate::platform_bridge::{self, HapticFeedback};
+use crate::{theme, workspace_action};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AgentSessionSection {
+    pub label: String,
+    pub sessions: Vec<AgentSessionSummary>,
+}
+
+pub fn group_sessions_by_day(sessions: Vec<AgentSessionSummary>) -> Vec<AgentSessionSection> {
+    let mut sorted = sessions;
+    sorted.sort_by(|left, right| {
+        right
+            .last_activity_at
+            .cmp(&left.last_activity_at)
+            .then_with(|| right.created_at.cmp(&left.created_at))
+    });
+
+    let mut sections = Vec::new();
+    for session in sorted {
+        let label = day_label(session.last_activity_at.or(session.created_at));
+        if sections
+            .last()
+            .is_some_and(|section: &AgentSessionSection| section.label == label)
+        {
+            sections
+                .last_mut()
+                .expect("section exists")
+                .sessions
+                .push(session);
+        } else {
+            sections.push(AgentSessionSection {
+                label,
+                sessions: vec![session],
+            });
+        }
+    }
+    sections
+}
+
+pub struct AgentSessionListProps {
+    pub sections: Vec<AgentSessionSection>,
+    pub loading: bool,
+    pub error: Option<String>,
+    pub empty_message: &'static str,
+    pub resume_on_tap: bool,
+}
+
+pub fn render_agent_session_list<C: 'static>(
+    props: AgentSessionListProps,
+    cx: &mut Context<C>,
+) -> impl IntoElement {
+    let mut list = div()
+        .id("agent-session-list")
+        .flex_1()
+        .min_h_0()
+        .overflow_y_scroll()
+        .px(px(theme::SPACING_MD))
+        .pb(px(theme::SPACING_MD))
+        .flex()
+        .flex_col()
+        .gap(px(theme::SPACING_SM));
+
+    if props.loading {
+        return list.child(empty_text("Loading sessions..."));
+    }
+    if let Some(error) = props.error {
+        return list.child(empty_text(format!("Failed to load sessions: {error}")));
+    }
+    if props.sections.is_empty() {
+        return list.child(empty_text(props.empty_message));
+    }
+
+    for section in props.sections {
+        list = list.child(section_header(&section.label));
+        for session in section.sessions {
+            list = list.child(render_agent_session_item(session, props.resume_on_tap, cx));
+        }
+    }
+    list
+}
+
+pub fn render_agent_session_item<C: 'static>(
+    session: AgentSessionSummary,
+    resume_on_tap: bool,
+    cx: &mut Context<C>,
+) -> Stateful<Div> {
+    let can_resume = session.resume.available;
+    let kind = session.kind;
+    let session_id = session.session_id.clone();
+    let item_id = SharedString::from(format!(
+        "agent-session-{}-{}",
+        kind_slug(kind),
+        short_id(&session.session_id)
+    ));
+
+    div()
+        .px(px(theme::SPACING_MD))
+        .py(px(theme::SPACING_SM))
+        .rounded(px(6.0))
+        .border_1()
+        .border_color(rgb(theme::BORDER_SUBTLE))
+        .bg(rgb(theme::BG_CARD))
+        .flex()
+        .flex_col()
+        .gap(px(6.0))
+        .when(resume_on_tap && can_resume, |el| {
+            el.cursor_pointer().on_press(cx.listener({
+                let session_id = session_id.clone();
+                move |_this, _event, window, cx| {
+                    platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
+                    window.dispatch_action(
+                        workspace_action::ResumeAgentSession {
+                            kind,
+                            session_id: session_id.clone(),
+                        }
+                        .boxed_clone(),
+                        cx,
+                    );
+                }
+            }))
+        })
+        .id(item_id)
+        .child(
+            div()
+                .flex()
+                .flex_row()
+                .items_start()
+                .gap(px(8.0))
+                .child(
+                    svg()
+                        .path(agent_icon(kind))
+                        .size(px(theme::ICON_SM))
+                        .text_color(rgb(theme::TEXT_MUTED)),
+                )
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .flex()
+                        .flex_col()
+                        .gap(px(2.0))
+                        .child(
+                            div()
+                                .min_w_0()
+                                .truncate()
+                                .text_size(px(theme::FONT_BODY))
+                                .text_color(rgb(theme::TEXT_PRIMARY))
+                                .child(session_title(&session)),
+                        )
+                        .child(
+                            div()
+                                .min_w_0()
+                                .truncate()
+                                .text_size(px(theme::FONT_DETAIL))
+                                .text_color(rgb(theme::TEXT_MUTED))
+                                .child(session_subtitle(&session)),
+                        ),
+                ),
+        )
+        .child(session_meta_row(&session))
+}
+
+fn section_header(label: &str) -> Div {
+    div()
+        .pt(px(theme::SPACING_SM))
+        .pb(px(4.0))
+        .text_size(px(theme::FONT_DETAIL))
+        .text_color(rgb(theme::TEXT_MUTED))
+        .child(label.to_string())
+}
+
+fn empty_text(text: impl Into<SharedString>) -> Div {
+    div()
+        .flex()
+        .flex_1()
+        .items_center()
+        .justify_center()
+        .px(px(theme::SPACING_MD))
+        .text_size(px(theme::FONT_BODY))
+        .text_color(rgb(theme::TEXT_MUTED))
+        .child(text.into())
+}
+
+fn session_meta_row(session: &AgentSessionSummary) -> Div {
+    let mut parts = Vec::new();
+    if let Some(at) = session.last_activity_at.or(session.created_at) {
+        parts.push(format_session_time(at));
+    }
+    if let Some(git) = session.git.as_ref() {
+        if let Some(branch) = git.branch.as_deref().filter(|value| !value.is_empty()) {
+            parts.push(branch.to_string());
+        }
+        if let Some(worktree) = git.worktree.as_deref().filter(|value| !value.is_empty()) {
+            parts.push(format!("worktree:{worktree}"));
+        }
+    }
+    if let Some(size) = session.transcript_size_bytes {
+        parts.push(format_size(size));
+    }
+    if let Some(model) = session.provider.model.as_deref() {
+        parts.push(model.to_string());
+    }
+    if session.flags.live_bound {
+        parts.push("live".to_string());
+    }
+
+    div()
+        .min_w_0()
+        .truncate()
+        .text_size(px(theme::FONT_DETAIL))
+        .text_color(rgb(theme::TEXT_MUTED))
+        .child(if parts.is_empty() {
+            short_id(&session.session_id)
+        } else {
+            parts.join(" · ")
+        })
+}
+
+pub fn session_title(session: &AgentSessionSummary) -> String {
+    session
+        .title
+        .clone()
+        .filter(|title| !title.is_empty())
+        .unwrap_or_else(|| "Unknown".to_string())
+}
+
+fn session_subtitle(session: &AgentSessionSummary) -> String {
+    let mut parts = vec![managed_agent_name(session.kind).to_string()];
+    parts.push(short_id(&session.session_id));
+    parts.join(" · ")
+}
+
+fn format_session_time(at: DateTime<Utc>) -> String {
+    at.format("%b %d · %H:%M").to_string()
+}
+
+fn day_label(at: Option<DateTime<Utc>>) -> String {
+    let Some(at) = at else {
+        return "Unknown date".to_string();
+    };
+    let today = Utc::now().date_naive();
+    let date = at.date_naive();
+    if date == today {
+        "Today".to_string()
+    } else if date == today.pred_opt().unwrap_or(today) {
+        "Yesterday".to_string()
+    } else {
+        at.format("%A, %b %d").to_string()
+    }
+}
+
+fn format_size(bytes: u64) -> String {
+    if bytes >= 1024 * 1024 {
+        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    } else if bytes >= 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+pub fn agent_icon(kind: ManagedAgentKind) -> &'static str {
+    match kind {
+        ManagedAgentKind::Claude => "icons/claude.svg",
+        ManagedAgentKind::Codex => "icons/codex.svg",
+        ManagedAgentKind::OpenCode => "icons/opencode.svg",
+    }
+}
+
+pub fn kind_slug(kind: ManagedAgentKind) -> &'static str {
+    match kind {
+        ManagedAgentKind::Claude => "claude",
+        ManagedAgentKind::Codex => "codex",
+        ManagedAgentKind::OpenCode => "opencode",
+    }
+}
+
+pub fn managed_agent_name(kind: ManagedAgentKind) -> &'static str {
+    match kind {
+        ManagedAgentKind::Claude => "Claude",
+        ManagedAgentKind::Codex => "Codex",
+        ManagedAgentKind::OpenCode => "OpenCode",
+    }
+}
+
+pub fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}

--- a/crates/zedra/src/agent_session_view.rs
+++ b/crates/zedra/src/agent_session_view.rs
@@ -1,0 +1,150 @@
+use gpui::*;
+use tracing::error;
+use zedra_rpc::proto::ManagedAgentKind;
+use zedra_session::SessionHandle;
+
+use crate::agent_session_list::{
+    AgentSessionListProps, group_sessions_by_day, render_agent_session_list,
+};
+use crate::theme;
+
+#[derive(Clone, Debug)]
+enum LoadState {
+    Loading,
+    Ready,
+    Error(String),
+}
+
+pub struct AgentSessionView {
+    session_handle: SessionHandle,
+    sections: Vec<crate::agent_session_list::AgentSessionSection>,
+    load_state: LoadState,
+    loading_epoch: u64,
+    _tasks: Vec<Task<()>>,
+}
+
+impl AgentSessionView {
+    pub fn new(session_handle: SessionHandle, cx: &mut Context<Self>) -> Self {
+        let mut view = Self {
+            session_handle,
+            sections: Vec::new(),
+            load_state: LoadState::Loading,
+            loading_epoch: 0,
+            _tasks: Vec::new(),
+        };
+        view.load(false, cx);
+        view
+    }
+
+    fn load(&mut self, refresh: bool, cx: &mut Context<Self>) {
+        self.loading_epoch = self.loading_epoch.wrapping_add(1);
+        let epoch = self.loading_epoch;
+        self.load_state = LoadState::Loading;
+        self.sections.clear();
+        cx.notify();
+
+        let handle = self.session_handle.clone();
+        let task = cx.spawn(async move |this, cx| {
+            let kinds = [
+                ManagedAgentKind::Claude,
+                ManagedAgentKind::Codex,
+                ManagedAgentKind::OpenCode,
+            ];
+            let (claude, codex, opencode) = tokio::join!(
+                handle.agent_sessions(ManagedAgentKind::Claude, refresh, 0),
+                handle.agent_sessions(ManagedAgentKind::Codex, refresh, 0),
+                handle.agent_sessions(ManagedAgentKind::OpenCode, refresh, 0),
+            );
+            let mut sessions = Vec::new();
+            let mut errors = Vec::new();
+            for (kind, result) in [
+                (ManagedAgentKind::Claude, claude),
+                (ManagedAgentKind::Codex, codex),
+                (ManagedAgentKind::OpenCode, opencode),
+            ] {
+                match result {
+                    Ok(mut rows) => sessions.append(&mut rows),
+                    Err(err) => errors.push(format!("{kind:?}: {err}")),
+                }
+            }
+            let _ = this.update(cx, |this, cx| {
+                if this.loading_epoch != epoch {
+                    return;
+                }
+                this.sections = group_sessions_by_day(sessions);
+                this.load_state = if errors.is_empty() {
+                    LoadState::Ready
+                } else if this.sections.is_empty() {
+                    LoadState::Error(errors.join("; "))
+                } else {
+                    error!("agent sessions partial failure: {}", errors.join("; "));
+                    LoadState::Ready
+                };
+                cx.notify();
+            });
+        });
+        self._tasks.push(task);
+    }
+}
+
+impl Render for AgentSessionView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .id("agent-session-view")
+            .size_full()
+            .min_h_0()
+            .bg(rgb(theme::BG_PRIMARY))
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .px(px(theme::SPACING_MD))
+                    .pt(px(theme::SPACING_MD))
+                    .pb(px(theme::SPACING_SM))
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .justify_between()
+                    .child(
+                        div()
+                            .text_size(px(theme::FONT_BODY))
+                            .text_color(rgb(theme::TEXT_SECONDARY))
+                            .child("All managed agent sessions in this workspace."),
+                    )
+                    .child(refresh_button(cx)),
+            )
+            .child(render_agent_session_list(
+                AgentSessionListProps {
+                    sections: self.sections.clone(),
+                    loading: matches!(self.load_state, LoadState::Loading),
+                    error: match &self.load_state {
+                        LoadState::Error(message) => Some(message.clone()),
+                        _ => None,
+                    },
+                    empty_message: "No sessions found for this workspace.",
+                    resume_on_tap: true,
+                },
+                cx,
+            ))
+    }
+}
+
+fn refresh_button(cx: &mut Context<AgentSessionView>) -> Stateful<Div> {
+    div()
+        .id("agent-session-refresh-btn")
+        .px(px(10.0))
+        .py(px(6.0))
+        .rounded(px(6.0))
+        .border_1()
+        .border_color(rgb(theme::BORDER_SUBTLE))
+        .cursor_pointer()
+        .on_press(cx.listener(|this, _event, _window, cx| {
+            this.load(true, cx);
+        }))
+        .child(
+            div()
+                .text_size(px(theme::FONT_DETAIL))
+                .text_color(rgb(theme::TEXT_SECONDARY))
+                .child("Refresh"),
+        )
+}

--- a/crates/zedra/src/android/bridge.rs
+++ b/crates/zedra/src/android/bridge.rs
@@ -3,7 +3,7 @@
 /// Delegates every call to the corresponding function in `super::jni`.
 use crate::android::jni;
 use crate::platform_bridge::{
-    AlertButton, CustomSheetOptions, HapticFeedback, NativeDictationPreviewOptions,
+    AlertButton, CustomSheetOptions, HapticFeedback, ListPickerItem, NativeDictationPreviewOptions,
     NativeFloatingButtonOptions, NativeNotificationOptions, PlatformBridge,
 };
 
@@ -67,6 +67,10 @@ impl PlatformBridge for AndroidBridge {
 
     fn present_selection(&self, id: u32, title: &str, message: &str, buttons: &[AlertButton]) {
         jni::show_selection(id, title, message, buttons);
+    }
+
+    fn present_list_picker(&self, id: u32, title: &str, message: &str, items: &[ListPickerItem]) {
+        jni::show_list_picker(id, title, message, items);
     }
 
     fn present_custom_sheet(&self, options: &CustomSheetOptions) {

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Mutex, Once};
 use crate::android::sheet;
 use crate::install_panic_hook;
 use crate::platform_bridge::{
-    self, AlertButton, AlertButtonStyle, CustomSheetOptions, HapticFeedback,
+    self, AlertButton, AlertButtonStyle, CustomSheetOptions, HapticFeedback, ListPickerItem,
     NativeDictationPreviewOptions, NativeFloatingButtonOptions, NativeNotificationOptions,
 };
 
@@ -607,6 +607,65 @@ pub fn show_selection(id: u32, title: &str, message: &str, buttons: &[AlertButto
         .collect();
     jni_call("show_selection", move || {
         present_buttons("showSelection", id, title, message, labels, styles);
+    });
+}
+
+pub fn show_list_picker(id: u32, title: &str, message: &str, items: &[ListPickerItem]) {
+    let title = title.to_string();
+    let message = message.to_string();
+    let labels: Vec<String> = items.iter().map(|item| item.label.clone()).collect();
+    let subtitles: Vec<String> = items
+        .iter()
+        .map(|item| item.subtitle.clone().unwrap_or_default())
+        .collect();
+    let image_names: Vec<String> = items
+        .iter()
+        .map(|item| item.image_name.clone().unwrap_or_default())
+        .collect();
+    jni_call("show_list_picker", move || {
+        with_main_activity_class("show_list_picker", |env, class| {
+            let title_value = env.new_string(&title).expect("title");
+            let message_value = env.new_string(&message).expect("message");
+            let string_class = env.find_class("java/lang/String").expect("String");
+            let label_array = env
+                .new_object_array(labels.len() as i32, string_class, JObject::null())
+                .expect("labels");
+            for (index, label) in labels.iter().enumerate() {
+                let label_value = env.new_string(label).expect("label");
+                env.set_object_array_element(&label_array, index as i32, label_value)
+                    .expect("set label");
+            }
+            let subtitle_array = env
+                .new_object_array(subtitles.len() as i32, string_class, JObject::null())
+                .expect("subtitles");
+            for (index, subtitle) in subtitles.iter().enumerate() {
+                let subtitle_value = env.new_string(subtitle).expect("subtitle");
+                env.set_object_array_element(&subtitle_array, index as i32, subtitle_value)
+                    .expect("set subtitle");
+            }
+            let image_array = env
+                .new_object_array(image_names.len() as i32, string_class, JObject::null())
+                .expect("images");
+            for (index, image) in image_names.iter().enumerate() {
+                let image_value = env.new_string(image).expect("image");
+                env.set_object_array_element(&image_array, index as i32, image_value)
+                    .expect("set image");
+            }
+            env.call_static_method(
+                class,
+                "showListPicker",
+                "(ILjava/lang/String;Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;)V",
+                &[
+                    JValue::Int(id as i32),
+                    JValue::Object(&title_value),
+                    JValue::Object(&message_value),
+                    JValue::Object(&label_array),
+                    JValue::Object(&subtitle_array),
+                    JValue::Object(&image_array),
+                ],
+            )
+            .expect("showListPicker");
+        });
     });
 }
 

--- a/crates/zedra/src/editor/markdown.rs
+++ b/crates/zedra/src/editor/markdown.rs
@@ -1,11 +1,13 @@
 use gpui::prelude::FluentBuilder;
 use gpui::*;
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::Path;
 use std::sync::Arc;
 
 use crate::editor::merge_highlights;
+use crate::editor::mermaid::{self, MermaidDiagram};
 use crate::fonts;
 use crate::platform_bridge;
 use crate::theme;
@@ -27,12 +29,24 @@ const TABLE_CELL_MAX_WIDTH: f32 = 220.0;
 const TABLE_CELL_CHAR_WIDTH_FACTOR: f32 = 0.62;
 const TABLE_CELL_PADDING_X: f32 = CODE_BLOCK_PADDING_X;
 const TABLE_CELL_PADDING_Y: f32 = CODE_BLOCK_PADDING_Y;
+const MERMAID_PENDING_HEIGHT: f32 = 120.0;
+const MERMAID_CONTENT_WIDTH: f32 = 360.0;
 pub const MARKDOWN_SELECTION_AREA_ID: &str = "markdown-preview-selection";
+
+#[derive(Clone, Debug)]
+enum MermaidBlockState {
+    Pending,
+    Ready(MermaidDiagram),
+    Failed,
+}
 
 pub struct MarkdownView {
     document: MarkdownDocument,
     list_state: ListState,
     focus_handle: Option<FocusHandle>,
+    mermaid_states: HashMap<usize, MermaidBlockState>,
+    mermaid_show_source: HashSet<usize>,
+    mermaid_generation: u64,
 }
 
 impl MarkdownView {
@@ -48,12 +62,15 @@ impl MarkdownView {
             document,
             list_state,
             focus_handle: None,
+            mermaid_states: HashMap::new(),
+            mermaid_show_source: HashSet::new(),
+            mermaid_generation: 0,
         }
     }
 
-    pub fn set_source(&mut self, source: impl Into<SharedString>) {
+    pub fn set_source(&mut self, source: impl Into<SharedString>, cx: &mut Context<Self>) {
         let source = source.into();
-        self.replace_document(parse_document(source.as_ref()));
+        self.replace_document(parse_document(source.as_ref()), cx);
     }
 
     pub fn line_range_for_selection(&self, range_utf16: Range<usize>) -> Option<(u32, u32)> {
@@ -65,17 +82,58 @@ impl MarkdownView {
         scroll_top.item_ix == 0 && scroll_top.offset_in_item <= px(0.5)
     }
 
-    pub(crate) fn set_parsed_source(&mut self, parsed: ParsedMarkdownSource) {
-        self.replace_document(parsed.document);
+    pub(crate) fn set_parsed_source(
+        &mut self,
+        parsed: ParsedMarkdownSource,
+        cx: &mut Context<Self>,
+    ) {
+        self.replace_document(parsed.document, cx);
     }
 
-    fn replace_document(&mut self, document: MarkdownDocument) {
+    fn replace_document(&mut self, document: MarkdownDocument, cx: &mut Context<Self>) {
         self.document = document;
+        self.mermaid_show_source.clear();
+        self.mermaid_generation = self.mermaid_generation.wrapping_add(1);
+        mermaid::clear_mermaid_svg_cache();
         // ListState caches row measurements. Reset it whenever the parsed block
         // tree changes, or scroll position and item heights can be reused from
         // the previous file.
         self.list_state
             .reset(markdown_list_item_count(self.document.blocks.len()));
+        self.schedule_mermaid_renders(cx);
+    }
+
+    fn schedule_mermaid_renders(&mut self, cx: &mut Context<Self>) {
+        self.mermaid_states.clear();
+        let generation = self.mermaid_generation;
+        for (block_ix, block) in self.document.blocks.iter().enumerate() {
+            let Block::Mermaid { text } = block else {
+                continue;
+            };
+            self.mermaid_states
+                .insert(block_ix, MermaidBlockState::Pending);
+            let source = text.clone();
+            let block_ix = block_ix;
+            cx.spawn(async move |this, cx| {
+                let rendered = cx
+                    .background_spawn(
+                        async move { mermaid::render_mermaid_diagram(block_ix, &source) },
+                    )
+                    .await;
+                let _ = this.update(cx, |view, cx| {
+                    if view.mermaid_generation != generation {
+                        return;
+                    }
+                    let state = match rendered {
+                        Some(diagram) => MermaidBlockState::Ready(diagram),
+                        None => MermaidBlockState::Failed,
+                    };
+                    view.mermaid_states.insert(block_ix, state);
+                    cx.notify();
+                });
+            })
+            .detach();
+        }
     }
 }
 
@@ -161,6 +219,10 @@ enum Block {
         items: Vec<Vec<Block>>,
     },
     CodeBlock {
+        language: Option<String>,
+        text: String,
+    },
+    Mermaid {
         text: String,
     },
     Table(TableBlock),
@@ -231,8 +293,11 @@ impl InlineRenderBuffer {
 }
 
 impl Render for MarkdownView {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let blocks = Arc::clone(&self.document.blocks);
+        let mermaid_states = self.mermaid_states.clone();
+        let mermaid_show_source = self.mermaid_show_source.clone();
+        let view = cx.weak_entity();
         let block_count = blocks.len();
         let bottom_inset = f32::max(
             platform_bridge::home_indicator_inset(),
@@ -240,7 +305,7 @@ impl Render for MarkdownView {
         );
         let focus_handle = self
             .focus_handle
-            .get_or_insert_with(|| _cx.focus_handle())
+            .get_or_insert_with(|| cx.focus_handle())
             .clone();
         let press_focus_handle = focus_handle.clone();
         // Keep each top-level markdown block as one variable-height list row.
@@ -257,7 +322,16 @@ impl Render for MarkdownView {
                     } else {
                         px(theme::SPACING_MD)
                     })
-                    .child(render_block(block, format!("md-{ix}"), window, cx))
+                    .child(render_block(
+                        block,
+                        ix,
+                        format!("md-{ix}"),
+                        &mermaid_states,
+                        &mermaid_show_source,
+                        view.clone(),
+                        window,
+                        cx,
+                    ))
                     .into_any_element()
             } else if ix == block_count {
                 div().h(px(bottom_inset)).into_any_element()
@@ -812,6 +886,32 @@ fn line_number_for_byte_offset(source: &str, byte_offset: usize) -> u32 {
         + 1
 }
 
+fn take_code_block_body(events: &[Event<'_>], cursor: &mut usize) -> String {
+    *cursor += 1;
+    let mut text = String::new();
+    while *cursor < events.len() {
+        match &events[*cursor] {
+            Event::End(TagEnd::CodeBlock) => {
+                *cursor += 1;
+                break;
+            }
+            Event::Text(value)
+            | Event::Code(value)
+            | Event::Html(value)
+            | Event::InlineHtml(value) => {
+                text.push_str(value);
+                *cursor += 1;
+            }
+            Event::SoftBreak | Event::HardBreak => {
+                text.push('\n');
+                *cursor += 1;
+            }
+            _ => *cursor += 1,
+        }
+    }
+    text
+}
+
 fn parse_blocks(events: &[Event<'_>], cursor: &mut usize, end: Option<TagEnd>) -> Vec<Block> {
     let mut blocks = Vec::new();
 
@@ -873,30 +973,24 @@ fn parse_blocks(events: &[Event<'_>], cursor: &mut usize, end: Option<TagEnd>) -
                     items,
                 });
             }
-            Event::Start(Tag::CodeBlock(_)) => {
-                *cursor += 1;
-                let mut text = String::new();
-                while *cursor < events.len() {
-                    match &events[*cursor] {
-                        Event::End(TagEnd::CodeBlock) => {
-                            *cursor += 1;
-                            break;
+            Event::Start(Tag::CodeBlock(kind)) => {
+                let language = match kind {
+                    CodeBlockKind::Fenced(lang) => {
+                        let lang = lang.to_string();
+                        if mermaid::is_mermaid_language(&lang) {
+                            blocks.push(Block::Mermaid {
+                                text: take_code_block_body(events, cursor),
+                            });
+                            continue;
                         }
-                        Event::Text(value)
-                        | Event::Code(value)
-                        | Event::Html(value)
-                        | Event::InlineHtml(value) => {
-                            text.push_str(value);
-                            *cursor += 1;
-                        }
-                        Event::SoftBreak | Event::HardBreak => {
-                            text.push('\n');
-                            *cursor += 1;
-                        }
-                        _ => *cursor += 1,
+                        Some(lang)
                     }
-                }
-                blocks.push(Block::CodeBlock { text });
+                    CodeBlockKind::Indented => None,
+                };
+                blocks.push(Block::CodeBlock {
+                    language,
+                    text: take_code_block_body(events, cursor),
+                });
             }
             Event::Start(Tag::Table(_)) => {
                 *cursor += 1;
@@ -1100,7 +1194,60 @@ fn parse_inline_event(events: &[Event<'_>], cursor: &mut usize) -> Vec<Inline> {
     }
 }
 
-fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -> AnyElement {
+fn render_code_block_content(text: &str, key: &str) -> AnyElement {
+    let code_width = code_block_content_min_width(text);
+    let code_lines = div()
+        .min_w(px(code_width))
+        .px(px(CODE_BLOCK_PADDING_X))
+        .py(px(CODE_BLOCK_PADDING_Y))
+        .flex()
+        .flex_col()
+        .children(text.lines().map(|line| {
+            let line = if line.is_empty() {
+                " ".to_string()
+            } else {
+                line.to_string()
+            };
+            div()
+                .w_full()
+                .text_color(rgb(theme::TEXT_PRIMARY))
+                .text_size(px(CODE_BLOCK_FONT_SIZE))
+                .line_height(px(CODE_BLOCK_LINE_HEIGHT))
+                .font_family(fonts::MONO_FONT_FAMILY)
+                .whitespace_nowrap()
+                .child(markdown_text(StyledText::new(line), "\n"))
+        }));
+
+    let mut container = div()
+        .id(format!("{key}-code-scroll"))
+        .w_full()
+        .bg(rgb(theme::BG_CARD))
+        .border_1()
+        .border_color(rgb(theme::BORDER_DEFAULT))
+        .rounded(px(6.0))
+        .overflow_x_scroll()
+        .child(code_lines);
+    container.style().restrict_scroll_to_axis = Some(true);
+
+    container.into_any_element()
+}
+
+fn mermaid_display_height(diagram: &MermaidDiagram) -> f32 {
+    let width = diagram.intrinsic_width.max(1.0);
+    let height = diagram.intrinsic_height.max(1.0);
+    (MERMAID_CONTENT_WIDTH * (height / width)).clamp(80.0, 2000.0)
+}
+
+fn render_block(
+    block: &Block,
+    block_ix: usize,
+    key: String,
+    mermaid_states: &HashMap<usize, MermaidBlockState>,
+    mermaid_show_source: &HashSet<usize>,
+    view: WeakEntity<MarkdownView>,
+    window: &mut Window,
+    cx: &mut App,
+) -> AnyElement {
     match block {
         Block::Paragraph(content) => render_inline_block(content, InlineBlockStyle::Body, key),
         Block::Heading { level, content } => {
@@ -1111,20 +1258,27 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
             };
             render_inline_block(content, style, key)
         }
-        Block::BlockQuote(children) => {
-            div()
-                .w_full()
-                .pl(px(theme::SPACING_MD))
-                .border_l_1()
-                .border_color(rgb(theme::BORDER_DEFAULT))
-                .flex()
-                .flex_col()
-                .gap(px(10.0))
-                .children(children.iter().enumerate().map(|(ix, child)| {
-                    render_block(child, format!("{key}-quote-{ix}"), window, cx)
-                }))
-                .into_any_element()
-        }
+        Block::BlockQuote(children) => div()
+            .w_full()
+            .pl(px(theme::SPACING_MD))
+            .border_l_1()
+            .border_color(rgb(theme::BORDER_DEFAULT))
+            .flex()
+            .flex_col()
+            .gap(px(10.0))
+            .children(children.iter().enumerate().map(|(ix, child)| {
+                render_block(
+                    child,
+                    usize::MAX,
+                    format!("{key}-quote-{ix}"),
+                    mermaid_states,
+                    mermaid_show_source,
+                    view.clone(),
+                    window,
+                    cx,
+                )
+            }))
+            .into_any_element(),
         Block::List {
             ordered,
             start,
@@ -1166,7 +1320,11 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
                             .children(item.iter().enumerate().map(|(child_ix, child)| {
                                 render_block(
                                     child,
+                                    usize::MAX,
                                     format!("{key}-item-{ix}-{child_ix}"),
+                                    mermaid_states,
+                                    mermaid_show_source,
+                                    view.clone(),
                                     window,
                                     cx,
                                 )
@@ -1174,43 +1332,119 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
                     )
             }))
             .into_any_element(),
-        Block::CodeBlock { text } => {
-            let code_width = code_block_content_min_width(text);
-            let code_lines = div()
-                .min_w(px(code_width))
-                .px(px(CODE_BLOCK_PADDING_X))
-                .py(px(CODE_BLOCK_PADDING_Y))
+        Block::Mermaid { text } => {
+            let show_source = mermaid_show_source.contains(&block_ix);
+            let state = mermaid_states.get(&block_ix);
+            let mut body: Vec<AnyElement> = Vec::new();
+
+            match state {
+                Some(MermaidBlockState::Ready(diagram)) => {
+                    let display_height = mermaid_display_height(diagram);
+                    let asset_path = diagram.asset_path.clone();
+                    body.push(
+                        div()
+                            .id(format!("{key}-mermaid"))
+                            .w_full()
+                            .h(px(display_height))
+                            .bg(rgb(theme::BG_CARD))
+                            .border_1()
+                            .border_color(rgb(theme::BORDER_DEFAULT))
+                            .rounded(px(6.0))
+                            .overflow_hidden()
+                            .child(
+                                img(asset_path)
+                                    .w_full()
+                                    .h_full()
+                                    .object_fit(ObjectFit::Contain),
+                            )
+                            .into_any_element(),
+                    );
+                }
+                Some(MermaidBlockState::Pending) => {
+                    body.push(
+                        div()
+                            .w_full()
+                            .h(px(MERMAID_PENDING_HEIGHT))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .bg(rgb(theme::BG_CARD))
+                            .border_1()
+                            .border_color(rgb(theme::BORDER_DEFAULT))
+                            .rounded(px(6.0))
+                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_size(px(theme::FONT_DETAIL))
+                            .font_family(fonts::MONO_FONT_FAMILY)
+                            .child("Rendering diagram…")
+                            .into_any_element(),
+                    );
+                }
+                Some(MermaidBlockState::Failed) | None => {
+                    body.push(render_code_block_content(
+                        text,
+                        &format!("{key}-mermaid-fallback"),
+                    ));
+                    body.push(
+                        div()
+                            .mt(px(6.0))
+                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_size(px(theme::FONT_DETAIL))
+                            .font_family(fonts::MONO_FONT_FAMILY)
+                            .child("Diagram could not be rendered.")
+                            .into_any_element(),
+                    );
+                }
+            }
+
+            if matches!(
+                state,
+                Some(MermaidBlockState::Ready(_)) | Some(MermaidBlockState::Pending)
+            ) {
+                let toggle_label = if show_source {
+                    "Hide source"
+                } else {
+                    "Show source"
+                };
+                let toggle_ix = block_ix;
+                body.push(
+                    div()
+                        .id(format!("{key}-mermaid-source-toggle"))
+                        .mt(px(6.0))
+                        .cursor_pointer()
+                        .text_color(rgb(theme::ACCENT_BLUE))
+                        .text_size(px(theme::FONT_DETAIL))
+                        .font_family(fonts::MONO_FONT_FAMILY)
+                        .on_click(move |_, _window, cx| {
+                            let _ = view.update(cx, |view, cx| {
+                                if view.mermaid_show_source.contains(&toggle_ix) {
+                                    view.mermaid_show_source.remove(&toggle_ix);
+                                } else {
+                                    view.mermaid_show_source.insert(toggle_ix);
+                                }
+                                cx.notify();
+                            });
+                        })
+                        .child(toggle_label)
+                        .into_any_element(),
+                );
+            }
+
+            if show_source {
+                body.push(render_code_block_content(
+                    text,
+                    &format!("{key}-mermaid-source"),
+                ));
+            }
+
+            div()
+                .w_full()
                 .flex()
                 .flex_col()
-                .children(text.lines().map(|line| {
-                    let line = if line.is_empty() {
-                        " ".to_string()
-                    } else {
-                        line.to_string()
-                    };
-                    div()
-                        .w_full()
-                        .text_color(rgb(theme::TEXT_PRIMARY))
-                        .text_size(px(CODE_BLOCK_FONT_SIZE))
-                        .line_height(px(CODE_BLOCK_LINE_HEIGHT))
-                        .font_family(fonts::MONO_FONT_FAMILY)
-                        .whitespace_nowrap()
-                        .child(markdown_text(StyledText::new(line), "\n"))
-                }));
-
-            let mut container = div()
-                .id(format!("{key}-code-scroll"))
-                .w_full()
-                .bg(rgb(theme::BG_CARD))
-                .border_1()
-                .border_color(rgb(theme::BORDER_DEFAULT))
-                .rounded(px(6.0))
-                .overflow_x_scroll()
-                .child(code_lines);
-            container.style().restrict_scroll_to_axis = Some(true);
-
-            container.into_any_element()
+                .gap(px(6.0))
+                .children(body)
+                .into_any_element()
         }
+        Block::CodeBlock { text, .. } => render_code_block_content(text, &key),
         Block::Table(table) => render_table(table, key),
         Block::Html(text) => {
             render_inline_block(&[Inline::Html(text.clone())], InlineBlockStyle::Html, key)
@@ -1687,7 +1921,13 @@ fn main() {}
         assert!(matches!(document.blocks[1], Block::Paragraph(_)));
         assert!(matches!(document.blocks[2], Block::BlockQuote(_)));
         assert!(matches!(document.blocks[3], Block::List { .. }));
-        assert!(matches!(document.blocks[4], Block::CodeBlock { .. }));
+        assert!(matches!(
+            document.blocks[4],
+            Block::CodeBlock {
+                language: Some(_),
+                ..
+            }
+        ));
         assert!(matches!(document.blocks[5], Block::Table(_)));
         assert!(document.total_block_count() > document.blocks.len());
     }
@@ -1770,16 +2010,39 @@ fn main() {}
     }
 
     #[test]
-    fn markdown_view_resets_virtualized_rows_when_source_changes() {
-        let mut view = MarkdownView::new("# Title\n\nBody paragraph.");
-        assert_eq!(
-            view.list_state.item_count(),
-            markdown_list_item_count(view.document.blocks.len())
-        );
-        assert_eq!(view.document.blocks.len(), 2);
+    fn parses_mermaid_fence_into_mermaid_block() {
+        let document = parse_document("```mermaid\nflowchart LR\n  A --> B\n```\n");
+        assert_eq!(document.blocks.len(), 1);
+        assert!(matches!(document.blocks[0], Block::Mermaid { .. }));
+    }
 
-        view.set_source(
-            r#"# Updated
+    #[test]
+    fn parses_non_mermaid_fenced_blocks_with_language() {
+        let document = parse_document("```rust\nfn main() {}\n```\n");
+        let Block::CodeBlock { language, .. } = &document.blocks[0] else {
+            panic!("expected code block");
+        };
+        assert_eq!(language.as_deref(), Some("rust"));
+    }
+
+    #[test]
+    fn markdown_view_resets_virtualized_rows_when_source_changes() {
+        use gpui::{AppContext as _, TestAppContext};
+
+        let mut cx = TestAppContext::single();
+        let view = cx.update(|cx| cx.new(|_cx| MarkdownView::new("# Title\n\nBody paragraph.")));
+
+        view.update(&mut cx, |view, _cx| {
+            assert_eq!(
+                view.list_state.item_count(),
+                markdown_list_item_count(view.document.blocks.len())
+            );
+            assert_eq!(view.document.blocks.len(), 2);
+        });
+
+        view.update(&mut cx, |view, cx| {
+            view.set_source(
+                r#"# Updated
 
 - First
 - Second
@@ -1788,12 +2051,16 @@ fn main() {}
 fn main() {}
 ```
 "#,
-        );
+                cx,
+            );
+        });
 
-        assert_eq!(view.document.blocks.len(), 3);
-        assert_eq!(
-            view.list_state.item_count(),
-            markdown_list_item_count(view.document.blocks.len())
-        );
+        view.update(&mut cx, |view, _cx| {
+            assert_eq!(view.document.blocks.len(), 3);
+            assert_eq!(
+                view.list_state.item_count(),
+                markdown_list_item_count(view.document.blocks.len())
+            );
+        });
     }
 }

--- a/crates/zedra/src/editor/mermaid.rs
+++ b/crates/zedra/src/editor/mermaid.rs
@@ -1,0 +1,137 @@
+use mermaid_rs_renderer::{RenderOptions, render_with_options};
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex, OnceLock};
+
+const MERMAID_ASSET_PREFIX: &str = "mermaid/";
+
+/// In-memory SVG assets for dynamically rendered Mermaid diagrams (`img()` embedded paths).
+static MERMAID_SVG_CACHE: OnceLock<Mutex<HashMap<String, Arc<[u8]>>>> = OnceLock::new();
+
+pub fn mermaid_asset_path(block_ix: usize, source: &str) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    source.hash(&mut hasher);
+    format!("{MERMAID_ASSET_PREFIX}{block_ix}-{:x}.svg", hasher.finish())
+}
+
+pub fn store_mermaid_svg(path: String, bytes: Arc<[u8]>) {
+    MERMAID_SVG_CACHE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("mermaid svg cache lock")
+        .insert(path, bytes);
+}
+
+pub fn load_mermaid_svg(path: &str) -> Option<Arc<[u8]>> {
+    MERMAID_SVG_CACHE
+        .get()
+        .and_then(|cache| cache.lock().ok().and_then(|g| g.get(path).cloned()))
+}
+
+pub fn clear_mermaid_svg_cache() {
+    if let Some(cache) = MERMAID_SVG_CACHE.get() {
+        cache.lock().expect("mermaid svg cache lock").clear();
+    }
+}
+
+pub fn is_mermaid_language(language: &str) -> bool {
+    language.eq_ignore_ascii_case("mermaid")
+}
+
+#[derive(Clone, Debug)]
+pub struct MermaidDiagram {
+    pub asset_path: String,
+    pub intrinsic_width: f32,
+    pub intrinsic_height: f32,
+}
+
+pub fn render_mermaid_diagram(block_ix: usize, source: &str) -> Option<MermaidDiagram> {
+    let source = source.trim();
+    if source.is_empty() {
+        return None;
+    }
+
+    let mut options = RenderOptions::default();
+    let mut theme = options.theme.clone();
+    theme.background = hex_color(crate::theme::BG_CARD);
+    theme.text_color = hex_color(crate::theme::TEXT_PRIMARY);
+    theme.primary_color = hex_color(crate::theme::BG_CARD);
+    theme.primary_text_color = hex_color(crate::theme::TEXT_PRIMARY);
+    theme.primary_border_color = hex_color(crate::theme::BORDER_DEFAULT);
+    theme.line_color = hex_color(crate::theme::BORDER_DEFAULT);
+    theme.secondary_color = hex_color(crate::theme::BG_CARD);
+    theme.tertiary_color = hex_color(crate::theme::BORDER_SUBTLE);
+    theme.cluster_background = hex_color(crate::theme::BG_CARD);
+    theme.cluster_border = hex_color(crate::theme::BORDER_DEFAULT);
+    options.theme = theme;
+
+    let svg = render_with_options(source, options).ok()?;
+    let (intrinsic_width, intrinsic_height) = svg_intrinsic_size(&svg)?;
+    let asset_path = mermaid_asset_path(block_ix, source);
+    store_mermaid_svg(asset_path.clone(), Arc::from(svg.into_bytes()));
+
+    Some(MermaidDiagram {
+        asset_path,
+        intrinsic_width,
+        intrinsic_height,
+    })
+}
+
+fn hex_color(rgb: u32) -> String {
+    format!("#{:06x}", rgb & 0xffffff)
+}
+
+/// Best-effort intrinsic size from SVG `viewBox` or `width`/`height` attributes.
+fn svg_intrinsic_size(svg: &str) -> Option<(f32, f32)> {
+    if let Some((w, h)) = parse_view_box(svg) {
+        if w > 0.0 && h > 0.0 {
+            return Some((w, h));
+        }
+    }
+
+    let width = parse_svg_length_attr(svg, "width")?;
+    let height = parse_svg_length_attr(svg, "height")?;
+    (width > 0.0 && height > 0.0).then_some((width, height))
+}
+
+fn parse_view_box(svg: &str) -> Option<(f32, f32)> {
+    let marker = "viewBox=\"";
+    let start = svg.find(marker)? + marker.len();
+    let end = svg[start..].find('"')? + start;
+    let mut parts = svg[start..end].split_whitespace();
+    let _min_x = parts.next()?;
+    let _min_y = parts.next()?;
+    let width: f32 = parts.next()?.parse().ok()?;
+    let height: f32 = parts.next()?.parse().ok()?;
+    Some((width, height))
+}
+
+fn parse_svg_length_attr(svg: &str, attr: &str) -> Option<f32> {
+    let marker = format!("{attr}=\"");
+    let start = svg.find(&marker)? + marker.len();
+    let end = svg[start..].find('"')? + start;
+    let raw = &svg[start..end];
+    raw.trim_end_matches("px").parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_svg_view_box_dimensions() {
+        let svg = r#"<svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg"></svg>"#;
+        assert_eq!(svg_intrinsic_size(svg), Some((320.0, 180.0)));
+    }
+
+    #[test]
+    fn renders_flowchart_to_asset_path() {
+        clear_mermaid_svg_cache();
+        let diagram = render_mermaid_diagram(3, "flowchart LR\n  A[Start] --> B[End]")
+            .expect("flowchart should render");
+        assert!(diagram.asset_path.starts_with(MERMAID_ASSET_PREFIX));
+        assert!(diagram.intrinsic_width > 0.0);
+        assert!(diagram.intrinsic_height > 0.0);
+        assert!(load_mermaid_svg(&diagram.asset_path).is_some());
+    }
+}

--- a/crates/zedra/src/editor/mod.rs
+++ b/crates/zedra/src/editor/mod.rs
@@ -4,6 +4,7 @@ pub mod code_editor;
 pub mod git_diff_view;
 pub mod git_sidebar;
 pub mod markdown;
+pub mod mermaid;
 pub mod syntax_highlighter;
 pub mod syntax_theme;
 pub mod text_buffer;

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -4,7 +4,7 @@ use tracing::*;
 use crate::active_terminal;
 use crate::deeplink;
 use crate::platform_bridge::{
-    self, AlertButton, AlertButtonStyle, CustomSheetOptions, HapticFeedback,
+    self, AlertButton, AlertButtonStyle, CustomSheetOptions, HapticFeedback, ListPickerItem,
     NativeDictationPreviewOptions, NativeEditMenuItem, NativeFloatingButtonOptions,
     NativeNotificationOptions, PlatformBridge,
 };
@@ -88,6 +88,15 @@ unsafe extern "C" {
         button_count: i32,
         labels: *const *const std::ffi::c_char,
         styles: *const i32,
+        image_names: *const *const std::ffi::c_char,
+    );
+    fn ios_present_list_picker(
+        callback_id: u32,
+        title: *const std::ffi::c_char,
+        message: *const std::ffi::c_char,
+        item_count: i32,
+        labels: *const *const std::ffi::c_char,
+        subtitles: *const *const std::ffi::c_char,
         image_names: *const *const std::ffi::c_char,
     );
     /// Present a native edit menu anchored at a window coordinate.
@@ -305,6 +314,52 @@ impl PlatformBridge for IosBridge {
                 buttons.len() as i32,
                 label_ptrs.as_ptr(),
                 styles.as_ptr(),
+                image_name_ptrs.as_ptr(),
+            );
+        }
+    }
+
+    fn present_list_picker(&self, id: u32, title: &str, message: &str, items: &[ListPickerItem]) {
+        use std::ffi::CString;
+
+        let c_title = CString::new(title).unwrap_or_else(|_| CString::new("").unwrap());
+        let c_message = CString::new(message).unwrap_or_else(|_| CString::new("").unwrap());
+        let c_labels: Vec<CString> = items
+            .iter()
+            .map(|item| {
+                CString::new(item.label.as_str()).unwrap_or_else(|_| CString::new("").unwrap())
+            })
+            .collect();
+        let label_ptrs: Vec<*const std::ffi::c_char> =
+            c_labels.iter().map(|label| label.as_ptr()).collect();
+        let c_subtitles: Vec<CString> = items
+            .iter()
+            .map(|item| {
+                CString::new(item.subtitle.as_deref().unwrap_or(""))
+                    .unwrap_or_else(|_| CString::new("").unwrap())
+            })
+            .collect();
+        let subtitle_ptrs: Vec<*const std::ffi::c_char> = c_subtitles
+            .iter()
+            .map(|subtitle| subtitle.as_ptr())
+            .collect();
+        let c_image_names: Vec<CString> = items
+            .iter()
+            .map(|item| {
+                CString::new(item.image_name.as_deref().unwrap_or(""))
+                    .unwrap_or_else(|_| CString::new("").unwrap())
+            })
+            .collect();
+        let image_name_ptrs: Vec<*const std::ffi::c_char> =
+            c_image_names.iter().map(|name| name.as_ptr()).collect();
+        unsafe {
+            ios_present_list_picker(
+                id,
+                c_title.as_ptr(),
+                c_message.as_ptr(),
+                items.len() as i32,
+                label_ptrs.as_ptr(),
+                subtitle_ptrs.as_ptr(),
                 image_name_ptrs.as_ptr(),
             );
         }

--- a/crates/zedra/src/ios_stub.c
+++ b/crates/zedra/src/ios_stub.c
@@ -55,6 +55,14 @@ __attribute__((weak)) void ios_present_selection(
     const char **labels,
     const int *styles,
     const char **image_names) {}
+__attribute__((weak)) void ios_present_list_picker(
+    unsigned int callback_id,
+    const char *title,
+    const char *message,
+    int item_count,
+    const char **labels,
+    const char **subtitles,
+    const char **image_names) {}
 __attribute__((weak)) void ios_present_native_edit_menu(
     unsigned int callback_id,
     float x_pts,

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -10,6 +10,9 @@ pub mod pending;
 
 // Components
 pub mod agent;
+pub mod agent_manage_view;
+pub mod agent_session_list;
+pub mod agent_session_view;
 pub mod button;
 pub mod docs_tree;
 pub mod editor;

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -66,6 +66,9 @@ pub struct ZedraAssets;
 
 impl gpui::AssetSource for ZedraAssets {
     fn load(&self, path: &str) -> gpui::Result<Option<std::borrow::Cow<'static, [u8]>>> {
+        if let Some(bytes) = editor::mermaid::load_mermaid_svg(path) {
+            return Ok(Some(std::borrow::Cow::Owned(bytes.to_vec())));
+        }
         Ok(Self::get(path).map(|f| f.data))
     }
 

--- a/crates/zedra/src/platform_bridge.rs
+++ b/crates/zedra/src/platform_bridge.rs
@@ -30,6 +30,13 @@ pub struct AlertButton {
 }
 
 #[derive(Clone, Debug)]
+pub struct ListPickerItem {
+    pub label: String,
+    pub subtitle: Option<String>,
+    pub image_name: Option<String>,
+}
+
+#[derive(Clone, Debug)]
 pub struct NativeEditMenuItem {
     pub label: String,
     pub image_name: Option<String>,
@@ -290,6 +297,24 @@ pub fn show_selection(
         .unwrap()
         .insert(id, Box::new(on_result));
     bridge().present_selection(id, title, message, &buttons);
+}
+
+/// Present a native scrollable list picker.
+///
+/// `on_result` receives `Some(index)` when the user picks an item, or `None`
+/// when the picker is dismissed without a selection.
+pub fn show_list_picker(
+    title: &str,
+    message: &str,
+    items: Vec<ListPickerItem>,
+    on_result: impl FnOnce(Option<usize>) + Send + 'static,
+) {
+    let id = NEXT_SELECTION_ID.fetch_add(1, Ordering::Relaxed);
+    selection_callbacks()
+        .lock()
+        .unwrap()
+        .insert(id, Box::new(on_result));
+    bridge().present_list_picker(id, title, message, &items);
 }
 
 /// Present a native text-input dialog (UIAlertController with a UITextField on iOS).
@@ -642,6 +667,15 @@ pub trait PlatformBridge: Send + Sync + 'static {
     /// `platform_bridge::dispatch_selection_result(id, button_index)` on selection,
     /// or `platform_bridge::dispatch_selection_dismiss(id)` if dismissed.
     fn present_selection(&self, _id: u32, _title: &str, _message: &str, _buttons: &[AlertButton]) {}
+    /// Display a native scrollable list picker.
+    fn present_list_picker(
+        &self,
+        _id: u32,
+        _title: &str,
+        _message: &str,
+        _items: &[ListPickerItem],
+    ) {
+    }
     /// Display a configurable native custom sheet that hosts GPUI content.
     fn present_custom_sheet(&self, _options: &CustomSheetOptions) {}
     /// Open a URL in the system browser.

--- a/crates/zedra/src/telemetry.rs
+++ b/crates/zedra/src/telemetry.rs
@@ -141,6 +141,16 @@ pub mod view_telemetry {
         "Workspace Git Diff",
         "WorkspaceGitdiff",
     );
+    pub const WORKSPACE_AGENT_SESSIONS: ViewDescriptor = ViewDescriptor::new(
+        "workspace_agent_sessions",
+        "Workspace Agent Sessions",
+        "AgentSessionView",
+    );
+    pub const WORKSPACE_AGENT_MANAGE: ViewDescriptor = ViewDescriptor::new(
+        "workspace_agent_manage",
+        "Workspace Agent Manage",
+        "AgentManageView",
+    );
     pub const WORKSPACE_NO_ACTIVE_TERMINAL: ViewDescriptor = ViewDescriptor::new(
         "workspace_no_active_terminal",
         "Workspace No Active Terminal",
@@ -193,6 +203,8 @@ pub mod view_telemetry {
             WorkspaceMainView::File { path } => Some(workspace_file(path)),
             WorkspaceMainView::GitDiff { .. } => Some(WORKSPACE_GIT_DIFF),
             WorkspaceMainView::Terminal { .. } => Some(WORKSPACE_TERMINAL),
+            WorkspaceMainView::AgentSessions => Some(WORKSPACE_AGENT_SESSIONS),
+            WorkspaceMainView::AgentManage => Some(WORKSPACE_AGENT_MANAGE),
             WorkspaceMainView::NoActiveTerminal => Some(WORKSPACE_NO_ACTIVE_TERMINAL),
         }
     }
@@ -240,6 +252,10 @@ pub mod view_telemetry {
             assert_eq!(
                 workspace_main_view(&WorkspaceMainView::NoActiveTerminal),
                 Some(WORKSPACE_NO_ACTIVE_TERMINAL)
+            );
+            assert_eq!(
+                workspace_main_view(&WorkspaceMainView::AgentManage),
+                Some(WORKSPACE_AGENT_MANAGE)
             );
             assert_eq!(workspace_main_view(&WorkspaceMainView::Default), None);
         }

--- a/crates/zedra/src/terminal_panel.rs
+++ b/crates/zedra/src/terminal_panel.rs
@@ -1,5 +1,6 @@
 use gpui::*;
 
+use crate::platform_bridge::{self, HapticFeedback};
 use crate::terminal_card::{TerminalCardProps, render_terminal_card};
 use crate::terminal_state::TerminalState;
 use crate::workspace_state::WorkspaceState;
@@ -43,6 +44,45 @@ impl Render for TerminalPanel {
 
         let mut content = div().pt(px(12.0)).flex().flex_col().flex_1();
 
+        content = content.child(
+            div()
+                .mx(px(theme::DRAWER_PADDING))
+                .mb(px(8.0))
+                .flex()
+                .flex_row()
+                .items_center()
+                .justify_between()
+                .gap(px(6.0))
+                .child(toolbar_button(
+                    "terminal-create-agent-btn",
+                    "icons/plus.svg",
+                    "Create agent",
+                    cx,
+                    workspace_action::CreateAgent,
+                ))
+                .child(toolbar_button(
+                    "terminal-create-terminal-btn",
+                    "icons/terminal.svg",
+                    "Create terminal",
+                    cx,
+                    workspace_action::CreateNewTerminal,
+                ))
+                .child(toolbar_button(
+                    "terminal-view-sessions-btn",
+                    "icons/list-tree.svg",
+                    "View sessions",
+                    cx,
+                    workspace_action::OpenAgentSessions,
+                ))
+                .child(toolbar_button(
+                    "terminal-manage-agents-btn",
+                    "icons/settings.svg",
+                    "Manage agents",
+                    cx,
+                    workspace_action::OpenAgentManage,
+                )),
+        );
+
         if !terminals.is_empty() {
             content = content.gap_1();
             for (index, tid, is_active, meta) in terminals {
@@ -83,26 +123,47 @@ impl Render for TerminalPanel {
             }
         }
 
-        content = content.child(
-            div()
-                .id("new-terminal-btn")
-                .mx(px(theme::DRAWER_PADDING))
-                .mt(px(8.0))
-                .px(px(8.0))
-                .py(px(8.0))
-                .cursor_pointer()
-                .on_press(cx.listener(|_this, _event, window, cx| {
-                    window.dispatch_action(workspace_action::CreateNewTerminal.boxed_clone(), cx);
-                }))
-                .child(
-                    div()
-                        .text_color(rgb(theme::TEXT_MUTED))
-                        .text_size(px(theme::FONT_BODY))
-                        .text_center()
-                        .child("+ New Terminal"),
-                ),
-        );
-
         content
     }
+}
+
+fn toolbar_button<A: Action>(
+    id: &'static str,
+    icon: &'static str,
+    label: &'static str,
+    cx: &mut Context<TerminalPanel>,
+    action: A,
+) -> Stateful<Div> {
+    div()
+        .id(id)
+        .flex_1()
+        .min_w_0()
+        .px(px(6.0))
+        .py(px(8.0))
+        .rounded(px(6.0))
+        .border_1()
+        .border_color(rgb(theme::BORDER_SUBTLE))
+        .flex()
+        .flex_col()
+        .items_center()
+        .justify_center()
+        .gap(px(4.0))
+        .cursor_pointer()
+        .on_press(cx.listener(move |_this, _event, window, cx| {
+            platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
+            window.dispatch_action(action.boxed_clone(), cx);
+        }))
+        .child(
+            svg()
+                .path(icon)
+                .size(px(theme::ICON_SM))
+                .text_color(rgb(theme::TEXT_MUTED)),
+        )
+        .child(
+            div()
+                .text_size(px(10.0))
+                .text_color(rgb(theme::TEXT_MUTED))
+                .text_center()
+                .child(label),
+        )
 }

--- a/crates/zedra/src/terminal_preview_view.rs
+++ b/crates/zedra/src/terminal_preview_view.rs
@@ -198,8 +198,8 @@ impl TerminalPreviewView {
                                     return;
                                 }
                                 this.state = PreviewState::Loaded;
-                                this.markdown_view.update(cx, |markdown_view, _cx| {
-                                    markdown_view.set_parsed_source(parsed);
+                                this.markdown_view.update(cx, |markdown_view, cx| {
+                                    markdown_view.set_parsed_source(parsed, cx);
                                 });
                                 this.update_sheet_scroll_boundary(cx);
                                 cx.notify();

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -7,7 +7,7 @@ use gpui::{prelude::FluentBuilder as _, *};
 use tokio::sync::{broadcast, mpsc};
 use tracing::*;
 use zedra_rpc::ZedraPairingTicket;
-use zedra_rpc::proto::{HostEvent, SyncSessionResult};
+use zedra_rpc::proto::{HostEvent, ManagedAgentKind, SyncSessionResult};
 use zedra_session::{
     ConnectEvent, ConnectPhase, ConnectSnapshot, ReconnectReason, Session, SessionHandle,
     SessionState, signer::ClientSigner,
@@ -15,10 +15,14 @@ use zedra_session::{
 
 use crate::active_terminal;
 use crate::agent;
+use crate::agent_manage_view::AgentManageView;
+use crate::agent_session_view::AgentSessionView;
 use crate::editor::git_sidebar::GitFileSection;
 use crate::pending::{SharedPendingSlot, shared_pending_slot, spawn_periodic_task};
 use crate::placeholder::render_placeholder;
-use crate::platform_bridge::{self, AlertButton, HapticFeedback, status_bar_inset};
+use crate::platform_bridge::{
+    self, AlertButton, HapticFeedback, ListPickerItem, show_list_picker, status_bar_inset,
+};
 use crate::telemetry::view_telemetry;
 use crate::terminal_card::strip_ps1_prefix;
 use crate::terminal_state::TerminalState;
@@ -27,9 +31,10 @@ use crate::transport_badge::ConnectionStatusIndicator;
 use crate::ui::{DrawerEvent, DrawerHost, DrawerSide};
 use crate::workspace_action::{self, GoHome, OpenQuickAction, RequestDisconnect};
 use crate::workspace_action::{
-    AddSelectionToChat, CloseDrawer, CloseTerminal, CreateNewTerminal, GitCommit,
-    GitShowItemActions, GitStage, GitUnstage, HideConnecting, OpenFile, OpenGitDiff, OpenTerminal,
-    RestartConnection, ShowConnecting, ToggleDrawer,
+    AddSelectionToChat, CloseDrawer, CloseTerminal, CreateAgent, CreateNewTerminal, GitCommit,
+    GitShowItemActions, GitStage, GitUnstage, HideConnecting, OpenAgentManage, OpenAgentSessions,
+    OpenFile, OpenGitDiff, OpenTerminal, RestartConnection, ResumeAgentSession, ShowConnecting,
+    SpawnAgentTerminal, ToggleDrawer,
 };
 use crate::workspace_connecting::WorkspaceConnecting;
 use crate::workspace_drawer::WorkspaceDrawer;
@@ -87,6 +92,9 @@ enum PendingWorkspaceAction {
     AddSelectionToChat {
         target: AddToChatTarget,
         input: agent::AddToChat,
+    },
+    SpawnAgentTerminal {
+        launch_cmd: String,
     },
 }
 
@@ -956,9 +964,11 @@ impl Workspace {
             return;
         };
 
-        // Ticket is only needed for initial registration. Once we have a session_id
-        // the ticket has already been consumed on the host and must not be reused.
-        if request.session_id.is_some() {
+        // Drop the one-time pairing ticket once registration has been
+        // attempted: it is consumed host-side and resending it would be
+        // rejected. `register_attempted` (not `register_ms`) is the guard so a
+        // connection that dropped before `RegisterComplete` still clears it.
+        if self.session_state.read(cx).snapshot.register_attempted {
             request.ticket = None;
         }
 
@@ -1291,6 +1301,24 @@ impl Workspace {
                     self.apply_route(WorkspaceMainView::Default, None, cx);
                 }
             }
+            WorkspaceMainView::AgentSessions => {
+                let view = cx.new(|cx| AgentSessionView::new(self.session.handle().clone(), cx));
+                self.content.update(cx, move |content, cx| {
+                    content.set_text_subtitle("Agent sessions", cx);
+                    content.set_main_view(view.into(), cx);
+                    content.hide_connecting_view(cx);
+                });
+                view_telemetry::record(view_telemetry::WORKSPACE_AGENT_SESSIONS);
+            }
+            WorkspaceMainView::AgentManage => {
+                let view = cx.new(|cx| AgentManageView::new(self.session.handle().clone(), cx));
+                self.content.update(cx, move |content, cx| {
+                    content.set_text_subtitle("Manage agents", cx);
+                    content.set_main_view(view.into(), cx);
+                    content.hide_connecting_view(cx);
+                });
+                view_telemetry::record(view_telemetry::WORKSPACE_AGENT_MANAGE);
+            }
         }
     }
 
@@ -1522,16 +1550,105 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.create_new_terminal("user_action", window, cx);
+        self.spawn_terminal("user_action", None, window, cx);
     }
 
-    fn create_new_terminal(
+    fn handle_create_agent(
         &mut self,
-        telemetry_source: &'static str,
+        _action: &CreateAgent,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        info!("handle CreateNewTerminal from workspace");
+        info!("handle CreateAgent from workspace");
+        self.drawer_host
+            .update(cx, |host, cx| host.close_with_window(&mut *window, cx));
+
+        let session_handle = self.session.handle().clone();
+        let pending_platform_action = self.pending_platform_action.clone();
+        cx.spawn(async move |workspace, cx| {
+            let agents = match session_handle.agent_installed_list(false).await {
+                Ok(agents) => agents,
+                Err(err) => {
+                    tracing::error!("agent installed list failed: {}", err);
+                    let _ = workspace.update(cx, |_ws, _cx| {
+                        platform_bridge::show_alert(
+                            "Create Agent",
+                            "Failed to load installed agents.",
+                            vec![AlertButton::default("OK")],
+                            |_| {},
+                        );
+                    });
+                    return;
+                }
+            };
+            let available: Vec<_> = agents.into_iter().filter(|agent| agent.available).collect();
+            if available.is_empty() {
+                let _ = workspace.update(cx, |_ws, _cx| {
+                    platform_bridge::show_alert(
+                        "Create Agent",
+                        "No supported agent CLIs are installed on the host.",
+                        vec![AlertButton::default("OK")],
+                        |_| {},
+                    );
+                });
+                return;
+            }
+
+            let picker_items: Vec<ListPickerItem> = available
+                .iter()
+                .map(|agent| ListPickerItem {
+                    label: agent.display_name.clone(),
+                    subtitle: agent.version.clone(),
+                    image_name: Some(agent.icon_name.clone()),
+                })
+                .collect();
+
+            let launch_cmds: Vec<Option<String>> = available
+                .iter()
+                .map(|agent| agent.launch_cmd.clone())
+                .collect();
+
+            let _ = workspace.update(cx, |_, _cx| {
+                show_list_picker(
+                    "Create Agent",
+                    "Choose an installed agent to launch in a new terminal.",
+                    picker_items,
+                    move |selection| {
+                        let Some(index) = selection else {
+                            return;
+                        };
+                        let Some(launch_cmd) = launch_cmds
+                            .get(index)
+                            .and_then(|launch_cmd| launch_cmd.clone())
+                        else {
+                            return;
+                        };
+                        pending_platform_action
+                            .set(PendingWorkspaceAction::SpawnAgentTerminal { launch_cmd });
+                    },
+                );
+            });
+        })
+        .detach();
+    }
+
+    fn handle_spawn_agent_terminal(
+        &mut self,
+        action: &SpawnAgentTerminal,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.spawn_terminal("create_agent", Some(action.launch_cmd.clone()), window, cx);
+    }
+
+    fn spawn_terminal(
+        &mut self,
+        telemetry_source: &'static str,
+        launch_cmd: Option<String>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        info!(?launch_cmd, "spawn_terminal");
         self.drawer_host
             .update(cx, |host, cx| host.close_with_window(&mut *window, cx));
 
@@ -1541,14 +1658,12 @@ impl Workspace {
         let cols = initial_grid_size.columns;
         let rows = initial_grid_size.rows;
 
-        // Pre-create a workspace terminal entity with a placeholder terminal ID.
-        // This is required due to the terminal view requires `window` to be available from main thread.
         let workspace_terminal =
             self.create_terminal_entity(TERMINAL_PENDING_ID.to_string(), window, cx);
 
         cx.spawn(async move |workspace, cx| {
             let terminal_id = match session_handle
-                .terminal_create(cols as u16, rows as u16)
+                .terminal_create_with_cmd(cols as u16, rows as u16, launch_cmd)
                 .await
             {
                 Ok(id) => id,
@@ -1564,7 +1679,6 @@ impl Workspace {
                 });
 
                 ws.workspace_state.update(cx, |_state, cx| {
-                    // The WorkspaceTerminal will need this subscription to attach the input/output channel.
                     cx.emit(WorkspaceStateEvent::TerminalCreated {
                         id: terminal_id.clone(),
                     });
@@ -1574,6 +1688,128 @@ impl Workspace {
                 let terminal_count = ws.workspace_state.read(cx).terminal_ids.len();
                 zedra_telemetry::send(zedra_telemetry::Event::TerminalOpened {
                     source: telemetry_source,
+                    terminal_count,
+                });
+            });
+        })
+        .detach();
+    }
+
+    fn create_new_terminal(
+        &mut self,
+        telemetry_source: &'static str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.spawn_terminal(telemetry_source, None, window, cx);
+    }
+
+    fn handle_open_agent_sessions(
+        &mut self,
+        _action: &OpenAgentSessions,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        info!("handle OpenAgentSessions from workspace");
+        self.drawer_host
+            .update(cx, |host, cx| host.close_with_window(&mut *window, cx));
+
+        self.workspace_state.update(cx, |state, cx| {
+            state.set_active_main_view(WorkspaceMainView::AgentSessions, cx);
+        });
+        let view = cx.new(|cx| AgentSessionView::new(self.session.handle().clone(), cx));
+        self.content.update(cx, move |content, cx| {
+            content.set_text_subtitle("Agent sessions", cx);
+            content.set_main_view(view.into(), cx);
+            content.hide_connecting_view(cx);
+        });
+        view_telemetry::record(view_telemetry::WORKSPACE_AGENT_SESSIONS);
+    }
+
+    fn handle_open_agent_manage(
+        &mut self,
+        _action: &OpenAgentManage,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        info!("handle OpenAgentManage from workspace");
+        self.drawer_host
+            .update(cx, |host, cx| host.close_with_window(&mut *window, cx));
+
+        self.workspace_state.update(cx, |state, cx| {
+            state.set_active_main_view(WorkspaceMainView::AgentManage, cx);
+        });
+        let view = cx.new(|cx| AgentManageView::new(self.session.handle().clone(), cx));
+        self.content.update(cx, move |content, cx| {
+            content.set_text_subtitle("Manage agents", cx);
+            content.set_main_view(view.into(), cx);
+            content.hide_connecting_view(cx);
+        });
+        view_telemetry::record(view_telemetry::WORKSPACE_AGENT_MANAGE);
+    }
+
+    fn handle_resume_agent_session(
+        &mut self,
+        action: &ResumeAgentSession,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        info!(
+            ?action.kind,
+            session_id = %action.session_id,
+            "handle ResumeAgentSession from workspace"
+        );
+        self.resume_agent_session(action.kind, action.session_id.clone(), window, cx);
+    }
+
+    fn resume_agent_session(
+        &mut self,
+        kind: ManagedAgentKind,
+        session_id: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let session_handle = self.session.handle().clone();
+        let initial_viewport = self.mainview_viewport(window, cx);
+        let initial_grid_size = TerminalView::compute_grid_size(window, initial_viewport);
+        let cols = initial_grid_size.columns;
+        let rows = initial_grid_size.rows;
+        let workspace_terminal =
+            self.create_terminal_entity(TERMINAL_PENDING_ID.to_string(), window, cx);
+
+        cx.spawn(async move |workspace, cx| {
+            let terminal_id = match session_handle
+                .agent_resume_session(kind, session_id, cols as u16, rows as u16)
+                .await
+            {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::error!(?kind, "agent session resume failed: {}", e);
+                    let _ = workspace.update(cx, |_ws, _cx| {
+                        platform_bridge::show_alert(
+                            "Resume Agent",
+                            "Failed to resume the agent session.",
+                            vec![AlertButton::default("OK")],
+                            |_| {},
+                        );
+                    });
+                    return;
+                }
+            };
+
+            let _ = workspace.update(cx, |ws, cx| {
+                workspace_terminal.update(cx, |terminal, cx| {
+                    terminal.set_terminal_id(terminal_id.clone(), cx);
+                });
+                ws.workspace_state.update(cx, |_state, cx| {
+                    cx.emit(WorkspaceStateEvent::TerminalCreated {
+                        id: terminal_id.clone(),
+                    });
+                });
+                ws.navigate_to(WorkspaceMainView::Terminal { id: terminal_id }, cx);
+                let terminal_count = ws.workspace_state.read(cx).terminal_ids.len();
+                zedra_telemetry::send(zedra_telemetry::Event::TerminalOpened {
+                    source: "resume_agent",
                     terminal_count,
                 });
             });
@@ -1763,6 +1999,14 @@ impl Workspace {
                 self.activate_existing_terminal(target.terminal_id.clone(), cx);
                 self.schedule_add_to_chat_after_activation(target, input, cx);
             }
+            PendingWorkspaceAction::SpawnAgentTerminal { launch_cmd } => {
+                let Some(window) = cx.active_window() else {
+                    return;
+                };
+                let _ = cx.update_window(window, |_, window, cx| {
+                    window.dispatch_action(SpawnAgentTerminal { launch_cmd }.boxed_clone(), cx);
+                });
+            }
         }
     }
 
@@ -1923,6 +2167,11 @@ impl Render for Workspace {
             .on_action(cx.listener(Self::handle_git_item_long_press))
             .on_action(cx.listener(Self::handle_git_commit))
             .on_action(cx.listener(Self::handle_create_new_terminal))
+            .on_action(cx.listener(Self::handle_create_agent))
+            .on_action(cx.listener(Self::handle_spawn_agent_terminal))
+            .on_action(cx.listener(Self::handle_open_agent_sessions))
+            .on_action(cx.listener(Self::handle_open_agent_manage))
+            .on_action(cx.listener(Self::handle_resume_agent_session))
             .on_action(cx.listener(Self::handle_open_terminal))
             .on_action(cx.listener(Self::handle_close_terminal))
             .size_full()
@@ -2363,6 +2612,9 @@ pub struct WorkspaceContent {
 
 enum WorkspaceSubtitle {
     Default,
+    Text {
+        text: SharedString,
+    },
     File {
         path: SharedString,
     },
@@ -2473,6 +2725,11 @@ impl WorkspaceContent {
         cx.notify();
     }
 
+    pub fn set_text_subtitle(&mut self, text: impl Into<SharedString>, cx: &mut Context<Self>) {
+        self.subtitle = WorkspaceSubtitle::Text { text: text.into() };
+        cx.notify();
+    }
+
     pub fn set_terminal_subtitle(&mut self, id: String, cx: &mut Context<Self>) {
         self.subtitle = WorkspaceSubtitle::Terminal { id };
         cx.notify();
@@ -2518,6 +2775,7 @@ impl WorkspaceContent {
     fn render_subtitle(&self, default_subtitle: &str, cx: &mut Context<Self>) -> AnyElement {
         match &self.subtitle {
             WorkspaceSubtitle::Default => render_subtitle(default_subtitle.to_owned()),
+            WorkspaceSubtitle::Text { text } => render_subtitle(text.clone()),
             WorkspaceSubtitle::File { path } => render_subtitle(path.clone()),
             WorkspaceSubtitle::Terminal { id } => {
                 let meta = self.terminal_state.read(cx).meta(id);

--- a/crates/zedra/src/workspace_action.rs
+++ b/crates/zedra/src/workspace_action.rs
@@ -1,4 +1,5 @@
 use gpui::Action;
+use zedra_rpc::proto::ManagedAgentKind;
 
 #[derive(Clone, PartialEq, Action)]
 #[action(namespace = workspace, no_json)]
@@ -72,6 +73,31 @@ pub struct RequestDisconnect;
 #[derive(Clone, PartialEq, Action)]
 #[action(namespace = workspace, no_json)]
 pub struct CreateNewTerminal;
+
+#[derive(Clone, PartialEq, Action)]
+#[action(namespace = workspace, no_json)]
+pub struct OpenAgentSessions;
+
+#[derive(Clone, PartialEq, Action)]
+#[action(namespace = workspace, no_json)]
+pub struct OpenAgentManage;
+
+#[derive(Clone, PartialEq, Action)]
+#[action(namespace = workspace, no_json)]
+pub struct CreateAgent;
+
+#[derive(Clone, PartialEq, Action)]
+#[action(namespace = workspace, no_json)]
+pub struct SpawnAgentTerminal {
+    pub launch_cmd: String,
+}
+
+#[derive(Clone, PartialEq, Action)]
+#[action(namespace = workspace, no_json)]
+pub struct ResumeAgentSession {
+    pub kind: ManagedAgentKind,
+    pub session_id: String,
+}
 
 #[derive(Clone, PartialEq, Action)]
 #[action(namespace = workspace, no_json)]

--- a/crates/zedra/src/workspace_editor.rs
+++ b/crates/zedra/src/workspace_editor.rs
@@ -143,8 +143,8 @@ impl WorkspaceEditor {
                                 return;
                             }
                             this.state = FileState::Loaded;
-                            this.markdown_view.update(cx, |markdown_view, _cx| {
-                                markdown_view.set_parsed_source(parsed);
+                            this.markdown_view.update(cx, |markdown_view, cx| {
+                                markdown_view.set_parsed_source(parsed, cx);
                             });
                             cx.notify();
                         }) {

--- a/crates/zedra/src/workspace_state.rs
+++ b/crates/zedra/src/workspace_state.rs
@@ -39,6 +39,8 @@ pub enum WorkspaceMainView {
     Terminal {
         id: String,
     },
+    AgentSessions,
+    AgentManage,
     NoActiveTerminal,
 }
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -17,7 +17,7 @@
 ## 0a. Home Install Guide Tabs
 
 1. Open the app with no saved workspaces visible on the Home screen
-2. Switch between the `mac/linux`, `windows`, `claude`, `codex`, and `opencode` guide tabs
+2. Switch between the `curl`, `claude`, `codex`, `opencode`, and `gemini` guide tabs
 3. Expected: each tab shows the same install commands as the landing page
 4. Tap a command line in each tab
 5. Expected: the tapped command line is copied to the system clipboard without navigating away from Home
@@ -104,7 +104,7 @@
 1. Run an iOS build with Firebase Analytics enabled, or add `android/google-services.json` with the `dev.zedra.app` client and run `./scripts/run-android.sh --release --target arm64-v8a`
 2. Open Home, Settings, Quick Actions, then connect to a workspace
 3. Open the workspace drawer and switch through Files, Documents, Git Diff, Terminals, and Session
-4. Open a non-markdown file, a markdown file, a git diff, and a terminal as the main workspace view
+4. Open a non-markdown file, a markdown file, a git diff, a terminal, and the managed-agent view as the main workspace view
 5. Tap terminal file links for both a source file and a markdown file so the native custom sheet opens
 6. Expected: manual `screen_view` events include `screen_name` and `screen_class` for `Home`, `Settings`, `Quick Actions`, `Workspace Connecting`, `Workspace Editor`, `Workspace Markdown`, `Workspace Git Diff`, `Workspace Terminal`, each drawer tab, `Custom Sheet Editor`, and `Custom Sheet Markdown`
 7. Expected: native automatic rows such as `UIViewController`, `CustomSheetViewController`, `UIAlertController`, and `ZedraQRScannerVC` on iOS or Android activity rows on Android are still present because native Firebase screen reporting remains enabled
@@ -919,6 +919,47 @@ Expected:
   `launch_cmd` path such as `claude --resume <session_id>`. Expected: while
   Claude is running, the terminal card shows the Claude icon even before a shell
   prompt emits fresh OSC metadata.
+
+## 18b. Agent Toolbar, Sessions, and Manage Views
+
+1. Open a connected workspace and open the workspace drawer Terminals tab.
+2. Expected: the top toolbar shows four icon actions: Create agent, Create
+   terminal, View sessions, and Manage agents.
+3. Tap `Create terminal`.
+4. Expected: the drawer closes, a new shell terminal opens in the main view,
+   and the terminal card appears in the drawer.
+5. Tap `Create agent`.
+6. Expected: a scrollable native list picker shows installed host agents with
+   icon and version subtitle; unavailable agents are omitted.
+7. Pick an installed agent such as Claude or Codex.
+8. Expected: Zedra creates a new terminal using the host-owned launch command,
+   opens it as the active main view, and the terminal card shows the matching
+   agent icon once OSC metadata arrives.
+9. Tap `View sessions`.
+10. Expected: the drawer closes and the main view shows a unified session list
+    grouped by day across Claude, Codex, and OpenCode for the current
+    workspace. Each row shows agent icon, title, datetime, branch/worktree,
+    transcript size, and model when available.
+11. Tap a resumable session row.
+12. Expected: Zedra immediately resumes the session in a new terminal and opens
+    it as the active main view.
+13. Tap `Manage agents`.
+14. Expected: the main view shows managed agents as a list with setup/session
+    counts. Tapping an agent opens detail with CLI/setup/account fields and a
+    session list below.
+15. In manage detail, verify discovered account fields:
+    - Claude: model, effort, permission mode, total sessions/messages/cost when
+      `stats-cache.json` exists
+    - Codex: logged in, last refresh, model/personality from `config.toml`
+    - OpenCode: config dir presence
+16. Tap `Resume` on a session from manage detail.
+17. Expected: same immediate resume behavior as the unified sessions view.
+18. Re-open `View sessions` or `Manage agents` without tapping Refresh.
+19. Expected: lists load quickly from the host startup cache (default limit 50
+    sessions per agent).
+20. Tap Refresh in either view.
+21. Expected: the host rescans agent metadata and session lists, then updates
+    the UI.
 
 ## 19. Xcode Rust Build Target
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -732,7 +732,26 @@ printf '/tmp/zedra-markdown-table.md:1\n'
 10. Swipe vertically starting inside the table
 11. Expected: the markdown preview scrolls vertically and the table does not drift horizontally
 
-## 15c. Markdown Bottom Padding And Link Hit Slop
+## 15c. Markdown Mermaid Diagram In Preview
+
+1. Connect to a session and open the terminal view
+2. Run:
+
+```bash
+printf '%s\n' '# Mermaid Test' '' '```mermaid' 'flowchart LR' '  A[Start] --> B[End]' '```' > /tmp/zedra-markdown-mermaid.md
+printf '/tmp/zedra-markdown-mermaid.md:1\n'
+```
+
+3. Tap `/tmp/zedra-markdown-mermaid.md:1`
+4. Expected: the preview opens in markdown mode
+5. Expected: a rendered flowchart appears in a card instead of raw `flowchart LR` source
+6. Expected: invalid mermaid syntax falls back to monospace source with a muted error line
+7. Tap `Show source` below a rendered diagram
+8. Expected: the fenced mermaid source appears and remains selectable for Add to Chat
+9. Open the same file from the workspace docs tree or editor
+10. Expected: the main workspace markdown view renders the diagram the same way
+
+## 15d. Markdown Bottom Padding And Link Hit Slop
 
 1. Connect to a session and open the terminal view
 2. Run:

--- a/docs/PROTOCOL_SPECS.md
+++ b/docs/PROTOCOL_SPECS.md
@@ -174,7 +174,8 @@ Most result structs carry `error: Option<String>`. When set, the operation faile
 Result types that carry `error: Option<String>`:
 `FsListResult`, `FsReadResult`, `FsStatResult`, `SessionSwitchResult`, `TermCreateResult`,
 `GitStatusResult`, `GitDiffResult`, `GitLogResult`, `GitCommitResult`, `GitStageResult`,
-`GitUnstageResult`, `GitBranchesResult`, `LspDiagnosticsResult`.
+`GitUnstageResult`, `GitBranchesResult`, `AgentListResult`, `AgentSessionsResult`,
+`AgentResumeResult`, `LspDiagnosticsResult`.
 
 Types that use non-string status fields or enum variants instead:
 `FsWriteResult` (`ok: bool`), `GitCheckoutResult` (`ok: bool`), `FsWatchResult`/`FsUnwatchResult` (enum),
@@ -281,11 +282,34 @@ All Git result types carry `error: Option<String>`. Host sends error when git re
 - `GitStage` stages the provided paths with `git add -- <paths>`.
 - `GitUnstage` removes the provided paths from the index while preserving working tree contents.
 
-## 5.7 AI and LSP
+## 5.7 AI, Managed Agents, and LSP
 
 - `AiPrompt(AiPromptReq) -> AiPromptResult`
+- `AgentList(AgentListReq) -> AgentListResult`
+- `AgentSessions(AgentSessionsReq) -> AgentSessionsResult`
+- `AgentResume(AgentResumeReq) -> AgentResumeResult`
+- `AgentInstalledList(AgentInstalledListReq) -> AgentInstalledListResult`
 - `LspDiagnostics(LspDiagnosticsReq) -> LspDiagnosticsResult`
 - `LspHover(LspHoverReq) -> LspHoverResult`
+
+### Managed agent conventions
+
+- `ManagedAgentKind` is intentionally narrower than the terminal AI-agent classifier. Current RPC-visible managed agents are `Claude`, `Codex`, and `OpenCode`.
+- `AgentListResult.agents` returns one `AgentSummary` for every supported managed agent, even when the CLI is missing or no sessions exist.
+- `AgentListReq.refresh` and `AgentInstalledListReq.refresh` default to `false`. When `false`, the host serves its startup cache; when `true`, the host rescans before responding.
+- `AgentSessionsResult.sessions` returns the latest workspace-matching sessions for one managed agent. `AgentSessionsResult.total` is the full match count before applying `limit`.
+- `AgentSessionsReq.limit` defaults to `0`, which uses the host default (`50`, overridable with `ZEDRA_AGENT_SESSION_LIMIT`, max `200`).
+- `AgentSessionsReq.refresh` follows the same cache rule as `AgentListReq.refresh`.
+- `AgentResume` creates a new terminal and starts the provider-specific resume command on the host. Clients must not build provider shell commands from summary fields.
+- `AgentInstalledList` returns all supported terminal agent slugs with host-owned `launch_cmd` values for available CLIs. Clients create agents through `TermCreate` with that launch command.
+- `AgentSummary.account.fields` exposes locally discovered account/setup metadata for manage-agent detail views. Values must remain privacy-safe.
+- `AgentSessionSummary.title` uses provider-stored titles when available, otherwise `"Unknown"`.
+- `AgentSessionSummary.transcript_size_bytes` reports transcript file size when the host scan has a local file path.
+- `AgentGitSummary.worktree` is populated for Claude when the encoded project path includes `--claude-worktrees-<name>`.
+- Summary timestamps use `DateTime<Utc>` serialization through serde/postcard.
+- Data sources are explicit through `AgentDataSource` so clients can distinguish CLI/setup checks, historical scans, terminal metadata, hook state, status lines, and provider CLI output.
+- Summaries must not expose prompt text, command arguments, tool input/output, transcript bodies, or last assistant messages. Allowed fields are safe labels, ids, timestamps, counts, paths already scoped to the workspace, and provider metadata such as model, source, permission mode, CLI version, git branch, and PR link metadata.
+- `AgentLifecycleStatus`, `AgentEventKind`, and `AgentActionKind` provide the cross-agent vocabulary for future hook-driven prompts and notifications.
 
 ---
 

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -64,6 +64,8 @@
 
 #define PANEL_ITEM_HEIGHT 28.0
 
+#define DRAWER_EDGE_ZONE 72.0
+
 #define DRAWER_EDGE_ZONE 56.0
 
 #define DRAWER_VELOCITY_THRESHOLD 12.0
@@ -143,6 +145,8 @@ extern void gpui_ios_detach_embedded_view(void *window_ptr);
 bool zedra_ios_check_pending_frame(void);
 
 void zedra_ios_app_will_terminate(void);
+
+bool zedra_ios_system_back(void);
 
 void zedra_ios_native_floating_button_pressed(uint32_t callback_id);
 
@@ -234,6 +238,14 @@ extern void ios_present_selection(uint32_t callback_id,
                                   const char *const *labels,
                                   const int32_t *styles,
                                   const char *const *image_names);
+
+extern void ios_present_list_picker(uint32_t callback_id,
+                                    const char *title,
+                                    const char *message,
+                                    int32_t item_count,
+                                    const char *const *labels,
+                                    const char *const *subtitles,
+                                    const char *const *image_names);
 
 /**
  * Present a native edit menu anchored at a window coordinate.

--- a/ios/Zedra/Presentations.swift
+++ b/ios/Zedra/Presentations.swift
@@ -139,6 +139,101 @@ private final class PresentationDismissDelegate: NSObject, UIAdaptivePresentatio
     }
 }
 
+private final class AgentListPickerViewController: UITableViewController {
+    private let callbackID: UInt32
+    private let pickerTitle: String?
+    private let pickerMessage: String?
+    private let itemLabels: [String]
+    private let itemSubtitles: [String?]
+    private let itemImageNames: [String?]
+    private var dismissed = false
+
+    init(
+        callbackID: UInt32,
+        title: String?,
+        message: String?,
+        itemLabels: [String],
+        itemSubtitles: [String?],
+        itemImageNames: [String?]
+    ) {
+        self.callbackID = callbackID
+        self.pickerTitle = title
+        self.pickerMessage = message
+        self.itemLabels = itemLabels
+        self.itemSubtitles = itemSubtitles
+        self.itemImageNames = itemImageNames
+        super.init(style: .insetGrouped)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = pickerTitle
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .cancel,
+            target: self,
+            action: #selector(cancelTapped)
+        )
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "AgentListPickerCell")
+        if let message = pickerMessage, !message.isEmpty {
+            let header = UILabel(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: 44))
+            header.text = message
+            header.font = .preferredFont(forTextStyle: .footnote)
+            header.textColor = .secondaryLabel
+            header.numberOfLines = 0
+            header.textAlignment = .center
+            tableView.tableHeaderView = header
+        }
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        guard !dismissed, presentingViewController == nil || isBeingDismissed else { return }
+        dismissed = true
+        zedra_ios_selection_dismiss(callbackID)
+    }
+
+    @objc private func cancelTapped() {
+        dismissed = true
+        dismiss(animated: true) {
+            zedra_ios_selection_dismiss(self.callbackID)
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        itemLabels.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "AgentListPickerCell", for: indexPath)
+        var content = UIListContentConfiguration.subtitleCell()
+        content.text = itemLabels[indexPath.row]
+        if let subtitle = itemSubtitles[safe: indexPath.row].flatMap({ $0 }), !subtitle.isEmpty {
+            content.secondaryText = subtitle
+        }
+        if let imageName = itemImageNames[safe: indexPath.row].flatMap({ $0 }),
+           let image = NativePresentationBridge.actionListImage(named: imageName) {
+            content.image = image
+            content.imageProperties.reservedLayoutSize = CGSize(width: 28, height: 28)
+        }
+        cell.contentConfiguration = content
+        cell.selectionStyle = .default
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        dismissed = true
+        dismiss(animated: true) {
+            zedra_ios_selection_result(self.callbackID, Int32(indexPath.row))
+        }
+    }
+}
+
 private final class AlertOutsideTapDismissHandler: NSObject, UIGestureRecognizerDelegate {
     private let callbackID: UInt32
     private weak var alert: UIAlertController?
@@ -255,6 +350,21 @@ enum NativePresentationBridge {
     static func actionImage(named imageName: String) -> UIImage? {
         let image = UIImage(named: imageName) ?? UIImage(systemName: imageName)
         return image?.withRenderingMode(.alwaysTemplate)
+    }
+
+    private static let actionListIconPointSize: CGFloat = 22
+    private static let actionListIconTint = UIColor(white: 1.0, alpha: 0.92)
+
+    static func actionListImage(named imageName: String) -> UIImage? {
+        guard let image = actionImage(named: imageName) else { return nil }
+        let size = CGSize(width: actionListIconPointSize, height: actionListIconPointSize)
+        let tinted = image.withTintColor(actionListIconTint, renderingMode: .alwaysTemplate)
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = UIScreen.main.scale
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        return renderer.image { _ in
+            tinted.draw(in: CGRect(origin: .zero, size: size))
+        }.withRenderingMode(.alwaysOriginal)
     }
 
     static func notificationImage(named imageName: String) -> UIImage? {
@@ -1431,6 +1541,42 @@ private enum PresentationCoordinator {
         }
     }
 
+    static func presentListPicker(
+        callbackID: UInt32,
+        title: String?,
+        message: String?,
+        itemLabels: [String],
+        itemSubtitles: [String?],
+        itemImageNames: [String?]
+    ) {
+        DispatchQueue.main.async {
+            guard !itemLabels.isEmpty else {
+                zedra_ios_selection_dismiss(callbackID)
+                return
+            }
+            guard let presenter = NativePresentationBridge.topViewController() else {
+                zedra_ios_selection_dismiss(callbackID)
+                return
+            }
+
+            let controller = AgentListPickerViewController(
+                callbackID: callbackID,
+                title: title,
+                message: message,
+                itemLabels: itemLabels,
+                itemSubtitles: itemSubtitles,
+                itemImageNames: itemImageNames
+            )
+            let navigation = UINavigationController(rootViewController: controller)
+            navigation.modalPresentationStyle = .formSheet
+            if let sheet = navigation.sheetPresentationController {
+                sheet.detents = [.medium(), .large()]
+                sheet.prefersGrabberVisible = true
+            }
+            presenter.present(navigation, animated: true)
+        }
+    }
+
     static func presentNativeEditMenu(
         callbackID: UInt32,
         sourcePoint: CGPoint,
@@ -1846,6 +1992,32 @@ func ios_present_alert(
         message: NativePresentationBridge.string(message),
         buttonLabels: NativePresentationBridge.strings(count: buttonCount, labels: labels),
         buttonStyles: NativePresentationBridge.styles(count: buttonCount, styles: styles)
+    )
+}
+
+@_cdecl("ios_present_list_picker")
+func ios_present_list_picker(
+    _ callbackID: UInt32,
+    _ title: UnsafePointer<CChar>?,
+    _ message: UnsafePointer<CChar>?,
+    _ itemCount: Int32,
+    _ labels: UnsafePointer<UnsafePointer<CChar>?>?,
+    _ subtitles: UnsafePointer<UnsafePointer<CChar>?>?,
+    _ imageNames: UnsafePointer<UnsafePointer<CChar>?>?
+) {
+    PresentationCoordinator.presentListPicker(
+        callbackID: callbackID,
+        title: NativePresentationBridge.string(title),
+        message: NativePresentationBridge.string(message),
+        itemLabels: NativePresentationBridge.strings(count: itemCount, labels: labels),
+        itemSubtitles: NativePresentationBridge.optionalStrings(
+            count: itemCount,
+            labels: subtitles
+        ),
+        itemImageNames: NativePresentationBridge.optionalStrings(
+            count: itemCount,
+            labels: imageNames
+        )
     )
 }
 

--- a/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
@@ -227,6 +227,14 @@ extern void ios_present_alert(uint32_t callback_id,
 /**
  * Present a dismissible native action sheet with dynamic items.
  */
+extern void ios_present_list_picker(uint32_t callback_id,
+                                    const char *title,
+                                    const char *message,
+                                    int32_t item_count,
+                                    const char *const *labels,
+                                    const char *const *subtitles,
+                                    const char *const *image_names);
+
 extern void ios_present_selection(uint32_t callback_id,
                                   const char *title,
                                   const char *message,

--- a/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
@@ -64,6 +64,8 @@
 
 #define PANEL_ITEM_HEIGHT 28.0
 
+#define DRAWER_EDGE_ZONE 72.0
+
 #define DRAWER_EDGE_ZONE 56.0
 
 #define DRAWER_VELOCITY_THRESHOLD 12.0
@@ -143,6 +145,8 @@ extern void gpui_ios_detach_embedded_view(void *window_ptr);
 bool zedra_ios_check_pending_frame(void);
 
 void zedra_ios_app_will_terminate(void);
+
+bool zedra_ios_system_back(void);
 
 void zedra_ios_native_floating_button_pressed(uint32_t callback_id);
 
@@ -234,6 +238,14 @@ extern void ios_present_selection(uint32_t callback_id,
                                   const char *const *labels,
                                   const int32_t *styles,
                                   const char *const *image_names);
+
+extern void ios_present_list_picker(uint32_t callback_id,
+                                    const char *title,
+                                    const char *message,
+                                    int32_t item_count,
+                                    const char *const *labels,
+                                    const char *const *subtitles,
+                                    const char *const *image_names);
 
 /**
  * Present a native edit menu anchored at a window coordinate.


### PR DESCRIPTION
## Summary
- Render fenced `mermaid` blocks in the workspace and terminal-sheet markdown preview using `mermaid-rs-renderer` and GPUI `img()` on cached SVG assets.
- Add a Show source toggle so diagram fences stay selectable for Add to Chat, with monospace fallback when rendering fails.
- Guard async renders with a generation counter and clear the SVG cache when markdown content reloads.

## Notes
- Diagram height uses a fixed content width estimate today; viewport-aware sizing is a reasonable follow-up.
- `mermaid-rs-renderer` does not cover every mermaid.js diagram type; unsupported syntax shows the source fallback.
- Manual verification: `docs/MANUAL_TEST.md` section 15c.

Made with [Cursor](https://cursor.com)