### PR TITLE
feat(markdown): render Mermaid diagrams in markdown preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4136,6 +4136,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
+dependencies = [
+ "serde",
+ "ucd-trie",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,6 +4499,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mermaid-rs-renderer"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b808a8c109e16ba5de1c829bd9326aea0a72c176174ddb681284f56579d892ac"
+dependencies = [
+ "anyhow",
+ "fontdb 0.23.0",
+ "json5",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -8295,6 +8322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10000,6 +10033,7 @@ dependencies = [
  "iroh",
  "jni",
  "log",
+ "mermaid-rs-renderer",
  "ndk",
  "ndk-context",
  "once_cell",

--- a/crates/zedra/Cargo.toml
+++ b/crates/zedra/Cargo.toml
@@ -27,6 +27,7 @@ futures.workspace = true
 tokio.workspace = true
 once_cell = "1.19"
 pulldown-cmark = "0.13"
+mermaid-rs-renderer = { version = "0.2.2", default-features = false }
 
 # Syntax highlighting
 tree-sitter = "0.26"

--- a/crates/zedra/src/editor/markdown.rs
+++ b/crates/zedra/src/editor/markdown.rs
@@ -1,11 +1,13 @@
 use gpui::prelude::FluentBuilder;
 use gpui::*;
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::Path;
 use std::sync::Arc;
 
 use crate::editor::merge_highlights;
+use crate::editor::mermaid::{self, MermaidDiagram};
 use crate::fonts;
 use crate::platform_bridge;
 use crate::theme;
@@ -27,12 +29,24 @@ const TABLE_CELL_MAX_WIDTH: f32 = 220.0;
 const TABLE_CELL_CHAR_WIDTH_FACTOR: f32 = 0.62;
 const TABLE_CELL_PADDING_X: f32 = CODE_BLOCK_PADDING_X;
 const TABLE_CELL_PADDING_Y: f32 = CODE_BLOCK_PADDING_Y;
+const MERMAID_PENDING_HEIGHT: f32 = 120.0;
+const MERMAID_CONTENT_WIDTH: f32 = 360.0;
 pub const MARKDOWN_SELECTION_AREA_ID: &str = "markdown-preview-selection";
+
+#[derive(Clone, Debug)]
+enum MermaidBlockState {
+    Pending,
+    Ready(MermaidDiagram),
+    Failed,
+}
 
 pub struct MarkdownView {
     document: MarkdownDocument,
     list_state: ListState,
     focus_handle: Option<FocusHandle>,
+    mermaid_states: HashMap<usize, MermaidBlockState>,
+    mermaid_show_source: HashSet<usize>,
+    mermaid_generation: u64,
 }
 
 impl MarkdownView {
@@ -48,12 +62,15 @@ impl MarkdownView {
             document,
             list_state,
             focus_handle: None,
+            mermaid_states: HashMap::new(),
+            mermaid_show_source: HashSet::new(),
+            mermaid_generation: 0,
         }
     }
 
-    pub fn set_source(&mut self, source: impl Into<SharedString>) {
+    pub fn set_source(&mut self, source: impl Into<SharedString>, cx: &mut Context<Self>) {
         let source = source.into();
-        self.replace_document(parse_document(source.as_ref()));
+        self.replace_document(parse_document(source.as_ref()), cx);
     }
 
     pub fn line_range_for_selection(&self, range_utf16: Range<usize>) -> Option<(u32, u32)> {
@@ -65,17 +82,58 @@ impl MarkdownView {
         scroll_top.item_ix == 0 && scroll_top.offset_in_item <= px(0.5)
     }
 
-    pub(crate) fn set_parsed_source(&mut self, parsed: ParsedMarkdownSource) {
-        self.replace_document(parsed.document);
+    pub(crate) fn set_parsed_source(
+        &mut self,
+        parsed: ParsedMarkdownSource,
+        cx: &mut Context<Self>,
+    ) {
+        self.replace_document(parsed.document, cx);
     }
 
-    fn replace_document(&mut self, document: MarkdownDocument) {
+    fn replace_document(&mut self, document: MarkdownDocument, cx: &mut Context<Self>) {
         self.document = document;
+        self.mermaid_show_source.clear();
+        self.mermaid_generation = self.mermaid_generation.wrapping_add(1);
+        mermaid::clear_mermaid_svg_cache();
         // ListState caches row measurements. Reset it whenever the parsed block
         // tree changes, or scroll position and item heights can be reused from
         // the previous file.
         self.list_state
             .reset(markdown_list_item_count(self.document.blocks.len()));
+        self.schedule_mermaid_renders(cx);
+    }
+
+    fn schedule_mermaid_renders(&mut self, cx: &mut Context<Self>) {
+        self.mermaid_states.clear();
+        let generation = self.mermaid_generation;
+        for (block_ix, block) in self.document.blocks.iter().enumerate() {
+            let Block::Mermaid { text } = block else {
+                continue;
+            };
+            self.mermaid_states
+                .insert(block_ix, MermaidBlockState::Pending);
+            let source = text.clone();
+            let block_ix = block_ix;
+            cx.spawn(async move |this, cx| {
+                let rendered = cx
+                    .background_spawn(
+                        async move { mermaid::render_mermaid_diagram(block_ix, &source) },
+                    )
+                    .await;
+                let _ = this.update(cx, |view, cx| {
+                    if view.mermaid_generation != generation {
+                        return;
+                    }
+                    let state = match rendered {
+                        Some(diagram) => MermaidBlockState::Ready(diagram),
+                        None => MermaidBlockState::Failed,
+                    };
+                    view.mermaid_states.insert(block_ix, state);
+                    cx.notify();
+                });
+            })
+            .detach();
+        }
     }
 }
 
@@ -161,6 +219,10 @@ enum Block {
         items: Vec<Vec<Block>>,
     },
     CodeBlock {
+        language: Option<String>,
+        text: String,
+    },
+    Mermaid {
         text: String,
     },
     Table(TableBlock),
@@ -231,8 +293,11 @@ impl InlineRenderBuffer {
 }
 
 impl Render for MarkdownView {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let blocks = Arc::clone(&self.document.blocks);
+        let mermaid_states = self.mermaid_states.clone();
+        let mermaid_show_source = self.mermaid_show_source.clone();
+        let view = cx.weak_entity();
         let block_count = blocks.len();
         let bottom_inset = f32::max(
             platform_bridge::home_indicator_inset(),
@@ -240,7 +305,7 @@ impl Render for MarkdownView {
         );
         let focus_handle = self
             .focus_handle
-            .get_or_insert_with(|| _cx.focus_handle())
+            .get_or_insert_with(|| cx.focus_handle())
             .clone();
         let press_focus_handle = focus_handle.clone();
         // Keep each top-level markdown block as one variable-height list row.
@@ -257,7 +322,16 @@ impl Render for MarkdownView {
                     } else {
                         px(theme::SPACING_MD)
                     })
-                    .child(render_block(block, format!("md-{ix}"), window, cx))
+                    .child(render_block(
+                        block,
+                        ix,
+                        format!("md-{ix}"),
+                        &mermaid_states,
+                        &mermaid_show_source,
+                        view.clone(),
+                        window,
+                        cx,
+                    ))
                     .into_any_element()
             } else if ix == block_count {
                 div().h(px(bottom_inset)).into_any_element()
@@ -812,6 +886,32 @@ fn line_number_for_byte_offset(source: &str, byte_offset: usize) -> u32 {
         + 1
 }
 
+fn take_code_block_body(events: &[Event<'_>], cursor: &mut usize) -> String {
+    *cursor += 1;
+    let mut text = String::new();
+    while *cursor < events.len() {
+        match &events[*cursor] {
+            Event::End(TagEnd::CodeBlock) => {
+                *cursor += 1;
+                break;
+            }
+            Event::Text(value)
+            | Event::Code(value)
+            | Event::Html(value)
+            | Event::InlineHtml(value) => {
+                text.push_str(value);
+                *cursor += 1;
+            }
+            Event::SoftBreak | Event::HardBreak => {
+                text.push('\n');
+                *cursor += 1;
+            }
+            _ => *cursor += 1,
+        }
+    }
+    text
+}
+
 fn parse_blocks(events: &[Event<'_>], cursor: &mut usize, end: Option<TagEnd>) -> Vec<Block> {
     let mut blocks = Vec::new();
 
@@ -873,30 +973,24 @@ fn parse_blocks(events: &[Event<'_>], cursor: &mut usize, end: Option<TagEnd>) -
                     items,
                 });
             }
-            Event::Start(Tag::CodeBlock(_)) => {
-                *cursor += 1;
-                let mut text = String::new();
-                while *cursor < events.len() {
-                    match &events[*cursor] {
-                        Event::End(TagEnd::CodeBlock) => {
-                            *cursor += 1;
-                            break;
+            Event::Start(Tag::CodeBlock(kind)) => {
+                let language = match kind {
+                    CodeBlockKind::Fenced(lang) => {
+                        let lang = lang.to_string();
+                        if mermaid::is_mermaid_language(&lang) {
+                            blocks.push(Block::Mermaid {
+                                text: take_code_block_body(events, cursor),
+                            });
+                            continue;
                         }
-                        Event::Text(value)
-                        | Event::Code(value)
-                        | Event::Html(value)
-                        | Event::InlineHtml(value) => {
-                            text.push_str(value);
-                            *cursor += 1;
-                        }
-                        Event::SoftBreak | Event::HardBreak => {
-                            text.push('\n');
-                            *cursor += 1;
-                        }
-                        _ => *cursor += 1,
+                        Some(lang)
                     }
-                }
-                blocks.push(Block::CodeBlock { text });
+                    CodeBlockKind::Indented => None,
+                };
+                blocks.push(Block::CodeBlock {
+                    language,
+                    text: take_code_block_body(events, cursor),
+                });
             }
             Event::Start(Tag::Table(_)) => {
                 *cursor += 1;
@@ -1100,7 +1194,60 @@ fn parse_inline_event(events: &[Event<'_>], cursor: &mut usize) -> Vec<Inline> {
     }
 }
 
-fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -> AnyElement {
+fn render_code_block_content(text: &str, key: &str) -> AnyElement {
+    let code_width = code_block_content_min_width(text);
+    let code_lines = div()
+        .min_w(px(code_width))
+        .px(px(CODE_BLOCK_PADDING_X))
+        .py(px(CODE_BLOCK_PADDING_Y))
+        .flex()
+        .flex_col()
+        .children(text.lines().map(|line| {
+            let line = if line.is_empty() {
+                " ".to_string()
+            } else {
+                line.to_string()
+            };
+            div()
+                .w_full()
+                .text_color(rgb(theme::TEXT_PRIMARY))
+                .text_size(px(CODE_BLOCK_FONT_SIZE))
+                .line_height(px(CODE_BLOCK_LINE_HEIGHT))
+                .font_family(fonts::MONO_FONT_FAMILY)
+                .whitespace_nowrap()
+                .child(markdown_text(StyledText::new(line), "\n"))
+        }));
+
+    let mut container = div()
+        .id(format!("{key}-code-scroll"))
+        .w_full()
+        .bg(rgb(theme::BG_CARD))
+        .border_1()
+        .border_color(rgb(theme::BORDER_DEFAULT))
+        .rounded(px(6.0))
+        .overflow_x_scroll()
+        .child(code_lines);
+    container.style().restrict_scroll_to_axis = Some(true);
+
+    container.into_any_element()
+}
+
+fn mermaid_display_height(diagram: &MermaidDiagram) -> f32 {
+    let width = diagram.intrinsic_width.max(1.0);
+    let height = diagram.intrinsic_height.max(1.0);
+    (MERMAID_CONTENT_WIDTH * (height / width)).clamp(80.0, 2000.0)
+}
+
+fn render_block(
+    block: &Block,
+    block_ix: usize,
+    key: String,
+    mermaid_states: &HashMap<usize, MermaidBlockState>,
+    mermaid_show_source: &HashSet<usize>,
+    view: WeakEntity<MarkdownView>,
+    window: &mut Window,
+    cx: &mut App,
+) -> AnyElement {
     match block {
         Block::Paragraph(content) => render_inline_block(content, InlineBlockStyle::Body, key),
         Block::Heading { level, content } => {
@@ -1111,20 +1258,27 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
             };
             render_inline_block(content, style, key)
         }
-        Block::BlockQuote(children) => {
-            div()
-                .w_full()
-                .pl(px(theme::SPACING_MD))
-                .border_l_1()
-                .border_color(rgb(theme::BORDER_DEFAULT))
-                .flex()
-                .flex_col()
-                .gap(px(10.0))
-                .children(children.iter().enumerate().map(|(ix, child)| {
-                    render_block(child, format!("{key}-quote-{ix}"), window, cx)
-                }))
-                .into_any_element()
-        }
+        Block::BlockQuote(children) => div()
+            .w_full()
+            .pl(px(theme::SPACING_MD))
+            .border_l_1()
+            .border_color(rgb(theme::BORDER_DEFAULT))
+            .flex()
+            .flex_col()
+            .gap(px(10.0))
+            .children(children.iter().enumerate().map(|(ix, child)| {
+                render_block(
+                    child,
+                    usize::MAX,
+                    format!("{key}-quote-{ix}"),
+                    mermaid_states,
+                    mermaid_show_source,
+                    view.clone(),
+                    window,
+                    cx,
+                )
+            }))
+            .into_any_element(),
         Block::List {
             ordered,
             start,
@@ -1166,7 +1320,11 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
                             .children(item.iter().enumerate().map(|(child_ix, child)| {
                                 render_block(
                                     child,
+                                    usize::MAX,
                                     format!("{key}-item-{ix}-{child_ix}"),
+                                    mermaid_states,
+                                    mermaid_show_source,
+                                    view.clone(),
                                     window,
                                     cx,
                                 )
@@ -1174,43 +1332,119 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
                     )
             }))
             .into_any_element(),
-        Block::CodeBlock { text } => {
-            let code_width = code_block_content_min_width(text);
-            let code_lines = div()
-                .min_w(px(code_width))
-                .px(px(CODE_BLOCK_PADDING_X))
-                .py(px(CODE_BLOCK_PADDING_Y))
+        Block::Mermaid { text } => {
+            let show_source = mermaid_show_source.contains(&block_ix);
+            let state = mermaid_states.get(&block_ix);
+            let mut body: Vec<AnyElement> = Vec::new();
+
+            match state {
+                Some(MermaidBlockState::Ready(diagram)) => {
+                    let display_height = mermaid_display_height(diagram);
+                    let asset_path = diagram.asset_path.clone();
+                    body.push(
+                        div()
+                            .id(format!("{key}-mermaid"))
+                            .w_full()
+                            .h(px(display_height))
+                            .bg(rgb(theme::BG_CARD))
+                            .border_1()
+                            .border_color(rgb(theme::BORDER_DEFAULT))
+                            .rounded(px(6.0))
+                            .overflow_hidden()
+                            .child(
+                                img(asset_path)
+                                    .w_full()
+                                    .h_full()
+                                    .object_fit(ObjectFit::Contain),
+                            )
+                            .into_any_element(),
+                    );
+                }
+                Some(MermaidBlockState::Pending) => {
+                    body.push(
+                        div()
+                            .w_full()
+                            .h(px(MERMAID_PENDING_HEIGHT))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .bg(rgb(theme::BG_CARD))
+                            .border_1()
+                            .border_color(rgb(theme::BORDER_DEFAULT))
+                            .rounded(px(6.0))
+                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_size(px(theme::FONT_DETAIL))
+                            .font_family(fonts::MONO_FONT_FAMILY)
+                            .child("Rendering diagram…")
+                            .into_any_element(),
+                    );
+                }
+                Some(MermaidBlockState::Failed) | None => {
+                    body.push(render_code_block_content(
+                        text,
+                        &format!("{key}-mermaid-fallback"),
+                    ));
+                    body.push(
+                        div()
+                            .mt(px(6.0))
+                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_size(px(theme::FONT_DETAIL))
+                            .font_family(fonts::MONO_FONT_FAMILY)
+                            .child("Diagram could not be rendered.")
+                            .into_any_element(),
+                    );
+                }
+            }
+
+            if matches!(
+                state,
+                Some(MermaidBlockState::Ready(_)) | Some(MermaidBlockState::Pending)
+            ) {
+                let toggle_label = if show_source {
+                    "Hide source"
+                } else {
+                    "Show source"
+                };
+                let toggle_ix = block_ix;
+                body.push(
+                    div()
+                        .id(format!("{key}-mermaid-source-toggle"))
+                        .mt(px(6.0))
+                        .cursor_pointer()
+                        .text_color(rgb(theme::ACCENT_BLUE))
+                        .text_size(px(theme::FONT_DETAIL))
+                        .font_family(fonts::MONO_FONT_FAMILY)
+                        .on_click(move |_, _window, cx| {
+                            let _ = view.update(cx, |view, cx| {
+                                if view.mermaid_show_source.contains(&toggle_ix) {
+                                    view.mermaid_show_source.remove(&toggle_ix);
+                                } else {
+                                    view.mermaid_show_source.insert(toggle_ix);
+                                }
+                                cx.notify();
+                            });
+                        })
+                        .child(toggle_label)
+                        .into_any_element(),
+                );
+            }
+
+            if show_source {
+                body.push(render_code_block_content(
+                    text,
+                    &format!("{key}-mermaid-source"),
+                ));
+            }
+
+            div()
+                .w_full()
                 .flex()
                 .flex_col()
-                .children(text.lines().map(|line| {
-                    let line = if line.is_empty() {
-                        " ".to_string()
-                    } else {
-                        line.to_string()
-                    };
-                    div()
-                        .w_full()
-                        .text_color(rgb(theme::TEXT_PRIMARY))
-                        .text_size(px(CODE_BLOCK_FONT_SIZE))
-                        .line_height(px(CODE_BLOCK_LINE_HEIGHT))
-                        .font_family(fonts::MONO_FONT_FAMILY)
-                        .whitespace_nowrap()
-                        .child(markdown_text(StyledText::new(line), "\n"))
-                }));
-
-            let mut container = div()
-                .id(format!("{key}-code-scroll"))
-                .w_full()
-                .bg(rgb(theme::BG_CARD))
-                .border_1()
-                .border_color(rgb(theme::BORDER_DEFAULT))
-                .rounded(px(6.0))
-                .overflow_x_scroll()
-                .child(code_lines);
-            container.style().restrict_scroll_to_axis = Some(true);
-
-            container.into_any_element()
+                .gap(px(6.0))
+                .children(body)
+                .into_any_element()
         }
+        Block::CodeBlock { text, .. } => render_code_block_content(text, &key),
         Block::Table(table) => render_table(table, key),
         Block::Html(text) => {
             render_inline_block(&[Inline::Html(text.clone())], InlineBlockStyle::Html, key)
@@ -1687,7 +1921,13 @@ fn main() {}
         assert!(matches!(document.blocks[1], Block::Paragraph(_)));
         assert!(matches!(document.blocks[2], Block::BlockQuote(_)));
         assert!(matches!(document.blocks[3], Block::List { .. }));
-        assert!(matches!(document.blocks[4], Block::CodeBlock { .. }));
+        assert!(matches!(
+            document.blocks[4],
+            Block::CodeBlock {
+                language: Some(_),
+                ..
+            }
+        ));
         assert!(matches!(document.blocks[5], Block::Table(_)));
         assert!(document.total_block_count() > document.blocks.len());
     }
@@ -1770,16 +2010,39 @@ fn main() {}
     }
 
     #[test]
-    fn markdown_view_resets_virtualized_rows_when_source_changes() {
-        let mut view = MarkdownView::new("# Title\n\nBody paragraph.");
-        assert_eq!(
-            view.list_state.item_count(),
-            markdown_list_item_count(view.document.blocks.len())
-        );
-        assert_eq!(view.document.blocks.len(), 2);
+    fn parses_mermaid_fence_into_mermaid_block() {
+        let document = parse_document("```mermaid\nflowchart LR\n  A --> B\n```\n");
+        assert_eq!(document.blocks.len(), 1);
+        assert!(matches!(document.blocks[0], Block::Mermaid { .. }));
+    }
 
-        view.set_source(
-            r#"# Updated
+    #[test]
+    fn parses_non_mermaid_fenced_blocks_with_language() {
+        let document = parse_document("```rust\nfn main() {}\n```\n");
+        let Block::CodeBlock { language, .. } = &document.blocks[0] else {
+            panic!("expected code block");
+        };
+        assert_eq!(language.as_deref(), Some("rust"));
+    }
+
+    #[test]
+    fn markdown_view_resets_virtualized_rows_when_source_changes() {
+        use gpui::{AppContext as _, TestAppContext};
+
+        let mut cx = TestAppContext::single();
+        let view = cx.update(|cx| cx.new(|_cx| MarkdownView::new("# Title\n\nBody paragraph.")));
+
+        view.update(&mut cx, |view, _cx| {
+            assert_eq!(
+                view.list_state.item_count(),
+                markdown_list_item_count(view.document.blocks.len())
+            );
+            assert_eq!(view.document.blocks.len(), 2);
+        });
+
+        view.update(&mut cx, |view, cx| {
+            view.set_source(
+                r#"# Updated
 
 - First
 - Second
@@ -1788,12 +2051,16 @@ fn main() {}
 fn main() {}
 ```
 "#,
-        );
+                cx,
+            );
+        });
 
-        assert_eq!(view.document.blocks.len(), 3);
-        assert_eq!(
-            view.list_state.item_count(),
-            markdown_list_item_count(view.document.blocks.len())
-        );
+        view.update(&mut cx, |view, _cx| {
+            assert_eq!(view.document.blocks.len(), 3);
+            assert_eq!(
+                view.list_state.item_count(),
+                markdown_list_item_count(view.document.blocks.len())
+            );
+        });
     }
 }

--- a/crates/zedra/src/editor/markdown.rs
+++ b/crates/zedra/src/editor/markdown.rs
@@ -65,9 +65,11 @@ impl MarkdownView {
         );
         let mut subscriptions = Vec::new();
         if let Some(theme_state) = theme_state(cx) {
-            subscriptions.push(cx.subscribe(&theme_state, |this, _, _: &ThemeStateEvent, cx| {
-                this.on_theme_changed(cx);
-            }));
+            subscriptions.push(
+                cx.subscribe(&theme_state, |this, _, _: &ThemeStateEvent, cx| {
+                    this.on_theme_changed(cx);
+                }),
+            );
         }
         let mut view = Self {
             document,
@@ -1264,8 +1266,8 @@ fn render_code_block_content(text: &str, key: &str, cx: &App) -> AnyElement {
 }
 
 fn mermaid_layout_size(diagram: &MermaidDiagram) -> (f32, f32) {
-    let width = (diagram.intrinsic_width.max(1.0) * MERMAID_DISPLAY_SCALE)
-        .min(MERMAID_MAX_DISPLAY_WIDTH);
+    let width =
+        (diagram.intrinsic_width.max(1.0) * MERMAID_DISPLAY_SCALE).min(MERMAID_MAX_DISPLAY_WIDTH);
     let height = (diagram.intrinsic_height.max(1.0) * MERMAID_DISPLAY_SCALE)
         .min(MERMAID_MAX_DISPLAY_HEIGHT)
         .max(MERMAID_MIN_DISPLAY_HEIGHT);
@@ -2114,9 +2116,7 @@ fn main() {}
         use gpui::{AppContext as _, TestAppContext};
 
         let mut cx = TestAppContext::single();
-        let view = cx.update(|cx| {
-            cx.new(|cx| MarkdownView::new("# Title\n\nBody paragraph.", cx))
-        });
+        let view = cx.update(|cx| cx.new(|cx| MarkdownView::new("# Title\n\nBody paragraph.", cx)));
 
         view.update(&mut cx, |view, _cx| {
             assert_eq!(

--- a/crates/zedra/src/editor/mermaid.rs
+++ b/crates/zedra/src/editor/mermaid.rs
@@ -116,11 +116,9 @@ pub fn render_mermaid_diagram(
     let svg = match kind {
         DiagramKind::Timeline => render_zedra_timeline_svg(source, preference)?,
         _ => {
-            let mut svg = render_with_options(
-                source,
-                mermaid_render_options_for(kind, source, preference),
-            )
-            .ok()?;
+            let mut svg =
+                render_with_options(source, mermaid_render_options_for(kind, source, preference))
+                    .ok()?;
             if kind == DiagramKind::Quadrant {
                 svg = post_process_quadrant_svg(&svg, preference);
             }
@@ -324,7 +322,11 @@ fn configure_gitgraph_layout(layout: &mut LayoutConfig) {
     git.highlight_inner_size = 7.0;
 }
 
-fn configure_mindmap_layout(layout: &mut LayoutConfig, ui: &ThemePalette, preference: ThemePreference) {
+fn configure_mindmap_layout(
+    layout: &mut LayoutConfig,
+    ui: &ThemePalette,
+    preference: ThemePreference,
+) {
     let mindmap = &mut layout.mindmap;
     mindmap.padding = 20.0;
     mindmap.max_node_width = 170.0;
@@ -362,7 +364,10 @@ fn configure_journey_layout(options: &mut RenderOptions) {
     options.layout.preferred_aspect_ratio = Some(2.2);
 }
 
-pub(crate) fn mermaid_theme_for_preference(ui: &ThemePalette, preference: ThemePreference) -> Theme {
+pub(crate) fn mermaid_theme_for_preference(
+    ui: &ThemePalette,
+    preference: ThemePreference,
+) -> Theme {
     let palette = MermaidPalette::from_ui(ui, preference);
     let canvas = hex_color(palette.canvas);
     let node = hex_color(palette.node_fill);
@@ -611,7 +616,16 @@ fn render_zedra_timeline_svg(source: &str, preference: ThemePreference) -> Optio
     );
 
     if let Some(title) = data.title.as_deref() {
-        write_svg_text(&mut svg, width / 2.0, 24.0, title, title_size, &ink, "middle", Some("600"));
+        write_svg_text(
+            &mut svg,
+            width / 2.0,
+            24.0,
+            title,
+            title_size,
+            &ink,
+            "middle",
+            Some("600"),
+        );
     }
 
     let _ = write!(
@@ -648,12 +662,23 @@ fn render_zedra_timeline_svg(source: &str, preference: ThemePreference) -> Optio
             r#"<rect x="{x:.2}" y="{card_y:.2}" width="{card_width:.2}" height="26" rx="6" ry="6" fill="{}" fill-opacity="0.35"/>"#,
             escape_xml(color)
         );
-        write_svg_text(&mut svg, center_x, card_y + 18.0, &entry.time, time_size, &ink, "middle", Some("600"));
+        write_svg_text(
+            &mut svg,
+            center_x,
+            card_y + 18.0,
+            &entry.time,
+            time_size,
+            &ink,
+            "middle",
+            Some("600"),
+        );
 
         let mut y = card_y + 43.0;
         for event in &entry.events {
             for line in wrap_text_words(event, 18).into_iter().take(3) {
-                write_svg_text(&mut svg, center_x, y, &line, label_size, &muted, "middle", None);
+                write_svg_text(
+                    &mut svg, center_x, y, &line, label_size, &muted, "middle", None,
+                );
                 y += label_size * 1.2;
             }
         }
@@ -776,20 +801,10 @@ fn write_svg_text(
 fn timeline_colors_for_preference(preference: ThemePreference) -> [&'static str; 6] {
     match preference {
         ThemePreference::Dark => [
-            "#4f84b8",
-            "#8a8a52",
-            "#6f8f62",
-            "#8a6aa1",
-            "#9b6f6f",
-            "#69918b",
+            "#4f84b8", "#8a8a52", "#6f8f62", "#8a6aa1", "#9b6f6f", "#69918b",
         ],
         ThemePreference::Light => [
-            "#d7e5f5",
-            "#ebe4d6",
-            "#dce8d2",
-            "#e8ddf0",
-            "#f0dddd",
-            "#d9e9e5",
+            "#d7e5f5", "#ebe4d6", "#dce8d2", "#e8ddf0", "#f0dddd", "#d9e9e5",
         ],
     }
 }
@@ -948,7 +963,8 @@ mod tests {
   section Share
     Long-press diagram source: 4: Alex
     Add selection to chat with agent: 5: Alex"#;
-        let options = mermaid_render_options_for(DiagramKind::Journey, source, ThemePreference::Dark);
+        let options =
+            mermaid_render_options_for(DiagramKind::Journey, source, ThemePreference::Dark);
         assert_eq!(options.layout.max_label_width_chars, 12);
         assert_eq!(options.layout.label_line_height, 1.25);
         assert_eq!(options.layout.preferred_aspect_ratio, Some(2.2));

--- a/crates/zedra/src/editor/mermaid.rs
+++ b/crates/zedra/src/editor/mermaid.rs
@@ -37,14 +37,26 @@ impl MermaidPalette {
             ThemePreference::Dark => 0x1f1f1f,
             ThemePreference::Light => ui.border_subtle,
         };
+        // Dark: bg_card=#131313, border_subtle=#1a1a1a — only 7-point delta,
+        // nodes invisible against canvas. Use a brighter fill so shapes pop.
+        let node_fill = match preference {
+            ThemePreference::Dark => 0x2c2c2c,
+            ThemePreference::Light => ui.border_subtle,
+        };
+        // Dark: bright accent_blue (#61afef) is visually heavy on dark canvas.
+        // Use a dim neutral so arrows recede behind node labels.
+        let edge_stroke = match preference {
+            ThemePreference::Dark => 0x888888,
+            ThemePreference::Light => ui.accent_blue,
+        };
         Self {
             canvas: ui.bg_card,
-            node_fill: ui.border_subtle,
+            node_fill,
             node_fill_alt,
             node_border: ui.border_default,
             ink: ui.text_primary,
             ink_muted: ui.text_secondary,
-            edge_stroke: ui.accent_blue,
+            edge_stroke,
             note_fill,
         }
     }
@@ -56,10 +68,7 @@ static MERMAID_SVG_CACHE: OnceLock<Mutex<HashMap<String, Arc<[u8]>>>> = OnceLock
 pub fn mermaid_asset_path(block_ix: usize, source: &str) -> String {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     source.hash(&mut hasher);
-    format!(
-        "{MERMAID_ASSET_PREFIX}{block_ix}-{:x}.svg",
-        hasher.finish()
-    )
+    format!("{MERMAID_ASSET_PREFIX}{block_ix}-{:x}.svg", hasher.finish())
 }
 
 pub fn store_mermaid_svg(path: String, bytes: Arc<[u8]>) {
@@ -102,8 +111,22 @@ pub fn render_mermaid_diagram(
     if source.is_empty() {
         return None;
     }
+    let kind = detect_diagram_kind(source);
 
-    let svg = render_with_options(source, mermaid_render_options(preference)).ok()?;
+    let svg = match kind {
+        DiagramKind::Timeline => render_zedra_timeline_svg(source, preference)?,
+        _ => {
+            let mut svg = render_with_options(
+                source,
+                mermaid_render_options_for(kind, source, preference),
+            )
+            .ok()?;
+            if kind == DiagramKind::Quadrant {
+                svg = post_process_quadrant_svg(&svg, preference);
+            }
+            svg
+        }
+    };
     let (intrinsic_width, intrinsic_height) = svg_intrinsic_size(&svg)?;
     let asset_path = mermaid_asset_path(block_ix, source);
     store_mermaid_svg(asset_path.clone(), Arc::from(svg.into_bytes()));
@@ -115,22 +138,232 @@ pub fn render_mermaid_diagram(
     })
 }
 
-pub(crate) fn mermaid_render_options(preference: ThemePreference) -> RenderOptions {
-    let mut options = RenderOptions::default();
-    options.theme = mermaid_theme_for_preference(preference);
-    configure_flowchart_layout(&mut options.layout);
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DiagramKind {
+    Timeline,
+    Quadrant,
+    State,
+    Journey,
+    Other,
+}
+
+fn detect_diagram_kind(source: &str) -> DiagramKind {
+    let first = match source.lines().find(|l| !l.trim().is_empty()) {
+        Some(l) => l.trim_start(),
+        None => return DiagramKind::Other,
+    };
+    if first.starts_with("timeline") {
+        DiagramKind::Timeline
+    } else if first.starts_with("quadrantChart") {
+        DiagramKind::Quadrant
+    } else if first.starts_with("stateDiagram") {
+        DiagramKind::State
+    } else if first.starts_with("journey") {
+        DiagramKind::Journey
+    } else {
+        DiagramKind::Other
+    }
+}
+
+pub(crate) fn mermaid_render_options_for(
+    kind: DiagramKind,
+    source: &str,
+    preference: ThemePreference,
+) -> RenderOptions {
+    let mut options = mermaid_render_options(preference);
+    // State diagrams skip the library's flowchart_label_spacing_floor heuristic
+    // (it only runs for DiagramKind::Flowchart). Even when we boost spacing,
+    // adaptive_spacing_for_nodes then reduces it back to ~avg_node_size*0.5.
+    // Disable auto_spacing so our explicit values are preserved, then set spacing
+    // proportional to the longest transition label.
+    if kind == DiagramKind::State {
+        let max_label_chars = longest_edge_label_chars(source);
+        let boost = ((max_label_chars as f32 - 10.0) / 24.0).clamp(0.0, 1.0);
+        let extra = boost * 60.0;
+        options.layout.flowchart.auto_spacing.enabled = false;
+        options.layout.rank_spacing = 50.0 + extra;
+        // Extra node_spacing gives bidirectional edge pairs (e.g. Ready↔ShowingSource)
+        // more horizontal separation so their labels don't stack.
+        options.layout.node_spacing = 50.0 + extra * 0.8;
+    }
+    if kind == DiagramKind::Journey {
+        configure_journey_layout(&mut options);
+    }
     options
 }
 
-fn configure_flowchart_layout(layout: &mut LayoutConfig) {
-    // Prefer straight vertical/horizontal segments over zig-zag grid detours.
-    layout.flowchart.routing.turn_penalty = 2.0;
-    layout.flowchart.routing.grid_cell = 12.0;
-    layout.flowchart.objective.edge_relax_passes = 3;
+pub(crate) fn mermaid_render_options(preference: ThemePreference) -> RenderOptions {
+    let ui = match preference {
+        ThemePreference::Dark => ThemePalette::dark(),
+        ThemePreference::Light => ThemePalette::light(),
+    };
+    let mut options = RenderOptions::default();
+    options.theme = mermaid_theme_for_preference(&ui, preference);
+    configure_flowchart_layout(&mut options.layout);
+    // Gantt row_height is fixed (one line); raising this cap prevents task
+    // labels from wrapping and bleeding into adjacent rows.
+    options.layout.max_label_width_chars = 50;
+    configure_pie_layout(&mut options.layout);
+    configure_gitgraph_layout(&mut options.layout);
+    configure_mindmap_layout(&mut options.layout, &ui, preference);
+    options
 }
 
-pub(crate) fn mermaid_theme_for_preference(preference: ThemePreference) -> Theme {
-    let palette = MermaidPalette::for_preference(preference);
+// Post-processing for quadrant charts: mermaid-rs-renderer hardcodes light
+// purple backgrounds and borders that ignore the theme. We swap them in a
+// single pass after rendering.
+//
+// This is context-blind string replacement. If a user label happens to contain
+// one of the old hex strings, it would also be swapped. This is acceptable
+// because the old colors are mermaid-internal pastel shades (e.g. #ECECFF)
+// that are vanishingly unlikely to appear in user text.
+const QUADRANT_DARK_REPLACEMENTS: [(&str, &str); 12] = [
+    ("#ECECFF", "#1a1a1a"),
+    ("#f1f1ff", "#1d1d1d"),
+    ("#f6f6ff", "#202020"),
+    ("#fbfbff", "#232323"),
+    ("#c7c7f1", "#505050"),
+    ("#131300", "#ffffff"),
+    ("#6366f1", "#61afef"),
+    ("#f59e0b", "#98c379"),
+    ("#10b981", "#e5c07b"),
+    ("#ef4444", "#e06c75"),
+    ("#8b5cf6", "#cacaca"),
+    ("#06b6d4", "#61afef"),
+];
+
+const QUADRANT_LIGHT_REPLACEMENTS: [(&str, &str); 12] = [
+    ("#ECECFF", "#f8f9fa"),
+    ("#f1f1ff", "#f5f6f7"),
+    ("#f6f6ff", "#f2f3f4"),
+    ("#fbfbff", "#eff0f1"),
+    ("#c7c7f1", "#d8d8d8"),
+    ("#131300", "#1a1a1a"),
+    ("#6366f1", "#0969da"),
+    ("#f59e0b", "#1a7f37"),
+    ("#10b981", "#9a6700"),
+    ("#ef4444", "#cf222e"),
+    ("#8b5cf6", "#8a8a8a"),
+    ("#06b6d4", "#0969da"),
+];
+
+fn post_process_quadrant_svg(svg: &str, preference: ThemePreference) -> String {
+    let table: &[(&str, &str)] = match preference {
+        ThemePreference::Dark => &QUADRANT_DARK_REPLACEMENTS,
+        ThemePreference::Light => &QUADRANT_LIGHT_REPLACEMENTS,
+    };
+    let mut result = svg.to_string();
+    for (old, new) in table {
+        result = result.replace(old, new);
+    }
+    result
+}
+
+/// Approximate longest edge label by scanning lines with `-->` or `:` transitions.
+fn longest_edge_label_chars(source: &str) -> usize {
+    source
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            // Matches `A --> B : label` and `A --> B: label`
+            let colon_pos = trimmed.find(':')?;
+            let before = &trimmed[..colon_pos];
+            if before.contains("-->") || before.contains("->") {
+                Some(trimmed[colon_pos + 1..].trim().chars().count())
+            } else {
+                None
+            }
+        })
+        .max()
+        .unwrap_or(0)
+}
+
+fn configure_flowchart_layout(layout: &mut LayoutConfig) {
+    // High turn_penalty strongly discourages diagonal routing so branch nodes
+    // stay in the same column and arrows remain straight.
+    layout.flowchart.routing.turn_penalty = 5.0;
+    layout.flowchart.routing.grid_cell = 12.0;
+    // More ordering and relaxation passes improve Sugiyama layer alignment.
+    layout.flowchart.order_passes = 8;
+    layout.flowchart.objective.edge_relax_passes = 6;
+    // Narrow aspect ratio keeps TD flowcharts portrait — discourages the
+    // layout from spreading branch columns horizontally.
+    layout.flowchart.objective.max_aspect_ratio = 2.5;
+}
+
+fn configure_pie_layout(layout: &mut LayoutConfig) {
+    // Default height=360 → center_x=180. A long title centered at 180 with
+    // text-anchor="middle" clips on the left (title half-width > center_x).
+    // Increasing height widens the pie canvas so center_x has more headroom.
+    layout.pie.height = 500.0;
+    // legend_rect_size matched to legend text size so swatches fill the same
+    // vertical span as the text, reducing the visual misalignment.
+    layout.pie.legend_rect_size = 15.0;
+    layout.pie.legend_spacing = 5.0;
+}
+
+fn configure_gitgraph_layout(layout: &mut LayoutConfig) {
+    let git = &mut layout.gitgraph;
+    git.rotate_commit_label = false;
+    git.commit_step = 52.0;
+    git.branch_spacing = 48.0;
+    git.branch_label_font_size = 12.0;
+    git.commit_label_font_size = 11.0;
+    git.commit_label_offset_y = 18.0;
+    git.commit_label_bg_offset_y = 6.5;
+    git.commit_label_padding = 4.0;
+    git.commit_label_bg_opacity = 0.92;
+    git.tag_label_font_size = 11.0;
+    git.arrow_stroke_width = 4.0;
+    git.branch_stroke_width = 0.6;
+    git.branch_dasharray = "3 4".to_string();
+    git.commit_radius = 6.0;
+    git.merge_radius_outer = 6.5;
+    git.merge_radius_inner = 4.0;
+    git.highlight_outer_size = 13.0;
+    git.highlight_inner_size = 7.0;
+}
+
+fn configure_mindmap_layout(layout: &mut LayoutConfig, ui: &ThemePalette, preference: ThemePreference) {
+    let mindmap = &mut layout.mindmap;
+    mindmap.padding = 20.0;
+    mindmap.max_node_width = 170.0;
+    mindmap.node_spacing = 36.0;
+    mindmap.rank_spacing = 34.0;
+    mindmap.node_spacing_multiplier = 0.85;
+    mindmap.rank_spacing_multiplier = 0.85;
+    mindmap.rounded_padding = 10.0;
+    mindmap.rect_padding = 8.0;
+    mindmap.circle_padding = 14.0;
+    mindmap.default_corner_radius = 5.0;
+    mindmap.edge_depth_base_width = 7.0;
+    mindmap.edge_depth_step = -1.1;
+    mindmap.divider_line_width = 1.2;
+    mindmap.section_colors = mindmap_section_colors(ui, preference).to_vec();
+    mindmap.section_label_colors = mindmap_section_label_colors(ui).to_vec();
+    mindmap.section_line_colors = mindmap_section_line_colors(ui, preference).to_vec();
+    mindmap.root_fill = Some(match preference {
+        ThemePreference::Dark => "#34465c".to_string(),
+        ThemePreference::Light => hex_color(ui.accent_blue),
+    });
+    mindmap.root_text = Some(match preference {
+        ThemePreference::Dark => hex_color(ui.text_primary),
+        ThemePreference::Light => hex_color(ui.bg_card),
+    });
+}
+
+fn configure_journey_layout(options: &mut RenderOptions) {
+    // Journey rows use one fixed card width based on the widest task. Mobile
+    // fixtures with sentence-length tasks otherwise create very wide SVGs that
+    // crop inside the preview card, leaving most of the card blank.
+    options.layout.max_label_width_chars = 12;
+    options.layout.label_line_height = 1.25;
+    options.theme.font_size = 13.0;
+    options.layout.preferred_aspect_ratio = Some(2.2);
+}
+
+pub(crate) fn mermaid_theme_for_preference(ui: &ThemePalette, preference: ThemePreference) -> Theme {
+    let palette = MermaidPalette::from_ui(ui, preference);
     let canvas = hex_color(palette.canvas);
     let node = hex_color(palette.node_fill);
     let node_alt = hex_color(palette.node_fill_alt);
@@ -141,7 +374,16 @@ pub(crate) fn mermaid_theme_for_preference(preference: ThemePreference) -> Theme
     let note = hex_color(palette.note_fill);
 
     let mut theme = Theme::modern();
-    theme.font_family = "IBM Plex Sans".to_string();
+    // GPUI's SVG renderer (usvg) only has Lora + JetBrains Mono bundled; IBM
+    // Plex Sans is absent, causing usvg to pick a different sans fallback than
+    // text_metrics does — sizing mismatch. "sans-serif" resolves to the same
+    // family in both paths.
+    theme.font_family = "sans-serif".to_string();
+    // Pie title is centered at x=height/2 (180 default). At 25px a long title
+    // overflows left. Reduce size so the text fits within the wider canvas
+    // set by configure_pie_layout (height=500 → center_x=250).
+    theme.pie_title_text_size = 19.0;
+    theme.pie_legend_text_size = 15.0;
     theme.background = canvas.clone();
 
     theme.primary_color = node.clone();
@@ -163,12 +405,21 @@ pub(crate) fn mermaid_theme_for_preference(preference: ThemePreference) -> Theme
     theme.sequence_activation_fill = node_alt.clone();
     theme.sequence_activation_border = node_border.clone();
 
-    theme.pie_colors = pie_colors_for_preference(preference);
+    theme.pie_colors = pie_colors(ui, preference);
     theme.pie_title_text_color = ink.clone();
     theme.pie_section_text_color = ink.clone();
     theme.pie_legend_text_color = ink.clone();
     theme.pie_stroke_color = node_border.clone();
     theme.pie_outer_stroke_color = node_border.clone();
+
+    theme.git_colors = git_colors(ui, preference);
+    theme.git_inv_colors = git_inverse_colors(ui, preference);
+    theme.git_branch_label_colors = git_branch_label_colors(ui, preference);
+    theme.git_commit_label_color = ink.clone();
+    theme.git_commit_label_background = node_alt.clone();
+    theme.git_tag_label_color = ink.clone();
+    theme.git_tag_label_background = node_alt.clone();
+    theme.git_tag_label_border = node_border.clone();
 
     theme
 }
@@ -177,11 +428,7 @@ fn hex_color(rgb: u32) -> String {
     format!("#{:06x}", rgb & 0xffffff)
 }
 
-fn pie_colors_for_preference(preference: ThemePreference) -> [String; 12] {
-    let ui = match preference {
-        ThemePreference::Dark => ThemePalette::dark(),
-        ThemePreference::Light => ThemePalette::light(),
-    };
+fn pie_colors(ui: &ThemePalette, preference: ThemePreference) -> [String; 12] {
     match preference {
         ThemePreference::Dark => [
             hex_color(ui.accent_blue),
@@ -199,6 +446,366 @@ fn pie_colors_for_preference(preference: ThemePreference) -> [String; 12] {
         ],
         ThemePreference::Light => Theme::modern().pie_colors,
     }
+}
+
+fn git_colors(ui: &ThemePalette, preference: ThemePreference) -> [String; 8] {
+    match preference {
+        ThemePreference::Dark => [
+            "#4f84b8".to_string(),
+            "#8a8a52".to_string(),
+            hex_color(ui.accent_green),
+            "#a06c72".to_string(),
+            "#6f8c8c".to_string(),
+            "#7d7da8".to_string(),
+            "#8a6f8c".to_string(),
+            hex_color(ui.accent_dim),
+        ],
+        ThemePreference::Light => [
+            hex_color(ui.accent_blue),
+            hex_color(ui.accent_yellow),
+            hex_color(ui.accent_green),
+            hex_color(ui.accent_red),
+            "#4f7f7f".to_string(),
+            "#6666a3".to_string(),
+            "#8a5c8a".to_string(),
+            hex_color(ui.accent_dim),
+        ],
+    }
+}
+
+fn git_inverse_colors(ui: &ThemePalette, preference: ThemePreference) -> [String; 8] {
+    let inverse = match preference {
+        ThemePreference::Dark => ui.bg_card,
+        ThemePreference::Light => ui.bg_primary,
+    };
+    std::array::from_fn(|_| hex_color(inverse))
+}
+
+fn git_branch_label_colors(ui: &ThemePalette, preference: ThemePreference) -> [String; 8] {
+    match preference {
+        ThemePreference::Dark => [
+            hex_color(ui.text_primary),
+            hex_color(ui.bg_card),
+            hex_color(ui.bg_card),
+            hex_color(ui.text_primary),
+            hex_color(ui.bg_card),
+            hex_color(ui.text_primary),
+            hex_color(ui.text_primary),
+            hex_color(ui.text_primary),
+        ],
+        ThemePreference::Light => std::array::from_fn(|_| hex_color(ui.bg_card)),
+    }
+}
+
+fn mindmap_section_colors(ui: &ThemePalette, preference: ThemePreference) -> [String; 12] {
+    match preference {
+        ThemePreference::Dark => [
+            "#3a4a34".to_string(),
+            "#3e364d".to_string(),
+            "#34465c".to_string(),
+            "#4a3838".to_string(),
+            "#354846".to_string(),
+            "#4b4436".to_string(),
+            "#3f3f52".to_string(),
+            "#43384a".to_string(),
+            "#344a3c".to_string(),
+            "#4a3d35".to_string(),
+            "#37454e".to_string(),
+            "#4a4040".to_string(),
+        ],
+        ThemePreference::Light => [
+            "#dce8d2".to_string(),
+            "#e8ddf0".to_string(),
+            "#d7e5f5".to_string(),
+            "#f0dddd".to_string(),
+            "#d9e9e5".to_string(),
+            "#ebe4d6".to_string(),
+            "#dedff0".to_string(),
+            "#eaddec".to_string(),
+            "#d8e9df".to_string(),
+            "#eee2d8".to_string(),
+            "#dbe6ec".to_string(),
+            hex_color(ui.border_subtle),
+        ],
+    }
+}
+
+fn mindmap_section_label_colors(ui: &ThemePalette) -> [String; 12] {
+    std::array::from_fn(|_| hex_color(ui.text_primary))
+}
+
+fn mindmap_section_line_colors(ui: &ThemePalette, preference: ThemePreference) -> [String; 12] {
+    match preference {
+        ThemePreference::Dark => [
+            "#6f8f62".to_string(),
+            "#8a6aa1".to_string(),
+            "#5f84ad".to_string(),
+            "#9b6f6f".to_string(),
+            "#69918b".to_string(),
+            "#9a855d".to_string(),
+            "#7778a4".to_string(),
+            "#8e6a94".to_string(),
+            "#6e967a".to_string(),
+            "#9a7b61".to_string(),
+            "#6f8fa4".to_string(),
+            "#8a7777".to_string(),
+        ],
+        ThemePreference::Light => mindmap_section_colors(ui, preference),
+    }
+}
+
+struct TimelineEntry {
+    time: String,
+    events: Vec<String>,
+}
+
+struct TimelineData {
+    title: Option<String>,
+    entries: Vec<TimelineEntry>,
+}
+
+fn render_zedra_timeline_svg(source: &str, preference: ThemePreference) -> Option<String> {
+    let data = parse_timeline_source(source);
+    if data.entries.is_empty() {
+        return None;
+    }
+
+    let palette = MermaidPalette::for_preference(preference);
+    let bg = hex_color(palette.canvas);
+    let card = hex_color(palette.node_fill);
+    let border = hex_color(palette.node_border);
+    let ink = hex_color(palette.ink);
+    let muted = hex_color(palette.ink_muted);
+    let line = hex_color(palette.edge_stroke);
+    let colors = timeline_colors_for_preference(preference);
+
+    let title_size = 14.0;
+    let label_size = 12.0;
+    let time_size = 12.0;
+    let margin_x = 32.0;
+    let title_height = if data.title.is_some() { 34.0 } else { 8.0 };
+    let line_y = title_height + 58.0;
+    let card_y = line_y + 36.0;
+    let card_width = 150.0;
+    let card_height = 86.0;
+    let gap = 28.0;
+    let width = margin_x * 2.0
+        + data.entries.len() as f32 * card_width
+        + data.entries.len().saturating_sub(1) as f32 * gap;
+    let height = card_y + card_height + 28.0;
+    let line_start = margin_x + card_width / 2.0;
+    let line_end = width - margin_x - card_width / 2.0;
+
+    // Rough capacity: ~400 bytes fixed overhead + ~500 bytes per entry.
+    let estimated = 400 + data.entries.len() * 500;
+    let mut svg = String::with_capacity(estimated);
+    use std::fmt::Write;
+    let _ = write!(
+        svg,
+        r#"<svg xmlns="http://www.w3.org/2000/svg" width="{width:.2}" height="{height:.2}" viewBox="0 0 {width:.2} {height:.2}" style="max-width: {width:.2}px;" font-family="sans-serif">"#
+    );
+    let _ = write!(
+        svg,
+        r#"<rect x="0" y="0" width="{width:.2}" height="{height:.2}" fill="{}"/>"#,
+        escape_xml(&bg)
+    );
+
+    if let Some(title) = data.title.as_deref() {
+        write_svg_text(&mut svg, width / 2.0, 24.0, title, title_size, &ink, "middle", Some("600"));
+    }
+
+    let _ = write!(
+        svg,
+        r#"<line x1="{line_start:.2}" y1="{line_y:.2}" x2="{line_end:.2}" y2="{line_y:.2}" stroke="{}" stroke-width="2" stroke-linecap="round"/>"#,
+        escape_xml(&line)
+    );
+
+    for (ix, entry) in data.entries.iter().enumerate() {
+        let x = margin_x + ix as f32 * (card_width + gap);
+        let center_x = x + card_width / 2.0;
+        let color = colors[ix % colors.len()];
+        let _ = write!(
+            svg,
+            r#"<line x1="{center_x:.2}" y1="{:.2}" x2="{center_x:.2}" y2="{:.2}" stroke="{}" stroke-width="1" stroke-dasharray="3 4"/>"#,
+            line_y + 9.0,
+            card_y,
+            escape_xml(&border)
+        );
+        let _ = write!(
+            svg,
+            r#"<circle cx="{center_x:.2}" cy="{line_y:.2}" r="8" fill="{}" stroke="{}" stroke-width="2"/>"#,
+            escape_xml(&card),
+            escape_xml(color)
+        );
+        let _ = write!(
+            svg,
+            r#"<rect x="{x:.2}" y="{card_y:.2}" width="{card_width:.2}" height="{card_height:.2}" rx="6" ry="6" fill="{}" stroke="{}" stroke-width="1"/>"#,
+            escape_xml(&card),
+            escape_xml(&border)
+        );
+        let _ = write!(
+            svg,
+            r#"<rect x="{x:.2}" y="{card_y:.2}" width="{card_width:.2}" height="26" rx="6" ry="6" fill="{}" fill-opacity="0.35"/>"#,
+            escape_xml(color)
+        );
+        write_svg_text(&mut svg, center_x, card_y + 18.0, &entry.time, time_size, &ink, "middle", Some("600"));
+
+        let mut y = card_y + 43.0;
+        for event in &entry.events {
+            for line in wrap_text_words(event, 18).into_iter().take(3) {
+                write_svg_text(&mut svg, center_x, y, &line, label_size, &muted, "middle", None);
+                y += label_size * 1.2;
+            }
+        }
+    }
+
+    svg.push_str("</svg>");
+    Some(svg)
+}
+
+fn parse_timeline_source(source: &str) -> TimelineData {
+    let mut title = None;
+    let mut entries = Vec::new();
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed == "timeline" {
+            continue;
+        }
+        if let Some(value) = trimmed.strip_prefix("title ") {
+            title = Some(value.trim_matches('"').to_string());
+            continue;
+        }
+        if trimmed.starts_with("section ") {
+            continue;
+        }
+        let mut parts = trimmed
+            .split(':')
+            .map(str::trim)
+            .filter(|part| !part.is_empty());
+        let Some(time) = parts.next() else {
+            continue;
+        };
+        let events: Vec<String> = parts
+            .map(|part| part.trim_matches('"').to_string())
+            .collect();
+        if !events.is_empty() {
+            entries.push(TimelineEntry {
+                time: time.to_string(),
+                events,
+            });
+        }
+    }
+    TimelineData { title, entries }
+}
+
+fn wrap_text_words(text: &str, max_chars: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    let mut current_len = 0usize;
+    for word in text.split_whitespace() {
+        let word_len = word.chars().count();
+        // A single word may exceed max_chars; split it so the fixed-width
+        // card (150 px at 12 px font) does not overflow.
+        if word_len > max_chars {
+            if !current.is_empty() {
+                lines.push(current);
+                current = String::new();
+                current_len = 0;
+            }
+            for c in word.chars() {
+                current.push(c);
+                current_len += 1;
+                if current_len == max_chars {
+                    lines.push(current);
+                    current = String::new();
+                    current_len = 0;
+                }
+            }
+            continue;
+        }
+        let next_len = if current.is_empty() {
+            word_len
+        } else {
+            current_len + 1 + word_len
+        };
+        if next_len > max_chars && !current.is_empty() {
+            lines.push(current);
+            current = String::new();
+            current_len = 0;
+        }
+        if !current.is_empty() {
+            current.push(' ');
+            current_len += 1;
+        }
+        current.push_str(word);
+        current_len += word_len;
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines
+}
+
+fn write_svg_text(
+    svg: &mut String,
+    x: f32,
+    y: f32,
+    text: &str,
+    size: f32,
+    color: &str,
+    anchor: &str,
+    weight: Option<&str>,
+) {
+    use std::fmt::Write;
+    let weight_attr = weight
+        .map(|value| format!(r#" font-weight="{}""#, escape_xml(value)))
+        .unwrap_or_default();
+    let _ = write!(
+        svg,
+        r#"<text x="{x:.2}" y="{y:.2}" text-anchor="{}" font-size="{size:.1}" fill="{}"{}>{}</text>"#,
+        escape_xml(anchor),
+        escape_xml(color),
+        weight_attr,
+        escape_xml(text)
+    );
+}
+
+fn timeline_colors_for_preference(preference: ThemePreference) -> [&'static str; 6] {
+    match preference {
+        ThemePreference::Dark => [
+            "#4f84b8",
+            "#8a8a52",
+            "#6f8f62",
+            "#8a6aa1",
+            "#9b6f6f",
+            "#69918b",
+        ],
+        ThemePreference::Light => [
+            "#d7e5f5",
+            "#ebe4d6",
+            "#dce8d2",
+            "#e8ddf0",
+            "#f0dddd",
+            "#d9e9e5",
+        ],
+    }
+}
+
+fn escape_xml(value: &str) -> String {
+    let mut result = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '&' => result.push_str("&amp;"),
+            '<' => result.push_str("&lt;"),
+            '>' => result.push_str("&gt;"),
+            '"' => result.push_str("&quot;"),
+            _ => result.push(c),
+        }
+    }
+    result
 }
 
 /// Best-effort intrinsic size from SVG `viewBox` or `width`/`height` attributes.
@@ -246,13 +853,150 @@ mod tests {
 
     #[test]
     fn dark_theme_uses_dark_nodes_and_light_canvas_text() {
-        let theme = mermaid_theme_for_preference(ThemePreference::Dark);
+        let theme = mermaid_theme_for_preference(&ThemePalette::dark(), ThemePreference::Dark);
         assert_eq!(theme.background, "#131313");
-        assert_eq!(theme.primary_color, "#1a1a1a");
+        assert_eq!(theme.primary_color, "#2c2c2c");
         assert_eq!(theme.primary_text_color, "#ffffff");
         assert_eq!(theme.pie_legend_text_color, "#ffffff");
         assert_eq!(theme.text_color, "#ffffff");
-        assert_eq!(theme.line_color, "#61afef");
+        assert_eq!(theme.line_color, "#888888");
+    }
+
+    #[test]
+    fn dark_gitgraph_uses_zedra_palette_and_readable_labels() {
+        let options = mermaid_render_options(ThemePreference::Dark);
+        assert_eq!(options.theme.git_colors[0], "#4f84b8");
+        assert_eq!(options.theme.git_colors[1], "#8a8a52");
+        assert_eq!(options.theme.git_commit_label_color, "#ffffff");
+        assert_eq!(options.theme.git_commit_label_background, "#1f1f1f");
+        assert!(!options.layout.gitgraph.rotate_commit_label);
+        assert_eq!(options.layout.gitgraph.commit_label_font_size, 11.0);
+
+        clear_mermaid_svg_cache();
+        let diagram = render_mermaid_diagram(
+            7,
+            r#"gitGraph
+  commit id: "be648bf" tag: "v0.2.5" type: HIGHLIGHT
+  branch feat-markdown-mermaid
+  checkout feat-markdown-mermaid
+  commit id: "feat-zedra-mermaid-parse-render"
+  checkout main
+  merge feat-markdown-mermaid"#,
+            ThemePreference::Dark,
+        )
+        .expect("gitGraph should render");
+        let bytes = load_mermaid_svg(&diagram.asset_path).expect("svg bytes");
+        let svg = std::str::from_utf8(bytes.as_ref()).expect("utf-8 svg");
+        assert!(
+            !svg.contains("rotate(-45"),
+            "commit labels should not be rotated on mobile"
+        );
+        assert!(
+            !svg.contains("hsl(240, 100%, 46.2745098039%)"),
+            "should not use Mermaid default gitGraph lane colors"
+        );
+    }
+
+    #[test]
+    fn dark_mindmap_uses_compact_muted_theme() {
+        let options = mermaid_render_options(ThemePreference::Dark);
+        assert_eq!(options.layout.mindmap.section_colors[0], "#3a4a34");
+        assert_eq!(options.layout.mindmap.root_fill.as_deref(), Some("#34465c"));
+        assert_eq!(options.layout.mindmap.edge_depth_base_width, 7.0);
+        assert_eq!(options.layout.mindmap.max_node_width, 170.0);
+
+        clear_mermaid_svg_cache();
+        let diagram = render_mermaid_diagram(
+            8,
+            r#"mindmap
+  ((Zedra iOS))
+    Workspace
+      Terminal grid
+      File explorer
+      Docs tree markdown only
+      Git diff sidebar
+    Platform
+      UIKit alerts sheets
+      Metal GPUI
+      Haptics light impact"#,
+            ThemePreference::Dark,
+        )
+        .expect("mindmap should render");
+        let bytes = load_mermaid_svg(&diagram.asset_path).expect("svg bytes");
+        let svg = std::str::from_utf8(bytes.as_ref()).expect("utf-8 svg");
+        assert!(
+            !svg.contains("hsl(60, 100%, 73.5294117647%)"),
+            "should not use Mermaid default neon mindmap fills"
+        );
+        assert!(
+            !svg.contains("stroke-width=\"11"),
+            "mindmap branch strokes should be compact on mobile"
+        );
+    }
+
+    #[test]
+    fn journey_wraps_task_labels_for_mobile_preview() {
+        let source = r#"journey
+  title Alex ships a diagram in internal README
+  section Commute
+    Open Zedra on LTE to home Mac: 4: Alex
+    Terminal shows agent done and file link: 5: Alex
+  section Preview
+    Tap link sheet loads README: 4: Alex
+    Scroll past table see flowchart: 5: Alex
+    Pinch mentally checks legibility: 3: Alex
+  section Share
+    Long-press diagram source: 4: Alex
+    Add selection to chat with agent: 5: Alex"#;
+        let options = mermaid_render_options_for(DiagramKind::Journey, source, ThemePreference::Dark);
+        assert_eq!(options.layout.max_label_width_chars, 12);
+        assert_eq!(options.layout.label_line_height, 1.25);
+        assert_eq!(options.layout.preferred_aspect_ratio, Some(2.2));
+
+        clear_mermaid_svg_cache();
+        let diagram = render_mermaid_diagram(9, source, ThemePreference::Dark)
+            .expect("journey should render");
+        assert!(
+            diagram.intrinsic_width < 1500.0,
+            "journey should wrap task cards instead of rendering an oversized row: {}",
+            diagram.intrinsic_width
+        );
+        let bytes = load_mermaid_svg(&diagram.asset_path).expect("svg bytes");
+        let svg = std::str::from_utf8(bytes.as_ref()).expect("utf-8 svg");
+        assert!(
+            svg.contains("Terminal") && svg.contains("agent") && svg.contains("done"),
+            "wrapped labels should retain task text"
+        );
+    }
+
+    #[test]
+    fn timeline_wraps_labels_inside_event_cards() {
+        let source = r#"timeline
+  title Zedra markdown preview history (mock)
+  section 2025
+    Q3 : Terminal OSC-8 file links
+    Q4 : Custom sheet code preview
+  section 2026
+    Q1 : Workspace markdown editor mode
+    Q2 : GFM tables and task lists
+         : Mermaid render via mermaid-rs-renderer"#;
+
+        clear_mermaid_svg_cache();
+        let diagram = render_mermaid_diagram(10, source, ThemePreference::Dark)
+            .expect("timeline should render");
+        assert!(
+            diagram.intrinsic_width < 900.0,
+            "timeline should stay card-sized: {}",
+            diagram.intrinsic_width
+        );
+        let bytes = load_mermaid_svg(&diagram.asset_path).expect("svg bytes");
+        let svg = std::str::from_utf8(bytes.as_ref()).expect("utf-8 svg");
+        assert!(svg.contains("Terminal OSC-8"));
+        assert!(svg.contains("file links"));
+        assert!(
+            !svg.contains("#ECECFF"),
+            "timeline should not use Mermaid default pastel cards"
+        );
     }
 
     #[test]
@@ -260,8 +1004,8 @@ mod tests {
         use mermaid_rs_renderer::parse_mermaid;
         use std::fs;
 
-        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../examples/markdown-mermaid/diagrams.md");
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/mermaid.md");
         let md = fs::read_to_string(&path).expect("diagrams fixture");
         let mut current_section = String::from("preamble");
         let mut in_fence = false;
@@ -303,14 +1047,13 @@ mod tests {
                 panic!("parse failed for [{section}]: {err}\n---\n{source}\n---")
             });
             clear_mermaid_svg_cache();
-            render_mermaid_diagram(0, source, ThemePreference::Dark).unwrap_or_else(|| {
-                panic!("render failed for [{section}]\n---\n{source}\n---")
-            });
+            render_mermaid_diagram(0, source, ThemePreference::Dark)
+                .unwrap_or_else(|| panic!("render failed for [{section}]\n---\n{source}\n---"));
         }
     }
 
     #[test]
-    fn flowchart_edges_use_accent_stroke() {
+    fn flowchart_edges_use_dim_stroke_in_dark_mode() {
         clear_mermaid_svg_cache();
         let diagram = render_mermaid_diagram(
             9,
@@ -321,8 +1064,8 @@ mod tests {
         let bytes = load_mermaid_svg(&diagram.asset_path).expect("svg bytes");
         let svg = std::str::from_utf8(bytes.as_ref()).expect("utf-8 svg");
         assert!(
-            svg.contains("stroke=\"#61afef\""),
-            "expected accent edge stroke"
+            svg.contains("stroke=\"#888888\""),
+            "expected dim neutral edge stroke in dark mode"
         );
     }
 
@@ -377,5 +1120,53 @@ mod tests {
         assert!(diagram.intrinsic_width > 0.0);
         assert!(diagram.intrinsic_height > 0.0);
         assert!(load_mermaid_svg(&diagram.asset_path).is_some());
+    }
+
+    #[test]
+    fn dark_quadrant_uses_theme_colors() {
+        clear_mermaid_svg_cache();
+        let diagram = render_mermaid_diagram(
+            12,
+            r#"quadrantChart
+  title Mobile markdown diagram backends
+  x-axis Low implementation cost --> High cost
+  y-axis Low visual fidelity --> High fidelity
+  quadrant-1 Quick win
+  quadrant-2 Heavyweight
+  quadrant-3 Avoid
+  quadrant-4 Ideal long-term
+  "mermaid-rs-renderer embedded SVG": [0.35, 0.72]
+  "WKWebView mermaid.js CDN": [0.55, 0.88]
+  "Host RPC pre-render PNG": [0.75, 0.8]
+  "Monospace fence only": [0.15, 0.2]"#,
+            ThemePreference::Dark,
+        )
+        .expect("quadrant should render");
+        let bytes = load_mermaid_svg(&diagram.asset_path).expect("svg bytes");
+        let svg = std::str::from_utf8(bytes.as_ref()).expect("utf-8 svg");
+        assert!(
+            !svg.contains("#ECECFF"),
+            "should not use mermaid default light quadrant bg"
+        );
+        assert!(
+            !svg.contains("#c7c7f1"),
+            "should not use mermaid default light quadrant border"
+        );
+        assert!(
+            !svg.contains("#131300"),
+            "should not use mermaid default dark quadrant text"
+        );
+        assert!(
+            svg.contains("fill=\"#1a1a1a\""),
+            "expected dark quadrant background"
+        );
+        assert!(
+            svg.contains("stroke=\"#505050\""),
+            "expected dark quadrant border"
+        );
+        assert!(
+            svg.contains("fill=\"#61afef\""),
+            "expected accent-blue point"
+        );
     }
 }

--- a/crates/zedra/src/editor/mermaid.rs
+++ b/crates/zedra/src/editor/mermaid.rs
@@ -1,0 +1,137 @@
+use mermaid_rs_renderer::{RenderOptions, render_with_options};
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex, OnceLock};
+
+const MERMAID_ASSET_PREFIX: &str = "mermaid/";
+
+/// In-memory SVG assets for dynamically rendered Mermaid diagrams (`img()` embedded paths).
+static MERMAID_SVG_CACHE: OnceLock<Mutex<HashMap<String, Arc<[u8]>>>> = OnceLock::new();
+
+pub fn mermaid_asset_path(block_ix: usize, source: &str) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    source.hash(&mut hasher);
+    format!("{MERMAID_ASSET_PREFIX}{block_ix}-{:x}.svg", hasher.finish())
+}
+
+pub fn store_mermaid_svg(path: String, bytes: Arc<[u8]>) {
+    MERMAID_SVG_CACHE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("mermaid svg cache lock")
+        .insert(path, bytes);
+}
+
+pub fn load_mermaid_svg(path: &str) -> Option<Arc<[u8]>> {
+    MERMAID_SVG_CACHE
+        .get()
+        .and_then(|cache| cache.lock().ok().and_then(|g| g.get(path).cloned()))
+}
+
+pub fn clear_mermaid_svg_cache() {
+    if let Some(cache) = MERMAID_SVG_CACHE.get() {
+        cache.lock().expect("mermaid svg cache lock").clear();
+    }
+}
+
+pub fn is_mermaid_language(language: &str) -> bool {
+    language.eq_ignore_ascii_case("mermaid")
+}
+
+#[derive(Clone, Debug)]
+pub struct MermaidDiagram {
+    pub asset_path: String,
+    pub intrinsic_width: f32,
+    pub intrinsic_height: f32,
+}
+
+pub fn render_mermaid_diagram(block_ix: usize, source: &str) -> Option<MermaidDiagram> {
+    let source = source.trim();
+    if source.is_empty() {
+        return None;
+    }
+
+    let mut options = RenderOptions::default();
+    let mut theme = options.theme.clone();
+    theme.background = hex_color(crate::theme::BG_CARD);
+    theme.text_color = hex_color(crate::theme::TEXT_PRIMARY);
+    theme.primary_color = hex_color(crate::theme::BG_CARD);
+    theme.primary_text_color = hex_color(crate::theme::TEXT_PRIMARY);
+    theme.primary_border_color = hex_color(crate::theme::BORDER_DEFAULT);
+    theme.line_color = hex_color(crate::theme::BORDER_DEFAULT);
+    theme.secondary_color = hex_color(crate::theme::BG_CARD);
+    theme.tertiary_color = hex_color(crate::theme::BORDER_SUBTLE);
+    theme.cluster_background = hex_color(crate::theme::BG_CARD);
+    theme.cluster_border = hex_color(crate::theme::BORDER_DEFAULT);
+    options.theme = theme;
+
+    let svg = render_with_options(source, options).ok()?;
+    let (intrinsic_width, intrinsic_height) = svg_intrinsic_size(&svg)?;
+    let asset_path = mermaid_asset_path(block_ix, source);
+    store_mermaid_svg(asset_path.clone(), Arc::from(svg.into_bytes()));
+
+    Some(MermaidDiagram {
+        asset_path,
+        intrinsic_width,
+        intrinsic_height,
+    })
+}
+
+fn hex_color(rgb: u32) -> String {
+    format!("#{:06x}", rgb & 0xffffff)
+}
+
+/// Best-effort intrinsic size from SVG `viewBox` or `width`/`height` attributes.
+fn svg_intrinsic_size(svg: &str) -> Option<(f32, f32)> {
+    if let Some((w, h)) = parse_view_box(svg) {
+        if w > 0.0 && h > 0.0 {
+            return Some((w, h));
+        }
+    }
+
+    let width = parse_svg_length_attr(svg, "width")?;
+    let height = parse_svg_length_attr(svg, "height")?;
+    (width > 0.0 && height > 0.0).then_some((width, height))
+}
+
+fn parse_view_box(svg: &str) -> Option<(f32, f32)> {
+    let marker = "viewBox=\"";
+    let start = svg.find(marker)? + marker.len();
+    let end = svg[start..].find('"')? + start;
+    let mut parts = svg[start..end].split_whitespace();
+    let _min_x = parts.next()?;
+    let _min_y = parts.next()?;
+    let width: f32 = parts.next()?.parse().ok()?;
+    let height: f32 = parts.next()?.parse().ok()?;
+    Some((width, height))
+}
+
+fn parse_svg_length_attr(svg: &str, attr: &str) -> Option<f32> {
+    let marker = format!("{attr}=\"");
+    let start = svg.find(&marker)? + marker.len();
+    let end = svg[start..].find('"')? + start;
+    let raw = &svg[start..end];
+    raw.trim_end_matches("px").parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_svg_view_box_dimensions() {
+        let svg = r#"<svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg"></svg>"#;
+        assert_eq!(svg_intrinsic_size(svg), Some((320.0, 180.0)));
+    }
+
+    #[test]
+    fn renders_flowchart_to_asset_path() {
+        clear_mermaid_svg_cache();
+        let diagram = render_mermaid_diagram(3, "flowchart LR\n  A[Start] --> B[End]")
+            .expect("flowchart should render");
+        assert!(diagram.asset_path.starts_with(MERMAID_ASSET_PREFIX));
+        assert!(diagram.intrinsic_width > 0.0);
+        assert!(diagram.intrinsic_height > 0.0);
+        assert!(load_mermaid_svg(&diagram.asset_path).is_some());
+    }
+}

--- a/crates/zedra/src/editor/mod.rs
+++ b/crates/zedra/src/editor/mod.rs
@@ -4,6 +4,7 @@ pub mod code_editor;
 pub mod git_diff_view;
 pub mod git_sidebar;
 pub mod markdown;
+pub mod mermaid;
 pub mod syntax_highlighter;
 pub mod syntax_theme;
 pub mod text_buffer;

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -63,6 +63,9 @@ pub struct ZedraAssets;
 
 impl gpui::AssetSource for ZedraAssets {
     fn load(&self, path: &str) -> gpui::Result<Option<std::borrow::Cow<'static, [u8]>>> {
+        if let Some(bytes) = editor::mermaid::load_mermaid_svg(path) {
+            return Ok(Some(std::borrow::Cow::Owned(bytes.to_vec())));
+        }
         Ok(Self::get(path).map(|f| f.data))
     }
 

--- a/crates/zedra/src/terminal_preview_view.rs
+++ b/crates/zedra/src/terminal_preview_view.rs
@@ -198,8 +198,8 @@ impl TerminalPreviewView {
                                     return;
                                 }
                                 this.state = PreviewState::Loaded;
-                                this.markdown_view.update(cx, |markdown_view, _cx| {
-                                    markdown_view.set_parsed_source(parsed);
+                                this.markdown_view.update(cx, |markdown_view, cx| {
+                                    markdown_view.set_parsed_source(parsed, cx);
                                 });
                                 this.update_sheet_scroll_boundary(cx);
                                 cx.notify();

--- a/crates/zedra/src/workspace_editor.rs
+++ b/crates/zedra/src/workspace_editor.rs
@@ -143,8 +143,8 @@ impl WorkspaceEditor {
                                 return;
                             }
                             this.state = FileState::Loaded;
-                            this.markdown_view.update(cx, |markdown_view, _cx| {
-                                markdown_view.set_parsed_source(parsed);
+                            this.markdown_view.update(cx, |markdown_view, cx| {
+                                markdown_view.set_parsed_source(parsed, cx);
                             });
                             cx.notify();
                         }) {

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -732,7 +732,26 @@ printf '/tmp/zedra-markdown-table.md:1\n'
 10. Swipe vertically starting inside the table
 11. Expected: the markdown preview scrolls vertically and the table does not drift horizontally
 
-## 15c. Markdown Bottom Padding And Link Hit Slop
+## 15c. Markdown Mermaid Diagram In Preview
+
+1. Connect to a session and open the terminal view
+2. Run:
+
+```bash
+printf '%s\n' '# Mermaid Test' '' '```mermaid' 'flowchart LR' '  A[Start] --> B[End]' '```' > /tmp/zedra-markdown-mermaid.md
+printf '/tmp/zedra-markdown-mermaid.md:1\n'
+```
+
+3. Tap `/tmp/zedra-markdown-mermaid.md:1`
+4. Expected: the preview opens in markdown mode
+5. Expected: a rendered flowchart appears in a card instead of raw `flowchart LR` source
+6. Expected: invalid mermaid syntax falls back to monospace source with a muted error line
+7. Tap `Show source` below a rendered diagram
+8. Expected: the fenced mermaid source appears and remains selectable for Add to Chat
+9. Open the same file from the workspace docs tree or editor
+10. Expected: the main workspace markdown view renders the diagram the same way
+
+## 15d. Markdown Bottom Padding And Link Hit Slop
 
 1. Connect to a session and open the terminal view
 2. Run:

--- a/examples/mermaid.md
+++ b/examples/mermaid.md
@@ -1,0 +1,337 @@
+# Markdown Mermaid preview test
+
+Fixture for fenced `mermaid` blocks in the workspace editor and terminal sheet preview. Each diagram uses **mock Zedra product content** (realistic labels, not empty boxes).
+
+**Copy to a connected host:**
+
+```bash
+scp examples/mermaid.md your-host:/tmp/zedra-mermaid-test.md
+# In the terminal, tap: /tmp/zedra-mermaid-test.md:1
+```
+
+Scroll the full file. Expect rendered diagrams (not monospace fences). Use **Show source** under a card to verify selection maps to the fence.
+
+**Note:** Do not put Markdown code fences (three backticks) inside a `mermaid` fence.
+
+---
+
+## Flowchart — open README.md from terminal
+
+Scenario: user taps an OSC-8 link to vendor/zed/README.md while zedra-host is connected.
+
+```mermaid
+flowchart TD
+  tap["Tap /vendor/zed/README.md:1 in agent terminal"]
+  sheet["Native sheet opens - TerminalPreviewView"]
+  read["SessionHandle.fs_read path"]
+  parse["background_spawn parse_markdown_source"]
+  classify{"Fence language mermaid?"}
+  mermaid["schedule_mermaid_renders - Pending card"]
+  code["Code block - mono scroll"]
+  render["mermaid-rs-renderer - SVG in ZedraAssets"]
+  img["GPUI img - scaled diagram card"]
+  tap --> sheet --> read --> parse --> classify
+  classify -->|mermaid fence| mermaid --> render --> img
+  classify -->|rust or bash| code
+```
+
+## Flowchart — session data path (LR)
+
+Scenario: remote markdown bytes become pixels on the phone.
+
+```mermaid
+flowchart LR
+  subgraph host["Mac - zedra-host"]
+    disk["Repo file AGENTS.md"]
+    rpc["RPC fs/read"]
+  end
+  subgraph phone["iOS - Zedra"]
+    handle["SessionHandle"]
+    state["WorkspaceState"]
+    view["MarkdownView list rows"]
+    cache["mermaid asset cache"]
+  end
+  disk --> rpc --> handle --> state --> view
+  view --> cache
+```
+
+## Sequence — preview sheet load
+
+```mermaid
+sequenceDiagram
+  actor Dev as Developer
+  participant Term as Workspace terminal
+  participant Sheet as Terminal preview sheet
+  participant Sess as SessionHandle
+  participant Host as zedra-host
+  participant Mmd as mermaid-rs-renderer
+
+  Dev->>Term: claude prints docs/MANUAL_TEST.md:42
+  Term->>Sheet: open_file path + epoch
+  Sheet->>Sess: fs_read /docs/MANUAL_TEST.md
+  Sess->>Host: RPC ReadFile
+  Host-->>Sess: UTF-8 markdown body
+  Sess-->>Sheet: content + FileReady
+  Sheet->>Sheet: parse_markdown_source (background)
+  Note over Sheet: Block Mermaid at index 4
+  Sheet->>Mmd: render flowchart TD
+  Mmd-->>Sheet: SVG + viewBox
+  Sheet-->>Dev: diagram card + Show source link
+```
+
+## Class — markdown preview model
+
+```mermaid
+classDiagram
+  class MarkdownView {
+    -document: MarkdownDocument
+    -mermaid_states: HashMap
+    -mermaid_generation: u64
+    +set_parsed_source()
+    +line_range_for_selection()
+    +render()
+  }
+  class MarkdownDocument {
+    +blocks: Block[]
+    +selection_map
+  }
+  class Block {
+    <<enumeration>>
+    Paragraph
+    CodeBlock
+    Mermaid
+    Table
+  }
+  class MermaidDiagram {
+    +asset_path: String
+    +intrinsic_width: f32
+    +intrinsic_height: f32
+  }
+  MarkdownView --> MarkdownDocument
+  MarkdownDocument *-- Block
+  MarkdownView o-- MermaidDiagram : Ready state
+```
+
+## State — Mermaid block lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle : new MarkdownView
+  Idle --> Pending : replace_document sees mermaid fence
+  Pending --> Ready : SVG stored
+  Pending --> Failed : parse or layout error
+  Ready --> Pending : set_source new text
+  Failed --> Pending : user fixes syntax
+  Ready --> ShowingSource : tap Show source
+  ShowingSource --> Ready : tap Hide source
+  note right of Pending
+    Placeholder card
+    Rendering diagram
+  end note
+  note right of Failed
+    Monospace fence
+    Diagram could not be rendered
+  end note
+```
+
+## ER — workspace on device
+
+```mermaid
+erDiagram
+  SAVED_WORKSPACE ||--o{ SESSION : reconnects
+  SESSION ||--|{ TERMINAL : multiplex
+  SESSION ||--o{ AGENT_RUN : resumes
+  TERMINAL ||--o{ PREVIEW_OPEN : osc_link
+  PREVIEW_OPEN }o--|| REMOTE_FILE : fs_read
+
+  SAVED_WORKSPACE {
+    string display_name
+    string node_id
+    datetime last_connected
+  }
+  SESSION {
+    string strip_path
+    enum connect_phase
+  }
+  TERMINAL {
+    string title
+    string agent_icon
+  }
+  AGENT_RUN {
+    string agent_kind
+    string session_id
+  }
+  REMOTE_FILE {
+    string path
+    int size_bytes
+  }
+```
+
+## Pie — time in workspace (mock telemetry)
+
+```mermaid
+pie title Where users spend time (beta cohort mock)
+  "Terminal agent sessions" : 52
+  "Markdown README preview" : 18
+  "Code editor patch files" : 15
+  "Git diff review" : 9
+  "Agent manage resume" : 6
+```
+
+## Gantt — Mermaid preview rollout (fiction)
+
+```mermaid
+gantt
+  title Zedra markdown preview mock schedule
+  dateFormat  YYYY-MM-DD
+  axisFormat %b %d
+
+  section Foundation
+  pulldown-cmark GFM tables     :done, gfm, 2026-04-01, 14d
+  Virtualized MarkdownView      :done, list, 2026-04-10, 10d
+
+  section Mermaid
+  mermaid-rs-renderer spike     :done, spike, 2026-05-10, 3d
+  Parse mermaid code fences     :done, parse, 2026-05-15, 4d
+  Async render and img          :active, ui, 2026-05-20, 7d
+  Manual test 15c on device     :crit, qa, after ui, 5d
+
+  section Follow-up
+  Viewport-aware diagram width  :active, width, after qa, 5d
+```
+
+## Git graph — feature branch (mock)
+
+```mermaid
+gitGraph
+  commit id: "be648bf" tag: "v0.2.5" type: HIGHLIGHT
+  branch feat-markdown-mermaid
+  checkout feat-markdown-mermaid
+  commit id: "feat-zedra-mermaid-parse-render"
+  commit id: "examples-markdown-mermaid-fixtures"
+  checkout main
+  merge feat-markdown-mermaid
+```
+
+## Mindmap — Zedra mobile surface area
+
+```mermaid
+mindmap
+  ((Zedra iOS))
+    Home
+      Scan QR pairing
+      Saved workspaces
+      Install guides
+    Workspace
+      Terminal grid
+      File explorer
+      Docs tree markdown only
+      Git diff sidebar
+    Preview
+      CodeEditorView
+      MarkdownView
+        Tables task lists
+        Mermaid diagrams
+        OSC-8 links
+      Sheet detent scroll
+    Platform
+      UIKit alerts sheets
+      Metal GPUI
+      Haptics light impact
+```
+
+## Journey — first Mermaid README (mock persona)
+
+```mermaid
+journey
+  title Alex ships a diagram in internal README
+  section Commute
+    Open Zedra on LTE to home Mac: 4: Alex
+    Terminal shows agent done and file link: 5: Alex
+  section Preview
+    Tap link sheet loads README: 4: Alex
+    Scroll past table see flowchart: 5: Alex
+    Pinch mentally checks legibility: 3: Alex
+  section Share
+    Long-press diagram source: 4: Alex
+    Add selection to chat with agent: 5: Alex
+```
+
+## Timeline — markdown capabilities
+
+```mermaid
+timeline
+  title Zedra markdown preview history (mock)
+  section 2025
+    Q3 : Terminal OSC-8 file links
+    Q4 : Custom sheet code preview
+  section 2026
+    Q1 : Workspace markdown editor mode
+    Q2 : GFM tables and task lists
+         : Mermaid render via mermaid-rs-renderer
+```
+
+## Quadrant — diagram renderers considered
+
+```mermaid
+quadrantChart
+  title Mobile markdown diagram backends
+  x-axis Low implementation cost --> High cost
+  y-axis Low visual fidelity --> High fidelity
+  quadrant-1 Quick win
+  quadrant-2 Heavyweight
+  quadrant-3 Avoid
+  quadrant-4 Ideal long-term
+  "mermaid-rs-renderer embedded SVG": [0.35, 0.72]
+  "WKWebView mermaid.js CDN": [0.55, 0.88]
+  "Host RPC pre-render PNG": [0.75, 0.8]
+  "Monospace fence only": [0.15, 0.2]
+```
+
+## XY chart — preview scroll FPS vs doc size (mock)
+
+```mermaid
+xychart-beta
+  title "Markdown list scroll FPS by doc size (mock lab)"
+  x-axis ["8 blocks", "40 blocks", "120 blocks with mermaid"]
+  y-axis "median FPS" 50 --> 120
+  line [112, 96, 78]
+  bar [110, 94, 74]
+```
+
+## Sequence — stale render guard
+
+```mermaid
+sequenceDiagram
+  participant View as MarkdownView
+  participant Gen as mermaid_generation
+  participant Task as background task
+
+  View->>Gen: increment on replace_document
+  View->>Task: spawn render block 2
+  Note over View: User opens different file
+  View->>Gen: increment again
+  Task-->>View: render complete (old gen)
+  View->>View: drop result gen mismatch
+  View->>Task: spawn render block 0
+  Task-->>View: render complete (current gen)
+  View->>View: insert Ready notify
+```
+
+## Intentional failure (fallback)
+
+Invalid syntax — expect monospace fence plus error line.
+
+```mermaid
+diagram-type-that-does-not-exist
+  Zedra --> should not render
+```
+
+## Control — Rust fence (not Mermaid)
+
+```rust
+// This block must stay a horizontal-scroll code card.
+pub fn is_markdown_path(path: &str) -> bool {
+    path.ends_with(".md") || path.eq_ignore_ascii_case("readme")
+}
+```


### PR DESCRIPTION
## Summary
- Render fenced `mermaid` blocks in the workspace and terminal-sheet markdown preview using `mermaid-rs-renderer` and GPUI `img()` on cached SVG assets.
- Add a Show source toggle so diagram fences stay selectable for Add to Chat, with monospace fallback when rendering fails.
- Guard async renders with a generation counter and clear the SVG cache when markdown content reloads.

## Notes
- Replaces #100: this branch is `main` plus a single cherry-picked commit (`f840fcdf71`), without the agent-management stack from `cursor/ceb92b5b`.
- Manual verification: `docs/MANUAL_TEST.md` section 15c.

Made with [Cursor](https://cursor.com)