### PR TITLE
feat(ios): add dark/light theming with persisted preference

### DIFF
--- a/crates/zedra-terminal/src/element.rs
+++ b/crates/zedra-terminal/src/element.rs
@@ -15,8 +15,8 @@ use crate::selection::TerminalSelectionDocument;
 use crate::terminal::*;
 use crate::view::TerminalView;
 
-/// Per-terminal color palette. Construct with `TerminalTheme::one_dark()` for the default
-/// One Dark palette, or supply custom values for alternative themes.
+/// Per-terminal color palette.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TerminalTheme {
     pub background: u32,
     pub foreground: u32,
@@ -40,7 +40,7 @@ pub struct TerminalTheme {
 }
 
 impl TerminalTheme {
-    pub fn one_dark() -> Self {
+    pub fn dark() -> Self {
         Self {
             background: 0x0e0c0c,
             foreground: 0xabb2bf,
@@ -62,6 +62,34 @@ impl TerminalTheme {
             bright_cyan: 0x56b6c2,
             bright_white: 0xffffff,
         }
+    }
+
+    pub fn light() -> Self {
+        Self {
+            background: 0xfafafa,
+            foreground: 0x24292f,
+            cursor: 0x0969da,
+            black: 0x24292f,
+            red: 0xcf222e,
+            green: 0x116329,
+            yellow: 0x953800,
+            blue: 0x0550ae,
+            magenta: 0x8250df,
+            cyan: 0x116329,
+            white: 0x24292f,
+            bright_black: 0x57606a,
+            bright_red: 0xcf222e,
+            bright_green: 0x116329,
+            bright_yellow: 0x953800,
+            bright_blue: 0x0550ae,
+            bright_magenta: 0x8250df,
+            bright_cyan: 0x116329,
+            bright_white: 0x1a1a1a,
+        }
+    }
+
+    pub fn one_dark() -> Self {
+        Self::dark()
     }
 
     fn named_color(&self, color: NamedColor) -> Hsla {
@@ -303,6 +331,7 @@ pub struct TerminalElement {
     scroll_offset_px: f32,
     keyboard_inset: Pixels,
     keyboard_content_offset: Pixels,
+    theme: TerminalTheme,
     view: WeakEntity<TerminalView>,
     terminal: WeakEntity<Terminal>,
     focus_handle: FocusHandle,
@@ -317,6 +346,7 @@ impl TerminalElement {
         scroll_offset_px: f32,
         keyboard_inset: Pixels,
         keyboard_content_offset: Pixels,
+        theme: TerminalTheme,
         view: WeakEntity<TerminalView>,
         terminal: WeakEntity<Terminal>,
         focus_handle: FocusHandle,
@@ -329,6 +359,7 @@ impl TerminalElement {
             scroll_offset_px,
             keyboard_inset,
             keyboard_content_offset,
+            theme,
             view,
             terminal,
             focus_handle,
@@ -784,7 +815,7 @@ impl Element for TerminalElement {
         );
         window.handle_input(&self.focus_handle, input_handler, cx);
 
-        let theme = TerminalTheme::one_dark();
+        let theme = self.theme;
 
         // Draw terminal background
         window.paint_quad(fill(bounds, rgb(theme.background)));

--- a/crates/zedra-terminal/src/view.rs
+++ b/crates/zedra-terminal/src/view.rs
@@ -11,7 +11,7 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::*;
 use zedra_osc::OscEvent;
 
-use crate::element::TerminalElement;
+use crate::element::{TerminalElement, TerminalTheme};
 use crate::selection::TerminalSelectionDocument;
 use crate::terminal::{Terminal, TerminalContent, TerminalEvent};
 
@@ -115,6 +115,7 @@ pub struct TerminalView {
     /// Cached from terminal mode; updated each render so parent views can read without
     /// creating a GPUI dependency on the inner terminal entity.
     pub is_alt_screen: bool,
+    terminal_theme: crate::element::TerminalTheme,
     _event_task: Task<()>,
     _subscriptions: Vec<Subscription>,
 }
@@ -180,6 +181,7 @@ impl TerminalView {
             keyboard_content_offset: px(0.0),
             suppress_touch_scroll_until: None,
             is_alt_screen: false,
+            terminal_theme: TerminalTheme::dark(),
             _event_task: event_task,
             _subscriptions: vec![],
         }
@@ -187,6 +189,14 @@ impl TerminalView {
 
     pub fn set_terminal_id(&mut self, terminal_id: String) {
         self.terminal_id = terminal_id;
+    }
+
+    pub fn set_terminal_theme(&mut self, theme: TerminalTheme, cx: &mut Context<Self>) {
+        if self.terminal_theme == theme {
+            return;
+        }
+        self.terminal_theme = theme;
+        cx.notify();
     }
 
     /// Computes the upward pixel shift needed to keep active bottom content visible above
@@ -610,7 +620,7 @@ impl Render for TerminalView {
             .key_context("Terminal")
             .size_full()
             .overflow_hidden()
-            .bg(rgb(0x0e0c0c))
+            .bg(rgb(self.terminal_theme.background))
             .track_focus(&focus_handle)
             .manual_focus()
             .on_press(cx.listener(|this, event: &PressEvent, window, cx| {
@@ -751,6 +761,7 @@ impl Render for TerminalView {
                 visual_scroll_offset_px,
                 self.keyboard_inset,
                 self.keyboard_content_offset,
+                self.terminal_theme,
                 cx.weak_entity(),
                 self.terminal.downgrade(),
                 self.focus_handle.clone(),

--- a/crates/zedra/src/agent_manage_view.rs
+++ b/crates/zedra/src/agent_manage_view.rs
@@ -177,8 +177,8 @@ impl AgentManageView {
                     .py(px(theme::SPACING_SM))
                     .rounded(px(6.0))
                     .border_1()
-                    .border_color(rgb(theme::BORDER_SUBTLE))
-                    .bg(rgb(theme::BG_CARD))
+                    .border_color(rgb(theme::border_subtle(cx)))
+                    .bg(rgb(theme::bg_card(cx)))
                     .cursor_pointer()
                     .on_press(cx.listener(move |this, _event, _window, cx| {
                         platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
@@ -194,7 +194,7 @@ impl AgentManageView {
                                 svg()
                                     .path(agent_icon(kind))
                                     .size(px(theme::ICON_SM))
-                                    .text_color(rgb(theme::TEXT_MUTED)),
+                                    .text_color(rgb(theme::text_muted(cx))),
                             )
                             .child(
                                 div()
@@ -204,14 +204,14 @@ impl AgentManageView {
                                         div()
                                             .truncate()
                                             .text_size(px(theme::FONT_BODY))
-                                            .text_color(rgb(theme::TEXT_PRIMARY))
+                                            .text_color(rgb(theme::text_primary(cx)))
                                             .child(agent.display_name.clone()),
                                     )
                                     .child(
                                         div()
                                             .truncate()
                                             .text_size(px(theme::FONT_DETAIL))
-                                            .text_color(rgb(theme::TEXT_MUTED))
+                                            .text_color(rgb(theme::text_muted(cx)))
                                             .child(format!(
                                                 "{} · {} sessions",
                                                 setup_label(agent.setup.state),
@@ -227,7 +227,7 @@ impl AgentManageView {
 
     fn render_detail(&self, cx: &mut Context<Self>) -> Div {
         let Some(agent) = self.selected_agent() else {
-            return empty_text("No agent selected.");
+            return empty_text(cx, "No agent selected.");
         };
         let kind = agent.kind;
 
@@ -254,21 +254,21 @@ impl AgentManageView {
                                 div()
                                     .truncate()
                                     .text_size(px(theme::FONT_BODY))
-                                    .text_color(rgb(theme::TEXT_PRIMARY))
+                                    .text_color(rgb(theme::text_primary(cx)))
                                     .child(agent.display_name.clone()),
                             )
                             .child(
                                 div()
                                     .truncate()
                                     .text_size(px(theme::FONT_DETAIL))
-                                    .text_color(rgb(theme::TEXT_MUTED))
+                                    .text_color(rgb(theme::text_muted(cx)))
                                     .child(managed_agent_name(kind)),
                             ),
                     )
                     .child(refresh_button(cx)),
             )
-            .child(render_detail_summary(agent))
-            .child(section_header("Sessions"))
+            .child(render_detail_summary(agent, cx))
+            .child(section_header(cx, "Sessions"))
             .child(render_agent_session_list(
                 AgentSessionListProps {
                     sections: crate::agent_session_list::group_sessions_by_day(
@@ -293,19 +293,20 @@ impl Render for AgentManageView {
             .id("agent-manage-view")
             .size_full()
             .min_h_0()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .flex_col();
 
         match &self.agent_state {
             LoadState::Loading => {
-                root = root.child(empty_text("Loading managed agents..."));
+                root = root.child(empty_text(cx, "Loading managed agents..."));
             }
             LoadState::Error(message) => {
                 root = root
-                    .child(empty_text(format!(
-                        "Failed to load managed agents: {message}"
-                    )))
+                    .child(empty_text(
+                        cx,
+                        format!("Failed to load managed agents: {message}"),
+                    ))
                     .child(refresh_button(cx));
             }
             LoadState::Ready => {
@@ -319,7 +320,7 @@ impl Render for AgentManageView {
     }
 }
 
-fn render_detail_summary(agent: &AgentSummary) -> Div {
+fn render_detail_summary(agent: &AgentSummary, cx: &App) -> Div {
     let mut summary = div()
         .mx(px(theme::SPACING_MD))
         .mb(px(theme::SPACING_SM))
@@ -327,8 +328,8 @@ fn render_detail_summary(agent: &AgentSummary) -> Div {
         .py(px(theme::SPACING_SM))
         .rounded(px(6.0))
         .border_1()
-        .border_color(rgb(theme::BORDER_SUBTLE))
-        .bg(rgb(theme::BG_CARD))
+        .border_color(rgb(theme::border_subtle(cx)))
+        .bg(rgb(theme::bg_card(cx)))
         .flex()
         .flex_col()
         .gap(px(4.0));
@@ -348,12 +349,14 @@ fn render_detail_summary(agent: &AgentSummary) -> Div {
     };
 
     summary = summary
-        .child(summary_line("CLI", cli))
+        .child(summary_line(cx, "CLI", cli))
         .child(summary_line(
+            cx,
             "Setup",
             setup_label(agent.setup.state).to_string(),
         ))
         .child(summary_line(
+            cx,
             "Sessions",
             format!(
                 "{} resumable / {} total",
@@ -362,11 +365,12 @@ fn render_detail_summary(agent: &AgentSummary) -> Div {
         ));
 
     for field in &agent.account.fields {
-        summary = summary.child(summary_line(&field.label, field.value.clone()));
+        summary = summary.child(summary_line(cx, &field.label, field.value.clone()));
     }
 
     if !agent.warnings.is_empty() {
         summary = summary.child(summary_line(
+            cx,
             "Warnings",
             agent
                 .warnings
@@ -386,7 +390,7 @@ fn back_button(cx: &mut Context<AgentManageView>) -> Stateful<Div> {
         .py(px(6.0))
         .rounded(px(6.0))
         .border_1()
-        .border_color(rgb(theme::BORDER_SUBTLE))
+        .border_color(rgb(theme::border_subtle(cx)))
         .cursor_pointer()
         .on_press(cx.listener(|this, _event, _window, cx| {
             platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
@@ -396,7 +400,7 @@ fn back_button(cx: &mut Context<AgentManageView>) -> Stateful<Div> {
             svg()
                 .path("icons/chevron-left.svg")
                 .size(px(theme::ICON_SM))
-                .text_color(rgb(theme::TEXT_SECONDARY)),
+                .text_color(rgb(theme::text_secondary(cx))),
         )
 }
 
@@ -407,7 +411,7 @@ fn refresh_button(cx: &mut Context<AgentManageView>) -> Stateful<Div> {
         .py(px(6.0))
         .rounded(px(6.0))
         .border_1()
-        .border_color(rgb(theme::BORDER_SUBTLE))
+        .border_color(rgb(theme::border_subtle(cx)))
         .cursor_pointer()
         .on_press(cx.listener(|this, _event, _window, cx| {
             this.load_agents(true, cx);
@@ -415,22 +419,22 @@ fn refresh_button(cx: &mut Context<AgentManageView>) -> Stateful<Div> {
         .child(
             div()
                 .text_size(px(theme::FONT_DETAIL))
-                .text_color(rgb(theme::TEXT_SECONDARY))
+                .text_color(rgb(theme::text_secondary(cx)))
                 .child("Refresh"),
         )
 }
 
-fn section_header(label: &'static str) -> Div {
+fn section_header(cx: &App, label: &'static str) -> Div {
     div()
         .px(px(theme::SPACING_MD))
         .pt(px(theme::SPACING_SM))
         .pb(px(4.0))
         .text_size(px(theme::FONT_DETAIL))
-        .text_color(rgb(theme::TEXT_MUTED))
+        .text_color(rgb(theme::text_muted(cx)))
         .child(label)
 }
 
-fn summary_line(label: &str, value: String) -> Div {
+fn summary_line(cx: &App, label: &str, value: String) -> Div {
     div()
         .flex()
         .flex_row()
@@ -441,7 +445,7 @@ fn summary_line(label: &str, value: String) -> Div {
                 .w(px(120.0))
                 .flex_shrink_0()
                 .text_size(px(theme::FONT_DETAIL))
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .child(label.to_string()),
         )
         .child(
@@ -449,12 +453,12 @@ fn summary_line(label: &str, value: String) -> Div {
                 .min_w_0()
                 .truncate()
                 .text_size(px(theme::FONT_DETAIL))
-                .text_color(rgb(theme::TEXT_SECONDARY))
+                .text_color(rgb(theme::text_secondary(cx)))
                 .child(value),
         )
 }
 
-fn empty_text(text: impl Into<SharedString>) -> Div {
+fn empty_text(cx: &App, text: impl Into<SharedString>) -> Div {
     div()
         .flex()
         .flex_1()
@@ -462,7 +466,7 @@ fn empty_text(text: impl Into<SharedString>) -> Div {
         .justify_center()
         .px(px(theme::SPACING_MD))
         .text_size(px(theme::FONT_BODY))
-        .text_color(rgb(theme::TEXT_MUTED))
+        .text_color(rgb(theme::text_muted(cx)))
         .child(text.into())
 }
 

--- a/crates/zedra/src/agent_session_list.rs
+++ b/crates/zedra/src/agent_session_list.rs
@@ -67,17 +67,17 @@ pub fn render_agent_session_list<C: 'static>(
         .gap(px(theme::SPACING_SM));
 
     if props.loading {
-        return list.child(empty_text("Loading sessions..."));
+        return list.child(empty_text(cx, "Loading sessions..."));
     }
     if let Some(error) = props.error {
-        return list.child(empty_text(format!("Failed to load sessions: {error}")));
+        return list.child(empty_text(cx, format!("Failed to load sessions: {error}")));
     }
     if props.sections.is_empty() {
-        return list.child(empty_text(props.empty_message));
+        return list.child(empty_text(cx, props.empty_message));
     }
 
     for section in props.sections {
-        list = list.child(section_header(&section.label));
+        list = list.child(section_header(cx, &section.label));
         for session in section.sessions {
             list = list.child(render_agent_session_item(session, props.resume_on_tap, cx));
         }
@@ -104,8 +104,8 @@ pub fn render_agent_session_item<C: 'static>(
         .py(px(theme::SPACING_SM))
         .rounded(px(6.0))
         .border_1()
-        .border_color(rgb(theme::BORDER_SUBTLE))
-        .bg(rgb(theme::BG_CARD))
+        .border_color(rgb(theme::border_subtle(cx)))
+        .bg(rgb(theme::bg_card(cx)))
         .flex()
         .flex_col()
         .gap(px(6.0))
@@ -136,7 +136,7 @@ pub fn render_agent_session_item<C: 'static>(
                     svg()
                         .path(agent_icon(kind))
                         .size(px(theme::ICON_SM))
-                        .text_color(rgb(theme::TEXT_MUTED)),
+                        .text_color(rgb(theme::text_muted(cx))),
                 )
                 .child(
                     div()
@@ -150,7 +150,7 @@ pub fn render_agent_session_item<C: 'static>(
                                 .min_w_0()
                                 .truncate()
                                 .text_size(px(theme::FONT_BODY))
-                                .text_color(rgb(theme::TEXT_PRIMARY))
+                                .text_color(rgb(theme::text_primary(cx)))
                                 .child(session_title(&session)),
                         )
                         .child(
@@ -158,24 +158,24 @@ pub fn render_agent_session_item<C: 'static>(
                                 .min_w_0()
                                 .truncate()
                                 .text_size(px(theme::FONT_DETAIL))
-                                .text_color(rgb(theme::TEXT_MUTED))
+                                .text_color(rgb(theme::text_muted(cx)))
                                 .child(session_subtitle(&session)),
                         ),
                 ),
         )
-        .child(session_meta_row(&session))
+        .child(session_meta_row(cx, &session))
 }
 
-fn section_header(label: &str) -> Div {
+fn section_header(cx: &App, label: &str) -> Div {
     div()
         .pt(px(theme::SPACING_SM))
         .pb(px(4.0))
         .text_size(px(theme::FONT_DETAIL))
-        .text_color(rgb(theme::TEXT_MUTED))
+        .text_color(rgb(theme::text_muted(cx)))
         .child(label.to_string())
 }
 
-fn empty_text(text: impl Into<SharedString>) -> Div {
+fn empty_text(cx: &App, text: impl Into<SharedString>) -> Div {
     div()
         .flex()
         .flex_1()
@@ -183,11 +183,11 @@ fn empty_text(text: impl Into<SharedString>) -> Div {
         .justify_center()
         .px(px(theme::SPACING_MD))
         .text_size(px(theme::FONT_BODY))
-        .text_color(rgb(theme::TEXT_MUTED))
+        .text_color(rgb(theme::text_muted(cx)))
         .child(text.into())
 }
 
-fn session_meta_row(session: &AgentSessionSummary) -> Div {
+fn session_meta_row(cx: &App, session: &AgentSessionSummary) -> Div {
     let mut parts = Vec::new();
     if let Some(at) = session.last_activity_at.or(session.created_at) {
         parts.push(format_session_time(at));
@@ -214,7 +214,7 @@ fn session_meta_row(session: &AgentSessionSummary) -> Div {
         .min_w_0()
         .truncate()
         .text_size(px(theme::FONT_DETAIL))
-        .text_color(rgb(theme::TEXT_MUTED))
+        .text_color(rgb(theme::text_muted(cx)))
         .child(if parts.is_empty() {
             short_id(&session.session_id)
         } else {

--- a/crates/zedra/src/agent_session_view.rs
+++ b/crates/zedra/src/agent_session_view.rs
@@ -93,7 +93,7 @@ impl Render for AgentSessionView {
             .id("agent-session-view")
             .size_full()
             .min_h_0()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .flex_col()
             .child(
@@ -108,7 +108,7 @@ impl Render for AgentSessionView {
                     .child(
                         div()
                             .text_size(px(theme::FONT_BODY))
-                            .text_color(rgb(theme::TEXT_SECONDARY))
+                            .text_color(rgb(theme::text_secondary(cx)))
                             .child("All managed agent sessions in this workspace."),
                     )
                     .child(refresh_button(cx)),
@@ -136,7 +136,7 @@ fn refresh_button(cx: &mut Context<AgentSessionView>) -> Stateful<Div> {
         .py(px(6.0))
         .rounded(px(6.0))
         .border_1()
-        .border_color(rgb(theme::BORDER_SUBTLE))
+        .border_color(rgb(theme::border_subtle(cx)))
         .cursor_pointer()
         .on_press(cx.listener(|this, _event, _window, cx| {
             this.load(true, cx);
@@ -144,7 +144,7 @@ fn refresh_button(cx: &mut Context<AgentSessionView>) -> Stateful<Div> {
         .child(
             div()
                 .text_size(px(theme::FONT_DETAIL))
-                .text_color(rgb(theme::TEXT_SECONDARY))
+                .text_color(rgb(theme::text_secondary(cx)))
                 .child("Refresh"),
         )
 }

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -11,6 +11,7 @@ use crate::platform_bridge;
 use crate::quick_action_panel::{QuickActionEvent, QuickActionPanel};
 use crate::settings_view::{SettingsEvent, SettingsView};
 use crate::telemetry::view_telemetry::{self, ViewDescriptor};
+use crate::theme_state::{ThemeState, ThemeStateEvent};
 use crate::ui::{DrawerHost, DrawerSide};
 use crate::workspaces::{Workspaces, WorkspacesEvent};
 
@@ -37,6 +38,7 @@ fn should_update_drawer_content(current: AppScreen, next: AppScreen) -> bool {
 
 pub struct ZedraApp {
     screen: AppScreen,
+    theme_state: Entity<ThemeState>,
     home_view: Entity<HomeView>,
     settings_view: Entity<SettingsView>,
     workspaces: Entity<Workspaces>,
@@ -50,6 +52,9 @@ impl ZedraApp {
 
         let mut subscriptions = Vec::new();
 
+        let theme_state = cx.new(ThemeState::new);
+        ThemeState::register_global(theme_state.downgrade(), cx);
+
         // --- Workspaces ---
         let workspaces = cx.new(|cx| Workspaces::new(cx));
 
@@ -58,8 +63,11 @@ impl ZedraApp {
         let sub = cx.subscribe(&home_view, Self::on_home_event);
         subscriptions.push(sub);
 
-        let settings_view = cx.new(SettingsView::new);
+        let settings_view = cx.new(|cx| SettingsView::new(theme_state.clone(), cx));
         let sub = cx.subscribe(&settings_view, Self::on_settings_event);
+        subscriptions.push(sub);
+
+        let sub = cx.subscribe(&theme_state, Self::on_theme_changed);
         subscriptions.push(sub);
 
         // --- Quick action panel ---
@@ -95,6 +103,7 @@ impl ZedraApp {
 
         let app = Self {
             screen: AppScreen::Home,
+            theme_state,
             home_view,
             settings_view,
             workspaces,
@@ -171,6 +180,15 @@ impl ZedraApp {
                 self.set_screen(AppScreen::Home, cx);
             }
         }
+    }
+
+    fn on_theme_changed(
+        &mut self,
+        _: Entity<ThemeState>,
+        _: &ThemeStateEvent,
+        cx: &mut Context<Self>,
+    ) {
+        cx.notify();
     }
 
     fn on_quick_action_event(

--- a/crates/zedra/src/button.rs
+++ b/crates/zedra/src/button.rs
@@ -7,7 +7,7 @@ use crate::theme;
 const DEFAULT_NATIVE_FLOATING_BUTTON_ICON_SIZE: f32 = 16.0;
 
 /// An outlined button - bordered, centered text.
-pub fn outline_button(id: impl Into<ElementId>, label: &str) -> Stateful<Div> {
+pub fn outline_button(cx: &App, id: impl Into<ElementId>, label: &str) -> Stateful<Div> {
     div()
         .id(id)
         .flex()
@@ -17,9 +17,9 @@ pub fn outline_button(id: impl Into<ElementId>, label: &str) -> Stateful<Div> {
         .py(px(10.0))
         .rounded(px(8.0))
         .border_1()
-        .border_color(rgb(theme::BORDER_DEFAULT))
+        .border_color(rgb(theme::border_default(cx)))
         .cursor_pointer()
-        .text_color(rgb(theme::TEXT_PRIMARY))
+        .text_color(rgb(theme::text_primary(cx)))
         .text_size(px(theme::FONT_BODY))
         .font_weight(FontWeight::MEDIUM)
         .child(label.to_string())

--- a/crates/zedra/src/docs_tree.rs
+++ b/crates/zedra/src/docs_tree.rs
@@ -335,7 +335,7 @@ impl DocsTree {
                         svg()
                             .path(icon_path)
                             .size(icon_size)
-                            .text_color(rgb(theme::TEXT_MUTED)),
+                            .text_color(rgb(theme::text_muted(cx))),
                     ),
                 )
                 .child(
@@ -343,7 +343,7 @@ impl DocsTree {
                         .flex_1()
                         .min_w_0()
                         .truncate()
-                        .text_color(rgb(theme::TEXT_SECONDARY))
+                        .text_color(rgb(theme::text_secondary(cx)))
                         .text_size(px(theme::FONT_BODY))
                         .child(row.name),
                 )
@@ -379,7 +379,7 @@ impl DocsTree {
                     svg()
                         .path("icons/file-text.svg")
                         .size(px(theme::ICON_FILE))
-                        .text_color(rgb(theme::TEXT_MUTED)),
+                        .text_color(rgb(theme::text_muted(cx))),
                 ),
             )
             .child(
@@ -387,17 +387,17 @@ impl DocsTree {
                     .flex_1()
                     .min_w_0()
                     .truncate()
-                    .text_color(rgb(theme::TEXT_SECONDARY))
+                    .text_color(rgb(theme::text_secondary(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child(row.name),
             );
         if is_selected {
-            row_el = row_el.bg(hsla(0.0, 0.0, 1.0, 0.10));
+            row_el = row_el.bg(theme::row_pressed_bg(cx));
         }
         row_el.into_any_element()
     }
 
-    fn render_status_row(&self, message: String) -> Div {
+    fn render_status_row(&self, cx: &App, message: String) -> Div {
         div()
             .min_h(px(96.0))
             .w_full()
@@ -409,7 +409,7 @@ impl DocsTree {
                 div()
                     .w_full()
                     .min_w_0()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .text_center()
                     .child(message),
@@ -441,14 +441,14 @@ impl DocsTree {
                     .flex_1()
                     .min_w_0()
                     .truncate()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child(label),
             )
             .into_any_element()
     }
 
-    fn render_all_loaded_row(&self) -> impl IntoElement {
+    fn render_all_loaded_row(&self, cx: &App) -> impl IntoElement {
         div()
             .id("docs-tree-all-loaded-row")
             .flex_1()
@@ -461,17 +461,17 @@ impl DocsTree {
                     .flex_1()
                     .min_w_0()
                     .truncate()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child("All loaded"),
             )
     }
 
-    fn render_refresh_icon(&self, is_building: bool) -> AnyElement {
+    fn render_refresh_icon(&self, cx: &App, is_building: bool) -> AnyElement {
         let icon = svg()
             .path("icons/refresh-ccw.svg")
             .size(px(14.0))
-            .text_color(rgb(theme::TEXT_MUTED));
+            .text_color(rgb(theme::text_muted(cx)));
 
         if !is_building {
             return icon.into_any_element();
@@ -497,7 +497,7 @@ impl DocsTree {
             .justify_center()
             .rounded(px(6.0))
             .opacity(if is_building { 0.45 } else { 1.0 })
-            .child(self.render_refresh_icon(is_building));
+            .child(self.render_refresh_icon(cx, is_building));
 
         if !is_building {
             button = button
@@ -528,7 +528,7 @@ impl DocsTree {
         if matches!(self.build_state, DocsBuildState::Building) {
             row = row.child(
                 div()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child("Building documents..."),
             );
@@ -568,7 +568,7 @@ impl DocsTree {
         if self.has_more {
             footer = footer.child(self.render_load_more_row(cx));
         } else {
-            footer = footer.child(self.render_all_loaded_row());
+            footer = footer.child(self.render_all_loaded_row(cx));
         }
 
         footer
@@ -612,7 +612,7 @@ impl Render for DocsTree {
                 .items_stretch()
                 .justify_center();
             if let Some(message) = status_message {
-                scroll_content = scroll_content.child(self.render_status_row(message));
+                scroll_content = scroll_content.child(self.render_status_row(cx, message));
             }
             return div()
                 .track_focus(&self.focus_handle)

--- a/crates/zedra/src/editor/code_editor.rs
+++ b/crates/zedra/src/editor/code_editor.rs
@@ -9,7 +9,7 @@ use super::text_buffer::Buffer;
 
 use crate::fonts;
 use crate::platform_bridge;
-use crate::theme;
+use crate::theme::{self, EditorTheme};
 use crate::workspace_action::AddSelectionToChat;
 
 const LINE_HEIGHT: f32 = theme::EDITOR_LINE_HEIGHT;
@@ -17,8 +17,6 @@ const GUTTER_WIDTH: f32 = theme::EDITOR_GUTTER_WIDTH;
 const FONT_SIZE: f32 = theme::EDITOR_FONT_SIZE;
 const GUTTER_FONT_SIZE: f32 = theme::EDITOR_GUTTER_FONT_SIZE;
 const BOTTOM_INSET_MIN: f32 = 100.0;
-const CODE_TEXT_COLOR: u32 = 0xabb2bf;
-const PENDING_SYNTAX_TEXT_COLOR: u32 = 0x7b8494;
 pub const CODE_EDITOR_SELECTION_AREA_ID: &str = "code-editor-selection";
 
 type LineHighlights = Vec<(Range<usize>, HighlightStyle)>;
@@ -32,20 +30,13 @@ struct CachedLine {
 
 pub struct ParsedEditorSyntax {
     highlighter: Highlighter,
-    line_highlights: Vec<LineHighlights>,
 }
 
 impl ParsedEditorSyntax {
     pub fn build(filename: &str, content: String) -> Self {
         let mut highlighter = Highlighter::from_filename(filename);
         highlighter.parse(&content);
-        let theme = SyntaxTheme::default_dark();
-        let buffer = Buffer::new(content);
-        let line_highlights = build_line_highlights(&buffer, &highlighter, &theme);
-        Self {
-            highlighter,
-            line_highlights,
-        }
+        Self { highlighter }
     }
 }
 
@@ -53,7 +44,7 @@ impl ParsedEditorSyntax {
 pub struct EditorView {
     buffer: Buffer,
     highlighter: Rc<Highlighter>,
-    theme: SyntaxTheme,
+    editor_theme: EditorTheme,
     scroll_handle: UniformListScrollHandle,
     /// Cached line data shared with the uniform_list closure via Rc.
     /// Only rebuilt when the buffer content changes.
@@ -92,7 +83,7 @@ impl EditorView {
         Self {
             buffer: Buffer::new(content),
             highlighter: Rc::new(highlighter),
-            theme: SyntaxTheme::default_dark(),
+            editor_theme: EditorTheme::dark(),
             scroll_handle: UniformListScrollHandle::new(),
             cached_lines: Rc::new(Vec::new()),
             cached_line_highlights: Rc::new(Vec::new()),
@@ -145,12 +136,16 @@ impl EditorView {
     }
 
     pub fn apply_parsed_syntax(&mut self, parsed: ParsedEditorSyntax) {
-        let ParsedEditorSyntax {
-            highlighter,
-            line_highlights,
-        } = parsed;
-        self.highlighter = Rc::new(highlighter);
-        self.cached_line_highlights = Rc::new(line_highlights);
+        self.highlighter = Rc::new(parsed.highlighter);
+        self.cached_line_highlights = if self.highlighter.is_waiting_for_syntax() {
+            Rc::new(vec![Vec::new(); self.buffer.line_count()])
+        } else {
+            Rc::new(build_line_highlights(
+                &self.buffer,
+                &self.highlighter,
+                &self.editor_theme.syntax,
+            ))
+        };
     }
 
     pub fn language(&self) -> Language {
@@ -170,6 +165,15 @@ impl EditorView {
         line_range_for_selection_lines(&lines, range_utf16)
     }
 
+    pub fn sync_editor_theme(&mut self, editor_theme: &EditorTheme) {
+        if self.editor_theme == *editor_theme {
+            return;
+        }
+        self.editor_theme = editor_theme.clone();
+        self.cached_line_highlights = Rc::new(Vec::new());
+        self.lines_dirty = true;
+    }
+
     /// Rebuild the cached line data from the buffer text only.
     fn rebuild_line_cache(&mut self) {
         let line_count = self.buffer.line_count();
@@ -180,14 +184,15 @@ impl EditorView {
             })
             .collect();
         self.max_line_chars = lines.iter().map(|l| l.text.len()).max().unwrap_or(0);
-        if self.cached_line_highlights.len() != line_count {
+        if self.cached_line_highlights.is_empty() || self.cached_line_highlights.len() != line_count
+        {
             self.cached_line_highlights = if self.highlighter.is_waiting_for_syntax() {
                 Rc::new(vec![Vec::new(); line_count])
             } else {
                 Rc::new(build_line_highlights(
                     &self.buffer,
                     &self.highlighter,
-                    &self.theme,
+                    &self.editor_theme.syntax,
                 ))
             };
         }
@@ -213,11 +218,11 @@ impl EditorView {
     }
 }
 
-fn code_text_color_for_highlighter(highlighter: &Highlighter) -> u32 {
+fn code_text_color_for_highlighter(editor_theme: &EditorTheme, highlighter: &Highlighter) -> u32 {
     if highlighter.is_waiting_for_syntax() {
-        PENDING_SYNTAX_TEXT_COLOR
+        editor_theme.pending_syntax
     } else {
-        CODE_TEXT_COLOR
+        editor_theme.foreground
     }
 }
 
@@ -305,6 +310,8 @@ fn line_range_for_selection_lines(lines: &[&str], range_utf16: Range<usize>) -> 
 
 impl Render for EditorView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.sync_editor_theme(&theme::bundle(cx).editor);
+
         // Rebuild line cache only when buffer content changed.
         // During scroll, this is skipped entirely.
         if self.lines_dirty {
@@ -323,9 +330,14 @@ impl Render for EditorView {
         // the vertical position doesn't drift during a horizontal swipe.
         let scroll_y_lock = self.scroll_handle.0.borrow().base_handle.offset().y;
 
+        let editor_theme = self.editor_theme.clone();
         let text_style = {
             let mut style = window.text_style();
-            style.color = rgb(code_text_color_for_highlighter(&self.highlighter)).into();
+            style.color = rgb(code_text_color_for_highlighter(
+                &editor_theme,
+                &self.highlighter,
+            ))
+            .into();
             style.font_family = fonts::MONO_FONT_FAMILY.into();
             style.font_size = px(FONT_SIZE).into();
             style
@@ -335,7 +347,7 @@ impl Render for EditorView {
             .flex()
             .flex_col()
             .size_full()
-            .bg(rgb(0x0e0c0c))
+            .bg(rgb(editor_theme.background))
             .font_family(fonts::MONO_FONT_FAMILY)
             .on_scroll_wheel(
                 cx.listener(move |this, event: &ScrollWheelEvent, _window, cx| {
@@ -418,7 +430,7 @@ impl Render for EditorView {
                                                 .items_center()
                                                 .justify_end()
                                                 .pr_2()
-                                                .text_color(hsla(0.0, 0.0, 0.83, 0.3))
+                                                .text_color(editor_theme.gutter)
                                                 .text_size(px(GUTTER_FONT_SIZE))
                                                 .child(cached.number.clone()),
                                         )
@@ -464,10 +476,11 @@ mod tests {
     use gpui::{ScrollStrategy, point, px};
 
     use super::{
-        CODE_TEXT_COLOR, EditorView, PENDING_SYNTAX_TEXT_COLOR, ParsedEditorSyntax,
-        code_text_color_for_highlighter, line_range_for_selection_lines,
+        EditorView, ParsedEditorSyntax, code_text_color_for_highlighter,
+        line_range_for_selection_lines,
     };
     use crate::editor::syntax_highlighter::{Highlighter, Language};
+    use crate::theme::EditorTheme;
 
     #[test]
     fn maps_utf16_selection_to_code_lines() {
@@ -515,21 +528,25 @@ mod tests {
 
     #[test]
     fn dims_code_text_only_while_syntax_is_pending() {
+        let editor_theme = EditorTheme::dark();
         let pending = Highlighter::from_filename("main.rs");
         assert_eq!(
-            code_text_color_for_highlighter(&pending),
-            PENDING_SYNTAX_TEXT_COLOR
+            code_text_color_for_highlighter(&editor_theme, &pending),
+            editor_theme.pending_syntax
         );
 
         let plain_text = Highlighter::from_language(Language::PlainText);
         assert_eq!(
-            code_text_color_for_highlighter(&plain_text),
-            CODE_TEXT_COLOR
+            code_text_color_for_highlighter(&editor_theme, &plain_text),
+            editor_theme.foreground
         );
 
         let mut parsed = Highlighter::from_filename("main.rs");
         parsed.parse("fn main() {}\n");
-        assert_eq!(code_text_color_for_highlighter(&parsed), CODE_TEXT_COLOR);
+        assert_eq!(
+            code_text_color_for_highlighter(&editor_theme, &parsed),
+            editor_theme.foreground
+        );
     }
 
     #[test]

--- a/crates/zedra/src/editor/git_diff_view.rs
+++ b/crates/zedra/src/editor/git_diff_view.rs
@@ -12,7 +12,7 @@ use tracing::info;
 use super::syntax_highlighter::Highlighter;
 use super::syntax_theme::SyntaxTheme;
 use crate::platform_bridge;
-use crate::theme;
+use crate::theme::{self, EditorTheme};
 
 // ── Diff data types ─────────────────────────────────────────────────────────
 
@@ -217,7 +217,7 @@ struct CachedDiffLine {
 pub struct GitDiffView {
     diff: FileDiff,
     highlighter: Highlighter,
-    theme: SyntaxTheme,
+    editor_theme: EditorTheme,
     scroll_handle: UniformListScrollHandle,
     focus_handle: FocusHandle,
     cached_lines: Rc<Vec<CachedDiffLine>>,
@@ -245,7 +245,7 @@ impl GitDiffView {
         Self {
             diff,
             highlighter,
-            theme: SyntaxTheme::default_dark(),
+            editor_theme: EditorTheme::dark(),
             scroll_handle: UniformListScrollHandle::new(),
             focus_handle: cx.focus_handle(),
             cached_lines: Rc::new(Vec::new()),
@@ -263,6 +263,14 @@ impl GitDiffView {
         self.highlighter = Highlighter::from_filename(&filename);
         self.rebuild_line_cache();
         cx.notify();
+    }
+
+    fn sync_editor_theme(&mut self, editor_theme: &EditorTheme) {
+        if self.editor_theme == *editor_theme {
+            return;
+        }
+        self.editor_theme = editor_theme.clone();
+        self.lines_dirty = true;
     }
 
     fn rebuild_line_cache(&mut self) {
@@ -334,7 +342,7 @@ impl GitDiffView {
         let mut result: Vec<(Range<usize>, HighlightStyle)> = Vec::new();
 
         for (span_range, capture_name) in &raw_highlights {
-            if let Some(style) = self.theme.get(capture_name) {
+            if let Some(style) = self.editor_theme.syntax.get(capture_name) {
                 let start = span_range.start.min(content_len);
                 let end = span_range.end.min(content_len);
                 if start < end {
@@ -357,6 +365,8 @@ impl Focusable for GitDiffView {
 
 impl Render for GitDiffView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.sync_editor_theme(&theme::bundle(cx).editor);
+
         if self.lines_dirty {
             info!("rebuilding gitdiff line cache by lines_dirty flag");
             self.rebuild_line_cache();
@@ -369,9 +379,11 @@ impl Render for GitDiffView {
         let h_scroll_offset = self.h_scroll_offset;
         let scroll_y_lock = self.scroll_handle.0.borrow().base_handle.offset().y;
 
+        let editor_theme = self.editor_theme.clone();
+        let diff = editor_theme.diff.clone();
         let text_style = {
             let mut style = window.text_style();
-            style.color = rgb(0xcacaca).into();
+            style.color = rgb(diff.body_text).into();
             style.font_size = px(FONT_SIZE).into();
             style
         };
@@ -380,7 +392,7 @@ impl Render for GitDiffView {
             .flex()
             .flex_col()
             .size_full()
-            .bg(rgb(0x0e0c0c))
+            .bg(rgb(editor_theme.background))
             .track_focus(&self.focus_handle)
             .on_scroll_wheel(
                 cx.listener(move |this, event: &ScrollWheelEvent, _window, cx| {
@@ -410,6 +422,8 @@ impl Render for GitDiffView {
             .child(
                 uniform_list("git-diff-view-lines", line_count + extra_items, {
                     let text_style = text_style.clone();
+                    let diff = diff.clone();
+                    let editor_theme = editor_theme.clone();
                     move |range: Range<usize>, _window: &mut Window, _cx: &mut App| {
                         range
                             .map(|i| {
@@ -423,27 +437,27 @@ impl Render for GitDiffView {
                                 };
 
                                 let (bg_color, gutter_text) = match line.kind {
-                                    DiffLineKind::Header => (rgb(0x131313), "".to_string()),
+                                    DiffLineKind::Header => (rgb(diff.header_bg), "".to_string()),
                                     DiffLineKind::Added => {
                                         let num = line
                                             .new_line_num
                                             .map(|n| format!("{:>3}", n))
                                             .unwrap_or_default();
-                                        (rgb(0x162016), num)
+                                        (rgb(diff.added_bg), num)
                                     }
                                     DiffLineKind::Removed => {
                                         let num = line
                                             .old_line_num
                                             .map(|n| format!("{:>3}", n))
                                             .unwrap_or_default();
-                                        (rgb(0x201616), num)
+                                        (rgb(diff.removed_bg), num)
                                     }
                                     DiffLineKind::Unchanged => {
                                         let num = line
                                             .new_line_num
                                             .map(|n| format!("{:>3}", n))
                                             .unwrap_or_default();
-                                        (rgb(0x0e0c0c), num)
+                                        (rgb(editor_theme.background), num)
                                     }
                                 };
 
@@ -460,7 +474,7 @@ impl Render for GitDiffView {
                                         .items_center()
                                         .child(
                                             div()
-                                                .text_color(rgb(0x61afef))
+                                                .text_color(rgb(diff.header_text))
                                                 .text_size(px(FONT_SIZE))
                                                 .child(content.clone()),
                                         )
@@ -491,7 +505,7 @@ impl Render for GitDiffView {
                                             .items_center()
                                             .justify_end()
                                             .pr_2()
-                                            .text_color(rgb(0x404040))
+                                            .text_color(rgb(diff.gutter_text))
                                             .text_size(px(GUTTER_FONT_SIZE))
                                             .child(gutter_text),
                                     )

--- a/crates/zedra/src/editor/git_sidebar.rs
+++ b/crates/zedra/src/editor/git_sidebar.rs
@@ -342,12 +342,12 @@ impl GitSidebar {
                                 "icons/chevron-right.svg"
                             })
                             .size(px(theme::FONT_DETAIL))
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .left(px(-2.0)),
                     )
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .text_size(px(theme::FONT_DETAIL))
                             .font_weight(FontWeight::MEDIUM)
                             .child(title),
@@ -356,7 +356,7 @@ impl GitSidebar {
             .child(
                 div()
                     .px_1()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_DETAIL))
                     .child(count.to_string()),
             )
@@ -374,14 +374,14 @@ impl GitSidebar {
             .as_ref()
             .is_some_and(|active| active.path == file.path && active.section == file.section);
         let status_color = if is_active {
-            theme::TEXT_SECONDARY
+            theme::text_secondary(cx)
         } else {
-            theme::TEXT_MUTED
+            theme::text_muted(cx)
         };
         let filename_color = if is_active {
-            theme::TEXT_PRIMARY
+            theme::text_primary(cx)
         } else {
-            theme::TEXT_SECONDARY
+            theme::text_secondary(cx)
         };
 
         let mut row = div()
@@ -452,21 +452,21 @@ impl GitSidebar {
                     .when(insertions > 0, |s| {
                         s.child(
                             div()
-                                .text_color(rgb(theme::TEXT_MUTED))
+                                .text_color(rgb(theme::text_muted(cx)))
                                 .child(format!("+{}", insertions)),
                         )
                     })
                     .when(deletions > 0, |s| {
                         s.child(
                             div()
-                                .text_color(rgb(theme::TEXT_MUTED))
+                                .text_color(rgb(theme::text_muted(cx)))
                                 .child(format!("-{}", deletions)),
                         )
                     }),
             );
 
         if is_active {
-            row = row.bg(hsla(0.0, 0.0, 1.0, 0.10));
+            row = row.bg(theme::row_pressed_bg(cx));
         }
 
         row
@@ -480,9 +480,9 @@ impl GitSidebar {
             "icons/check.svg"
         };
         let icon_color = if is_enabled || self.committing {
-            theme::TEXT_SECONDARY
+            theme::text_secondary(cx)
         } else {
-            theme::TEXT_MUTED
+            theme::text_muted(cx)
         };
         let icon_size = if self.committing { px(14.0) } else { px(20.0) };
 
@@ -600,7 +600,7 @@ impl Render for GitSidebar {
             .flex()
             .flex_col()
             .size_full()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .child(self.render_commit_composer(cx))
             // File sections (scrollable)
             .child(

--- a/crates/zedra/src/editor/markdown.rs
+++ b/crates/zedra/src/editor/markdown.rs
@@ -231,7 +231,8 @@ impl InlineRenderBuffer {
 }
 
 impl Render for MarkdownView {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let _theme = theme::palette(cx);
         let blocks = Arc::clone(&self.document.blocks);
         let block_count = blocks.len();
         let bottom_inset = f32::max(
@@ -240,7 +241,7 @@ impl Render for MarkdownView {
         );
         let focus_handle = self
             .focus_handle
-            .get_or_insert_with(|| _cx.focus_handle())
+            .get_or_insert_with(|| cx.focus_handle())
             .clone();
         let press_focus_handle = focus_handle.clone();
         // Keep each top-level markdown block as one variable-height list row.
@@ -1102,21 +1103,21 @@ fn parse_inline_event(events: &[Event<'_>], cursor: &mut usize) -> Vec<Inline> {
 
 fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -> AnyElement {
     match block {
-        Block::Paragraph(content) => render_inline_block(content, InlineBlockStyle::Body, key),
+        Block::Paragraph(content) => render_inline_block(content, InlineBlockStyle::Body, key, cx),
         Block::Heading { level, content } => {
             let style = match level {
                 HeadingLevel::H1 => InlineBlockStyle::Title,
                 HeadingLevel::H2 => InlineBlockStyle::Section,
                 _ => InlineBlockStyle::Heading,
             };
-            render_inline_block(content, style, key)
+            render_inline_block(content, style, key, cx)
         }
         Block::BlockQuote(children) => {
             div()
                 .w_full()
                 .pl(px(theme::SPACING_MD))
                 .border_l_1()
-                .border_color(rgb(theme::BORDER_DEFAULT))
+                .border_color(rgb(theme::border_default(cx)))
                 .flex()
                 .flex_col()
                 .gap(px(10.0))
@@ -1149,7 +1150,7 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
                         div()
                             .flex_shrink_0()
                             .min_w(px(16.0))
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .text_size(px(theme::FONT_BODY))
                             .line_height(px(theme::FONT_BODY + 6.0))
                             .font_family(fonts::MONO_FONT_FAMILY)
@@ -1190,7 +1191,7 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
                     };
                     div()
                         .w_full()
-                        .text_color(rgb(theme::TEXT_PRIMARY))
+                        .text_color(rgb(theme::text_primary(cx)))
                         .text_size(px(CODE_BLOCK_FONT_SIZE))
                         .line_height(px(CODE_BLOCK_LINE_HEIGHT))
                         .font_family(fonts::MONO_FONT_FAMILY)
@@ -1201,9 +1202,9 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
             let mut container = div()
                 .id(format!("{key}-code-scroll"))
                 .w_full()
-                .bg(rgb(theme::BG_CARD))
+                .bg(rgb(theme::bg_card(cx)))
                 .border_1()
-                .border_color(rgb(theme::BORDER_DEFAULT))
+                .border_color(rgb(theme::border_default(cx)))
                 .rounded(px(6.0))
                 .overflow_x_scroll()
                 .child(code_lines);
@@ -1211,14 +1212,17 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
 
             container.into_any_element()
         }
-        Block::Table(table) => render_table(table, key),
-        Block::Html(text) => {
-            render_inline_block(&[Inline::Html(text.clone())], InlineBlockStyle::Html, key)
-        }
+        Block::Table(table) => render_table(table, key, cx),
+        Block::Html(text) => render_inline_block(
+            &[Inline::Html(text.clone())],
+            InlineBlockStyle::Html,
+            key,
+            cx,
+        ),
         Block::Rule => div()
             .w_full()
             .h(px(1.0))
-            .bg(rgb(theme::BORDER_SUBTLE))
+            .bg(rgb(theme::border_subtle(cx)))
             .into_any_element(),
     }
 }
@@ -1245,7 +1249,7 @@ fn code_block_display_columns(line: &str) -> usize {
     columns
 }
 
-fn render_table(table: &TableBlock, key: String) -> AnyElement {
+fn render_table(table: &TableBlock, key: String, cx: &App) -> AnyElement {
     let column_widths = table_column_widths(table);
     let table_width = column_widths.iter().sum::<f32>().max(TABLE_CELL_MIN_WIDTH);
     let rows = (!table.headers.is_empty())
@@ -1269,9 +1273,9 @@ fn render_table(table: &TableBlock, key: String) -> AnyElement {
                         .flex()
                         .border_b_1()
                         .when(is_last_row, |this| {
-                            this.border_color(rgb(theme::BORDER_SUBTLE))
+                            this.border_color(rgb(theme::border_subtle(cx)))
                         })
-                        .border_color(rgb(theme::BORDER_SUBTLE))
+                        .border_color(rgb(theme::border_subtle(cx)))
                         .children(row.iter().enumerate().map(|(cell_ix, cell)| {
                             let cell_width = column_widths
                                 .get(cell_ix)
@@ -1285,7 +1289,7 @@ fn render_table(table: &TableBlock, key: String) -> AnyElement {
                                 .px(px(TABLE_CELL_PADDING_X))
                                 .py(px(TABLE_CELL_PADDING_Y))
                                 .border_r_1()
-                                .border_color(rgb(theme::BORDER_SUBTLE))
+                                .border_color(rgb(theme::border_subtle(cx)))
                                 .child(render_inline_block(
                                     &cell,
                                     if is_header {
@@ -1294,6 +1298,7 @@ fn render_table(table: &TableBlock, key: String) -> AnyElement {
                                         InlineBlockStyle::TableCell
                                     },
                                     format!("{key}-row-{row_ix}-cell-{cell_ix}"),
+                                    cx,
                                 ))
                         }))
                 }),
@@ -1302,9 +1307,9 @@ fn render_table(table: &TableBlock, key: String) -> AnyElement {
     let mut container = div()
         .id(format!("{key}-table-scroll"))
         .w_full()
-        .bg(rgb(theme::BG_CARD))
+        .bg(rgb(theme::bg_card(cx)))
         .border_1()
-        .border_color(rgb(theme::BORDER_DEFAULT))
+        .border_color(rgb(theme::border_default(cx)))
         .rounded(px(6.0))
         .overflow_x_scroll()
         .child(table_body);
@@ -1405,11 +1410,16 @@ enum InlineBlockStyle {
     Html,
 }
 
-fn render_inline_block(content: &[Inline], style: InlineBlockStyle, key: String) -> AnyElement {
+fn render_inline_block(
+    content: &[Inline],
+    style: InlineBlockStyle,
+    key: String,
+    cx: &App,
+) -> AnyElement {
     let mut buffer = InlineRenderBuffer::default();
-    flatten_inlines(content, &mut buffer, InlineMarks::default());
+    flatten_inlines(content, &mut buffer, InlineMarks::default(), cx);
 
-    let base = block_style(style);
+    let base = block_style(style, cx);
     let styled = StyledText::new(buffer.text.clone()).with_highlights(merge_highlights(
         buffer
             .highlights
@@ -1464,47 +1474,47 @@ struct InlineMarks {
     html: bool,
 }
 
-fn flatten_inlines(content: &[Inline], out: &mut InlineRenderBuffer, marks: InlineMarks) {
+fn flatten_inlines(content: &[Inline], out: &mut InlineRenderBuffer, marks: InlineMarks, cx: &App) {
     for inline in content {
         match inline {
-            Inline::Text(text) => push_text_with_marks(out, text, marks),
+            Inline::Text(text) => push_text_with_marks(out, text, marks, cx),
             Inline::Code(text) => {
                 let mut next = marks;
                 next.code = true;
-                push_text_with_marks(out, text, next);
+                push_text_with_marks(out, text, next, cx);
             }
             Inline::Html(text) => {
                 let mut next = marks;
                 next.html = true;
-                push_text_with_marks(out, text, next);
+                push_text_with_marks(out, text, next, cx);
             }
             Inline::Emphasis(children) => {
                 let mut next = marks;
                 next.emphasis = true;
-                flatten_inlines(children, out, next);
+                flatten_inlines(children, out, next, cx);
             }
             Inline::Strong(children) => {
                 let mut next = marks;
                 next.strong = true;
-                flatten_inlines(children, out, next);
+                flatten_inlines(children, out, next, cx);
             }
             Inline::Strikethrough(children) => {
                 let mut next = marks;
                 next.strike = true;
-                flatten_inlines(children, out, next);
+                flatten_inlines(children, out, next, cx);
             }
             Inline::Link { url, content } => {
                 let start = out.text.len();
-                flatten_inlines(content, out, marks);
+                flatten_inlines(content, out, marks, cx);
                 let end = out.text.len();
                 if start != end {
                     let range = start..end;
                     out.highlights.push(StyledRun {
                         range: range.clone(),
                         style: HighlightStyle {
-                            color: Some(rgb(theme::ACCENT_BLUE).into()),
+                            color: Some(rgb(theme::accent_blue(cx)).into()),
                             underline: Some(UnderlineStyle {
-                                color: Some(rgb(theme::ACCENT_BLUE).into()),
+                                color: Some(rgb(theme::accent_blue(cx)).into()),
                                 thickness: px(1.0),
                                 wavy: false,
                             }),
@@ -1530,7 +1540,7 @@ fn flatten_inlines(content: &[Inline], out: &mut InlineRenderBuffer, marks: Inli
     }
 }
 
-fn push_text_with_marks(out: &mut InlineRenderBuffer, text: &str, marks: InlineMarks) {
+fn push_text_with_marks(out: &mut InlineRenderBuffer, text: &str, marks: InlineMarks, cx: &App) {
     if text.is_empty() {
         return;
     }
@@ -1548,19 +1558,19 @@ fn push_text_with_marks(out: &mut InlineRenderBuffer, text: &str, marks: InlineM
     }
     if marks.strike {
         style.strikethrough = Some(StrikethroughStyle {
-            color: Some(rgb(theme::TEXT_SECONDARY).into()),
+            color: Some(rgb(theme::text_secondary(cx)).into()),
             thickness: px(1.0),
         });
         has_style = true;
     }
     if marks.code {
-        style.background_color = Some(rgb(theme::BG_CARD).into());
-        style.color = Some(rgb(theme::TEXT_PRIMARY).into());
+        style.background_color = Some(rgb(theme::bg_card(cx)).into());
+        style.color = Some(rgb(theme::text_primary(cx)).into());
         has_style = true;
     }
     if marks.html {
-        style.background_color = Some(rgb(theme::BG_CARD).into());
-        style.color = Some(rgb(theme::TEXT_MUTED).into());
+        style.background_color = Some(rgb(theme::bg_card(cx)).into());
+        style.color = Some(rgb(theme::text_muted(cx)).into());
         has_style = true;
     }
 
@@ -1577,47 +1587,47 @@ struct BlockStyleSpec {
     weight: Option<FontWeight>,
 }
 
-fn block_style(style: InlineBlockStyle) -> BlockStyleSpec {
+fn block_style(style: InlineBlockStyle, cx: &App) -> BlockStyleSpec {
     match style {
         InlineBlockStyle::Title => BlockStyleSpec {
             size: theme::FONT_TITLE,
             line_height: theme::FONT_TITLE + 8.0,
-            color: rgb(theme::TEXT_PRIMARY).into(),
+            color: rgb(theme::text_primary(cx)).into(),
             font_family: fonts::HEADING_FONT_FAMILY,
             weight: Some(FontWeight::MEDIUM),
         },
         InlineBlockStyle::Section => BlockStyleSpec {
             size: theme::FONT_HEADING + 2.0,
             line_height: theme::FONT_HEADING + 8.0,
-            color: rgb(theme::TEXT_PRIMARY).into(),
+            color: rgb(theme::text_primary(cx)).into(),
             font_family: fonts::HEADING_FONT_FAMILY,
             weight: Some(FontWeight::MEDIUM),
         },
         InlineBlockStyle::Heading => BlockStyleSpec {
             size: theme::FONT_HEADING,
             line_height: theme::FONT_HEADING + 6.0,
-            color: rgb(theme::TEXT_PRIMARY).into(),
+            color: rgb(theme::text_primary(cx)).into(),
             font_family: fonts::HEADING_FONT_FAMILY,
             weight: Some(FontWeight::MEDIUM),
         },
         InlineBlockStyle::TableHeader => BlockStyleSpec {
             size: theme::FONT_BODY,
             line_height: theme::FONT_BODY + 6.0,
-            color: rgb(theme::TEXT_PRIMARY).into(),
+            color: rgb(theme::text_primary(cx)).into(),
             font_family: fonts::MONO_FONT_FAMILY,
             weight: Some(FontWeight::MEDIUM),
         },
         InlineBlockStyle::TableCell | InlineBlockStyle::Body => BlockStyleSpec {
             size: theme::FONT_BODY,
             line_height: theme::FONT_BODY + 6.0,
-            color: rgb(theme::TEXT_SECONDARY).into(),
+            color: rgb(theme::text_secondary(cx)).into(),
             font_family: fonts::MONO_FONT_FAMILY,
             weight: None,
         },
         InlineBlockStyle::Html => BlockStyleSpec {
             size: theme::FONT_DETAIL,
             line_height: theme::FONT_DETAIL + 5.0,
-            color: rgb(theme::TEXT_MUTED).into(),
+            color: rgb(theme::text_muted(cx)).into(),
             font_family: fonts::MONO_FONT_FAMILY,
             weight: None,
         },

--- a/crates/zedra/src/editor/syntax_theme.rs
+++ b/crates/zedra/src/editor/syntax_theme.rs
@@ -1,34 +1,63 @@
 use gpui::HighlightStyle;
+use serde::{Deserialize, Serialize};
 
 /// Maps tree-sitter capture names to highlight styles.
 /// Lookup uses longest prefix match so e.g. `"function.method"` matches `"function"`.
+#[derive(Clone, Debug, PartialEq)]
 pub struct SyntaxTheme {
     styles: Vec<(String, HighlightStyle)>,
 }
 
 impl SyntaxTheme {
-    /// A dark theme inspired by One Dark.
-    pub fn default_dark() -> Self {
+    pub fn dark() -> Self {
         use gpui::rgb;
 
         let entries = vec![
-            ("keyword", rgb(0xc678dd)),     // purple
-            ("function", rgb(0x61afef)),    // blue
-            ("type", rgb(0xe5c07b)),        // yellow
-            ("string", rgb(0x98c379)),      // green
-            ("comment", rgb(0x5c6370)),     // gray
-            ("number", rgb(0xd19a66)),      // orange
-            ("constant", rgb(0xd19a66)),    // orange
-            ("property", rgb(0x56b6c2)),    // cyan
-            ("operator", rgb(0xc678dd)),    // purple
-            ("variable", rgb(0xabb2bf)),    // foreground
-            ("punctuation", rgb(0x636d83)), // dim gray
-            ("attribute", rgb(0xd19a66)),   // orange
-            ("label", rgb(0xe06c75)),       // red
-            ("constructor", rgb(0x61afef)), // blue
-            ("tag", rgb(0xe06c75)),         // red
+            ("keyword", rgb(0xc678dd)),
+            ("function", rgb(0x61afef)),
+            ("type", rgb(0xe5c07b)),
+            ("string", rgb(0x98c379)),
+            ("comment", rgb(0x5c6370)),
+            ("number", rgb(0xd19a66)),
+            ("constant", rgb(0xd19a66)),
+            ("property", rgb(0x56b6c2)),
+            ("operator", rgb(0xc678dd)),
+            ("variable", rgb(0xabb2bf)),
+            ("punctuation", rgb(0x636d83)),
+            ("attribute", rgb(0xd19a66)),
+            ("label", rgb(0xe06c75)),
+            ("constructor", rgb(0x61afef)),
+            ("tag", rgb(0xe06c75)),
         ];
 
+        Self::from_entries(entries)
+    }
+
+    pub fn light() -> Self {
+        use gpui::rgb;
+
+        let entries = vec![
+            ("keyword", rgb(0xcf222e)),
+            ("function", rgb(0x8250df)),
+            ("type", rgb(0x953800)),
+            ("string", rgb(0x0a3069)),
+            ("comment", rgb(0x6e7781)),
+            ("number", rgb(0x0550ae)),
+            ("constant", rgb(0x0550ae)),
+            ("property", rgb(0x116329)),
+            ("operator", rgb(0xcf222e)),
+            ("variable", rgb(0x24292f)),
+            ("punctuation", rgb(0x57606a)),
+            ("attribute", rgb(0x0550ae)),
+            ("label", rgb(0xcf222e)),
+            ("constructor", rgb(0x8250df)),
+            ("tag", rgb(0xcf222e)),
+        ];
+
+        Self::from_entries(entries)
+    }
+
+    fn from_entries(entries: Vec<(&str, gpui::Rgba)>) -> Self {
         let styles = entries
             .into_iter()
             .map(|(name, color)| {
@@ -68,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_prefix_match() {
-        let theme = SyntaxTheme::default_dark();
+        let theme = SyntaxTheme::dark();
         assert!(theme.get("keyword").is_some());
         assert!(theme.get("function").is_some());
         assert!(theme.get("function.method").is_some());

--- a/crates/zedra/src/file_explorer.rs
+++ b/crates/zedra/src/file_explorer.rs
@@ -729,9 +729,9 @@ impl FileExplorer {
         let entry_depth = entry.depth;
         let indent = entry_depth as f32 * 16.0;
         let text_color = if entry.is_dir {
-            rgb(0xffffff)
+            rgb(theme::text_primary(cx))
         } else {
-            rgb(0xcacaca)
+            rgb(theme::text_secondary(cx))
         };
         let index_path = entry.index_path.clone();
         let is_dir = entry.is_dir;
@@ -760,7 +760,7 @@ impl FileExplorer {
                         .flex_1()
                         .min_w_0()
                         .truncate()
-                        .text_color(rgb(theme::TEXT_MUTED))
+                        .text_color(rgb(theme::text_muted(cx)))
                         .text_size(px(theme::FONT_BODY))
                         .child(name),
                 )
@@ -769,7 +769,7 @@ impl FileExplorer {
 
         let icon_element: AnyElement = if loading {
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_BODY))
                 .child("...")
                 .into_any_element()
@@ -782,13 +782,13 @@ impl FileExplorer {
             svg()
                 .path(icon_path)
                 .size(icon_size)
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .into_any_element()
         } else {
             svg()
                 .path("icons/file.svg")
                 .size(px(theme::ICON_FILE))
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .into_any_element()
         };
 
@@ -836,7 +836,7 @@ impl FileExplorer {
                     .child(name),
             );
         if is_selected {
-            row = row.bg(hsla(0.0, 0.0, 1.0, 0.10));
+            row = row.bg(theme::row_pressed_bg(cx));
         }
         row.into_any_element()
     }

--- a/crates/zedra/src/home_view.rs
+++ b/crates/zedra/src/home_view.rs
@@ -273,12 +273,12 @@ impl Render for HomeView {
                 svg()
                     .path("icons/logo.svg")
                     .size(px(60.0))
-                    .text_color(rgb(theme::TEXT_PRIMARY))
+                    .text_color(rgb(theme::text_primary(cx)))
                     .mb(px(theme::SPACING_LG)),
             )
             .child(
                 div()
-                    .text_color(rgb(theme::TEXT_PRIMARY))
+                    .text_color(rgb(theme::text_primary(cx)))
                     .text_size(px(theme::FONT_APP_TITLE))
                     .font_family(fonts::HEADING_FONT_FAMILY)
                     .font_weight(FontWeight::EXTRA_BOLD)
@@ -288,7 +288,7 @@ impl Render for HomeView {
                 div()
                     .flex()
                     .items_center()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child("Code from anywhere. ")
                     .child(
@@ -305,7 +305,6 @@ impl Render for HomeView {
             )
             .mb(px(theme::SPACING_LG));
 
-        #[cfg(debug_assertions)]
         let settings_button = div()
             .id("home-settings-button")
             .absolute()
@@ -322,7 +321,7 @@ impl Render for HomeView {
                 svg()
                     .path("icons/settings.svg")
                     .size(px(theme::ICON_LG))
-                    .text_color(rgb(theme::TEXT_MUTED)),
+                    .text_color(rgb(theme::text_muted(cx))),
             );
 
         let mut content = div()
@@ -350,8 +349,8 @@ impl Render for HomeView {
 
                 let connect_phase = state.connect_phase.clone();
                 let status_color = match connect_phase.as_ref() {
-                    Some(p) => phase_indicator_color(p),
-                    None => theme::ACCENT_DIM,
+                    Some(p) => phase_indicator_color(&theme::palette(cx), p),
+                    None => theme::accent_dim(cx),
                 };
                 let status_label = match connect_phase.as_ref() {
                     Some(ConnectPhase::Connected) => "Connected",
@@ -393,7 +392,7 @@ impl Render for HomeView {
         }
 
         content = content.child(
-            outline_button("home-scan-qr", "Scan QR Code")
+            outline_button(cx, "home-scan-qr", "Scan QR Code")
                 .w(px(theme::HOME_CARD_WIDTH))
                 .on_press(cx.listener(|this, _event, _window, _cx| {
                     this.handle_scan_qr();
@@ -441,7 +440,7 @@ impl Render for HomeView {
             )
             .child(
                 div()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_DETAIL))
                     .child(app_version_text()),
             );
@@ -450,16 +449,16 @@ impl Render for HomeView {
             .id("home-view")
             .track_focus(&self.focus_handle)
             .size_full()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .flex_col()
             .items_center()
             .justify_center();
 
-        #[cfg(debug_assertions)]
-        let root = root.child(settings_button);
-
-        root.child(header).child(content).child(footer)
+        root.child(settings_button)
+            .child(header)
+            .child(content)
+            .child(footer)
     }
 }
 
@@ -748,9 +747,9 @@ fn install_guide(selected_tab: GuideTab, cx: &mut Context<HomeView>) -> impl Int
                 .w_full()
                 .max_h(px(184.0))
                 .rounded(px(8.0))
-                .bg(rgb(theme::BG_CARD))
+                .bg(rgb(theme::bg_card(cx)))
                 .border_1()
-                .border_color(rgb(theme::BORDER_SUBTLE))
+                .border_color(rgb(theme::border_subtle(cx)))
                 .px(px(theme::SPACING_SM))
                 .pb(px(theme::SPACING_SM))
                 .child(tab_list)
@@ -773,9 +772,9 @@ fn guide_tab_button(
         .cursor_pointer()
         .border_b_1()
         .border_color(rgb(if selected {
-            theme::BORDER_HIGHLIGHT
+            theme::border_highlight(cx)
         } else {
-            theme::BG_CARD
+            theme::bg_card(cx)
         }))
         .hit_slop(px(10.0))
         .on_press(cx.listener(move |this, _event, _window, cx| {
@@ -786,9 +785,9 @@ fn guide_tab_button(
                 .path(spec.icon)
                 .size(px(spec.icon_size))
                 .text_color(rgb(if selected {
-                    theme::TEXT_SECONDARY
+                    theme::text_secondary(cx)
                 } else {
-                    theme::TEXT_MUTED
+                    theme::text_muted(cx)
                 })),
         )
 }
@@ -800,7 +799,7 @@ fn guide_line(
     line: &'static GuideLine,
     selection_order: u64,
     is_last_line: bool,
-    _cx: &mut Context<HomeView>,
+    cx: &mut Context<HomeView>,
 ) -> AnyElement {
     let text = StyledText::new(line.text)
         .selectable()
@@ -814,9 +813,9 @@ fn guide_line(
         )))
         .w_full()
         .text_color(rgb(if line.comment {
-            theme::TEXT_MUTED
+            theme::text_muted(cx)
         } else {
-            theme::TEXT_SECONDARY
+            theme::text_secondary(cx)
         }))
         .text_size(px(theme::FONT_DETAIL))
         .child(text);
@@ -850,9 +849,9 @@ fn workspace_card(
         .id(SharedString::from(format!("ws-card-{}", index)))
         .w_full()
         .rounded(px(8.0))
-        .bg(rgb(theme::BG_CARD))
+        .bg(rgb(theme::bg_card(cx)))
         .border_1()
-        .border_color(rgb(theme::BORDER_SUBTLE))
+        .border_color(rgb(theme::border_subtle(cx)))
         .p(px(12.0))
         .cursor_pointer()
         .on_press(cx.listener(move |this, _event, window, cx| {
@@ -872,11 +871,12 @@ fn workspace_card(
                 .child(ConnectionStatusIndicator::from_phase(
                     ("home-connect-status", index),
                     connect_phase.as_ref(),
+                    &theme::palette(cx),
                 ))
                 .child(
                     div()
                         .flex_1()
-                        .text_color(rgb(theme::TEXT_PRIMARY))
+                        .text_color(rgb(theme::text_primary(cx)))
                         .text_size(px(theme::FONT_BODY))
                         .font_weight(FontWeight::MEDIUM)
                         .child(project_name),
@@ -894,7 +894,7 @@ fn workspace_card(
             Some(
                 div()
                     .mt(px(4.0))
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_DETAIL))
                     .text_overflow(TextOverflow::Truncate(SharedString::new("...")))
                     .child(subtitle),
@@ -923,6 +923,6 @@ fn social_button(
             svg()
                 .path(icon)
                 .size(px(size))
-                .text_color(rgb(theme::TEXT_MUTED)),
+                .text_color(rgb(theme::text_muted(cx))),
         )
 }

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -19,6 +19,7 @@ pub mod editor;
 pub mod fonts;
 pub mod placeholder;
 pub mod theme;
+pub mod theme_state;
 pub mod ui;
 
 // Sceens

--- a/crates/zedra/src/placeholder.rs
+++ b/crates/zedra/src/placeholder.rs
@@ -2,7 +2,7 @@ use gpui::*;
 
 use crate::theme;
 
-pub fn render_placeholder(message: impl Into<String>) -> Div {
+pub fn render_placeholder(cx: &App, message: impl Into<String>) -> Div {
     div()
         .size_full()
         .flex()
@@ -13,7 +13,7 @@ pub fn render_placeholder(message: impl Into<String>) -> Div {
             div()
                 // Magic! It's more balance with this
                 .top(px(-32.0))
-                .text_color(rgb(theme::TEXT_SECONDARY))
+                .text_color(rgb(theme::text_secondary(cx)))
                 .text_size(px(theme::FONT_BODY))
                 .text_align(TextAlign::Center)
                 .child(message.into()),

--- a/crates/zedra/src/quick_action_panel.rs
+++ b/crates/zedra/src/quick_action_panel.rs
@@ -108,9 +108,9 @@ impl Render for QuickActionPanel {
         let panel = div()
             .w_full()
             .h(viewport_h)
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .border_l_1()
-            .border_color(rgb(theme::BORDER_SUBTLE))
+            .border_color(rgb(theme::border_subtle(cx)))
             .flex()
             .flex_col()
             .child(div().h(px(top_inset)))
@@ -121,7 +121,7 @@ impl Render for QuickActionPanel {
                     .flex_row()
                     .items_center()
                     .border_b_1()
-                    .border_color(rgb(theme::BORDER_SUBTLE))
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .child(
                         div()
                             .id("quick-action-home-icon")
@@ -141,13 +141,13 @@ impl Render for QuickActionPanel {
                                 svg()
                                     .path("icons/logo.svg")
                                     .size(px(theme::ICON_LOGO))
-                                    .text_color(rgb(theme::TEXT_SECONDARY)),
+                                    .text_color(rgb(theme::text_secondary(cx))),
                             ),
                     )
                     .child(
                         div().flex_1().flex().flex_col().child(
                             div()
-                                .text_color(rgb(theme::TEXT_SECONDARY))
+                                .text_color(rgb(theme::text_secondary(cx)))
                                 .text_size(px(theme::FONT_BODY))
                                 .text_center()
                                 .font_weight(FontWeight::MEDIUM)
@@ -172,7 +172,7 @@ impl Render for QuickActionPanel {
                                 svg()
                                     .path("icons/x.svg")
                                     .size(px(16.0))
-                                    .text_color(rgb(theme::TEXT_SECONDARY)),
+                                    .text_color(rgb(theme::text_secondary(cx))),
                             ),
                     ),
             );
@@ -225,11 +225,12 @@ impl Render for QuickActionPanel {
                                     .child(ConnectionStatusIndicator::from_phase(
                                         ("quick-action-connect-status", index),
                                         connect_phase.as_ref(),
+                                        &theme::palette(cx),
                                     ))
                                     .child(
                                         div()
                                             .flex_1()
-                                            .text_color(rgb(theme::TEXT_PRIMARY))
+                                            .text_color(rgb(theme::text_primary(cx)))
                                             .text_size(px(theme::FONT_BODY))
                                             .font_weight(FontWeight::MEDIUM)
                                             .min_w_0()
@@ -239,7 +240,7 @@ impl Render for QuickActionPanel {
                             )
                             .child(
                                 div()
-                                    .text_color(rgb(theme::TEXT_MUTED))
+                                    .text_color(rgb(theme::text_muted(cx)))
                                     .text_size(px(theme::FONT_BODY))
                                     .min_w_0()
                                     .truncate()
@@ -269,7 +270,7 @@ impl Render for QuickActionPanel {
                                 svg()
                                     .path("icons/plus.svg")
                                     .size(px(16.0))
-                                    .text_color(rgb(theme::TEXT_MUTED)),
+                                    .text_color(rgb(theme::text_muted(cx))),
                             ),
                     ),
             );
@@ -291,22 +292,23 @@ impl Render for QuickActionPanel {
                         this.handle_terminal_delete(index, tid_del.clone(), cx);
                     }));
 
-                    let card = render_terminal_card(TerminalCardProps {
-                        id: format!("{}-{}", index, tid),
-                        index: i + 1,
-                        is_active,
-                        title: meta.title,
-                        cwd: meta.cwd,
-                        agent_icon: meta.agent_icon,
-                        shell_state: meta.shell_state,
-                        last_exit_code: meta.last_exit_code,
-                        on_close: Some(on_close),
-                    })
-                    .on_press(cx.listener(
-                        move |this, _event, _window, cx| {
-                            this.handle_switch_terminal(index, tid_click.clone(), cx);
+                    let card = render_terminal_card(
+                        cx,
+                        TerminalCardProps {
+                            id: format!("{}-{}", index, tid),
+                            index: i + 1,
+                            is_active,
+                            title: meta.title,
+                            cwd: meta.cwd,
+                            agent_icon: meta.agent_icon,
+                            shell_state: meta.shell_state,
+                            last_exit_code: meta.last_exit_code,
+                            on_close: Some(on_close),
                         },
-                    ));
+                    )
+                    .on_press(cx.listener(move |this, _event, _window, cx| {
+                        this.handle_switch_terminal(index, tid_click.clone(), cx);
+                    }));
 
                     content = content.child(card);
                 }
@@ -317,7 +319,7 @@ impl Render for QuickActionPanel {
                     .h(px(1.0))
                     .mx(px(16.0))
                     .mt(px(6.0))
-                    .bg(rgb(theme::BORDER_SUBTLE)),
+                    .bg(rgb(theme::border_subtle(cx))),
             );
         }
 
@@ -326,14 +328,14 @@ impl Render for QuickActionPanel {
                 div()
                     .px(px(16.0))
                     .py(px(16.0))
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child("No active workspaces"),
             );
         }
 
         content = content.child(
-            crate::button::outline_button("quick-action-scan-qr", "Scan QR Code")
+            crate::button::outline_button(cx, "quick-action-scan-qr", "Scan QR Code")
                 .mx(px(16.0))
                 .mt(px(12.0))
                 .on_press(cx.listener(|this, _event, _window, cx| {

--- a/crates/zedra/src/session_panel.rs
+++ b/crates/zedra/src/session_panel.rs
@@ -51,7 +51,7 @@ impl Render for SessionPanel {
                 .flex()
                 .items_center()
                 .justify_center()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_BODY))
                 .child("No active session");
         }
@@ -63,35 +63,36 @@ impl Render for SessionPanel {
 
         if !snap.username.is_empty() && !snap.hostname.is_empty() {
             let host = format!("{}@{}", snap.username, snap.hostname);
-            info = info.child(info_row("Host", host));
+            info = info.child(info_row(cx, "Host", host));
         }
 
         if let Some(os) = snap.os_version.as_deref()
             && let Some(arch) = snap.arch.as_deref()
         {
             let platform = format!("{} / {}", os, arch,);
-            info = info.child(info_row("Platform", platform));
+            info = info.child(info_row(cx, "Platform", platform));
         }
 
         if let Some(host_info) = host_info.as_ref() {
-            info = info.child(render_host_info(host_info));
+            info = info.child(render_host_info(cx, host_info));
         }
 
         if !snap.strip_path.is_empty() {
-            info = info.child(info_row("Directory", snap.strip_path.clone()));
+            info = info.child(info_row(cx, "Directory", snap.strip_path.clone()));
         }
 
         if let Some(alpn) = snap.alpn.clone() {
-            info = info.child(info_row("Protocol", alpn));
+            info = info.child(info_row(cx, "Protocol", alpn));
         }
 
         if let Some(version) = snap.host_version.as_deref() {
             let daemon_version = format!("v{}", version);
-            info = info.child(info_row("Daemon version", daemon_version));
+            info = info.child(info_row(cx, "Daemon version", daemon_version));
         }
 
         // --- Connection badge ---
-        let (badge_label, badge_color) = transport_badge(&phase, snap.transport.as_ref());
+        let (badge_label, badge_color) =
+            transport_badge(&theme::palette(cx), &phase, snap.transport.as_ref());
         info = info.child(
             div()
                 .id("session-connection-section")
@@ -116,7 +117,7 @@ impl Render for SessionPanel {
                         .flex_col()
                         .child(
                             div()
-                                .text_color(rgb(theme::TEXT_MUTED))
+                                .text_color(rgb(theme::text_muted(cx)))
                                 .text_size(px(theme::FONT_DETAIL))
                                 .child("Connection"),
                         )
@@ -132,7 +133,7 @@ impl Render for SessionPanel {
                         svg()
                             .path("icons/chevron-right.svg")
                             .size(px(theme::ICON_SM))
-                            .text_color(rgb(theme::TEXT_MUTED)),
+                            .text_color(rgb(theme::text_muted(cx))),
                     ),
                 ),
         );
@@ -140,9 +141,10 @@ impl Render for SessionPanel {
         // --- Transport details ---
         if let Some(t) = &snap.transport {
             let remote_addr_label = format!("{} ({})", t.remote_addr, t.num_paths);
-            info = info.child(info_row("Remote Address", remote_addr_label));
+            info = info.child(info_row(cx, "Remote Address", remote_addr_label));
 
             info = info.child(info_row(
+                cx,
                 "Data",
                 format!(
                     "{} sent / {} recv",
@@ -154,11 +156,11 @@ impl Render for SessionPanel {
 
         // --- Session section ---
         if let Some(sid) = &snap.session_id {
-            info = info.child(info_row("Session ID", sid.clone()));
+            info = info.child(info_row(cx, "Session ID", sid.clone()));
         }
 
         // --- Phase timing section ---
-        info = info.child(render_timing(&snap));
+        info = info.child(render_timing(cx, &snap));
 
         // --- Disconnect button ---
         let disconnect_button = div()
@@ -168,8 +170,8 @@ impl Render for SessionPanel {
             .py(px(8.0))
             .rounded(px(6.0))
             .border_1()
-            .border_color(rgb(theme::ACCENT_RED))
-            .text_color(rgb(theme::ACCENT_RED))
+            .border_color(rgb(theme::accent_red(cx)))
+            .text_color(rgb(theme::accent_red(cx)))
             .text_size(px(theme::FONT_BODY))
             .cursor_pointer()
             .on_press(cx.listener(|_this, _event, window, cx| {
@@ -181,7 +183,7 @@ impl Render for SessionPanel {
     }
 }
 
-fn render_host_info(host_info: &HostInfoSnapshot) -> Div {
+fn render_host_info(cx: &App, host_info: &HostInfoSnapshot) -> Div {
     let mut parts = vec![
         format!("CPU {:.0}%", host_info.cpu_usage_percent),
         format!(
@@ -194,7 +196,7 @@ fn render_host_info(host_info: &HostInfoSnapshot) -> Div {
         parts.push(format!("Batteries {batteries}"));
     }
 
-    info_row("System Stats", parts.join(" \u{00b7} "))
+    info_row(cx, "System Stats", parts.join(" \u{00b7} "))
 }
 
 fn format_percent(used: u64, total: u64) -> String {
@@ -222,7 +224,7 @@ fn format_batteries(batteries: &[HostBatteryInfo]) -> Option<String> {
 }
 
 /// Render phase timing summary row.
-fn render_timing(snap: &zedra_session::ConnectSnapshot) -> Div {
+fn render_timing(cx: &App, snap: &zedra_session::ConnectSnapshot) -> Div {
     let mut timing_parts: Vec<String> = Vec::new();
     if let Some(ms) = snap.binding_ms {
         timing_parts.push(format!("Bind {ms}ms"));
@@ -249,40 +251,40 @@ fn render_timing(snap: &zedra_session::ConnectSnapshot) -> Div {
         return div();
     }
 
-    muted_info_row("Timing", timing_parts.join(" \u{00b7} "))
+    muted_info_row(cx, "Timing", timing_parts.join(" \u{00b7} "))
 }
 
-fn info_row(label: &'static str, value: String) -> Div {
+fn info_row(cx: &App, label: &'static str, value: String) -> Div {
     div()
         .py(px(4.0))
         .child(
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(label),
         )
         .child(
             div()
                 .mt(px(1.0))
-                .text_color(rgb(theme::TEXT_SECONDARY))
+                .text_color(rgb(theme::text_secondary(cx)))
                 .text_size(px(theme::FONT_BODY))
                 .child(value),
         )
 }
 
-fn muted_info_row(label: &'static str, value: String) -> Div {
+fn muted_info_row(cx: &App, label: &'static str, value: String) -> Div {
     div()
         .py(px(4.0))
         .child(
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(label),
         )
         .child(
             div()
                 .mt(px(1.0))
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_BODY))
                 .child(value),
         )

--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -1,4 +1,4 @@
-use gpui::*;
+use gpui::{prelude::FluentBuilder as _, *};
 
 use crate::fonts;
 use crate::platform_bridge::{
@@ -7,7 +7,8 @@ use crate::platform_bridge::{
 };
 use crate::sheet_demo_state::SheetDemoState;
 use crate::telemetry::view_telemetry;
-use crate::theme;
+use crate::theme::{self, ThemePreference};
+use crate::theme_state::ThemeState;
 
 #[derive(Clone, Debug)]
 pub enum SettingsEvent {
@@ -18,20 +19,29 @@ impl EventEmitter<SettingsEvent> for SettingsView {}
 
 pub struct SettingsView {
     focus_handle: FocusHandle,
+    theme_state: Entity<ThemeState>,
     sheet_state: Entity<SheetDemoState>,
     sheet_view: Entity<crate::sheet_demo_view::SheetDemoView>,
 }
 
 impl SettingsView {
-    pub fn new(cx: &mut Context<Self>) -> Self {
+    pub fn new(theme_state: Entity<ThemeState>, cx: &mut Context<Self>) -> Self {
         let sheet_state = cx.new(|cx| SheetDemoState::new(cx));
         let sheet_view =
             cx.new(|cx| crate::sheet_demo_view::SheetDemoView::new(sheet_state.clone(), cx));
         Self {
             focus_handle: cx.focus_handle(),
+            theme_state,
             sheet_state,
             sheet_view,
         }
+    }
+
+    fn set_theme_preference(&self, preference: ThemePreference, cx: &mut Context<Self>) {
+        platform_bridge::trigger_haptic(HapticFeedback::SelectionChanged);
+        self.theme_state.update(cx, |state, cx| {
+            state.set_preference(preference, cx);
+        });
     }
 
     fn show_test_alert(&self) {
@@ -122,12 +132,13 @@ impl Render for SettingsView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let top_inset = platform_bridge::status_bar_inset();
         let bottom_inset = platform_bridge::home_indicator_inset();
+        let preference = self.theme_state.read(cx).preference();
 
         div()
             .id("settings-view")
             .track_focus(&self.focus_handle)
             .size_full()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .flex_col()
             .child(
@@ -141,6 +152,7 @@ impl Render for SettingsView {
                     .items_center()
                     .justify_between()
                     .border_b_1()
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .child(
                         div()
                             .flex()
@@ -159,24 +171,17 @@ impl Render for SettingsView {
                                         svg()
                                             .path("icons/chevron-left.svg")
                                             .size(px(theme::ICON_SM))
-                                            .text_color(rgb(theme::TEXT_MUTED))
-                                            .into_any_element()
-                                    )
+                                            .text_color(rgb(theme::text_muted(cx)))
+                                            .into_any_element(),
+                                    ),
                             )
                             .child(
                                 div()
-                                    .flex()
-                                    .flex_row()
-                                    .items_center()
-                                    .gap(px(8.0))
-                                    .child(
-                                        div()
-                                            .text_color(rgb(theme::TEXT_PRIMARY))
-                                            .text_size(px(theme::FONT_TITLE))
-                                            .font_family(fonts::HEADING_FONT_FAMILY)
-                                            .font_weight(FontWeight::MEDIUM)
-                                            .child("Settings"),
-                                    )
+                                    .text_color(rgb(theme::text_primary(cx)))
+                                    .text_size(px(theme::FONT_TITLE))
+                                    .font_family(fonts::HEADING_FONT_FAMILY)
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .child("Settings"),
                             ),
                     ),
             )
@@ -194,95 +199,180 @@ impl Render for SettingsView {
                             .mx_auto()
                             .flex()
                             .flex_col()
+                            .gap(px(theme::SPACING_MD))
+                            .child(section_header(cx, "Appearance"))
                             .child(
                                 div()
-                                    .pt(px(12.0))
-                                    .pb(px(10.0))
-                                    .border_b_1()
-                                    .border_color(rgb(theme::BORDER_SUBTLE))
                                     .flex()
                                     .flex_col()
-                                    .gap(px(4.0))
+                                    .gap(px(8.0))
                                     .child(
                                         div()
-                                            .text_color(rgb(theme::TEXT_PRIMARY))
-                                            .text_size(px(theme::FONT_HEADING))
+                                            .text_color(rgb(theme::text_secondary(cx)))
+                                            .text_size(px(theme::FONT_BODY))
                                             .font_family(fonts::MONO_FONT_FAMILY)
-                                            .font_weight(FontWeight::MEDIUM)
-                                            .child("Developer"),
+                                            .child("Theme"),
                                     )
+                                    .child(
+                                        div()
+                                            .flex()
+                                            .flex_row()
+                                            .gap(px(8.0))
+                                            .child(theme_option_button(
+                                                cx,
+                                                "settings-theme-dark",
+                                                ThemePreference::Dark,
+                                                preference == ThemePreference::Dark,
+                                                cx.listener(|this, _event, _window, cx| {
+                                                    this.set_theme_preference(
+                                                        ThemePreference::Dark,
+                                                        cx,
+                                                    );
+                                                }),
+                                            ))
+                                            .child(theme_option_button(
+                                                cx,
+                                                "settings-theme-light",
+                                                ThemePreference::Light,
+                                                preference == ThemePreference::Light,
+                                                cx.listener(|this, _event, _window, cx| {
+                                                    this.set_theme_preference(
+                                                        ThemePreference::Light,
+                                                        cx,
+                                                    );
+                                                }),
+                                            )),
+                                    ),
                             )
-                            .child(
-                                action_row(
-                                    "settings-test-alert",
-                                    "Native Alert",
-                                    "Native confirmation/failure prompts",
-                                )
-                                .on_press(cx.listener(|this, _event, _window, _cx| {
-                                    this.show_test_alert();
-                                })),
-                            )
-                            .child(
-                                action_row(
-                                    "settings-test-selection",
-                                    "Native Selection",
-                                    "Action sheet selection and behavior",
-                                )
-                                .on_press(cx.listener(|this, _event, _window, _cx| {
-                                    this.show_test_selection();
-                                })),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .w_full()
-                            .max_w(px(520.0))
-                            .mx_auto()
-                            .child(
-                                action_row(
-                                    "settings-test-native-notification",
-                                    "Native Notification",
-                                    "In-app glass banner presentation",
-                                )
-                                .on_press(cx.listener(|this, _event, _window, _cx| {
-                                    this.show_test_native_notification();
-                                })),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .w_full()
-                            .max_w(px(520.0))
-                            .mx_auto()
-                            .child(
-                                action_row(
-                                    "settings-test-custom-sheet",
-                                    "Custom Sheet",
-                                    "Native sheet with GPUI-rendered content",
-                                )
-                                .on_press(cx.listener(|this, _event, _window, cx| {
-                                    this.show_test_custom_sheet(cx);
-                                })),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .w_full()
-                            .max_w(px(520.0))
-                            .mx_auto()
                             .child(
                                 div()
-                                    .text_color(rgb(theme::TEXT_MUTED))
+                                    .text_color(rgb(theme::text_muted(cx)))
                                     .text_size(px(theme::FONT_DETAIL))
                                     .font_family(fonts::MONO_FONT_FAMILY)
-                                    .child("QR scanner and dictation preview remain separate native flows."),
-                            ),
+                                    .child("Custom themes will be supported in a future update."),
+                            )
+                            .when(cfg!(debug_assertions), |section| {
+                                section
+                                    .child(section_header(cx, "Developer"))
+                                    .child(
+                                        action_row(
+                                            cx,
+                                            "settings-test-alert",
+                                            "Native Alert",
+                                            "Native confirmation/failure prompts",
+                                        )
+                                        .on_press(cx.listener(|this, _event, _window, _cx| {
+                                            this.show_test_alert();
+                                        })),
+                                    )
+                                    .child(
+                                        action_row(
+                                            cx,
+                                            "settings-test-selection",
+                                            "Native Selection",
+                                            "Action sheet selection and behavior",
+                                        )
+                                        .on_press(cx.listener(|this, _event, _window, _cx| {
+                                            this.show_test_selection();
+                                        })),
+                                    )
+                                    .child(
+                                        action_row(
+                                            cx,
+                                            "settings-test-native-notification",
+                                            "Native Notification",
+                                            "In-app glass banner presentation",
+                                        )
+                                        .on_press(cx.listener(|this, _event, _window, _cx| {
+                                            this.show_test_native_notification();
+                                        })),
+                                    )
+                                    .child(
+                                        action_row(
+                                            cx,
+                                            "settings-test-custom-sheet",
+                                            "Custom Sheet",
+                                            "Native sheet with GPUI-rendered content",
+                                        )
+                                        .on_press(cx.listener(|this, _event, _window, cx| {
+                                            this.show_test_custom_sheet(cx);
+                                        })),
+                                    )
+                                    .child(
+                                        div()
+                                            .text_color(rgb(theme::text_muted(cx)))
+                                            .text_size(px(theme::FONT_DETAIL))
+                                            .font_family(fonts::MONO_FONT_FAMILY)
+                                            .child(
+                                                "QR scanner and dictation preview remain separate native flows.",
+                                            ),
+                                    )
+                            }),
                     ),
             )
     }
 }
 
-fn action_row(id: &'static str, title: &'static str, description: &'static str) -> Stateful<Div> {
+fn section_header(cx: &App, title: &'static str) -> Div {
+    div()
+        .pt(px(12.0))
+        .pb(px(10.0))
+        .border_b_1()
+        .border_color(rgb(theme::border_subtle(cx)))
+        .child(
+            div()
+                .text_color(rgb(theme::text_primary(cx)))
+                .text_size(px(theme::FONT_HEADING))
+                .font_family(fonts::MONO_FONT_FAMILY)
+                .font_weight(FontWeight::MEDIUM)
+                .child(title),
+        )
+}
+
+fn theme_option_button(
+    cx: &App,
+    id: &'static str,
+    preference: ThemePreference,
+    selected: bool,
+    on_press: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+) -> Stateful<Div> {
+    div()
+        .id(id)
+        .flex_1()
+        .h(px(36.0))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(8.0))
+        .border_1()
+        .border_color(rgb(if selected {
+            theme::border_highlight(cx)
+        } else {
+            theme::border_default(cx)
+        }))
+        .bg(rgb(if selected {
+            theme::bg_card(cx)
+        } else {
+            theme::bg_primary(cx)
+        }))
+        .cursor_pointer()
+        .text_color(rgb(if selected {
+            theme::text_primary(cx)
+        } else {
+            theme::text_secondary(cx)
+        }))
+        .text_size(px(theme::FONT_BODY))
+        .font_family(fonts::MONO_FONT_FAMILY)
+        .on_press(on_press)
+        .child(preference.label())
+}
+
+fn action_row(
+    cx: &App,
+    id: &'static str,
+    title: &'static str,
+    description: &'static str,
+) -> Stateful<Div> {
     div()
         .id(id)
         .w_full()
@@ -304,7 +394,7 @@ fn action_row(id: &'static str, title: &'static str, description: &'static str) 
                 .overflow_hidden()
                 .child(
                     div()
-                        .text_color(rgb(theme::TEXT_SECONDARY))
+                        .text_color(rgb(theme::text_secondary(cx)))
                         .text_size(px(theme::FONT_BODY))
                         .font_family(fonts::MONO_FONT_FAMILY)
                         .font_weight(FontWeight::MEDIUM)
@@ -312,7 +402,7 @@ fn action_row(id: &'static str, title: &'static str, description: &'static str) 
                 )
                 .child(
                     div()
-                        .text_color(rgb(theme::TEXT_MUTED))
+                        .text_color(rgb(theme::text_muted(cx)))
                         .text_size(px(theme::FONT_DETAIL))
                         .font_family(fonts::MONO_FONT_FAMILY)
                         .child(description),
@@ -323,7 +413,7 @@ fn action_row(id: &'static str, title: &'static str, description: &'static str) 
                 svg()
                     .path("icons/chevron-right.svg")
                     .size(px(theme::ICON_SM))
-                    .text_color(rgb(theme::TEXT_MUTED)),
+                    .text_color(rgb(theme::text_muted(cx))),
             ),
         )
 }

--- a/crates/zedra/src/sheet_demo_view.rs
+++ b/crates/zedra/src/sheet_demo_view.rs
@@ -19,7 +19,7 @@ impl Render for SheetDemoView {
         div()
             .id("sheet-demo")
             .size_full()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .justify_center()
             .px(px(18.0))
@@ -30,8 +30,8 @@ impl Render for SheetDemoView {
                     .max_w(px(680.0))
                     .rounded(px(14.0))
                     .border_1()
-                    .border_color(rgb(theme::BORDER_DEFAULT))
-                    .bg(rgb(theme::BG_CARD))
+                    .border_color(rgb(theme::border_default(cx)))
+                    .bg(rgb(theme::bg_card(cx)))
                     .px(px(20.0))
                     .py(px(18.0))
                     .flex()
@@ -39,7 +39,7 @@ impl Render for SheetDemoView {
                     .gap(px(theme::SPACING_MD))
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_PRIMARY))
+                            .text_color(rgb(theme::text_primary(cx)))
                             .text_size(px(theme::FONT_BODY))
                             .font_family(fonts::MONO_FONT_FAMILY)
                             .font_weight(FontWeight::MEDIUM)
@@ -47,7 +47,7 @@ impl Render for SheetDemoView {
                     )
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .text_size(px(theme::FONT_DETAIL))
                             .font_family(fonts::MONO_FONT_FAMILY)
                             .child(state.subtitle.clone()),
@@ -57,8 +57,8 @@ impl Render for SheetDemoView {
                             .w_full()
                             .rounded(px(8.0))
                             .border_1()
-                            .border_color(rgb(theme::BORDER_SUBTLE))
-                            .bg(rgb(theme::BG_SURFACE))
+                            .border_color(rgb(theme::border_subtle(cx)))
+                            .bg(rgb(theme::bg_surface(cx)))
                             .px(px(14.0))
                             .py(px(12.0))
                             .flex()
@@ -66,14 +66,14 @@ impl Render for SheetDemoView {
                             .gap(px(6.0))
                             .child(
                                 div()
-                                    .text_color(rgb(theme::ACCENT_BLUE))
+                                    .text_color(rgb(theme::accent_blue(cx)))
                                     .text_size(px(theme::FONT_DETAIL))
                                     .font_family(fonts::MONO_FONT_FAMILY)
                                     .child("// Mock presentation entrypoint"),
                             )
                             .children(state.mock_code.iter().cloned().map(|line| {
                                 div()
-                                    .text_color(rgb(theme::TEXT_SECONDARY))
+                                    .text_color(rgb(theme::text_secondary(cx)))
                                     .text_size(px(theme::FONT_DETAIL))
                                     .font_family(fonts::MONO_FONT_FAMILY)
                                     .child(line)
@@ -81,7 +81,7 @@ impl Render for SheetDemoView {
                     )
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .text_size(px(theme::FONT_DETAIL))
                             .font_family(fonts::MONO_FONT_FAMILY)
                             .child(format!(

--- a/crates/zedra/src/terminal_card.rs
+++ b/crates/zedra/src/terminal_card.rs
@@ -29,13 +29,13 @@ pub struct TerminalCardProps {
 }
 
 /// Colour of the status dot based on shell state and last exit code.
-fn dot_color(shell_state: &ShellState, last_exit_code: Option<i32>) -> u32 {
+fn dot_color(cx: &App, shell_state: &ShellState, last_exit_code: Option<i32>) -> u32 {
     match shell_state {
-        ShellState::Unknown => theme::TEXT_MUTED,
-        ShellState::Running => theme::ACCENT_YELLOW,
+        ShellState::Unknown => theme::text_muted(cx),
+        ShellState::Running => theme::accent_yellow(cx),
         ShellState::Idle => match last_exit_code {
-            None | Some(0) => theme::ACCENT_GREEN,
-            _ => theme::ACCENT_RED,
+            None | Some(0) => theme::accent_green(cx),
+            _ => theme::accent_red(cx),
         },
     }
 }
@@ -67,7 +67,7 @@ pub fn strip_ps1_prefix(title: &str) -> &str {
 ///
 /// Returns a `Div` — chain `.on_press()` and `.on_long_press()` for tap and
 /// long-press actions respectively.
-pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
+pub fn render_terminal_card(cx: &App, props: TerminalCardProps) -> Stateful<Div> {
     // Primary label: OSC 2 title (stripped of user@host: prefix) — the most
     // dynamic source, updated each prompt and with each command via preexec.
     // Falls back to cwd last component, then to the numbered placeholder.
@@ -94,7 +94,7 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
         .unwrap_or_default();
     let has_subtitle = !subtitle.is_empty();
 
-    let status_color = dot_color(&props.shell_state, props.last_exit_code);
+    let status_color = dot_color(cx, &props.shell_state, props.last_exit_code);
     let card_id = SharedString::from(format!("term-card-{}", props.id));
     let close_btn_id = SharedString::from(format!("term-close-{}", props.id));
     let is_active = props.is_active;
@@ -120,7 +120,7 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
                 svg()
                     .path("icons/x.svg")
                     .size(px(14.0))
-                    .text_color(rgb(theme::TEXT_MUTED)),
+                    .text_color(rgb(theme::text_muted(cx))),
             )
             .into_any_element()
     } else {
@@ -144,9 +144,9 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
         .px(px(12.0))
         .py(px(8.0))
         .rounded(px(6.0))
-        .bg(rgb(theme::BG_CARD))
+        .bg(rgb(theme::bg_card(cx)))
         .border_1()
-        .border_color(rgb(theme::BORDER_SUBTLE))
+        .border_color(rgb(theme::border_subtle(cx)))
         .cursor_pointer()
         // Icon — brand icon for known AI agents, terminal icon otherwise.
         // Colour tied to active state only for visual consistency.
@@ -156,9 +156,9 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
                 .size(px(theme::ICON_TERMINAL))
                 .flex_shrink_0()
                 .text_color(if is_active {
-                    rgb(theme::TEXT_PRIMARY)
+                    rgb(theme::text_primary(cx))
                 } else {
-                    rgb(theme::TEXT_MUTED)
+                    rgb(theme::text_muted(cx))
                 }),
         )
         // Text column: always two rows for a fixed card height.
@@ -178,9 +178,9 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
                         .whitespace_nowrap()
                         .font_family(fonts::MONO_FONT_FAMILY)
                         .text_color(if is_active {
-                            rgb(theme::TEXT_PRIMARY)
+                            rgb(theme::text_primary(cx))
                         } else {
-                            rgb(theme::TEXT_SECONDARY)
+                            rgb(theme::text_secondary(cx))
                         })
                         .text_size(px(theme::FONT_BODY))
                         .when(is_active, |s| s.font_weight(FontWeight::MEDIUM))
@@ -193,7 +193,7 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
                         .overflow_hidden()
                         .whitespace_nowrap()
                         .font_family(fonts::MONO_FONT_FAMILY)
-                        .text_color(rgb(theme::TEXT_MUTED))
+                        .text_color(rgb(theme::text_muted(cx)))
                         .text_size(px(theme::FONT_BODY - 1.0))
                         .when(!has_subtitle, |s| s.invisible())
                         .child(subtitle),

--- a/crates/zedra/src/terminal_panel.rs
+++ b/crates/zedra/src/terminal_panel.rs
@@ -98,17 +98,20 @@ impl Render for TerminalPanel {
                 }));
 
                 let tid_tap = tid.clone();
-                let card = render_terminal_card(TerminalCardProps {
-                    id: tid,
-                    index: index + 1,
-                    is_active,
-                    title: meta.title,
-                    cwd: meta.cwd,
-                    agent_icon: meta.agent_icon,
-                    shell_state: meta.shell_state,
-                    last_exit_code: meta.last_exit_code,
-                    on_close: Some(on_close),
-                })
+                let card = render_terminal_card(
+                    cx,
+                    TerminalCardProps {
+                        id: tid,
+                        index: index + 1,
+                        is_active,
+                        title: meta.title,
+                        cwd: meta.cwd,
+                        agent_icon: meta.agent_icon,
+                        shell_state: meta.shell_state,
+                        last_exit_code: meta.last_exit_code,
+                        on_close: Some(on_close),
+                    },
+                )
                 .on_press(cx.listener(move |_this, _event, window, cx| {
                     window.dispatch_action(
                         workspace_action::OpenTerminal {
@@ -142,7 +145,7 @@ fn toolbar_button<A: Action>(
         .py(px(8.0))
         .rounded(px(6.0))
         .border_1()
-        .border_color(rgb(theme::BORDER_SUBTLE))
+        .border_color(rgb(theme::border_subtle(cx)))
         .flex()
         .flex_col()
         .items_center()
@@ -157,12 +160,12 @@ fn toolbar_button<A: Action>(
             svg()
                 .path(icon)
                 .size(px(theme::ICON_SM))
-                .text_color(rgb(theme::TEXT_MUTED)),
+                .text_color(rgb(theme::text_muted(cx))),
         )
         .child(
             div()
                 .text_size(px(10.0))
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_center()
                 .child(label),
         )

--- a/crates/zedra/src/terminal_preview_view.rs
+++ b/crates/zedra/src/terminal_preview_view.rs
@@ -254,17 +254,17 @@ fn preview_content_for_path(path: &str) -> PreviewContent {
 }
 
 impl Render for TerminalPreviewView {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let body: AnyElement = match &self.state {
             PreviewState::Idle => {
-                render_placeholder("Tap a file path in the terminal").into_any_element()
+                render_placeholder(cx, "Tap a file path in the terminal").into_any_element()
             }
-            PreviewState::Loading => render_placeholder("Loading ...").into_any_element(),
+            PreviewState::Loading => render_placeholder(cx, "Loading ...").into_any_element(),
             PreviewState::TooLarge => {
-                render_placeholder("File too large (>500 KB)").into_any_element()
+                render_placeholder(cx, "File too large (>500 KB)").into_any_element()
             }
             PreviewState::Error(error) => {
-                render_placeholder(format!("Error: {error}")).into_any_element()
+                render_placeholder(cx, format!("Error: {error}")).into_any_element()
             }
             PreviewState::Loaded => match self.content {
                 PreviewContent::Editor => self.editor_view.clone().into_any_element(),
@@ -282,7 +282,7 @@ impl Render for TerminalPreviewView {
         div()
             .id("terminal-preview-sheet")
             .size_full()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .flex_col()
             .child(
@@ -292,13 +292,13 @@ impl Render for TerminalPreviewView {
                     .pt(px(8.0))
                     .pb(px(8.0))
                     .border_b_1()
-                    .border_color(rgb(theme::BORDER_SUBTLE))
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_PRIMARY))
+                            .text_color(rgb(theme::text_primary(cx)))
                             .text_size(px(theme::FONT_HEADING))
                             .font_family(fonts::HEADING_FONT_FAMILY)
                             .font_weight(FontWeight::MEDIUM)
@@ -306,7 +306,7 @@ impl Render for TerminalPreviewView {
                     )
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .text_size(px(theme::FONT_DETAIL))
                             .font_family(fonts::MONO_FONT_FAMILY)
                             .child(self.subtitle.clone()),
@@ -321,7 +321,7 @@ impl Render for TerminalPreviewView {
                     .flex_col()
                     // The custom sheet owns native handoff state; the active
                     // content view only reports whether its scroll is at top.
-                    .on_scroll_wheel(_cx.listener(|this, _event, _window, cx| {
+                    .on_scroll_wheel(cx.listener(|this, _event, _window, cx| {
                         this.update_sheet_scroll_boundary(cx);
                     }))
                     .child(body),

--- a/crates/zedra/src/theme.rs
+++ b/crates/zedra/src/theme.rs
@@ -1,37 +1,18 @@
 use gpui::Hsla;
+use zedra_terminal::element::TerminalTheme;
 
-// Background colors
-pub const BG_PRIMARY: u32 = 0x0e0c0c;
-pub const BG_CARD: u32 = 0x131313;
-pub const BG_OVERLAY: u32 = 0x131313;
-pub const BG_SURFACE: u32 = 0x0e0c0c; // Terminal / input field background (matches BG_PRIMARY)
+use crate::editor::syntax_theme::SyntaxTheme;
 
-// Text colors
-pub const TEXT_PRIMARY: u32 = 0xffffff;
-pub const TEXT_SECONDARY: u32 = 0xcacaca;
-pub const TEXT_MUTED: u32 = 0x505050;
+// ---------------------------------------------------------------------------
+// Layout and typography (theme-independent)
+// ---------------------------------------------------------------------------
 
-// Border colors
-pub const BORDER_HIGHLIGHT: u32 = 0xcacaca;
-pub const BORDER_DEFAULT: u32 = 0x2c2c2c;
-pub const BORDER_ACTIVE: u32 = 0x505050;
-pub const BORDER_SUBTLE: u32 = 0x1a1a1a;
-
-// Accent / button colors
-pub const ACCENT_GREEN: u32 = 0x98c379;
-pub const ACCENT_BLUE: u32 = 0x61afef;
-pub const ACCENT_YELLOW: u32 = 0xe5c07b;
-pub const ACCENT_RED: u32 = 0xe06c75;
-pub const ACCENT_DIM: u32 = 0x505050;
-
-// Spacing
-pub const DRAWER_PADDING: f32 = 12.0; // Horizontal padding for drawer tab content
+pub const DRAWER_PADDING: f32 = 12.0;
 pub const SPACING_XS: f32 = 4.0;
 pub const SPACING_SM: f32 = 8.0;
 pub const SPACING_MD: f32 = 12.0;
 pub const SPACING_LG: f32 = 16.0;
 
-// Layout dimensions
 pub const HEADER_HEIGHT: f32 = 48.0;
 pub const HOME_CARD_WIDTH: f32 = 300.0;
 pub const HOME_GUIDE_WIDTH: f32 = 300.0;
@@ -41,7 +22,6 @@ pub const DRAWER_ICON_ZONE: f32 = 38.0;
 pub const TERMINAL_LINE_HEIGHT: f32 = 16.0;
 pub const PANEL_ITEM_HEIGHT: f32 = 28.0;
 
-// Drawer gesture thresholds
 #[cfg(target_os = "android")]
 pub const DRAWER_EDGE_ZONE: f32 = 72.0;
 #[cfg(not(target_os = "android"))]
@@ -52,41 +32,269 @@ pub const DRAWER_DEFAULT_WIDTH: f32 = 295.0;
 pub const DRAWER_OPEN_ANIMATION_DURATION_MS: u64 = 160;
 pub const DRAWER_CLOSE_ANIMATION_DURATION_MS: u64 = 100;
 
-// Font sizes (pixels) — change these to scale all UI text
-pub const FONT_APP_TITLE: f32 = 28.0; // App main title ("Zedra")
-pub const FONT_TITLE: f32 = 20.0; // Screen title
-pub const FONT_HEADING: f32 = 13.0; // Section headings, dialog titles
-pub const FONT_BODY: f32 = 12.0; // Standard UI text: labels, buttons, file names, values
-pub const FONT_DETAIL: f32 = 12.0; // Small metadata, code previews, badges
+pub const FONT_APP_TITLE: f32 = 28.0;
+pub const FONT_TITLE: f32 = 20.0;
+pub const FONT_HEADING: f32 = 13.0;
+pub const FONT_BODY: f32 = 12.0;
+pub const FONT_DETAIL: f32 = 12.0;
 
-// Icon sizes (pixels)
 pub const ICON_LOGO: f32 = 20.0;
 pub const ICON_LG: f32 = 24.0;
 pub const ICON_MD: f32 = 18.0;
 pub const ICON_SM: f32 = 16.0;
 pub const ICON_XS: f32 = 14.0;
-pub const ICON_FILE: f32 = 12.0; // File tree icons
-pub const ICON_FILE_DIR: f32 = 14.0; // Directory icons (slightly larger than file)
-pub const ICON_STATUS: f32 = 6.0; // Status dots (connected/disconnected)
-pub const ICON_TERMINAL: f32 = 16.0; // Terminal icon
+pub const ICON_FILE: f32 = 12.0;
+pub const ICON_FILE_DIR: f32 = 14.0;
+pub const ICON_STATUS: f32 = 6.0;
+pub const ICON_TERMINAL: f32 = 16.0;
 
-// Editor / diff code view constants
-pub const EDITOR_FONT_SIZE: f32 = 12.0; // Code text in editor and diff views
-pub const EDITOR_GUTTER_FONT_SIZE: f32 = 11.0; // Line numbers in gutter
-pub const EDITOR_LINE_HEIGHT: f32 = 15.0; // Row height for code lines
-pub const EDITOR_GUTTER_WIDTH: f32 = 36.0; // Gutter column width
+pub const EDITOR_FONT_SIZE: f32 = 12.0;
+pub const EDITOR_GUTTER_FONT_SIZE: f32 = 11.0;
+pub const EDITOR_LINE_HEIGHT: f32 = 15.0;
+pub const EDITOR_GUTTER_WIDTH: f32 = 36.0;
 
-// Line number color (white at 30% opacity)
-pub fn line_number_color() -> Hsla {
-    gpui::hsla(0.0, 0.0, 0.83, 0.3)
+// ---------------------------------------------------------------------------
+// Theme preference
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThemePreference {
+    #[default]
+    Dark,
+    Light,
 }
 
-// Backdrop overlay
-pub fn backdrop_color() -> Hsla {
-    gpui::hsla(0.0, 0.0, 0.075, 0.6)
+impl ThemePreference {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Dark => "Dark",
+            Self::Light => "Light",
+        }
+    }
 }
 
-// Transport badge background
-pub fn badge_bg() -> Hsla {
-    gpui::hsla(0.0, 0.0, 0.08, 0.8)
+// ---------------------------------------------------------------------------
+// UI palette
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+pub struct ThemePalette {
+    pub bg_primary: u32,
+    pub bg_card: u32,
+    pub bg_overlay: u32,
+    pub bg_surface: u32,
+    pub text_primary: u32,
+    pub text_secondary: u32,
+    pub text_muted: u32,
+    pub border_highlight: u32,
+    pub border_default: u32,
+    pub border_active: u32,
+    pub border_subtle: u32,
+    pub accent_green: u32,
+    pub accent_blue: u32,
+    pub accent_yellow: u32,
+    pub accent_red: u32,
+    pub accent_dim: u32,
+    pub git_added: u32,
+    pub git_removed: u32,
+    pub row_pressed_bg: Hsla,
+    pub overlay_backdrop: Hsla,
+}
+
+impl ThemePalette {
+    pub fn dark() -> Self {
+        Self {
+            bg_primary: 0x0e0c0c,
+            bg_card: 0x131313,
+            bg_overlay: 0x131313,
+            bg_surface: 0x0e0c0c,
+            text_primary: 0xffffff,
+            text_secondary: 0xcacaca,
+            text_muted: 0x505050,
+            border_highlight: 0xcacaca,
+            border_default: 0x2c2c2c,
+            border_active: 0x505050,
+            border_subtle: 0x1a1a1a,
+            accent_green: 0x98c379,
+            accent_blue: 0x61afef,
+            accent_yellow: 0xe5c07b,
+            accent_red: 0xe06c75,
+            accent_dim: 0x505050,
+            git_added: 0x6fc17a,
+            git_removed: 0xd57a7a,
+            row_pressed_bg: gpui::hsla(0.0, 0.0, 1.0, 0.10),
+            overlay_backdrop: gpui::hsla(0.0, 0.0, 0.0, 1.0),
+        }
+    }
+
+    pub fn light() -> Self {
+        Self {
+            bg_primary: 0xf5f5f5,
+            bg_card: 0xffffff,
+            bg_overlay: 0xffffff,
+            bg_surface: 0xffffff,
+            text_primary: 0x1a1a1a,
+            text_secondary: 0x4a4a4a,
+            text_muted: 0x8a8a8a,
+            border_highlight: 0x4a4a4a,
+            border_default: 0xd8d8d8,
+            border_active: 0x8a8a8a,
+            border_subtle: 0xe8e8e8,
+            accent_green: 0x1a7f37,
+            accent_blue: 0x0969da,
+            accent_yellow: 0x9a6700,
+            accent_red: 0xcf222e,
+            accent_dim: 0x8a8a8a,
+            git_added: 0x1a7f37,
+            git_removed: 0xcf222e,
+            row_pressed_bg: gpui::hsla(0.0, 0.0, 0.0, 0.06),
+            overlay_backdrop: gpui::hsla(0.0, 0.0, 0.0, 1.0),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Editor + diff
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DiffTheme {
+    pub header_bg: u32,
+    pub added_bg: u32,
+    pub removed_bg: u32,
+    pub header_text: u32,
+    pub gutter_text: u32,
+    pub body_text: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct EditorTheme {
+    pub background: u32,
+    pub foreground: u32,
+    pub pending_syntax: u32,
+    pub gutter: Hsla,
+    pub syntax: SyntaxTheme,
+    pub diff: DiffTheme,
+}
+
+impl EditorTheme {
+    pub fn dark() -> Self {
+        Self {
+            background: 0x0e0c0c,
+            foreground: 0xabb2bf,
+            pending_syntax: 0x7b8494,
+            gutter: gpui::hsla(0.0, 0.0, 0.83, 0.3),
+            syntax: SyntaxTheme::dark(),
+            diff: DiffTheme {
+                header_bg: 0x131313,
+                added_bg: 0x162016,
+                removed_bg: 0x201616,
+                header_text: 0x61afef,
+                gutter_text: 0x404040,
+                body_text: 0xcacaca,
+            },
+        }
+    }
+
+    pub fn light() -> Self {
+        Self {
+            background: 0xfafafa,
+            foreground: 0x24292f,
+            pending_syntax: 0x8b949e,
+            gutter: gpui::hsla(0.0, 0.0, 0.45, 0.6),
+            syntax: SyntaxTheme::light(),
+            diff: DiffTheme {
+                header_bg: 0xf6f8fa,
+                added_bg: 0xdafbe1,
+                removed_bg: 0xffebe9,
+                header_text: 0x0969da,
+                gutter_text: 0x8b949e,
+                body_text: 0x24292f,
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Full bundle
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub struct ThemeBundle {
+    pub ui: ThemePalette,
+    pub editor: EditorTheme,
+    pub terminal: TerminalTheme,
+}
+
+impl ThemeBundle {
+    pub fn dark() -> Self {
+        Self {
+            ui: ThemePalette::dark(),
+            editor: EditorTheme::dark(),
+            terminal: TerminalTheme::dark(),
+        }
+    }
+
+    pub fn light() -> Self {
+        Self {
+            ui: ThemePalette::light(),
+            editor: EditorTheme::light(),
+            terminal: TerminalTheme::light(),
+        }
+    }
+
+    pub fn for_preference(preference: ThemePreference) -> Self {
+        match preference {
+            ThemePreference::Dark => Self::dark(),
+            ThemePreference::Light => Self::light(),
+        }
+    }
+}
+
+pub fn palette(cx: &gpui::App) -> ThemePalette {
+    crate::theme_state::palette(cx)
+}
+
+pub fn bundle(cx: &gpui::App) -> ThemeBundle {
+    crate::theme_state::bundle(cx)
+}
+
+macro_rules! palette_accessor {
+    ($name:ident, $field:ident) => {
+        pub fn $name(cx: &gpui::App) -> u32 {
+            palette(cx).$field
+        }
+    };
+}
+
+palette_accessor!(bg_primary, bg_primary);
+palette_accessor!(bg_card, bg_card);
+palette_accessor!(bg_overlay, bg_overlay);
+palette_accessor!(bg_surface, bg_surface);
+palette_accessor!(text_primary, text_primary);
+palette_accessor!(text_secondary, text_secondary);
+palette_accessor!(text_muted, text_muted);
+palette_accessor!(border_highlight, border_highlight);
+palette_accessor!(border_default, border_default);
+palette_accessor!(border_active, border_active);
+palette_accessor!(border_subtle, border_subtle);
+palette_accessor!(accent_green, accent_green);
+palette_accessor!(accent_blue, accent_blue);
+palette_accessor!(accent_yellow, accent_yellow);
+palette_accessor!(accent_red, accent_red);
+palette_accessor!(accent_dim, accent_dim);
+palette_accessor!(git_added, git_added);
+palette_accessor!(git_removed, git_removed);
+
+pub fn row_pressed_bg(cx: &gpui::App) -> Hsla {
+    palette(cx).row_pressed_bg
+}
+
+pub fn overlay_backdrop(cx: &gpui::App) -> Hsla {
+    palette(cx).overlay_backdrop
+}
+
+pub fn overlay_backdrop_with_opacity(base: Hsla, opacity: f32) -> Hsla {
+    gpui::hsla(base.h, base.s, base.l, opacity)
 }

--- a/crates/zedra/src/theme_state.rs
+++ b/crates/zedra/src/theme_state.rs
@@ -1,0 +1,151 @@
+use std::path::PathBuf;
+
+use gpui::{App, Context, Entity, EventEmitter, Global, WeakEntity};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::theme::{ThemeBundle, ThemePreference};
+
+const STORE_DIR: &str = "zedra";
+const SETTINGS_FILE: &str = "settings.json";
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct AppSettings {
+    #[serde(default)]
+    theme_preference: ThemePreference,
+}
+
+pub enum ThemeStateEvent {
+    Changed,
+}
+
+impl EventEmitter<ThemeStateEvent> for ThemeState {}
+
+pub struct ThemeState {
+    preference: ThemePreference,
+    bundle: ThemeBundle,
+}
+
+impl ThemeState {
+    pub fn new(_cx: &mut Context<Self>) -> Self {
+        let preference = Self::load_preference();
+        let bundle = ThemeBundle::for_preference(preference);
+        Self { preference, bundle }
+    }
+
+    pub fn preference(&self) -> ThemePreference {
+        self.preference
+    }
+
+    pub fn bundle(&self) -> &ThemeBundle {
+        &self.bundle
+    }
+
+    pub fn palette(&self) -> &crate::theme::ThemePalette {
+        &self.bundle.ui
+    }
+
+    pub fn set_preference(&mut self, preference: ThemePreference, cx: &mut Context<Self>) {
+        if self.preference == preference {
+            return;
+        }
+        self.preference = preference;
+        self.bundle = ThemeBundle::for_preference(preference);
+        Self::save_preference(preference);
+        cx.emit(ThemeStateEvent::Changed);
+        cx.notify();
+    }
+
+    pub fn register_global(entity: WeakEntity<Self>, cx: &mut App) {
+        cx.set_global(ThemeStateHandle(entity));
+    }
+
+    fn load_preference() -> ThemePreference {
+        match read_settings() {
+            Ok(settings) => settings.theme_preference,
+            Err(err) => {
+                debug!(err = %err, "theme: using default preference");
+                ThemePreference::default()
+            }
+        }
+    }
+
+    fn save_preference(preference: ThemePreference) {
+        let mut settings = read_settings().unwrap_or_default();
+        settings.theme_preference = preference;
+        if let Err(err) = write_settings(&settings) {
+            warn!(err = %err, "theme: failed to save preference");
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ThemeStateHandle(WeakEntity<ThemeState>);
+
+impl Global for ThemeStateHandle {}
+
+pub fn entity(cx: &App) -> Option<Entity<ThemeState>> {
+    cx.try_global::<ThemeStateHandle>()
+        .and_then(|handle| handle.0.upgrade())
+}
+
+pub fn palette(cx: &App) -> crate::theme::ThemePalette {
+    entity(cx)
+        .map(|theme| theme.read(cx).palette().clone())
+        .unwrap_or_else(|| ThemeBundle::dark().ui)
+}
+
+pub fn bundle(cx: &App) -> ThemeBundle {
+    entity(cx)
+        .map(|theme| theme.read(cx).bundle().clone())
+        .unwrap_or_else(ThemeBundle::dark)
+}
+
+fn data_directory() -> Option<PathBuf> {
+    crate::platform_bridge::bridge()
+        .data_directory()
+        .map(PathBuf::from)
+}
+
+fn settings_path() -> Option<PathBuf> {
+    let dir = data_directory()?.join(STORE_DIR);
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir).ok()?;
+    }
+    Some(dir.join(SETTINGS_FILE))
+}
+
+fn read_settings() -> Result<AppSettings, String> {
+    let path = settings_path().ok_or_else(|| "settings path unavailable".to_string())?;
+    if !path.exists() {
+        return Ok(AppSettings::default());
+    }
+    let contents = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&contents).map_err(|e| e.to_string())
+}
+
+fn write_settings(settings: &AppSettings) -> Result<(), String> {
+    let path = settings_path().ok_or_else(|| "settings path unavailable".to_string())?;
+    let contents = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
+    std::fs::write(path, contents).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::theme::{ThemeBundle, ThemePalette, ThemePreference};
+
+    #[test]
+    fn default_preference_is_dark() {
+        assert_eq!(ThemePreference::default(), ThemePreference::Dark);
+    }
+
+    #[test]
+    fn bundle_matches_preference() {
+        assert_eq!(
+            ThemeBundle::for_preference(ThemePreference::Light)
+                .ui
+                .bg_primary,
+            ThemePalette::light().bg_primary
+        );
+    }
+}

--- a/crates/zedra/src/transport_badge.rs
+++ b/crates/zedra/src/transport_badge.rs
@@ -4,16 +4,17 @@ use std::time::Duration;
 use gpui::*;
 use zedra_session::{ConnectPhase, TransportSnapshot};
 
-use crate::theme;
+use crate::theme::{self, ThemePalette};
 
 /// Compute badge label and dot color from phase and transport.
 /// Returns `(label, dot_color)`.
 pub(crate) fn transport_badge(
+    palette: &ThemePalette,
     phase: &ConnectPhase,
     transport: Option<&TransportSnapshot>,
 ) -> (String, u32) {
     match phase {
-        ConnectPhase::Init => ("Initializing".into(), theme::ACCENT_YELLOW),
+        ConnectPhase::Init => ("Initializing".into(), palette.accent_yellow),
         ConnectPhase::Connected => {
             let (conn_type, relay): (String, Option<&str>) = match transport {
                 Some(t) if t.is_direct => {
@@ -34,13 +35,13 @@ pub(crate) fn transport_badge(
                 _ => conn_type.to_string(),
             };
             let color = match transport {
-                Some(t) if t.is_direct => theme::ACCENT_GREEN,
-                Some(_) => theme::ACCENT_GREEN,
-                None => theme::ACCENT_GREEN,
+                Some(t) if t.is_direct => palette.accent_green,
+                Some(_) => palette.accent_green,
+                None => palette.accent_green,
             };
             (label, color)
         }
-        ConnectPhase::Disconnected => ("Tap refresh to reconnect.".into(), theme::ACCENT_RED),
+        ConnectPhase::Disconnected => ("Tap refresh to reconnect.".into(), palette.accent_red),
         ConnectPhase::Reconnecting {
             attempt,
             next_retry_secs,
@@ -51,36 +52,36 @@ pub(crate) fn transport_badge(
             } else {
                 format!("Reconnecting ({attempt})")
             };
-            (label, theme::ACCENT_RED)
+            (label, palette.accent_red)
         }
-        ConnectPhase::Failed(err) => (err.user_message(), theme::ACCENT_RED),
-        ConnectPhase::BindingEndpoint => ("Binding endpoint".into(), theme::ACCENT_YELLOW),
-        ConnectPhase::HolePunching => ("Hole punching".into(), theme::ACCENT_YELLOW),
-        ConnectPhase::Registering => ("Registering device".into(), theme::ACCENT_YELLOW),
-        ConnectPhase::Authenticating => ("Authenticating".into(), theme::ACCENT_YELLOW),
-        ConnectPhase::Proving => ("Auth challenge".into(), theme::ACCENT_YELLOW),
-        ConnectPhase::Sync => ("Syncing state".into(), theme::ACCENT_YELLOW),
+        ConnectPhase::Failed(err) => (err.user_message(), palette.accent_red),
+        ConnectPhase::BindingEndpoint => ("Binding endpoint".into(), palette.accent_yellow),
+        ConnectPhase::HolePunching => ("Hole punching".into(), palette.accent_yellow),
+        ConnectPhase::Registering => ("Registering device".into(), palette.accent_yellow),
+        ConnectPhase::Authenticating => ("Authenticating".into(), palette.accent_yellow),
+        ConnectPhase::Proving => ("Auth challenge".into(), palette.accent_yellow),
+        ConnectPhase::Sync => ("Syncing state".into(), palette.accent_yellow),
         ConnectPhase::Idle { idle_since } => (
             format!("Idle {}s", idle_since.elapsed().as_secs()),
-            theme::ACCENT_YELLOW,
+            palette.accent_yellow,
         ),
     }
 }
 
-pub(crate) fn phase_indicator_color(phase: &ConnectPhase) -> u32 {
+pub(crate) fn phase_indicator_color(palette: &ThemePalette, phase: &ConnectPhase) -> u32 {
     if phase.is_connected() {
-        theme::ACCENT_GREEN
+        palette.accent_green
     } else if phase.is_idle() || phase.is_connecting() || phase.is_reconnecting() {
-        theme::ACCENT_YELLOW
+        palette.accent_yellow
     } else if phase.is_failed() {
-        theme::ACCENT_RED
+        palette.accent_red
     } else {
-        theme::ACCENT_DIM
+        palette.accent_dim
     }
 }
 
-fn phase_indicator_blinks(phase: &ConnectPhase) -> bool {
-    phase_indicator_color(phase) == theme::ACCENT_YELLOW
+fn phase_indicator_blinks(palette: &ThemePalette, phase: &ConnectPhase) -> bool {
+    phase_indicator_color(palette, phase) == palette.accent_yellow
 }
 
 const STATUS_PULSE_MS: u64 = 1800;
@@ -95,11 +96,17 @@ pub(crate) struct ConnectionStatusIndicator {
 }
 
 impl ConnectionStatusIndicator {
-    pub(crate) fn from_phase(id: impl Into<ElementId>, phase: Option<&ConnectPhase>) -> Self {
+    pub(crate) fn from_phase(
+        id: impl Into<ElementId>,
+        phase: Option<&ConnectPhase>,
+        palette: &ThemePalette,
+    ) -> Self {
         let color = phase
-            .map(phase_indicator_color)
-            .unwrap_or(theme::ACCENT_DIM);
-        let blink = phase.map(phase_indicator_blinks).unwrap_or(false);
+            .map(|phase| phase_indicator_color(palette, phase))
+            .unwrap_or(palette.accent_dim);
+        let blink = phase
+            .map(|phase| phase_indicator_blinks(palette, phase))
+            .unwrap_or(false);
 
         Self {
             id: id.into(),
@@ -165,7 +172,7 @@ pub fn format_bytes(bytes: u64) -> String {
 mod tests {
     use std::time::Instant;
 
-    use crate::theme;
+    use crate::theme::ThemePalette;
     use crate::transport_badge::{
         ConnectionStatusIndicator, phase_indicator_color, transport_badge,
     };
@@ -173,15 +180,18 @@ mod tests {
 
     #[test]
     fn disconnected_badge_uses_manual_reconnect_hint() {
-        let (label, color) = transport_badge(&ConnectPhase::Disconnected, None);
+        let palette = ThemePalette::dark();
+        let (label, color) = transport_badge(&palette, &ConnectPhase::Disconnected, None);
 
         assert_eq!(label, "Tap refresh to reconnect.");
-        assert_eq!(color, theme::ACCENT_RED);
+        assert_eq!(color, palette.accent_red);
     }
 
     #[test]
     fn reconnecting_badge_includes_retry_countdown() {
+        let palette = ThemePalette::dark();
         let (label, color) = transport_badge(
+            &palette,
             &ConnectPhase::Reconnecting {
                 attempt: 2,
                 reason: zedra_session::ReconnectReason::ConnectionLost,
@@ -191,11 +201,12 @@ mod tests {
         );
 
         assert_eq!(label, "Reconnecting (2) \u{00b7} 3s");
-        assert_eq!(color, theme::ACCENT_RED);
+        assert_eq!(color, palette.accent_red);
     }
 
     #[test]
     fn warning_status_indicator_blinks() {
+        let palette = ThemePalette::dark();
         let idle = ConnectPhase::Idle {
             idle_since: Instant::now(),
         };
@@ -208,20 +219,29 @@ mod tests {
         let failed = ConnectPhase::Failed(ConnectError::HostUnreachable);
 
         for phase in [&idle, &reconnecting] {
-            let indicator = ConnectionStatusIndicator::from_phase("test-dot", Some(phase));
-            assert_eq!(phase_indicator_color(phase), theme::ACCENT_YELLOW);
+            let indicator =
+                ConnectionStatusIndicator::from_phase("test-dot", Some(phase), &palette);
+            assert_eq!(
+                phase_indicator_color(&palette, phase),
+                palette.accent_yellow
+            );
             assert!(indicator.blink);
         }
 
         for phase in [&connected, &failed] {
-            let indicator = ConnectionStatusIndicator::from_phase("test-dot", Some(phase));
-            assert_ne!(phase_indicator_color(phase), theme::ACCENT_YELLOW);
+            let indicator =
+                ConnectionStatusIndicator::from_phase("test-dot", Some(phase), &palette);
+            assert_ne!(
+                phase_indicator_color(&palette, phase),
+                palette.accent_yellow
+            );
             assert!(!indicator.blink);
         }
     }
 
     #[test]
     fn failed_badge_uses_friendly_error_message() {
+        let palette = ThemePalette::dark();
         let cases = [
             (
                 ConnectError::AlpnMismatch,
@@ -246,10 +266,10 @@ mod tests {
         ];
 
         for (error, message) in cases {
-            let (label, color) = transport_badge(&ConnectPhase::Failed(error), None);
+            let (label, color) = transport_badge(&palette, &ConnectPhase::Failed(error), None);
 
             assert_eq!(label, message);
-            assert_eq!(color, theme::ACCENT_RED);
+            assert_eq!(color, palette.accent_red);
         }
     }
 }

--- a/crates/zedra/src/ui/drawer_host.rs
+++ b/crates/zedra/src/ui/drawer_host.rs
@@ -445,6 +445,7 @@ impl Render for DrawerHost {
         let animating = self.is_snap_animating() && !is_dragging;
         let side = self.drawer_side;
         let edge_inset = self.edge_inset;
+        let backdrop_base_color = theme::overlay_backdrop(cx);
 
         let show_overlay = drawer_offset > 0.0 || snap_target.is_some() || is_dragging;
 
@@ -492,7 +493,7 @@ impl Render for DrawerHost {
                         .top_0()
                         .bottom_0()
                         .w(px(drawer_width))
-                        .bg(rgb(0x0e0c0c))
+                        .bg(rgb(theme::bg_primary(cx)))
                         .flex()
                         .flex_col()
                         .overflow_hidden()
@@ -523,10 +524,8 @@ impl Render for DrawerHost {
                                 ),
                                 anim.clone(),
                                 move |el, delta| {
-                                    el.bg(hsla(
-                                        0.0,
-                                        0.0,
-                                        0.0,
+                                    el.bg(theme::overlay_backdrop_with_opacity(
+                                        backdrop_base_color,
                                         from_opacity + (target_opacity - from_opacity) * delta,
                                     ))
                                 },
@@ -550,7 +549,10 @@ impl Render for DrawerHost {
                     let opacity = (drawer_offset / drawer_width).clamp(0.0, 1.0) * max_opacity;
                     (
                         backdrop_base
-                            .bg(hsla(0.0, 0.0, 0.0, opacity))
+                            .bg(theme::overlay_backdrop_with_opacity(
+                                backdrop_base_color,
+                                opacity,
+                            ))
                             .into_any_element(),
                         match side {
                             DrawerSide::Left => panel_base

--- a/crates/zedra/src/ui/input.rs
+++ b/crates/zedra/src/ui/input.rs
@@ -94,7 +94,7 @@ impl Element for MultilineInputText {
         };
         let caret = fill(
             Bounds::new(origin, size(px(2.0), line_height)),
-            rgb(theme::TEXT_SECONDARY),
+            rgb(theme::text_secondary(cx)),
         );
         window.paint_quad(caret);
     }
@@ -694,7 +694,7 @@ impl Input {
         div()
             .w(px(2.0))
             .h(px(if self.compact { 14.0 } else { 18.0 }))
-            .bg(rgb(theme::TEXT_SECONDARY))
+            .bg(rgb(theme::text_secondary(cx)))
             .rounded(px(1.0))
             .with_animation(
                 cursor_id,
@@ -1143,15 +1143,15 @@ impl Render for Input {
         let show_placeholder = self.value.is_empty() && !is_focused;
 
         let text_color = if show_placeholder {
-            rgb(theme::TEXT_MUTED)
+            rgb(theme::text_muted(cx))
         } else {
-            rgb(theme::TEXT_SECONDARY)
+            rgb(theme::text_secondary(cx))
         };
 
         let border_color = if is_focused {
-            rgb(theme::BORDER_ACTIVE)
+            rgb(theme::border_active(cx))
         } else {
-            rgb(theme::BORDER_DEFAULT)
+            rgb(theme::border_default(cx))
         };
         let text_size = if self.compact {
             theme::FONT_DETAIL
@@ -1189,7 +1189,7 @@ impl Render for Input {
             .py(px(vertical_padding))
             .w_full()
             .min_h(px(min_height))
-            .bg(rgb(theme::BG_SURFACE))
+            .bg(rgb(theme::bg_surface(cx)))
             .rounded(px(6.0))
             .border_1()
             .border_color(border_color)

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -2628,20 +2628,25 @@ enum WorkspaceSubtitle {
     },
 }
 
-fn render_subtitle(text: impl IntoElement) -> AnyElement {
+fn render_subtitle(cx: &App, text: impl IntoElement) -> AnyElement {
     div()
         .w_full()
         .min_w_0()
         .truncate()
         .text_center()
-        .text_color(rgb(theme::TEXT_SECONDARY))
+        .text_color(rgb(theme::text_secondary(cx)))
         .text_size(px(theme::FONT_BODY))
         .font_weight(FontWeight::MEDIUM)
         .child(text)
         .into_any_element()
 }
 
-fn render_gitdiff_subtitle(filename: SharedString, added: usize, removed: usize) -> AnyElement {
+fn render_gitdiff_subtitle(
+    cx: &App,
+    filename: SharedString,
+    added: usize,
+    removed: usize,
+) -> AnyElement {
     div()
         .w_full()
         .min_w_0()
@@ -2659,14 +2664,14 @@ fn render_gitdiff_subtitle(filename: SharedString, added: usize, removed: usize)
                 .flex_shrink()
                 .truncate()
                 .text_center()
-                .text_color(rgb(theme::TEXT_SECONDARY))
+                .text_color(rgb(theme::text_secondary(cx)))
                 .child(filename),
         )
         .when(added > 0, |this| {
             this.child(
                 div()
                     .flex_shrink_0()
-                    .text_color(rgb(0x6fc17a))
+                    .text_color(rgb(theme::git_added(cx)))
                     .child(format!("+{}", added)),
             )
         })
@@ -2674,7 +2679,7 @@ fn render_gitdiff_subtitle(filename: SharedString, added: usize, removed: usize)
             this.child(
                 div()
                     .flex_shrink_0()
-                    .text_color(rgb(0xd57a7a))
+                    .text_color(rgb(theme::git_removed(cx)))
                     .child(format!("-{}", removed)),
             )
         })
@@ -2774,9 +2779,9 @@ impl WorkspaceContent {
 
     fn render_subtitle(&self, default_subtitle: &str, cx: &mut Context<Self>) -> AnyElement {
         match &self.subtitle {
-            WorkspaceSubtitle::Default => render_subtitle(default_subtitle.to_owned()),
-            WorkspaceSubtitle::Text { text } => render_subtitle(text.clone()),
-            WorkspaceSubtitle::File { path } => render_subtitle(path.clone()),
+            WorkspaceSubtitle::Default => render_subtitle(cx, default_subtitle.to_owned()),
+            WorkspaceSubtitle::Text { text } => render_subtitle(cx, text.clone()),
+            WorkspaceSubtitle::File { path } => render_subtitle(cx, path.clone()),
             WorkspaceSubtitle::Terminal { id } => {
                 let meta = self.terminal_state.read(cx).meta(id);
                 let subtitle = meta
@@ -2786,13 +2791,13 @@ impl WorkspaceContent {
                     .filter(|title| !title.is_empty())
                     .unwrap_or(default_subtitle)
                     .to_owned();
-                render_subtitle(subtitle)
+                render_subtitle(cx, subtitle)
             }
             WorkspaceSubtitle::GitDiff {
                 filename,
                 added,
                 removed,
-            } => render_gitdiff_subtitle(filename.clone(), *added, *removed),
+            } => render_gitdiff_subtitle(cx, filename.clone(), *added, *removed),
         }
     }
 
@@ -2822,7 +2827,7 @@ struct NoActiveTerminalView;
 
 impl Render for NoActiveTerminalView {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        render_placeholder("No active terminal")
+        render_placeholder(_cx, "No active terminal")
     }
 }
 
@@ -2858,7 +2863,7 @@ impl Render for WorkspaceContent {
             .flex()
             .flex_col()
             .min_h_0()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .child(div().h(px(top_inset)))
             .child(
                 div()
@@ -2867,7 +2872,7 @@ impl Render for WorkspaceContent {
                     .flex_row()
                     .items_center()
                     .border_b_1()
-                    .border_color(rgb(theme::BORDER_SUBTLE))
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .child(
                         div()
                             .id("drawer-toggle-btn")
@@ -2889,7 +2894,7 @@ impl Render for WorkspaceContent {
                                 svg()
                                     .path("icons/menu.svg")
                                     .size(px(16.0))
-                                    .text_color(rgb(theme::TEXT_SECONDARY)),
+                                    .text_color(rgb(theme::text_secondary(cx))),
                             ),
                     )
                     .child(
@@ -2918,6 +2923,7 @@ impl Render for WorkspaceContent {
                                                 ConnectionStatusIndicator::from_phase(
                                                     "workspace-connect-status",
                                                     connect_phase.as_ref(),
+                                                    &theme::palette(cx),
                                                 )
                                                 .size(6.0),
                                             )
@@ -2925,7 +2931,7 @@ impl Render for WorkspaceContent {
                                                 div()
                                                     .min_w_0()
                                                     .truncate()
-                                                    .text_color(rgb(theme::TEXT_MUTED))
+                                                    .text_color(rgb(theme::text_muted(cx)))
                                                     .text_size(px(theme::FONT_DETAIL))
                                                     .child(title),
                                             ),
@@ -2954,7 +2960,7 @@ impl Render for WorkspaceContent {
                                 svg()
                                     .path("icons/package.svg")
                                     .size(px(16.0))
-                                    .text_color(rgb(theme::TEXT_SECONDARY)),
+                                    .text_color(rgb(theme::text_secondary(cx))),
                             ),
                     ),
             )

--- a/crates/zedra/src/workspace_connecting.rs
+++ b/crates/zedra/src/workspace_connecting.rs
@@ -32,7 +32,7 @@ impl Render for WorkspaceConnecting {
             .id("connecting-view")
             .size_full()
             .relative()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .flex_col()
             .justify_start()
@@ -55,7 +55,7 @@ impl Render for WorkspaceConnecting {
                     ))
                     .child(render_details_toggle(expanded, cx))
                     .when(expanded, |d| {
-                        d.child(render_detail(&state.phase, &state.snapshot))
+                        d.child(render_detail(cx, &state.phase, &state.snapshot))
                     }),
             )
             .child(render_close_button(cx))
@@ -82,7 +82,7 @@ fn render_close_button(cx: &mut Context<WorkspaceConnecting>) -> Stateful<Div> {
             svg()
                 .path("icons/x.svg")
                 .size(px(16.0))
-                .text_color(rgb(theme::TEXT_MUTED)),
+                .text_color(rgb(theme::text_muted(cx))),
         )
 }
 
@@ -113,14 +113,14 @@ fn render_details_toggle(expanded: bool, cx: &mut Context<WorkspaceConnecting>) 
         .child(
             div()
                 .text_size(px(theme::FONT_DETAIL))
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .child(label),
         )
         .child(
             svg()
                 .path(chevron)
                 .size(px(12.0))
-                .text_color(rgb(theme::TEXT_MUTED)),
+                .text_color(rgb(theme::text_muted(cx))),
         )
 }
 
@@ -130,7 +130,7 @@ fn render_phase_title(
     restart_animation_id: u64,
     cx: &mut Context<WorkspaceConnecting>,
 ) -> Div {
-    let (label, color) = transport_badge(phase, snap.transport.as_ref());
+    let (label, color) = transport_badge(&theme::palette(cx), phase, snap.transport.as_ref());
 
     let title = match phase {
         ConnectPhase::BindingEndpoint | ConnectPhase::HolePunching => "Connect",
@@ -162,7 +162,7 @@ fn render_phase_title(
                         .min_w_0()
                         .truncate()
                         .text_align(TextAlign::Center)
-                        .text_color(rgb(theme::TEXT_PRIMARY))
+                        .text_color(rgb(theme::text_primary(cx)))
                         .text_size(px(theme::FONT_HEADING))
                         .font_weight(FontWeight::MEDIUM)
                         .child(title),
@@ -204,14 +204,14 @@ fn render_restart_button(
             window.dispatch_action(workspace_action::RestartConnection.boxed_clone(), cx);
             cx.notify();
         }))
-        .child(render_restart_icon(restart_animation_id))
+        .child(render_restart_icon(cx, restart_animation_id))
 }
 
-fn render_restart_icon(restart_animation_id: u64) -> AnyElement {
+fn render_restart_icon(cx: &App, restart_animation_id: u64) -> AnyElement {
     let icon = svg()
         .path("icons/refresh-ccw.svg")
         .size(px(14.0))
-        .text_color(rgb(theme::TEXT_MUTED));
+        .text_color(rgb(theme::text_muted(cx)));
 
     if restart_animation_id == 0 {
         icon.into_any_element()
@@ -235,7 +235,7 @@ fn has_discovery_data(snap: &ConnectSnapshot) -> bool {
         || snap.relay_latency_ms.is_some()
 }
 
-fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
+fn render_discovery_rows(cx: &App, snap: &ConnectSnapshot) -> Div {
     let mut d = div().flex().flex_col().gap(px(2.0));
 
     let relay_status = if snap.relay_connected {
@@ -246,7 +246,7 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
     } else {
         "Connecting\u{2026}".into()
     };
-    d = d.child(kv_row("Relay", &relay_status));
+    d = d.child(kv_row(cx, "Relay", &relay_status));
 
     if !snap.direct_addrs.is_empty() {
         let count = snap.direct_addrs.len();
@@ -279,7 +279,7 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
                     div()
                         .w(px(60.0))
                         .flex_shrink_0()
-                        .text_color(rgb(theme::TEXT_MUTED))
+                        .text_color(rgb(theme::text_muted(cx)))
                         .text_size(px(theme::FONT_DETAIL))
                         .child("Direct"),
                 )
@@ -288,7 +288,7 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
                         .flex_1()
                         .min_w_0()
                         .truncate()
-                        .text_color(rgb(theme::TEXT_SECONDARY))
+                        .text_color(rgb(theme::text_secondary(cx)))
                         .text_size(px(theme::FONT_DETAIL))
                         .child(direct_label),
                 ),
@@ -301,7 +301,7 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
         (false, true) => "IPv6 only",
         (false, false) => "probing\u{2026}",
     };
-    d = d.child(kv_row("UDP", ip_status));
+    d = d.child(kv_row(cx, "UDP", ip_status));
 
     if let Some(varies) = snap.mapping_varies {
         let nat = if varies {
@@ -309,11 +309,11 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
         } else {
             "Cone / direct"
         };
-        d = d.child(kv_row("NAT", nat));
+        d = d.child(kv_row(cx, "NAT", nat));
     }
 
     if snap.captive_portal == Some(true) {
-        d = d.child(kv_row("Portal", "Captive portal detected"));
+        d = d.child(kv_row(cx, "Portal", "Captive portal detected"));
     }
 
     d
@@ -321,7 +321,7 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
 
 // ─── Vertical detail panel ───────────────────────────────────────────────────
 
-fn render_detail(phase: &ConnectPhase, snap: &ConnectSnapshot) -> Div {
+fn render_detail(cx: &App, phase: &ConnectPhase, snap: &ConnectSnapshot) -> Div {
     let mut col = div()
         .w(px(theme::CONNECT_DETAIL_WIDTH))
         .min_w_0()
@@ -330,30 +330,42 @@ fn render_detail(phase: &ConnectPhase, snap: &ConnectSnapshot) -> Div {
         .gap(px(theme::SPACING_SM));
 
     if snap.local_node_id.is_some() || snap.remote_node_id.is_some() || snap.relay_url.is_some() {
-        col = col.child(render_section("Endpoint", render_endpoint_rows(snap)));
+        col = col.child(render_section(
+            cx,
+            "Endpoint",
+            render_endpoint_rows(cx, snap),
+        ));
     }
 
     if has_discovery_data(snap) {
-        col = col.child(render_section("Discovery", render_discovery_rows(snap)));
+        col = col.child(render_section(
+            cx,
+            "Discovery",
+            render_discovery_rows(cx, snap),
+        ));
     }
 
     if let Some(t) = &snap.transport {
-        col = col.child(render_section("Transport", render_transport_rows(t)));
+        col = col.child(render_section(
+            cx,
+            "Transport",
+            render_transport_rows(cx, t),
+        ));
     }
 
     if snap.session_id.is_some() || snap.auth_outcome.is_some() {
-        col = col.child(render_section("Auth", render_auth_rows(snap)));
+        col = col.child(render_section(cx, "Auth", render_auth_rows(cx, snap)));
     }
 
     if !snap.hostname.is_empty() {
-        col = col.child(render_section("Daemon", render_host_rows(snap)));
+        col = col.child(render_section(cx, "Daemon", render_host_rows(cx, snap)));
     }
 
     let timing = build_timing_string(snap);
     if !timing.is_empty() {
         col = col.child(
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(timing),
         );
@@ -368,7 +380,7 @@ fn render_detail(phase: &ConnectPhase, snap: &ConnectSnapshot) -> Div {
     {
         col = col.child(
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(format!(
                     "Attempt {} · retry in {}s",
@@ -380,14 +392,14 @@ fn render_detail(phase: &ConnectPhase, snap: &ConnectSnapshot) -> Div {
     col
 }
 
-fn render_section(title: &'static str, rows: Div) -> Div {
+fn render_section(cx: &App, title: &'static str, rows: Div) -> Div {
     div()
         .flex()
         .flex_col()
         .gap(px(2.0))
         .child(
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .mb(px(2.0))
                 .child(title),
@@ -395,24 +407,24 @@ fn render_section(title: &'static str, rows: Div) -> Div {
         .child(rows)
 }
 
-fn render_endpoint_rows(snap: &ConnectSnapshot) -> Div {
+fn render_endpoint_rows(cx: &App, snap: &ConnectSnapshot) -> Div {
     let mut d = div().flex().flex_col().gap(px(2.0));
     if let Some(id) = &snap.local_node_id {
-        d = d.child(kv_row("Local", id));
+        d = d.child(kv_row(cx, "Local", id));
     }
     if let Some(id) = &snap.remote_node_id {
-        d = d.child(kv_row("Remote", id));
+        d = d.child(kv_row(cx, "Remote", id));
     }
     if let Some(relay) = &snap.relay_url {
-        d = d.child(kv_row("Relay", relay));
+        d = d.child(kv_row(cx, "Relay", relay));
     }
     if let Some(alpn) = &snap.alpn {
-        d = d.child(kv_row("Protocol", alpn));
+        d = d.child(kv_row(cx, "Protocol", alpn));
     }
     d
 }
 
-fn render_transport_rows(t: &TransportSnapshot) -> Div {
+fn render_transport_rows(cx: &App, t: &TransportSnapshot) -> Div {
     let conn_type = if t.is_direct {
         match &t.network_hint {
             Some(h) => format!("P2P \u{00b7} {}", h.label()),
@@ -426,14 +438,15 @@ fn render_transport_rows(t: &TransportSnapshot) -> Div {
         .flex()
         .flex_col()
         .gap(px(2.0))
-        .child(kv_row("Type", &conn_type))
+        .child(kv_row(cx, "Type", &conn_type))
         .child(kv_row(
+            cx,
             "Address",
             &format!("{} ({})", t.remote_addr, t.num_paths),
         ));
 
     if let Some(relay) = &t.relay_url {
-        d = d.child(kv_row("Relay", relay));
+        d = d.child(kv_row(cx, "Relay", relay));
     }
     let net = format!(
         "{}ms - {} \u{2191} / {} \u{2193}",
@@ -441,44 +454,44 @@ fn render_transport_rows(t: &TransportSnapshot) -> Div {
         format_bytes(t.bytes_sent),
         format_bytes(t.bytes_recv)
     );
-    d = d.child(kv_row("Net", &net));
+    d = d.child(kv_row(cx, "Net", &net));
     d
 }
 
-fn render_auth_rows(snap: &ConnectSnapshot) -> Div {
+fn render_auth_rows(cx: &App, snap: &ConnectSnapshot) -> Div {
     let mut d = div().flex().flex_col().gap(px(2.0));
     if let Some(sid) = &snap.session_id {
-        d = d.child(kv_row("Session", sid));
+        d = d.child(kv_row(cx, "Session", sid));
     }
     if let Some(outcome) = &snap.auth_outcome {
         let label = match outcome {
             zedra_session::AuthOutcome::Registered => "Registered (first pairing)",
             zedra_session::AuthOutcome::Authenticated => "Authorized",
         };
-        d = d.child(kv_row("Status", label));
+        d = d.child(kv_row(cx, "Status", label));
     }
     d
 }
 
-fn render_host_rows(snap: &ConnectSnapshot) -> Div {
+fn render_host_rows(cx: &App, snap: &ConnectSnapshot) -> Div {
     let mut d = div().flex().flex_col().gap(px(2.0));
     if !snap.hostname.is_empty() && !snap.username.is_empty() {
         let host_label = format!("{}@{}", snap.username, snap.hostname);
-        d = d.child(kv_row("Host", &host_label));
+        d = d.child(kv_row(cx, "Host", &host_label));
     }
     if let Some(os) = &snap.os {
         let label = match &snap.arch {
             Some(arch) if !arch.is_empty() => format!("{os} / {arch}"),
             _ => os.clone(),
         };
-        d = d.child(kv_row("OS", &label));
+        d = d.child(kv_row(cx, "OS", &label));
     }
     if !snap.workdir.is_empty() {
-        d = d.child(kv_row("Workdir", &snap.workdir));
+        d = d.child(kv_row(cx, "Workdir", &snap.workdir));
     }
     if let Some(v) = &snap.host_version {
         if !v.is_empty() {
-            d = d.child(kv_row("Version", v));
+            d = d.child(kv_row(cx, "Version", v));
         }
     }
     d
@@ -509,7 +522,7 @@ fn build_timing_string(snap: &ConnectSnapshot) -> String {
     parts.join(" \u{00b7} ")
 }
 
-fn kv_row(key: &'static str, value: &str) -> Div {
+fn kv_row(cx: &App, key: &'static str, value: &str) -> Div {
     div()
         .flex()
         .flex_row()
@@ -518,7 +531,7 @@ fn kv_row(key: &'static str, value: &str) -> Div {
             div()
                 .w(px(60.0))
                 .flex_shrink_0()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(key),
         )
@@ -527,7 +540,7 @@ fn kv_row(key: &'static str, value: &str) -> Div {
                 .flex_1()
                 .min_w_0()
                 .truncate()
-                .text_color(rgb(theme::TEXT_SECONDARY))
+                .text_color(rgb(theme::text_secondary(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(value.to_string()),
         )

--- a/crates/zedra/src/workspace_drawer.rs
+++ b/crates/zedra/src/workspace_drawer.rs
@@ -188,7 +188,7 @@ impl WorkspaceDrawer {
                     .clone()
                     .unwrap_or_else(|| session_state.phase());
                 let transport = session_state.snapshot().transport;
-                let (label, _) = transport_badge(&phase, transport.as_ref());
+                let (label, _) = transport_badge(&theme::palette(cx), &phase, transport.as_ref());
                 label
             }
         };
@@ -225,14 +225,14 @@ impl WorkspaceDrawer {
     fn nav_icon(&self, tab: DrawerTab, cx: &mut Context<Self>) -> impl IntoElement {
         let is_active = self.current_tab == tab;
         let color = if is_active {
-            rgb(theme::TEXT_PRIMARY)
+            rgb(theme::text_primary(cx))
         } else {
-            rgb(theme::TEXT_MUTED)
+            rgb(theme::text_muted(cx))
         };
         let fill = if is_active {
-            rgb(theme::BG_CARD)
+            rgb(theme::bg_card(cx))
         } else {
-            rgb(theme::BG_PRIMARY)
+            rgb(theme::bg_primary(cx))
         };
 
         div()
@@ -268,9 +268,9 @@ impl WorkspaceDrawer {
     fn file_mode_button(&self, mode: FileDisplayMode, cx: &mut Context<Self>) -> impl IntoElement {
         let is_active = self.file_display_mode == mode;
         let color = if is_active {
-            rgb(theme::TEXT_SECONDARY)
+            rgb(theme::text_secondary(cx))
         } else {
-            rgb(theme::TEXT_MUTED)
+            rgb(theme::text_muted(cx))
         };
 
         div()
@@ -305,13 +305,13 @@ impl WorkspaceDrawer {
             .top(px(0.0))
             .right(px(0.0))
             .pb_1()
-            .bg(rgb(theme::BG_SURFACE))
+            .bg(rgb(theme::bg_surface(cx)))
             .occlude()
             .on_pointer_down(|_, _, cx| cx.stop_propagation())
             .rounded_bl(px(6.0))
             .border_b_1()
             .border_l_1()
-            .border_color(rgb(theme::BORDER_SUBTLE))
+            .border_color(rgb(theme::border_subtle(cx)))
             .flex()
             .flex_col()
             .child(self.file_mode_button(FileDisplayMode::Explorer, cx))
@@ -351,7 +351,7 @@ impl Render for WorkspaceDrawer {
             .flex_col()
             .w_full()
             .h(viewport_h)
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .child(div().h(px(top_inset)))
             // Header
             .child(
@@ -361,7 +361,7 @@ impl Render for WorkspaceDrawer {
                     .flex_row()
                     .items_center()
                     .border_b_1()
-                    .border_color(rgb(theme::BORDER_SUBTLE))
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .child(
                         div()
                             .id("drawer-home-icon")
@@ -379,7 +379,7 @@ impl Render for WorkspaceDrawer {
                                 svg()
                                     .path("icons/logo.svg")
                                     .size(px(theme::ICON_LOGO))
-                                    .text_color(rgb(theme::TEXT_PRIMARY)),
+                                    .text_color(rgb(theme::text_primary(cx))),
                             ),
                     )
                     .child(
@@ -395,7 +395,7 @@ impl Render for WorkspaceDrawer {
                                     .min_w_0()
                                     .truncate()
                                     .text_center()
-                                    .text_color(rgb(theme::TEXT_SECONDARY))
+                                    .text_color(rgb(theme::text_secondary(cx)))
                                     .text_size(px(theme::FONT_BODY))
                                     .font_weight(FontWeight::MEDIUM)
                                     .child(title),
@@ -406,7 +406,7 @@ impl Render for WorkspaceDrawer {
                                     .min_w_0()
                                     .truncate()
                                     .text_center()
-                                    .text_color(rgb(theme::TEXT_MUTED))
+                                    .text_color(rgb(theme::text_muted(cx)))
                                     .text_size(px(theme::FONT_BODY))
                                     .font_weight(FontWeight::MEDIUM)
                                     .child(subtitle),
@@ -422,6 +422,7 @@ impl Render for WorkspaceDrawer {
                                 ConnectionStatusIndicator::from_phase(
                                     "drawer-connect-status",
                                     connect_phase.as_ref(),
+                                    &theme::palette(cx),
                                 )
                                 .size(6.0),
                             ),
@@ -451,7 +452,7 @@ impl Render for WorkspaceDrawer {
                     .justify_center()
                     .gap(px(36.0))
                     .border_t_1()
-                    .border_color(rgb(theme::BORDER_SUBTLE))
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .child(self.nav_icon(DrawerTab::FileExplorer, cx))
                     .child(self.nav_icon(DrawerTab::GitDiff, cx))
                     .child(self.nav_icon(DrawerTab::Terminals, cx))

--- a/crates/zedra/src/workspace_editor.rs
+++ b/crates/zedra/src/workspace_editor.rs
@@ -6,6 +6,7 @@ use crate::editor::markdown::{
     MARKDOWN_SELECTION_AREA_ID, MarkdownView, is_markdown_path, parse_markdown_source,
 };
 use crate::placeholder::render_placeholder;
+use crate::theme;
 
 #[derive(Clone, Debug)]
 enum FileState {
@@ -64,7 +65,6 @@ impl WorkspaceEditor {
         self.state = FileState::Loading;
         cx.notify();
 
-        // Drop any previous task before starting a new one.
         let prev_task = self.read_task.take();
         drop(prev_task);
 
@@ -212,11 +212,11 @@ pub struct EditorSelection {
 }
 
 impl Render for WorkspaceEditor {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         match self.state.clone() {
-            FileState::Loading => render_placeholder("Loading ..."),
-            FileState::TooLarge => render_placeholder("File too large (>500 KB)"),
-            FileState::Error { error } => render_placeholder(format!("Error: {}", error)),
+            FileState::Loading => render_placeholder(cx, "Loading ..."),
+            FileState::TooLarge => render_placeholder(cx, "File too large (>500 KB)"),
+            FileState::Error { error } => render_placeholder(cx, format!("Error: {}", error)),
             FileState::Loaded => match self.content {
                 EditorContent::Code => div().size_full().child(self.editor_view.clone()),
                 EditorContent::Markdown => div()

--- a/crates/zedra/src/workspace_gitdiff.rs
+++ b/crates/zedra/src/workspace_gitdiff.rs
@@ -121,11 +121,11 @@ impl WorkspaceGitdiff {
 }
 
 impl Render for WorkspaceGitdiff {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         match self.state.clone() {
-            GitdiffState::Loading => render_placeholder("Loading ..."),
-            GitdiffState::TooLarge => render_placeholder("Diff too large (>200 KB)"),
-            GitdiffState::Error { error } => render_placeholder(&format!("Error: {}", error)),
+            GitdiffState::Loading => render_placeholder(cx, "Loading ..."),
+            GitdiffState::TooLarge => render_placeholder(cx, "Diff too large (>200 KB)"),
+            GitdiffState::Error { error } => render_placeholder(cx, &format!("Error: {}", error)),
             GitdiffState::Loaded => div().size_full().child(self.diff_view.clone()),
         }
     }

--- a/crates/zedra/src/workspace_terminal.rs
+++ b/crates/zedra/src/workspace_terminal.rs
@@ -19,6 +19,7 @@ use crate::platform_bridge::{
 use crate::telemetry::view_telemetry;
 use crate::terminal_preview_view::TerminalPreviewView;
 use crate::terminal_state::TerminalState;
+use crate::theme_state::{ThemeStateEvent, entity as theme_entity};
 use crate::workspace_state::{WorkspaceState, WorkspaceStateEvent};
 
 pub const TERMINAL_PENDING_ID: &str = "___PENDING___";
@@ -55,6 +56,13 @@ pub struct WorkspaceTerminal {
 }
 
 impl WorkspaceTerminal {
+    fn sync_terminal_theme(&mut self, cx: &mut Context<Self>) {
+        let terminal_theme = crate::theme::bundle(cx).terminal;
+        self.terminal_view.update(cx, |terminal_view, cx| {
+            terminal_view.set_terminal_theme(terminal_theme, cx);
+        });
+    }
+
     fn keyboard_inset() -> Pixels {
         let bridge = platform_bridge::bridge();
         let density = bridge.density();
@@ -378,7 +386,16 @@ impl WorkspaceTerminal {
             },
         );
 
-        Self {
+        let mut subscriptions = vec![attach_sub, terminal_events_sub, keyboard_offset_hook];
+        if let Some(theme_state) = theme_entity(cx) {
+            subscriptions.push(
+                cx.subscribe(&theme_state, |this, _, _: &ThemeStateEvent, cx| {
+                    this.sync_terminal_theme(cx);
+                }),
+            );
+        }
+
+        let mut this = Self {
             terminal_id,
             workspace_state,
             terminal_state,
@@ -392,8 +409,10 @@ impl WorkspaceTerminal {
             scroll_to_bottom_button_visible: false,
             scroll_to_bottom_button_hide_pending: false,
             scroll_to_bottom_button_hide_generation: 0,
-            _subscriptions: vec![attach_sub, terminal_events_sub, keyboard_offset_hook],
-        }
+            _subscriptions: subscriptions,
+        };
+        this.sync_terminal_theme(cx);
+        this
     }
 
     pub fn register_as_active_input(&mut self, cx: &mut Context<Self>) {


### PR DESCRIPTION
## Summary

- Add `ThemeState` / `ThemeBundle` with GPUI global access and persistence to `data_directory()/zedra/settings.json`
- Settings → Appearance toggle for Dark/Light; editor, terminal, and UI views read active palette via `theme::*(cx)` accessors
- Distinct light syntax palette (GitHub Light–style); terminal theme synced via `ThemeStateEvent` subscription (not render side effects)
- Async syntax highlighting rebuilds colors on apply using the current theme to avoid stale highlights after toggling mid-load

## Notes

- Stacks on `feat/agent-management` (theme migration touches agent views)
- Layout constants remain static in `theme.rs`; only colors are theme-dependent
- Settings save merges into existing `settings.json` rather than replacing the file

Made with [Cursor](https://cursor.com)