### PR TITLE
fix(ios): release logging and build-ios staticlib

### DIFF
--- a/crates/zedra/Cargo.toml
+++ b/crates/zedra/Cargo.toml
@@ -12,8 +12,8 @@ android-platform = []
 ios-platform = []
 # Log every telemetry event to stderr/logcat. Never enable in production builds.
 debug-telemetry = []
-# Set log level to Debug (default is Info). Enables verbose iroh/quinn logs.
-debug-logs = []
+# Set log level to Debug (default is Info). Enables verbose iroh/quinn logs and tracing subscriber.
+debug-logs = ["tracing-subscriber"]
 devtool = ["gpui_android/devtool"]
 
 [dependencies]
@@ -21,7 +21,7 @@ gpui = { path = "../../vendor/zed/crates/gpui", default-features = false }
 http_client = { path = "../../vendor/zed/crates/http_client" }
 anyhow.workspace = true
 tracing.workspace = true
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"], optional = true }
 log.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/crates/zedra/src/ios/logger.rs
+++ b/crates/zedra/src/ios/logger.rs
@@ -1,10 +1,14 @@
-/// iOS logger that routes Rust logs into the device log stream.
+/// iOS logger that routes `log` output through NSLog (visible in idevicesyslog).
 ///
-/// `log` crate lines are formatted as `[I dev.zedra.app::module] message`.
-/// `tracing` lines use the compact subscriber format.
+/// Release builds use only this path. `tracing` macros are not subscribed unless
+/// the `debug-logs` feature is enabled — matching v0.2.4 behavior and avoiding
+/// synchronous NSLog/os_log storms during iroh connect.
 use log::{Level, Log, Metadata, Record};
 use std::ffi::CString;
+
+#[cfg(feature = "debug-logs")]
 use std::io::{self, Write};
+#[cfg(feature = "debug-logs")]
 use tracing_subscriber::{EnvFilter, fmt::MakeWriter};
 
 unsafe extern "C" {
@@ -20,11 +24,13 @@ impl IosLogger {
             Err(_) => log::set_max_level(level),
         }
 
-        install_tracing_logger(level);
+        #[cfg(feature = "debug-logs")]
+        install_tracing_subscriber(level);
     }
 }
 
-fn install_tracing_logger(level: log::LevelFilter) {
+#[cfg(feature = "debug-logs")]
+fn install_tracing_subscriber(level: log::LevelFilter) {
     if level == log::LevelFilter::Off {
         return;
     }
@@ -41,6 +47,7 @@ fn install_tracing_logger(level: log::LevelFilter) {
     let _ = tracing::subscriber::set_global_default(subscriber);
 }
 
+#[cfg(feature = "debug-logs")]
 fn ios_tracing_filter(level: log::LevelFilter) -> EnvFilter {
     let level = match level {
         log::LevelFilter::Off => "off",
@@ -51,17 +58,16 @@ fn ios_tracing_filter(level: log::LevelFilter) -> EnvFilter {
         log::LevelFilter::Trace => "trace",
     };
 
-    if cfg!(feature = "debug-logs") {
-        EnvFilter::new(level)
-    } else {
-        EnvFilter::new(format!(
-            "{level},iroh=warn,iroh_quinn=warn,iroh_relay=warn,quinn=warn"
-        ))
-    }
+    EnvFilter::new(format!(
+        "{level},iroh=warn,iroh_quinn=warn,iroh_quinn_proto=warn,\
+         iroh_relay=warn,iroh_net_report=warn,quinn=warn"
+    ))
 }
 
+#[cfg(feature = "debug-logs")]
 struct IosTracingMakeWriter;
 
+#[cfg(feature = "debug-logs")]
 impl<'a> MakeWriter<'a> for IosTracingMakeWriter {
     type Writer = IosTracingWriter;
 
@@ -70,10 +76,12 @@ impl<'a> MakeWriter<'a> for IosTracingMakeWriter {
     }
 }
 
+#[cfg(feature = "debug-logs")]
 struct IosTracingWriter {
     buffer: Vec<u8>,
 }
 
+#[cfg(feature = "debug-logs")]
 impl Write for IosTracingWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.buffer.extend_from_slice(buf);
@@ -85,6 +93,7 @@ impl Write for IosTracingWriter {
     }
 }
 
+#[cfg(feature = "debug-logs")]
 impl Drop for IosTracingWriter {
     fn drop(&mut self) {
         if self.buffer.is_empty() {
@@ -108,7 +117,6 @@ impl Log for IosLogger {
         if matches!(target, "tracing::span" | "tracing::span::active") {
             return false;
         }
-        // Without debug-logs feature, suppress noisy iroh/quinn below warn
         if !cfg!(feature = "debug-logs")
             && metadata.level() > Level::Warn
             && (target.starts_with("iroh") || target.starts_with("quinn"))

--- a/crates/zedra/src/ios/nslog_bridge.m
+++ b/crates/zedra/src/ios/nslog_bridge.m
@@ -1,12 +1,10 @@
 #import <Foundation/Foundation.h>
-#import <os/log.h>
 
-// Called from Rust's iOS logger to route log output into the device log stream.
+// Routes Rust log output through NSLog (ASL), which idevicesyslog captures over USB.
 void zedra_nslog(const char *msg) {
     if (msg == NULL) {
         return;
     }
 
     NSLog(@"%s", msg);
-    os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_INFO, "%{public}s", msg);
 }

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -2438,7 +2438,7 @@ impl WorkspaceContent {
         cx: &mut Context<Self>,
     ) -> Self {
         let empty_view = cx.new(|_cx| Empty);
-        let connecting = cx.new(|_cx| WorkspaceConnecting::new(session_state));
+        let connecting = cx.new(|cx| WorkspaceConnecting::new(session_state, cx));
 
         let terminal_state_sub = cx.observe(&terminal_state, |_, _, cx| cx.notify());
         let workspace_state_sub = cx.observe(&workspace_state, |_, _, cx| cx.notify());

--- a/crates/zedra/src/workspace_connecting.rs
+++ b/crates/zedra/src/workspace_connecting.rs
@@ -12,14 +12,18 @@ pub struct WorkspaceConnecting {
     session_state: Entity<SessionState>,
     details_expanded: bool,
     restart_animation_id: u64,
+    _session_state_subscription: Subscription,
 }
 
 impl WorkspaceConnecting {
-    pub fn new(session_state: Entity<SessionState>) -> Self {
+    pub fn new(session_state: Entity<SessionState>, cx: &mut Context<Self>) -> Self {
+        let session_state_subscription = cx.observe(&session_state, |_, _, cx| cx.notify());
+
         Self {
             session_state,
             details_expanded: false,
             restart_animation_id: 0,
+            _session_state_subscription: session_state_subscription,
         }
     }
 }

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -942,3 +942,9 @@ Expected:
 4. Archive the Release build and inspect the generated `Info.plist`
 5. Expected: the base `UISupportedInterfaceOrientations` key contains `UIInterfaceOrientationPortrait`
 6. Expected: the iPad-specific `UISupportedInterfaceOrientations~ipad` key contains portrait, portrait upside down, landscape left, and landscape right
+
+## 21. iOS Release logging
+
+1. Install a **Release** build on device (not Xcode Run with debugger attached)
+2. Connect via **Scan QR**; optional: `scripts/log-ios.sh --grep connect`
+3. Expected: no burst of per-packet iroh/quinn trace lines (`tracing-subscriber` requires `debug-logs`)

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -144,6 +144,8 @@ bool zedra_ios_check_pending_frame(void);
 
 void zedra_ios_app_will_terminate(void);
 
+bool zedra_ios_system_back(void);
+
 void zedra_ios_native_floating_button_pressed(uint32_t callback_id);
 
 void zedra_ios_dictation_preview_dismiss(uint32_t preview_id);

--- a/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
@@ -144,6 +144,8 @@ bool zedra_ios_check_pending_frame(void);
 
 void zedra_ios_app_will_terminate(void);
 
+bool zedra_ios_system_back(void);
+
 void zedra_ios_native_floating_button_pressed(uint32_t callback_id);
 
 void zedra_ios_dictation_preview_dismiss(uint32_t preview_id);

--- a/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
@@ -144,6 +144,8 @@ bool zedra_ios_check_pending_frame(void);
 
 void zedra_ios_app_will_terminate(void);
 
+bool zedra_ios_system_back(void);
+
 void zedra_ios_native_floating_button_pressed(uint32_t callback_id);
 
 void zedra_ios_dictation_preview_dismiss(uint32_t preview_id);

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# Always package artifacts from this repo's target/ directory.
+unset CARGO_TARGET_DIR
+
 LIB_NAME="zedra"
 FRAMEWORK_NAME="ZedraFFI"
 
@@ -67,25 +70,57 @@ echo "==> Deployment target: iOS $IPHONEOS_DEPLOYMENT_TARGET"
 # Build the static library explicitly and fail hard on cargo errors.
 # Remove any stale output first so the XCFramework step cannot accidentally
 # package an older libzedra.a from a previous successful build.
+#
+# With crate-type = ["cdylib", "staticlib"], recent Cargo places libzedra.a
+# under deps/ rather than the profile root; resolve either location.
+resolve_staticlib() {
+    local target_triple="$1"
+    local base="target/${target_triple}/${PROFILE_DIR}"
+    if [ -f "${base}/lib${LIB_NAME}.a" ]; then
+        echo "${base}/lib${LIB_NAME}.a"
+        return 0
+    fi
+    if [ -f "${base}/deps/lib${LIB_NAME}.a" ]; then
+        echo "${base}/deps/lib${LIB_NAME}.a"
+        return 0
+    fi
+    return 1
+}
+
+clear_staticlib() {
+    local target_triple="$1"
+    local base="target/${target_triple}/${PROFILE_DIR}"
+    rm -f "${base}/lib${LIB_NAME}.a" "${base}/deps/lib${LIB_NAME}.a"
+}
+
+DEVICE_STATICLIB=""
+SIM_STATICLIB=""
+
+build_ios_staticlib() {
+    local target_triple="$1"
+    clear_staticlib "$target_triple"
+    cargo build --target "$target_triple" $PROFILE $FEATURES -p zedra
+    if ! resolve_staticlib "$target_triple" >/dev/null; then
+        # Recent Cargo may only link cdylib on incremental builds; force staticlib.
+        cargo rustc --target "$target_triple" $PROFILE $FEATURES -p zedra --crate-type staticlib
+    fi
+    resolve_staticlib "$target_triple"
+}
 
 if [ "$BUILD_DEVICE" = true ]; then
     echo "==> Building for iOS device (aarch64-apple-ios)..."
-    rm -f "target/aarch64-apple-ios/${PROFILE_DIR}/lib${LIB_NAME}.a"
-    cargo build --target aarch64-apple-ios $PROFILE $FEATURES -p zedra
-    if [ ! -f "target/aarch64-apple-ios/${PROFILE_DIR}/lib${LIB_NAME}.a" ]; then
+    DEVICE_STATICLIB="$(build_ios_staticlib aarch64-apple-ios)" || {
         echo "ERROR: staticlib not produced for device"
         exit 1
-    fi
+    }
 fi
 
 if [ "$BUILD_SIM" = true ]; then
     echo "==> Building for iOS simulator (aarch64-apple-ios-sim)..."
-    rm -f "target/aarch64-apple-ios-sim/${PROFILE_DIR}/lib${LIB_NAME}.a"
-    cargo build --target aarch64-apple-ios-sim $PROFILE $FEATURES -p zedra
-    if [ ! -f "target/aarch64-apple-ios-sim/${PROFILE_DIR}/lib${LIB_NAME}.a" ]; then
+    SIM_STATICLIB="$(build_ios_staticlib aarch64-apple-ios-sim)" || {
         echo "ERROR: staticlib not produced for simulator"
         exit 1
-    fi
+    }
 fi
 
 echo "==> XCFramework..."
@@ -95,10 +130,10 @@ trap 'rm -rf "$TMP"' EXIT
 
 XCF_ARGS=()
 if [ "$BUILD_DEVICE" = true ]; then
-    XCF_ARGS+=(-library "target/aarch64-apple-ios/${PROFILE_DIR}/lib${LIB_NAME}.a" -headers include/)
+    XCF_ARGS+=(-library "$DEVICE_STATICLIB" -headers include/)
 fi
 if [ "$BUILD_SIM" = true ]; then
-    XCF_ARGS+=(-library "target/aarch64-apple-ios-sim/${PROFILE_DIR}/lib${LIB_NAME}.a" -headers include/)
+    XCF_ARGS+=(-library "$SIM_STATICLIB" -headers include/)
 fi
 
 NEW="$TMP/${FRAMEWORK_NAME}.xcframework"


### PR DESCRIPTION
## Summary

- Release iOS builds use NSLog-only logging; `tracing-subscriber` is optional via `debug-logs` (fixes connect/QR stalls from duplicate os_log + tracing on the main thread).
- `build-ios.sh` finds `libzedra.a` under `deps/`, forces staticlib when needed, and uses the repo `target/` directory.
- Connecting overlay observes `session_state` so **View Details** updates during connect.
- Regenerated headers add `zedra_ios_system_back` (Rust export already on main).

## Notes

- No vendor/zed change. Mobile frame-time work stays in a follow-up phase; profile on Release device builds, not Xcode Debug attach.