### PR TITLE
feat(ios): add dark/light theming with persisted preference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Mobile remote editor for iOS and Android. Primary platform is iOS (`gpui_ios` + 
 - Use `platform_bridge::bridge()` for platform integration. Do not call platform APIs directly from UI code.
 - Use existing imports and concise module-qualified calls for platform UI affordances, such as `platform_bridge::trigger_haptic(HapticFeedback::ImpactLight)`. Normal taps and workspace switches should use light haptics; reserve stronger feedback for long press, confirmation, or destructive actions.
 - Use `tracing` for logging. Never add `log::` calls.
-- Read `docs/DESIGN.md` before creating or redesigning UI.
+- Read `docs/DESIGN.md` before creating or redesigning UI. Read `docs/THEMING.md` before adding colors; new GPUI UI must use `theme::` tokens, not hardcoded hex in views.
 - GPUI tasks are cancelled when their `Task` handle is dropped. Await, detach, or store tasks according to the intended lifetime.
 - Inside GPUI entity `update`, `read_with`, and related closures, use the inner `cx` passed to the closure and avoid reentrant updates of the same entity.
 - Keep lifecycle helpers aligned with their names. Entry points that own the user action should own policy checks such as dedupe, reconnect, or stale cleanup; lower-level helpers that create/connect/initialize should not also switch entries, disconnect existing state, or hide caller contracts.
@@ -95,6 +95,7 @@ Mobile remote editor for iOS and Android. Primary platform is iOS (`gpui_ios` + 
 - `docs/CONVENTIONS.md` — imports, Rust style, error handling, GPUI lifecycle, logging, git commit subjects, docs style, async runtime choice, `WorkspaceState`, platform bridge, scroll container rules
 - `docs/ARCHITECTURE.md` — crate boundaries, session flow, auth, RPC, transport
 - `docs/DESIGN.md` — product UI tone and component direction
+- `docs/THEMING.md` — theme tokens, light/dark, editor/terminal palettes, subscription pattern
 - `docs/IOS_WORKFLOW.md` — iOS build pipeline, FFI workflow, pitfalls
 - `docs/PROTOCOL_SPECS.md` — protocol contract
 - `docs/TELEMETRY.md` — telemetry events and privacy

--- a/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
@@ -1,6 +1,7 @@
 package dev.zedra.app
 
 import android.app.Activity
+import android.content.res.Configuration
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -229,6 +230,19 @@ class MainActivity : AppCompatActivity() {
             val activity = sActivity ?: return
             activity.runOnUiThread {
                 activity.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+            }
+        }
+
+        /** Returns 1 for dark, 0 for light, -1 when unavailable. */
+        @JvmStatic
+        fun systemInDarkTheme(): Int {
+            val activity = sActivity ?: return -1
+            val nightMode =
+                activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+            return when (nightMode) {
+                Configuration.UI_MODE_NIGHT_YES -> 1
+                Configuration.UI_MODE_NIGHT_NO -> 0
+                else -> -1
             }
         }
 

--- a/crates/zedra-host/src/setup.rs
+++ b/crates/zedra-host/src/setup.rs
@@ -9,7 +9,6 @@ use zedra_host::utils;
 const PLUGIN_REPO: &str = "tanlethanh/zedra-plugin";
 const CLAUDE_MARKETPLACE: &str = "zedra";
 const CLAUDE_PLUGIN: &str = "zedra@zedra";
-const PLUGIN_GIT_URL: &str = "https://github.com/tanlethanh/zedra-plugin.git";
 const PLUGIN_RAW_BASE: &str = "https://raw.githubusercontent.com/tanlethanh/zedra-plugin/main";
 const SKILL_NAMES: &[&str] = &[
     "zedra-start",

--- a/crates/zedra-host/src/setup.rs
+++ b/crates/zedra-host/src/setup.rs
@@ -9,6 +9,7 @@ use zedra_host::utils;
 const PLUGIN_REPO: &str = "tanlethanh/zedra-plugin";
 const CLAUDE_MARKETPLACE: &str = "zedra";
 const CLAUDE_PLUGIN: &str = "zedra@zedra";
+const PLUGIN_GIT_URL: &str = "https://github.com/tanlethanh/zedra-plugin.git";
 const PLUGIN_RAW_BASE: &str = "https://raw.githubusercontent.com/tanlethanh/zedra-plugin/main";
 const SKILL_NAMES: &[&str] = &[
     "zedra-start",

--- a/crates/zedra-terminal/AGENTS.md
+++ b/crates/zedra-terminal/AGENTS.md
@@ -16,6 +16,12 @@ Reusable terminal emulator and GPUI renderer. Owns alacritty terminal state, ter
 - Preserve packet-safe parsing. `Processor` and `OscScanner` are intentionally stateful so escape sequences can span network chunks.
 - Keep replay semantics intact. The terminal model expects ordered output bytes and tracks state such as `last_seq`, selection, title, and OSC-derived metadata.
 
+## Theming
+
+- Terminal colors live in `src/theme.rs` (`TerminalTheme`). The app passes the active bundle via `TerminalView::set_terminal_theme`; painting uses `TerminalTheme::convert_color` in `element.rs`.
+- Do not tune ANSI, indexed, or truecolor contrast in `element.rs` or `terminal.rs` render paths—adjust tokens and derived tables in `theme.rs` only. See `docs/THEMING.md`.
+- `apply_theme` stores the palette for GPUI paint and OSC `ColorRequest` replies; it does not inject setup sequences into scrollback.
+
 ## Rendering And Sizing
 
 - `TerminalView` is responsible for converting viewport size into terminal grid size and emitting `TerminalEvent::RequestResize` when the remote PTY should change size.

--- a/crates/zedra-terminal/src/element.rs
+++ b/crates/zedra-terminal/src/element.rs
@@ -13,157 +13,8 @@ use crate::MONO_FONT_FAMILY;
 use crate::input::TerminalInputHandler;
 use crate::selection::TerminalSelectionDocument;
 use crate::terminal::*;
+use crate::theme::TerminalTheme;
 use crate::view::TerminalView;
-
-/// Per-terminal color palette.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct TerminalTheme {
-    pub background: u32,
-    pub foreground: u32,
-    pub cursor: u32,
-    pub black: u32,
-    pub red: u32,
-    pub green: u32,
-    pub yellow: u32,
-    pub blue: u32,
-    pub magenta: u32,
-    pub cyan: u32,
-    pub white: u32,
-    pub bright_black: u32,
-    pub bright_red: u32,
-    pub bright_green: u32,
-    pub bright_yellow: u32,
-    pub bright_blue: u32,
-    pub bright_magenta: u32,
-    pub bright_cyan: u32,
-    pub bright_white: u32,
-}
-
-impl TerminalTheme {
-    pub fn dark() -> Self {
-        Self {
-            background: 0x0e0c0c,
-            foreground: 0xabb2bf,
-            cursor: 0x528bff,
-            black: 0x282c34,
-            red: 0xe06c75,
-            green: 0x98c379,
-            yellow: 0xe5c07b,
-            blue: 0x61afef,
-            magenta: 0xc678dd,
-            cyan: 0x56b6c2,
-            white: 0xabb2bf,
-            bright_black: 0x5c6370,
-            bright_red: 0xe06c75,
-            bright_green: 0x98c379,
-            bright_yellow: 0xe5c07b,
-            bright_blue: 0x61afef,
-            bright_magenta: 0xc678dd,
-            bright_cyan: 0x56b6c2,
-            bright_white: 0xffffff,
-        }
-    }
-
-    pub fn light() -> Self {
-        Self {
-            background: 0xfafafa,
-            foreground: 0x24292f,
-            cursor: 0x0969da,
-            black: 0x24292f,
-            red: 0xcf222e,
-            green: 0x116329,
-            yellow: 0x953800,
-            blue: 0x0550ae,
-            magenta: 0x8250df,
-            cyan: 0x116329,
-            white: 0x24292f,
-            bright_black: 0x57606a,
-            bright_red: 0xcf222e,
-            bright_green: 0x116329,
-            bright_yellow: 0x953800,
-            bright_blue: 0x0550ae,
-            bright_magenta: 0x8250df,
-            bright_cyan: 0x116329,
-            bright_white: 0x1a1a1a,
-        }
-    }
-
-    pub fn one_dark() -> Self {
-        Self::dark()
-    }
-
-    fn named_color(&self, color: NamedColor) -> Hsla {
-        let hex = match color {
-            NamedColor::Black => self.black,
-            NamedColor::Red => self.red,
-            NamedColor::Green => self.green,
-            NamedColor::Yellow => self.yellow,
-            NamedColor::Blue => self.blue,
-            NamedColor::Magenta => self.magenta,
-            NamedColor::Cyan => self.cyan,
-            NamedColor::White => self.white,
-            NamedColor::BrightBlack => self.bright_black,
-            NamedColor::BrightRed => self.bright_red,
-            NamedColor::BrightGreen => self.bright_green,
-            NamedColor::BrightYellow => self.bright_yellow,
-            NamedColor::BrightBlue => self.bright_blue,
-            NamedColor::BrightMagenta => self.bright_magenta,
-            NamedColor::BrightCyan => self.bright_cyan,
-            NamedColor::BrightWhite => self.bright_white,
-            NamedColor::Foreground => self.foreground,
-            NamedColor::Background => self.background,
-            _ => self.foreground,
-        };
-        rgb(hex).into()
-    }
-
-    pub fn convert_color(&self, color: &AlacColor) -> Hsla {
-        match color {
-            AlacColor::Named(named) => self.named_color(*named),
-            AlacColor::Spec(rgb_color) => {
-                let r = rgb_color.r as u32;
-                let g = rgb_color.g as u32;
-                let b = rgb_color.b as u32;
-                rgb((r << 16) | (g << 8) | b).into()
-            }
-            AlacColor::Indexed(index) => {
-                if *index < 16 {
-                    let named = match index {
-                        0 => NamedColor::Black,
-                        1 => NamedColor::Red,
-                        2 => NamedColor::Green,
-                        3 => NamedColor::Yellow,
-                        4 => NamedColor::Blue,
-                        5 => NamedColor::Magenta,
-                        6 => NamedColor::Cyan,
-                        7 => NamedColor::White,
-                        8 => NamedColor::BrightBlack,
-                        9 => NamedColor::BrightRed,
-                        10 => NamedColor::BrightGreen,
-                        11 => NamedColor::BrightYellow,
-                        12 => NamedColor::BrightBlue,
-                        13 => NamedColor::BrightMagenta,
-                        14 => NamedColor::BrightCyan,
-                        15 => NamedColor::BrightWhite,
-                        _ => NamedColor::Foreground,
-                    };
-                    self.named_color(named)
-                } else if *index < 232 {
-                    // 216-color cube (indices 16-231)
-                    let idx = *index as u32 - 16;
-                    let r = (idx / 36) * 51;
-                    let g = ((idx / 6) % 6) * 51;
-                    let b = (idx % 6) * 51;
-                    rgb((r << 16) | (g << 8) | b).into()
-                } else {
-                    // Grayscale (indices 232-255)
-                    let level = (*index as u32 - 232) * 10 + 8;
-                    rgb((level << 16) | (level << 8) | level).into()
-                }
-            }
-        }
-    }
-}
 
 /// A batched text run that combines multiple adjacent cells with the same style
 #[derive(Debug)]
@@ -423,10 +274,11 @@ impl TerminalElement {
                     mem::swap(&mut fg, &mut bg);
                 }
 
-                let fg_color = theme.convert_color(&fg);
+                let mut fg_color = theme.convert_color(&fg);
+                if cell.cell.flags.contains(CellFlags::DIM) {
+                    fg_color = theme.apply_dim(fg_color, true);
+                }
                 let bg_color = theme.convert_color(&bg);
-
-                // Collect background rectangles (skip default background)
                 if !matches!(bg, AlacColor::Named(NamedColor::Background)) {
                     // Try to extend the last rect if it's adjacent and same color
                     if let Some(last_rect) = rects.last_mut() {
@@ -571,7 +423,7 @@ impl TerminalElement {
 
             let mut fg_color = theme.convert_color(&fg);
             if flags.contains(CellFlags::DIM) {
-                fg_color.a *= 0.7;
+                fg_color = theme.apply_dim(fg_color, true);
             }
 
             token_cells.push(TokenCell {
@@ -666,7 +518,7 @@ impl TerminalElement {
                 };
                 let mut color = theme.convert_color(&display_fg);
                 if flags.contains(CellFlags::DIM) {
-                    color.a *= 0.7;
+                    color = theme.apply_dim(color, true);
                 }
                 color.a = (color.a * 0.55).clamp(0.0, 1.0);
 
@@ -907,8 +759,9 @@ impl Element for TerminalElement {
 mod tests {
     use gpui::px;
 
-    use super::{LayoutUnderline, TerminalElement, TerminalTheme};
+    use super::{LayoutUnderline, TerminalElement};
     use crate::Terminal;
+    use crate::TerminalTheme;
 
     fn underline_spans(output: &[u8]) -> Vec<LayoutUnderline> {
         let mut terminal = Terminal::new(160, 8, px(10.0), px(20.0));
@@ -1050,8 +903,11 @@ fn paint_cursor(
         return;
     }
 
-    // Focused: full opacity. Unfocused: dim ghost cursor at 30%.
-    let opacity = if focused { 1.0f32 } else { 0.3f32 };
+    let opacity = if focused {
+        theme.cursor_focused_alpha()
+    } else {
+        0.3
+    };
 
     // Cursor uses floor for position (following Zed's shape_cursor)
     let cursor_origin = point(

--- a/crates/zedra-terminal/src/element.rs
+++ b/crates/zedra-terminal/src/element.rs
@@ -15,8 +15,8 @@ use crate::selection::TerminalSelectionDocument;
 use crate::terminal::*;
 use crate::view::TerminalView;
 
-/// Per-terminal color palette. Construct with `TerminalTheme::one_dark()` for the default
-/// One Dark palette, or supply custom values for alternative themes.
+/// Per-terminal color palette.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TerminalTheme {
     pub background: u32,
     pub foreground: u32,
@@ -40,7 +40,7 @@ pub struct TerminalTheme {
 }
 
 impl TerminalTheme {
-    pub fn one_dark() -> Self {
+    pub fn dark() -> Self {
         Self {
             background: 0x0e0c0c,
             foreground: 0xabb2bf,
@@ -62,6 +62,34 @@ impl TerminalTheme {
             bright_cyan: 0x56b6c2,
             bright_white: 0xffffff,
         }
+    }
+
+    pub fn light() -> Self {
+        Self {
+            background: 0xfafafa,
+            foreground: 0x24292f,
+            cursor: 0x0969da,
+            black: 0x24292f,
+            red: 0xcf222e,
+            green: 0x116329,
+            yellow: 0x953800,
+            blue: 0x0550ae,
+            magenta: 0x8250df,
+            cyan: 0x116329,
+            white: 0x24292f,
+            bright_black: 0x57606a,
+            bright_red: 0xcf222e,
+            bright_green: 0x116329,
+            bright_yellow: 0x953800,
+            bright_blue: 0x0550ae,
+            bright_magenta: 0x8250df,
+            bright_cyan: 0x116329,
+            bright_white: 0x1a1a1a,
+        }
+    }
+
+    pub fn one_dark() -> Self {
+        Self::dark()
     }
 
     fn named_color(&self, color: NamedColor) -> Hsla {
@@ -303,6 +331,7 @@ pub struct TerminalElement {
     scroll_offset_px: f32,
     keyboard_inset: Pixels,
     keyboard_content_offset: Pixels,
+    theme: TerminalTheme,
     view: WeakEntity<TerminalView>,
     terminal: WeakEntity<Terminal>,
     focus_handle: FocusHandle,
@@ -317,6 +346,7 @@ impl TerminalElement {
         scroll_offset_px: f32,
         keyboard_inset: Pixels,
         keyboard_content_offset: Pixels,
+        theme: TerminalTheme,
         view: WeakEntity<TerminalView>,
         terminal: WeakEntity<Terminal>,
         focus_handle: FocusHandle,
@@ -329,6 +359,7 @@ impl TerminalElement {
             scroll_offset_px,
             keyboard_inset,
             keyboard_content_offset,
+            theme,
             view,
             terminal,
             focus_handle,
@@ -784,7 +815,7 @@ impl Element for TerminalElement {
         );
         window.handle_input(&self.focus_handle, input_handler, cx);
 
-        let theme = TerminalTheme::one_dark();
+        let theme = self.theme;
 
         // Draw terminal background
         window.paint_quad(fill(bounds, rgb(theme.background)));

--- a/crates/zedra-terminal/src/lib.rs
+++ b/crates/zedra-terminal/src/lib.rs
@@ -3,12 +3,14 @@ pub mod input;
 pub mod keys;
 mod selection;
 pub mod terminal;
+pub mod theme;
 pub mod view;
 
-pub use element::*;
+pub use element::{TerminalElement, TerminalElementLayout};
 pub use input::*;
 pub use keys::*;
 pub use terminal::*;
+pub use theme::{AnsiPalette, TerminalTheme};
 pub use view::*;
 
 use gpui::*;

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -12,9 +12,7 @@ use alacritty_terminal::term::Config;
 use alacritty_terminal::term::cell::{Cell, Flags as CellFlags};
 use alacritty_terminal::term::color::COUNT as ALACRITTY_COLOR_COUNT;
 use alacritty_terminal::term::{Term, TermMode};
-use alacritty_terminal::vte::ansi::{
-    Color as AlacColor, CursorShape, NamedColor, Processor, Rgb as AlacRgb,
-};
+use alacritty_terminal::vte::ansi::{Color as AlacColor, CursorShape, NamedColor, Processor};
 use gpui::{
     Context, Keystroke, Pixels, Point as GpuiPoint, ScrollDelta, ScrollWheelEvent, Task, px,
 };
@@ -24,6 +22,7 @@ use zedra_osc::{OscEvent, OscScanner};
 const REMOTE_TOUCH_SCROLL_STEP_PX: f32 = 12.0;
 
 use crate::keys::to_esc_str;
+use crate::theme::TerminalTheme;
 /// Events emitted by the terminal to observers.
 #[derive(Debug, Clone)]
 pub enum TerminalEvent {
@@ -62,67 +61,6 @@ pub enum TerminalHyperlinkTarget {
         line: Option<u32>,
         column: Option<u32>,
     },
-}
-
-const DEFAULT_TERMINAL_BACKGROUND: u32 = 0x0e0c0c;
-const DEFAULT_TERMINAL_FOREGROUND: u32 = 0xabb2bf;
-const DEFAULT_TERMINAL_CURSOR: u32 = 0x528bff;
-const DEFAULT_TERMINAL_ANSI_COLORS: [u32; 16] = [
-    0x282c34, 0xe06c75, 0x98c379, 0xe5c07b, 0x61afef, 0xc678dd, 0x56b6c2, 0xabb2bf, 0x5c6370,
-    0xe06c75, 0x98c379, 0xe5c07b, 0x61afef, 0xc678dd, 0x56b6c2, 0xffffff,
-];
-
-fn default_color_for_index(index: usize) -> AlacRgb {
-    match index {
-        0..=15 => rgb_from_hex(DEFAULT_TERMINAL_ANSI_COLORS[index]),
-        16..=231 => {
-            let color = index - 16;
-            AlacRgb {
-                r: xterm_cube_component(color / 36),
-                g: xterm_cube_component((color / 6) % 6),
-                b: xterm_cube_component(color % 6),
-            }
-        }
-        232..=255 => {
-            let value = ((index - 232) * 10 + 8) as u8;
-            AlacRgb {
-                r: value,
-                g: value,
-                b: value,
-            }
-        }
-        256 => rgb_from_hex(DEFAULT_TERMINAL_FOREGROUND),
-        257 => rgb_from_hex(DEFAULT_TERMINAL_BACKGROUND),
-        258 => rgb_from_hex(DEFAULT_TERMINAL_CURSOR),
-        259..=266 => dim_rgb(rgb_from_hex(DEFAULT_TERMINAL_ANSI_COLORS[index - 259])),
-        267 => rgb_from_hex(DEFAULT_TERMINAL_FOREGROUND),
-        268 => dim_rgb(rgb_from_hex(DEFAULT_TERMINAL_FOREGROUND)),
-        _ => rgb_from_hex(DEFAULT_TERMINAL_FOREGROUND),
-    }
-}
-
-fn rgb_from_hex(hex: u32) -> AlacRgb {
-    AlacRgb {
-        r: ((hex >> 16) & 0xff) as u8,
-        g: ((hex >> 8) & 0xff) as u8,
-        b: (hex & 0xff) as u8,
-    }
-}
-
-fn dim_rgb(color: AlacRgb) -> AlacRgb {
-    AlacRgb {
-        r: color.r / 2,
-        g: color.g / 2,
-        b: color.b / 2,
-    }
-}
-
-fn xterm_cube_component(value: usize) -> u8 {
-    if value == 0 {
-        0
-    } else {
-        (value * 40 + 55) as u8
-    }
 }
 
 /// Event listener that queues alacritty events for Terminal to process after VTE parsing.
@@ -269,6 +207,7 @@ pub struct Terminal {
     input_tx: Option<mpsc::Sender<Vec<u8>>>,
     output_task: Option<Task<()>>,
     selection_range: Option<Range<usize>>,
+    theme: TerminalTheme,
 }
 
 impl Terminal {
@@ -286,7 +225,8 @@ impl Terminal {
         };
         let term = Term::new(config, &term_size, listener);
 
-        Self {
+        let theme = TerminalTheme::dark();
+        let terminal = Self {
             term,
             processor: Processor::new(),
             mode: TermMode::empty(),
@@ -303,7 +243,16 @@ impl Terminal {
             input_tx: None,
             output_task: None,
             selection_range: None,
-        }
+            theme,
+        };
+        terminal
+    }
+
+    /// Store the active render/query palette. GPUI paint and OSC color queries use
+    /// `theme` directly; we do not feed setup sequences through `advance_bytes` so
+    /// theme toggles cannot dirty the grid or scrollback.
+    pub fn apply_theme(&mut self, theme: TerminalTheme) {
+        self.theme = theme;
     }
 
     pub fn is_channel_attached(&self) -> bool {
@@ -403,7 +352,7 @@ impl Terminal {
                 } else {
                     None
                 }
-                .unwrap_or_else(|| default_color_for_index(index));
+                .unwrap_or_else(|| self.theme.color_at_index(index));
                 self.send_bytes_sync(format(color).into_bytes());
             }
             _ => {}
@@ -2573,6 +2522,7 @@ pub fn is_blank(cell: &IndexedCell) -> bool {
 mod tests {
     use std::path::Path;
 
+    use crate::TerminalTheme;
     use alacritty_terminal::index::{Column, Line, Point};
     use alacritty_terminal::term::TermMode;
     use gpui::px;
@@ -2701,6 +2651,21 @@ mod tests {
 
         let background = String::from_utf8(input_rx.try_recv().unwrap()).unwrap();
         assert_eq!(background, "\x1b]11;rgb:1111/2222/3333\x1b\\");
+    }
+
+    #[test]
+    fn responds_to_osc_queries_with_light_theme_palette() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+        let (input_tx, mut input_rx) = mpsc::channel(8);
+        terminal.input_tx = Some(input_tx);
+        terminal.apply_theme(TerminalTheme::light());
+
+        terminal.advance_bytes(b"\x1b]10;?\x07\x1b]11;?\x1b\\");
+
+        let foreground = String::from_utf8(input_rx.try_recv().unwrap()).unwrap();
+        let background = String::from_utf8(input_rx.try_recv().unwrap()).unwrap();
+        assert_eq!(foreground, "\x1b]10;rgb:1f1f/2323/2828\x07");
+        assert_eq!(background, "\x1b]11;rgb:fafa/fafa/fafa\x1b\\");
     }
 
     #[test]

--- a/crates/zedra-terminal/src/theme.rs
+++ b/crates/zedra-terminal/src/theme.rs
@@ -1,0 +1,463 @@
+//! Terminal color tokens and xterm-256 tables for light/dark appearance.
+//!
+//! Product UI chrome uses `zedra::theme::ThemePalette`; terminal ANSI/truecolor uses this module only.
+//! See `docs/THEMING.md`.
+
+use alacritty_terminal::vte::ansi::{Color as AlacColor, NamedColor, Rgb as AlacRgb};
+use gpui::{Hsla, rgb};
+
+/// Minimum relative-luminance gap between a foreground and the light background.
+const LIGHT_FG_LUMINANCE_DELTA: f32 = 0.35;
+
+/// Standard 16 ANSI terminal colors — edit these for contrast; the 256 table is derived.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AnsiPalette {
+    pub black: u32,
+    pub red: u32,
+    pub green: u32,
+    pub yellow: u32,
+    pub blue: u32,
+    pub magenta: u32,
+    pub cyan: u32,
+    pub white: u32,
+    pub bright_black: u32,
+    pub bright_red: u32,
+    pub bright_green: u32,
+    pub bright_yellow: u32,
+    pub bright_blue: u32,
+    pub bright_magenta: u32,
+    pub bright_cyan: u32,
+    pub bright_white: u32,
+}
+
+impl AnsiPalette {
+    pub fn color(self, index: u8) -> u32 {
+        match index {
+            0 => self.black,
+            1 => self.red,
+            2 => self.green,
+            3 => self.yellow,
+            4 => self.blue,
+            5 => self.magenta,
+            6 => self.cyan,
+            7 => self.white,
+            8 => self.bright_black,
+            9 => self.bright_red,
+            10 => self.bright_green,
+            11 => self.bright_yellow,
+            12 => self.bright_blue,
+            13 => self.bright_magenta,
+            14 => self.bright_cyan,
+            15 => self.bright_white,
+            _ => self.black,
+        }
+    }
+}
+
+/// Terminal theme: tokens + precomputed xterm-256 table (built once per light/dark).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TerminalTheme {
+    pub background: u32,
+    pub foreground: u32,
+    pub cursor: u32,
+    pub ansi: AnsiPalette,
+    pub dim_lightness_factor: f32,
+    pub dim_alpha_factor: f32,
+    indexed: [u32; 256],
+}
+
+impl TerminalTheme {
+    pub fn dark() -> Self {
+        let background = 0x0e0c0c;
+        let foreground = 0xabb2bf;
+        let cursor = 0x528bff;
+        let ansi = AnsiPalette {
+            black: 0x282c34,
+            red: 0xe06c75,
+            green: 0x98c379,
+            yellow: 0xe5c07b,
+            blue: 0x61afef,
+            magenta: 0xc678dd,
+            cyan: 0x56b6c2,
+            white: 0xabb2bf,
+            bright_black: 0x5c6370,
+            bright_red: 0xe06c75,
+            bright_green: 0x98c379,
+            bright_yellow: 0xe5c07b,
+            bright_blue: 0x61afef,
+            bright_magenta: 0xc678dd,
+            bright_cyan: 0x56b6c2,
+            bright_white: 0xffffff,
+        };
+        Self::from_parts(background, foreground, cursor, ansi, 1.0, 0.7, false)
+    }
+
+    pub fn light() -> Self {
+        let background = 0xfafafa;
+        let foreground = 0x1f2328;
+        let cursor = 0x0969da;
+        let ansi = AnsiPalette {
+            black: 0x1f2328,
+            red: 0xb62324,
+            green: 0x116329,
+            yellow: 0x633c01,
+            blue: 0x012f7a,
+            magenta: 0x512a93,
+            cyan: 0x024a6b,
+            white: 0x32383f,
+            bright_black: 0x32383f,
+            bright_red: 0x8c1921,
+            bright_green: 0x0a4d22,
+            bright_yellow: 0x573400,
+            bright_blue: 0x012152,
+            bright_magenta: 0x3f1f6e,
+            bright_cyan: 0x023b5a,
+            bright_white: 0x1f2328,
+        };
+        Self::from_parts(background, foreground, cursor, ansi, 0.92, 0.85, true)
+    }
+
+    pub fn one_dark() -> Self {
+        Self::dark()
+    }
+
+    fn from_parts(
+        background: u32,
+        foreground: u32,
+        cursor: u32,
+        ansi: AnsiPalette,
+        dim_lightness_factor: f32,
+        dim_alpha_factor: f32,
+        light: bool,
+    ) -> Self {
+        Self {
+            background,
+            foreground,
+            cursor,
+            ansi,
+            dim_lightness_factor,
+            dim_alpha_factor,
+            indexed: build_indexed_table(background, ansi, light),
+        }
+    }
+
+    pub fn is_light(&self) -> bool {
+        relative_luminance(self.background) >= 0.5
+    }
+
+    /// Focused GPUI cursor alpha; on light backgrounds, high-luminance cursors need less opacity.
+    pub fn cursor_focused_alpha(&self) -> f32 {
+        if !self.is_light() {
+            return 1.0;
+        }
+        let contrast =
+            (relative_luminance(self.cursor) - relative_luminance(self.background)).abs();
+        (0.38 + contrast * 0.5).clamp(0.35, 0.65)
+    }
+
+    pub fn color_at_index(&self, index: usize) -> AlacRgb {
+        match index {
+            0..=255 => rgb_from_hex(self.indexed[index]),
+            256 => rgb_from_hex(self.foreground),
+            257 => rgb_from_hex(self.background),
+            258 => rgb_from_hex(self.cursor),
+            259..=266 => dim_rgb(rgb_from_hex(self.ansi.color((index - 259) as u8))),
+            267 => rgb_from_hex(self.foreground),
+            268 => dim_rgb(rgb_from_hex(self.foreground)),
+            _ => rgb_from_hex(self.foreground),
+        }
+    }
+
+    pub fn osc_color_setup_sequence(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(512);
+        append_dynamic_color(&mut buf, b"10", self.foreground);
+        append_dynamic_color(&mut buf, b"11", self.background);
+        append_dynamic_color(&mut buf, b"12", self.cursor);
+        for index in 0..16u8 {
+            append_palette_color(&mut buf, index, self.indexed[index as usize]);
+        }
+        buf
+    }
+
+    pub fn apply_dim(&self, color: Hsla, dim: bool) -> Hsla {
+        if !dim {
+            return color;
+        }
+        gpui::hsla(
+            color.h,
+            color.s,
+            color.l * self.dim_lightness_factor,
+            color.a * self.dim_alpha_factor,
+        )
+    }
+
+    pub fn convert_color(&self, color: &AlacColor) -> Hsla {
+        let hex = match color {
+            AlacColor::Named(named) => self.named_hex(*named),
+            AlacColor::Spec(rgb_color) => {
+                pack_rgb(rgb_color.r as u32, rgb_color.g as u32, rgb_color.b as u32)
+            }
+            AlacColor::Indexed(index) => self.indexed[usize::from(*index)],
+        };
+        let mut hsla: Hsla = rgb(hex).into();
+        if matches!(color, AlacColor::Spec(_)) && self.is_light() {
+            hsla = mute_truecolor_on_light(hsla, self.foreground);
+        }
+        hsla
+    }
+
+    fn named_hex(self, color: NamedColor) -> u32 {
+        let rgb = self.color_at_index(color as usize);
+        pack_rgb(rgb.r as u32, rgb.g as u32, rgb.b as u32)
+    }
+}
+
+fn build_indexed_table(background: u32, ansi: AnsiPalette, light: bool) -> [u32; 256] {
+    let mut table = [0u32; 256];
+    for index in 0..16 {
+        table[index] = ansi.color(index as u8);
+    }
+    for index in 16..232 {
+        let idx = index - 16;
+        let hex = pack_rgb(
+            xterm_cube_channel(idx / 36),
+            xterm_cube_channel((idx / 6) % 6),
+            xterm_cube_channel(idx % 6),
+        );
+        table[index] = if light {
+            ensure_readable_on_light(hex, background)
+        } else {
+            hex
+        };
+    }
+    for index in 232..256 {
+        let step = (index - 232) as u32;
+        let level = if light {
+            (96 + step * 4).min(176)
+        } else {
+            step * 10 + 8
+        };
+        table[index] = pack_rgb(level, level, level);
+    }
+    table
+}
+
+fn ensure_readable_on_light(fg: u32, bg: u32) -> u32 {
+    const MAX_PASSES: u8 = 8;
+    let bg_lum = relative_luminance(bg);
+    let mut current = fg;
+    for _ in 0..MAX_PASSES {
+        // On light backgrounds, readable indexed colors should be darker than the background.
+        if bg_lum - relative_luminance(current) >= LIGHT_FG_LUMINANCE_DELTA {
+            return current;
+        }
+        current = scale_rgb(current, 0.55);
+    }
+    current
+}
+
+fn scale_rgb(hex: u32, scale: f32) -> u32 {
+    let r = ((hex >> 16) as f32 * scale) as u32;
+    let g = (((hex >> 8) & 0xff) as f32 * scale) as u32;
+    let b = ((hex & 0xff) as f32 * scale) as u32;
+    pack_rgb(r, g, b)
+}
+
+/// Claude-style 24-bit pastels: softer than neon, separate from indexed-token contrast rules.
+fn mute_truecolor_on_light(color: Hsla, foreground: u32) -> Hsla {
+    let fg: Hsla = rgb(foreground).into();
+    let l = color.l;
+    let s = color.s;
+    if l <= 0.48 && s < 0.45 {
+        return gpui::hsla(color.h, s * 0.9, l, color.a);
+    }
+    let new_l = (l * 0.5 + 0.43).clamp(0.38, 0.48);
+    let new_s = (s * 0.68).clamp(0.22, 0.58);
+    let softened = gpui::hsla(color.h, new_s, new_l, color.a);
+    blend_rgb(softened, fg, 0.1)
+}
+
+fn relative_luminance(hex: u32) -> f32 {
+    let channel = |c: u32| {
+        let x = c as f32 / 255.0;
+        if x <= 0.03928 {
+            x / 12.92
+        } else {
+            ((x + 0.055) / 1.055).powf(2.4)
+        }
+    };
+    let r = channel((hex >> 16) & 0xff);
+    let g = channel((hex >> 8) & 0xff);
+    let b = channel(hex & 0xff);
+    0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+fn blend_rgb(a: Hsla, b: Hsla, t: f32) -> Hsla {
+    let t = t.clamp(0.0, 1.0);
+    let a: gpui::Rgba = a.into();
+    let b: gpui::Rgba = b.into();
+    let channel = |x: f32, y: f32| ((x + (y - x) * t) * 255.0).round().clamp(0.0, 255.0) as u32;
+    rgb(pack_rgb(
+        channel(a.r, b.r),
+        channel(a.g, b.g),
+        channel(a.b, b.b),
+    ))
+    .into()
+}
+
+fn append_dynamic_color(buf: &mut Vec<u8>, kind: &[u8], hex: u32) {
+    let rgb = rgb_from_hex(hex);
+    buf.extend_from_slice(b"\x1b]");
+    buf.extend_from_slice(kind);
+    buf.extend_from_slice(b";rgb:");
+    append_rgb_duplicated(buf, &rgb);
+    buf.push(0x07);
+}
+
+fn append_palette_color(buf: &mut Vec<u8>, index: u8, hex: u32) {
+    let rgb = rgb_from_hex(hex);
+    buf.extend_from_slice(b"\x1b]4;");
+    append_decimal_u8(buf, index);
+    buf.extend_from_slice(b";rgb:");
+    append_rgb_duplicated(buf, &rgb);
+    buf.push(0x07);
+}
+
+fn append_decimal_u8(buf: &mut Vec<u8>, value: u8) {
+    if value >= 10 {
+        buf.push(b'1');
+        buf.push(b'0' + (value - 10));
+    } else {
+        buf.push(b'0' + value);
+    }
+}
+
+fn append_rgb_duplicated(buf: &mut Vec<u8>, rgb: &AlacRgb) {
+    use std::fmt::Write as _;
+    let mut channel = String::with_capacity(4);
+    for byte in [rgb.r, rgb.g, rgb.b] {
+        channel.clear();
+        write!(&mut channel, "{byte:02x}{byte:02x}").expect("fmt");
+        buf.extend_from_slice(channel.as_bytes());
+        buf.push(b'/');
+    }
+    buf.pop();
+}
+
+pub(crate) fn rgb_from_hex(hex: u32) -> AlacRgb {
+    AlacRgb {
+        r: ((hex >> 16) & 0xff) as u8,
+        g: ((hex >> 8) & 0xff) as u8,
+        b: (hex & 0xff) as u8,
+    }
+}
+
+fn dim_rgb(color: AlacRgb) -> AlacRgb {
+    AlacRgb {
+        r: color.r / 2,
+        g: color.g / 2,
+        b: color.b / 2,
+    }
+}
+
+fn xterm_cube_channel(component: usize) -> u32 {
+    match component {
+        0 => 0,
+        1 => 95,
+        2 => 135,
+        3 => 175,
+        4 => 215,
+        _ => 255,
+    }
+}
+
+fn pack_rgb(r: u32, g: u32, b: u32) -> u32 {
+    (r << 16) | (g << 8) | b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alacritty_terminal::vte::ansi::Color as AlacColor;
+
+    #[test]
+    fn light_named_blue_uses_palette_token() {
+        let theme = TerminalTheme::light();
+        let blue: Hsla = theme.convert_color(&AlacColor::Named(NamedColor::Blue));
+        assert_eq!(theme.ansi.blue, 0x012f7a);
+        assert!(
+            blue.l < 0.45,
+            "light blue token should be readable, got {}",
+            blue.l
+        );
+    }
+
+    #[test]
+    fn light_indexed_cube_uses_standard_xterm_values() {
+        let theme = TerminalTheme::light();
+        let indexed: Hsla = theme.convert_color(&AlacColor::Indexed(17));
+        let expected: Hsla = rgb(pack_rgb(0, 0, 95)).into();
+        assert_eq!(indexed, expected);
+    }
+
+    #[test]
+    fn dark_indexed_cube_uses_standard_xterm_values() {
+        let theme = TerminalTheme::dark();
+        let indexed: Hsla = theme.convert_color(&AlacColor::Indexed(17));
+        let expected: Hsla = rgb(pack_rgb(0, 0, 95)).into();
+        assert_eq!(indexed, expected);
+    }
+
+    #[test]
+    fn light_truecolor_is_softened_not_neon() {
+        let theme = TerminalTheme::light();
+        let raw: Hsla = rgb(pack_rgb(0x9c, 0xb8, 0xff)).into();
+        let color = theme.convert_color(&AlacColor::Spec(alacritty_terminal::vte::ansi::Rgb {
+            r: 0x9c,
+            g: 0xb8,
+            b: 0xff,
+        }));
+        assert!(color.l < raw.l);
+        assert!(color.l >= 0.38 && color.l <= 0.48);
+        assert!(color.s < raw.s);
+    }
+
+    #[test]
+    fn dark_truecolor_is_unchanged() {
+        let theme = TerminalTheme::dark();
+        let color = theme.convert_color(&AlacColor::Spec(alacritty_terminal::vte::ansi::Rgb {
+            r: 0x9c,
+            g: 0xb8,
+            b: 0xff,
+        }));
+        let expected: Hsla = rgb(pack_rgb(0x9c, 0xb8, 0xff)).into();
+        assert_eq!(color, expected);
+    }
+
+    #[test]
+    fn light_indexed_cube_meets_luminance_delta() {
+        let theme = TerminalTheme::light();
+        let bg_lum = relative_luminance(theme.background);
+        for index in 16..232 {
+            let hex = theme.color_at_index(index);
+            let packed = pack_rgb(hex.r as u32, hex.g as u32, hex.b as u32);
+            let fg_lum = relative_luminance(packed);
+            let delta = if fg_lum > bg_lum {
+                fg_lum - bg_lum
+            } else {
+                bg_lum - fg_lum
+            };
+            assert!(
+                delta >= LIGHT_FG_LUMINANCE_DELTA,
+                "indexed {index} too low contrast on light background"
+            );
+        }
+    }
+
+    #[test]
+    fn light_cursor_alpha_scales_with_cursor_luminance() {
+        let light = TerminalTheme::light().cursor_focused_alpha();
+        assert!((0.35..=0.65).contains(&light));
+        assert_eq!(TerminalTheme::dark().cursor_focused_alpha(), 1.0);
+    }
+}

--- a/crates/zedra-terminal/src/view.rs
+++ b/crates/zedra-terminal/src/view.rs
@@ -11,7 +11,7 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::*;
 use zedra_osc::OscEvent;
 
-use crate::element::TerminalElement;
+use crate::element::{TerminalElement, TerminalTheme};
 use crate::selection::TerminalSelectionDocument;
 use crate::terminal::{Terminal, TerminalContent, TerminalEvent};
 
@@ -115,6 +115,7 @@ pub struct TerminalView {
     /// Cached from terminal mode; updated each render so parent views can read without
     /// creating a GPUI dependency on the inner terminal entity.
     pub is_alt_screen: bool,
+    terminal_theme: crate::element::TerminalTheme,
     _event_task: Task<()>,
     _subscriptions: Vec<Subscription>,
 }
@@ -180,6 +181,7 @@ impl TerminalView {
             keyboard_content_offset: px(0.0),
             suppress_touch_scroll_until: None,
             is_alt_screen: false,
+            terminal_theme: TerminalTheme::dark(),
             _event_task: event_task,
             _subscriptions: vec![],
         }
@@ -187,6 +189,14 @@ impl TerminalView {
 
     pub fn set_terminal_id(&mut self, terminal_id: String) {
         self.terminal_id = terminal_id;
+    }
+
+    pub fn set_terminal_theme(&mut self, theme: TerminalTheme, cx: &mut Context<Self>) {
+        if self.terminal_theme == theme {
+            return;
+        }
+        self.terminal_theme = theme;
+        cx.notify();
     }
 
     /// Computes the upward pixel shift needed to keep active bottom content visible above
@@ -610,7 +620,7 @@ impl Render for TerminalView {
             .key_context("Terminal")
             .size_full()
             .overflow_hidden()
-            .bg(rgb(0x0e0c0c))
+            .bg(rgb(self.terminal_theme.background))
             .track_focus(&focus_handle)
             .manual_focus()
             .on_press(cx.listener(|this, event: &PressEvent, window, cx| {
@@ -751,6 +761,7 @@ impl Render for TerminalView {
                 visual_scroll_offset_px,
                 self.keyboard_inset,
                 self.keyboard_content_offset,
+                self.terminal_theme,
                 cx.weak_entity(),
                 self.terminal.downgrade(),
                 self.focus_handle.clone(),

--- a/crates/zedra-terminal/src/view.rs
+++ b/crates/zedra-terminal/src/view.rs
@@ -11,7 +11,8 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::*;
 use zedra_osc::OscEvent;
 
-use crate::element::{TerminalElement, TerminalTheme};
+use crate::TerminalTheme;
+use crate::element::TerminalElement;
 use crate::selection::TerminalSelectionDocument;
 use crate::terminal::{Terminal, TerminalContent, TerminalEvent};
 
@@ -115,7 +116,7 @@ pub struct TerminalView {
     /// Cached from terminal mode; updated each render so parent views can read without
     /// creating a GPUI dependency on the inner terminal entity.
     pub is_alt_screen: bool,
-    terminal_theme: crate::element::TerminalTheme,
+    terminal_theme: TerminalTheme,
     _event_task: Task<()>,
     _subscriptions: Vec<Subscription>,
 }
@@ -196,6 +197,9 @@ impl TerminalView {
             return;
         }
         self.terminal_theme = theme;
+        self.terminal.update(cx, |terminal, _| {
+            terminal.apply_theme(theme);
+        });
         cx.notify();
     }
 

--- a/crates/zedra/AGENTS.md
+++ b/crates/zedra/AGENTS.md
@@ -21,6 +21,7 @@ Main mobile app crate. Owns GPUI application flow, workspace orchestration, plat
 
 - `WorkspaceState` remains the display source of truth. Views should read workspace display fields from `WorkspaceState`, not from `SessionHandle` directly during render.
 - Keep `render()` pure. Mutations belong in event handlers, subscriptions, `cx.spawn`, `cx.spawn_in`, or platform callbacks.
+- **Theming**: follow `docs/THEMING.md`. GPUI views use `theme::palette(cx)` / `theme::bg_primary(cx)` (and related accessors) for colors; editor and terminal use `theme::bundle(cx)` sub-themes. No hardcoded hex in view `render()`. Subscribe to `ThemeStateEvent::Changed` when the view must refresh on appearance toggle.
 - `Workspace` is the orchestrator between `Session`, `SessionState`, `WorkspaceState`, terminal entities, and action handling. Avoid pushing app-level orchestration down into leaf views.
 - `Workspaces` manages the list of active workspace entities and saved workspace state. Preserve the distinction between persisted state and live workspace entries.
 

--- a/crates/zedra/assets/icons/moon.svg
+++ b/crates/zedra/assets/icons/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
+</svg>

--- a/crates/zedra/assets/icons/sun.svg
+++ b/crates/zedra/assets/icons/sun.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="4"/>
+  <path d="M12 2v2"/>
+  <path d="M12 20v2"/>
+  <path d="m4.93 4.93 1.41 1.41"/>
+  <path d="m17.66 17.66 1.41 1.41"/>
+  <path d="M2 12h2"/>
+  <path d="M20 12h2"/>
+  <path d="m6.34 17.66-1.41 1.41"/>
+  <path d="m19.07 4.93-1.41 1.41"/>
+</svg>

--- a/crates/zedra/build.rs
+++ b/crates/zedra/build.rs
@@ -46,10 +46,11 @@ fn main() {
             .compile("nslog_bridge");
 
         let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let config = cbindgen::Config::from_file(format!("{crate_dir}/cbindgen.toml"))
+            .expect("read cbindgen.toml");
         cbindgen::Builder::new()
             .with_crate(crate_dir)
-            .with_language(cbindgen::Language::C)
-            .with_include_guard("ZEDRA_IOS_H")
+            .with_config(config)
             .generate()
             .expect("Unable to generate bindings")
             .write_to_file("../../include/zedra_ios.h");

--- a/crates/zedra/cbindgen.toml
+++ b/crates/zedra/cbindgen.toml
@@ -4,7 +4,9 @@ include_guard = "ZEDRA_IOS_H"
 # Exclude symbols that cbindgen picks up from Rust `unsafe extern "C"` import
 # blocks. These are declarations of ObjC functions that Rust *calls*, not
 # functions that Rust *exports* to ObjC. They don't belong in the public header.
+# Layout tokens live in Rust only; the iOS header should expose FFI functions.
 [export]
+item_types = ["functions"]
 exclude = [
     "zedra_nslog",
     "gpui_ios_initialize",

--- a/crates/zedra/src/android/bridge.rs
+++ b/crates/zedra/src/android/bridge.rs
@@ -4,7 +4,7 @@
 use crate::android::jni;
 use crate::platform_bridge::{
     AlertButton, CustomSheetOptions, HapticFeedback, NativeDictationPreviewOptions,
-    NativeFloatingButtonOptions, NativeNotificationOptions, PlatformBridge,
+    NativeFloatingButtonOptions, NativeNotificationOptions, PlatformBridge, SystemTheme,
 };
 
 pub struct AndroidBridge;
@@ -99,5 +99,9 @@ impl PlatformBridge for AndroidBridge {
 
     fn present_text_input(&self, id: u32, title: &str, placeholder: &str, initial_value: &str) {
         jni::show_text_input(id, title, placeholder, initial_value);
+    }
+
+    fn system_prefers_theme(&self) -> SystemTheme {
+        jni::system_prefers_theme()
     }
 }

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -26,6 +26,7 @@ use crate::install_panic_hook;
 use crate::platform_bridge::{
     self, AlertButton, AlertButtonStyle, CustomSheetOptions, HapticFeedback,
     NativeDictationPreviewOptions, NativeFloatingButtonOptions, NativeNotificationOptions,
+    SystemTheme,
 };
 
 // ============================================================================
@@ -947,6 +948,26 @@ pub fn trigger_haptic(feedback: HapticFeedback) {
             }
         });
     });
+}
+
+pub fn system_prefers_theme() -> SystemTheme {
+    let mut theme = SystemTheme::Unknown;
+    jni_call("system_prefers_theme", || {
+        with_main_activity_class("system_prefers_theme", |env, class| {
+            let Ok(value) = env.call_static_method(class, "systemInDarkTheme", "()I", &[]) else {
+                return;
+            };
+            let Ok(code) = value.i() else {
+                return;
+            };
+            theme = match code {
+                1 => SystemTheme::Dark,
+                0 => SystemTheme::Light,
+                _ => SystemTheme::Unknown,
+            };
+        });
+    });
+    theme
 }
 
 // Suppress unused-import warning for GlobalRef, kept for potential future use.

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -9,9 +9,9 @@ use crate::fonts;
 use crate::home_view::{HomeEvent, HomeView};
 use crate::platform_bridge;
 use crate::quick_action_panel::{QuickActionEvent, QuickActionPanel};
+use crate::settings::{ThemeState, ThemeStateEvent};
 use crate::settings_view::{SettingsEvent, SettingsView};
 use crate::telemetry::view_telemetry::{self, ViewDescriptor};
-use crate::theme_state::{ThemeState, ThemeStateEvent};
 use crate::ui::{DrawerHost, DrawerSide};
 use crate::workspaces::{Workspaces, WorkspacesEvent};
 

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -11,6 +11,7 @@ use crate::platform_bridge;
 use crate::quick_action_panel::{QuickActionEvent, QuickActionPanel};
 use crate::settings_view::{SettingsEvent, SettingsView};
 use crate::telemetry::view_telemetry::{self, ViewDescriptor};
+use crate::theme_state::{ThemeState, ThemeStateEvent};
 use crate::ui::{DrawerHost, DrawerSide};
 use crate::workspaces::{Workspaces, WorkspacesEvent};
 
@@ -37,6 +38,7 @@ fn should_update_drawer_content(current: AppScreen, next: AppScreen) -> bool {
 
 pub struct ZedraApp {
     screen: AppScreen,
+    theme_state: Entity<ThemeState>,
     home_view: Entity<HomeView>,
     settings_view: Entity<SettingsView>,
     workspaces: Entity<Workspaces>,
@@ -50,6 +52,9 @@ impl ZedraApp {
 
         let mut subscriptions = Vec::new();
 
+        let theme_state = cx.new(ThemeState::new);
+        ThemeState::register_global(theme_state.downgrade(), cx);
+
         // --- Workspaces ---
         let workspaces = cx.new(|cx| Workspaces::new(cx));
 
@@ -58,8 +63,11 @@ impl ZedraApp {
         let sub = cx.subscribe(&home_view, Self::on_home_event);
         subscriptions.push(sub);
 
-        let settings_view = cx.new(SettingsView::new);
+        let settings_view = cx.new(|cx| SettingsView::new(theme_state.clone(), cx));
         let sub = cx.subscribe(&settings_view, Self::on_settings_event);
+        subscriptions.push(sub);
+
+        let sub = cx.subscribe(&theme_state, Self::on_theme_changed);
         subscriptions.push(sub);
 
         // --- Quick action panel ---
@@ -95,6 +103,7 @@ impl ZedraApp {
 
         let app = Self {
             screen: AppScreen::Home,
+            theme_state,
             home_view,
             settings_view,
             workspaces,
@@ -171,6 +180,15 @@ impl ZedraApp {
                 self.set_screen(AppScreen::Home, cx);
             }
         }
+    }
+
+    fn on_theme_changed(
+        &mut self,
+        _: Entity<ThemeState>,
+        _: &ThemeStateEvent,
+        cx: &mut Context<Self>,
+    ) {
+        cx.notify();
     }
 
     fn on_quick_action_event(

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -38,7 +38,6 @@ fn should_update_drawer_content(current: AppScreen, next: AppScreen) -> bool {
 
 pub struct ZedraApp {
     screen: AppScreen,
-    theme_state: Entity<ThemeState>,
     home_view: Entity<HomeView>,
     settings_view: Entity<SettingsView>,
     workspaces: Entity<Workspaces>,
@@ -103,7 +102,6 @@ impl ZedraApp {
 
         let app = Self {
             screen: AppScreen::Home,
-            theme_state,
             home_view,
             settings_view,
             workspaces,

--- a/crates/zedra/src/button.rs
+++ b/crates/zedra/src/button.rs
@@ -7,7 +7,7 @@ use crate::theme;
 const DEFAULT_NATIVE_FLOATING_BUTTON_ICON_SIZE: f32 = 16.0;
 
 /// An outlined button - bordered, centered text.
-pub fn outline_button(id: impl Into<ElementId>, label: &str) -> Stateful<Div> {
+pub fn outline_button(cx: &App, id: impl Into<ElementId>, label: &str) -> Stateful<Div> {
     div()
         .id(id)
         .flex()
@@ -17,9 +17,9 @@ pub fn outline_button(id: impl Into<ElementId>, label: &str) -> Stateful<Div> {
         .py(px(10.0))
         .rounded(px(8.0))
         .border_1()
-        .border_color(rgb(theme::BORDER_DEFAULT))
+        .border_color(rgb(theme::border_default(cx)))
         .cursor_pointer()
-        .text_color(rgb(theme::TEXT_PRIMARY))
+        .text_color(rgb(theme::text_primary(cx)))
         .text_size(px(theme::FONT_BODY))
         .font_weight(FontWeight::MEDIUM)
         .child(label.to_string())

--- a/crates/zedra/src/docs_tree.rs
+++ b/crates/zedra/src/docs_tree.rs
@@ -335,7 +335,7 @@ impl DocsTree {
                         svg()
                             .path(icon_path)
                             .size(icon_size)
-                            .text_color(rgb(theme::TEXT_MUTED)),
+                            .text_color(rgb(theme::text_muted(cx))),
                     ),
                 )
                 .child(
@@ -343,7 +343,7 @@ impl DocsTree {
                         .flex_1()
                         .min_w_0()
                         .truncate()
-                        .text_color(rgb(theme::TEXT_SECONDARY))
+                        .text_color(rgb(theme::text_secondary(cx)))
                         .text_size(px(theme::FONT_BODY))
                         .child(row.name),
                 )
@@ -379,7 +379,7 @@ impl DocsTree {
                     svg()
                         .path("icons/file-text.svg")
                         .size(px(theme::ICON_FILE))
-                        .text_color(rgb(theme::TEXT_MUTED)),
+                        .text_color(rgb(theme::text_muted(cx))),
                 ),
             )
             .child(
@@ -387,17 +387,17 @@ impl DocsTree {
                     .flex_1()
                     .min_w_0()
                     .truncate()
-                    .text_color(rgb(theme::TEXT_SECONDARY))
+                    .text_color(rgb(theme::text_secondary(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child(row.name),
             );
         if is_selected {
-            row_el = row_el.bg(hsla(0.0, 0.0, 1.0, 0.10));
+            row_el = row_el.bg(theme::row_pressed_bg(cx));
         }
         row_el.into_any_element()
     }
 
-    fn render_status_row(&self, message: String) -> Div {
+    fn render_status_row(&self, cx: &App, message: String) -> Div {
         div()
             .min_h(px(96.0))
             .w_full()
@@ -409,7 +409,7 @@ impl DocsTree {
                 div()
                     .w_full()
                     .min_w_0()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .text_center()
                     .child(message),
@@ -441,14 +441,14 @@ impl DocsTree {
                     .flex_1()
                     .min_w_0()
                     .truncate()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child(label),
             )
             .into_any_element()
     }
 
-    fn render_all_loaded_row(&self) -> impl IntoElement {
+    fn render_all_loaded_row(&self, cx: &App) -> impl IntoElement {
         div()
             .id("docs-tree-all-loaded-row")
             .flex_1()
@@ -461,17 +461,17 @@ impl DocsTree {
                     .flex_1()
                     .min_w_0()
                     .truncate()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child("All loaded"),
             )
     }
 
-    fn render_refresh_icon(&self, is_building: bool) -> AnyElement {
+    fn render_refresh_icon(&self, cx: &App, is_building: bool) -> AnyElement {
         let icon = svg()
             .path("icons/refresh-ccw.svg")
             .size(px(14.0))
-            .text_color(rgb(theme::TEXT_MUTED));
+            .text_color(rgb(theme::text_muted(cx)));
 
         if !is_building {
             return icon.into_any_element();
@@ -497,7 +497,7 @@ impl DocsTree {
             .justify_center()
             .rounded(px(6.0))
             .opacity(if is_building { 0.45 } else { 1.0 })
-            .child(self.render_refresh_icon(is_building));
+            .child(self.render_refresh_icon(cx, is_building));
 
         if !is_building {
             button = button
@@ -528,7 +528,7 @@ impl DocsTree {
         if matches!(self.build_state, DocsBuildState::Building) {
             row = row.child(
                 div()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child("Building documents..."),
             );
@@ -568,7 +568,7 @@ impl DocsTree {
         if self.has_more {
             footer = footer.child(self.render_load_more_row(cx));
         } else {
-            footer = footer.child(self.render_all_loaded_row());
+            footer = footer.child(self.render_all_loaded_row(cx));
         }
 
         footer
@@ -612,7 +612,7 @@ impl Render for DocsTree {
                 .items_stretch()
                 .justify_center();
             if let Some(message) = status_message {
-                scroll_content = scroll_content.child(self.render_status_row(message));
+                scroll_content = scroll_content.child(self.render_status_row(cx, message));
             }
             return div()
                 .track_focus(&self.focus_handle)

--- a/crates/zedra/src/editor/code_editor.rs
+++ b/crates/zedra/src/editor/code_editor.rs
@@ -9,7 +9,7 @@ use super::text_buffer::Buffer;
 
 use crate::fonts;
 use crate::platform_bridge;
-use crate::theme;
+use crate::theme::{self, EditorTheme};
 use crate::workspace_action::AddSelectionToChat;
 
 const LINE_HEIGHT: f32 = theme::EDITOR_LINE_HEIGHT;
@@ -17,8 +17,6 @@ const GUTTER_WIDTH: f32 = theme::EDITOR_GUTTER_WIDTH;
 const FONT_SIZE: f32 = theme::EDITOR_FONT_SIZE;
 const GUTTER_FONT_SIZE: f32 = theme::EDITOR_GUTTER_FONT_SIZE;
 const BOTTOM_INSET_MIN: f32 = 100.0;
-const CODE_TEXT_COLOR: u32 = 0xabb2bf;
-const PENDING_SYNTAX_TEXT_COLOR: u32 = 0x7b8494;
 pub const CODE_EDITOR_SELECTION_AREA_ID: &str = "code-editor-selection";
 
 type LineHighlights = Vec<(Range<usize>, HighlightStyle)>;
@@ -32,20 +30,13 @@ struct CachedLine {
 
 pub struct ParsedEditorSyntax {
     highlighter: Highlighter,
-    line_highlights: Vec<LineHighlights>,
 }
 
 impl ParsedEditorSyntax {
     pub fn build(filename: &str, content: String) -> Self {
         let mut highlighter = Highlighter::from_filename(filename);
         highlighter.parse(&content);
-        let theme = SyntaxTheme::default_dark();
-        let buffer = Buffer::new(content);
-        let line_highlights = build_line_highlights(&buffer, &highlighter, &theme);
-        Self {
-            highlighter,
-            line_highlights,
-        }
+        Self { highlighter }
     }
 }
 
@@ -53,7 +44,7 @@ impl ParsedEditorSyntax {
 pub struct EditorView {
     buffer: Buffer,
     highlighter: Rc<Highlighter>,
-    theme: SyntaxTheme,
+    editor_theme: EditorTheme,
     scroll_handle: UniformListScrollHandle,
     /// Cached line data shared with the uniform_list closure via Rc.
     /// Only rebuilt when the buffer content changes.
@@ -92,7 +83,7 @@ impl EditorView {
         Self {
             buffer: Buffer::new(content),
             highlighter: Rc::new(highlighter),
-            theme: SyntaxTheme::default_dark(),
+            editor_theme: EditorTheme::dark(),
             scroll_handle: UniformListScrollHandle::new(),
             cached_lines: Rc::new(Vec::new()),
             cached_line_highlights: Rc::new(Vec::new()),
@@ -145,12 +136,16 @@ impl EditorView {
     }
 
     pub fn apply_parsed_syntax(&mut self, parsed: ParsedEditorSyntax) {
-        let ParsedEditorSyntax {
-            highlighter,
-            line_highlights,
-        } = parsed;
-        self.highlighter = Rc::new(highlighter);
-        self.cached_line_highlights = Rc::new(line_highlights);
+        self.highlighter = Rc::new(parsed.highlighter);
+        self.cached_line_highlights = if self.highlighter.is_waiting_for_syntax() {
+            Rc::new(vec![Vec::new(); self.buffer.line_count()])
+        } else {
+            Rc::new(build_line_highlights(
+                &self.buffer,
+                &self.highlighter,
+                &self.editor_theme.syntax,
+            ))
+        };
     }
 
     pub fn language(&self) -> Language {
@@ -170,6 +165,15 @@ impl EditorView {
         line_range_for_selection_lines(&lines, range_utf16)
     }
 
+    pub fn sync_editor_theme(&mut self, editor_theme: &EditorTheme) {
+        if self.editor_theme == *editor_theme {
+            return;
+        }
+        self.editor_theme = editor_theme.clone();
+        self.cached_line_highlights = Rc::new(Vec::new());
+        self.lines_dirty = true;
+    }
+
     /// Rebuild the cached line data from the buffer text only.
     fn rebuild_line_cache(&mut self) {
         let line_count = self.buffer.line_count();
@@ -180,14 +184,15 @@ impl EditorView {
             })
             .collect();
         self.max_line_chars = lines.iter().map(|l| l.text.len()).max().unwrap_or(0);
-        if self.cached_line_highlights.len() != line_count {
+        if self.cached_line_highlights.is_empty() || self.cached_line_highlights.len() != line_count
+        {
             self.cached_line_highlights = if self.highlighter.is_waiting_for_syntax() {
                 Rc::new(vec![Vec::new(); line_count])
             } else {
                 Rc::new(build_line_highlights(
                     &self.buffer,
                     &self.highlighter,
-                    &self.theme,
+                    &self.editor_theme.syntax,
                 ))
             };
         }
@@ -213,11 +218,11 @@ impl EditorView {
     }
 }
 
-fn code_text_color_for_highlighter(highlighter: &Highlighter) -> u32 {
+fn code_text_color_for_highlighter(editor_theme: &EditorTheme, highlighter: &Highlighter) -> u32 {
     if highlighter.is_waiting_for_syntax() {
-        PENDING_SYNTAX_TEXT_COLOR
+        editor_theme.pending_syntax
     } else {
-        CODE_TEXT_COLOR
+        editor_theme.foreground
     }
 }
 
@@ -305,6 +310,8 @@ fn line_range_for_selection_lines(lines: &[&str], range_utf16: Range<usize>) -> 
 
 impl Render for EditorView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.sync_editor_theme(&theme::bundle(cx).editor);
+
         // Rebuild line cache only when buffer content changed.
         // During scroll, this is skipped entirely.
         if self.lines_dirty {
@@ -323,9 +330,14 @@ impl Render for EditorView {
         // the vertical position doesn't drift during a horizontal swipe.
         let scroll_y_lock = self.scroll_handle.0.borrow().base_handle.offset().y;
 
+        let editor_theme = self.editor_theme.clone();
         let text_style = {
             let mut style = window.text_style();
-            style.color = rgb(code_text_color_for_highlighter(&self.highlighter)).into();
+            style.color = rgb(code_text_color_for_highlighter(
+                &editor_theme,
+                &self.highlighter,
+            ))
+            .into();
             style.font_family = fonts::MONO_FONT_FAMILY.into();
             style.font_size = px(FONT_SIZE).into();
             style
@@ -335,7 +347,7 @@ impl Render for EditorView {
             .flex()
             .flex_col()
             .size_full()
-            .bg(rgb(0x0e0c0c))
+            .bg(rgb(editor_theme.background))
             .font_family(fonts::MONO_FONT_FAMILY)
             .on_scroll_wheel(
                 cx.listener(move |this, event: &ScrollWheelEvent, _window, cx| {
@@ -418,7 +430,7 @@ impl Render for EditorView {
                                                 .items_center()
                                                 .justify_end()
                                                 .pr_2()
-                                                .text_color(hsla(0.0, 0.0, 0.83, 0.3))
+                                                .text_color(editor_theme.gutter)
                                                 .text_size(px(GUTTER_FONT_SIZE))
                                                 .child(cached.number.clone()),
                                         )
@@ -464,10 +476,11 @@ mod tests {
     use gpui::{ScrollStrategy, point, px};
 
     use super::{
-        CODE_TEXT_COLOR, EditorView, PENDING_SYNTAX_TEXT_COLOR, ParsedEditorSyntax,
-        code_text_color_for_highlighter, line_range_for_selection_lines,
+        EditorView, ParsedEditorSyntax, code_text_color_for_highlighter,
+        line_range_for_selection_lines,
     };
     use crate::editor::syntax_highlighter::{Highlighter, Language};
+    use crate::theme::EditorTheme;
 
     #[test]
     fn maps_utf16_selection_to_code_lines() {
@@ -515,21 +528,25 @@ mod tests {
 
     #[test]
     fn dims_code_text_only_while_syntax_is_pending() {
+        let editor_theme = EditorTheme::dark();
         let pending = Highlighter::from_filename("main.rs");
         assert_eq!(
-            code_text_color_for_highlighter(&pending),
-            PENDING_SYNTAX_TEXT_COLOR
+            code_text_color_for_highlighter(&editor_theme, &pending),
+            editor_theme.pending_syntax
         );
 
         let plain_text = Highlighter::from_language(Language::PlainText);
         assert_eq!(
-            code_text_color_for_highlighter(&plain_text),
-            CODE_TEXT_COLOR
+            code_text_color_for_highlighter(&editor_theme, &plain_text),
+            editor_theme.foreground
         );
 
         let mut parsed = Highlighter::from_filename("main.rs");
         parsed.parse("fn main() {}\n");
-        assert_eq!(code_text_color_for_highlighter(&parsed), CODE_TEXT_COLOR);
+        assert_eq!(
+            code_text_color_for_highlighter(&editor_theme, &parsed),
+            editor_theme.foreground
+        );
     }
 
     #[test]

--- a/crates/zedra/src/editor/code_editor.rs
+++ b/crates/zedra/src/editor/code_editor.rs
@@ -509,16 +509,14 @@ mod tests {
         assert!(editor.cached_line_highlights[0].is_empty());
 
         let parsed = ParsedEditorSyntax::build("main.rs", content);
-        assert_eq!(parsed.line_highlights.len(), editor.cached_lines.len());
-        let parsed_first_line_highlights = parsed.line_highlights[0].clone();
-        assert!(!parsed_first_line_highlights.is_empty());
         editor.apply_parsed_syntax(parsed);
 
         assert!(Rc::ptr_eq(&original_lines, &editor.cached_lines));
         assert_eq!(
-            editor.cached_line_highlights[0],
-            parsed_first_line_highlights
+            editor.cached_line_highlights.len(),
+            editor.cached_lines.len()
         );
+        assert!(!editor.cached_line_highlights[0].is_empty());
         assert!(
             editor.cached_line_highlights[0]
                 .iter()

--- a/crates/zedra/src/editor/git_diff_view.rs
+++ b/crates/zedra/src/editor/git_diff_view.rs
@@ -10,7 +10,6 @@ use gpui::*;
 use tracing::info;
 
 use super::syntax_highlighter::Highlighter;
-use super::syntax_theme::SyntaxTheme;
 use crate::platform_bridge;
 use crate::theme::{self, EditorTheme};
 

--- a/crates/zedra/src/editor/git_diff_view.rs
+++ b/crates/zedra/src/editor/git_diff_view.rs
@@ -12,7 +12,7 @@ use tracing::info;
 use super::syntax_highlighter::Highlighter;
 use super::syntax_theme::SyntaxTheme;
 use crate::platform_bridge;
-use crate::theme;
+use crate::theme::{self, EditorTheme};
 
 // ── Diff data types ─────────────────────────────────────────────────────────
 
@@ -217,7 +217,7 @@ struct CachedDiffLine {
 pub struct GitDiffView {
     diff: FileDiff,
     highlighter: Highlighter,
-    theme: SyntaxTheme,
+    editor_theme: EditorTheme,
     scroll_handle: UniformListScrollHandle,
     focus_handle: FocusHandle,
     cached_lines: Rc<Vec<CachedDiffLine>>,
@@ -245,7 +245,7 @@ impl GitDiffView {
         Self {
             diff,
             highlighter,
-            theme: SyntaxTheme::default_dark(),
+            editor_theme: EditorTheme::dark(),
             scroll_handle: UniformListScrollHandle::new(),
             focus_handle: cx.focus_handle(),
             cached_lines: Rc::new(Vec::new()),
@@ -263,6 +263,14 @@ impl GitDiffView {
         self.highlighter = Highlighter::from_filename(&filename);
         self.rebuild_line_cache();
         cx.notify();
+    }
+
+    fn sync_editor_theme(&mut self, editor_theme: &EditorTheme) {
+        if self.editor_theme == *editor_theme {
+            return;
+        }
+        self.editor_theme = editor_theme.clone();
+        self.lines_dirty = true;
     }
 
     fn rebuild_line_cache(&mut self) {
@@ -334,7 +342,7 @@ impl GitDiffView {
         let mut result: Vec<(Range<usize>, HighlightStyle)> = Vec::new();
 
         for (span_range, capture_name) in &raw_highlights {
-            if let Some(style) = self.theme.get(capture_name) {
+            if let Some(style) = self.editor_theme.syntax.get(capture_name) {
                 let start = span_range.start.min(content_len);
                 let end = span_range.end.min(content_len);
                 if start < end {
@@ -357,6 +365,8 @@ impl Focusable for GitDiffView {
 
 impl Render for GitDiffView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.sync_editor_theme(&theme::bundle(cx).editor);
+
         if self.lines_dirty {
             info!("rebuilding gitdiff line cache by lines_dirty flag");
             self.rebuild_line_cache();
@@ -369,9 +379,11 @@ impl Render for GitDiffView {
         let h_scroll_offset = self.h_scroll_offset;
         let scroll_y_lock = self.scroll_handle.0.borrow().base_handle.offset().y;
 
+        let editor_theme = self.editor_theme.clone();
+        let diff = editor_theme.diff.clone();
         let text_style = {
             let mut style = window.text_style();
-            style.color = rgb(0xcacaca).into();
+            style.color = rgb(diff.body_text).into();
             style.font_size = px(FONT_SIZE).into();
             style
         };
@@ -380,7 +392,7 @@ impl Render for GitDiffView {
             .flex()
             .flex_col()
             .size_full()
-            .bg(rgb(0x0e0c0c))
+            .bg(rgb(editor_theme.background))
             .track_focus(&self.focus_handle)
             .on_scroll_wheel(
                 cx.listener(move |this, event: &ScrollWheelEvent, _window, cx| {
@@ -410,6 +422,8 @@ impl Render for GitDiffView {
             .child(
                 uniform_list("git-diff-view-lines", line_count + extra_items, {
                     let text_style = text_style.clone();
+                    let diff = diff.clone();
+                    let editor_theme = editor_theme.clone();
                     move |range: Range<usize>, _window: &mut Window, _cx: &mut App| {
                         range
                             .map(|i| {
@@ -423,27 +437,27 @@ impl Render for GitDiffView {
                                 };
 
                                 let (bg_color, gutter_text) = match line.kind {
-                                    DiffLineKind::Header => (rgb(0x131313), "".to_string()),
+                                    DiffLineKind::Header => (rgb(diff.header_bg), "".to_string()),
                                     DiffLineKind::Added => {
                                         let num = line
                                             .new_line_num
                                             .map(|n| format!("{:>3}", n))
                                             .unwrap_or_default();
-                                        (rgb(0x162016), num)
+                                        (rgb(diff.added_bg), num)
                                     }
                                     DiffLineKind::Removed => {
                                         let num = line
                                             .old_line_num
                                             .map(|n| format!("{:>3}", n))
                                             .unwrap_or_default();
-                                        (rgb(0x201616), num)
+                                        (rgb(diff.removed_bg), num)
                                     }
                                     DiffLineKind::Unchanged => {
                                         let num = line
                                             .new_line_num
                                             .map(|n| format!("{:>3}", n))
                                             .unwrap_or_default();
-                                        (rgb(0x0e0c0c), num)
+                                        (rgb(editor_theme.background), num)
                                     }
                                 };
 
@@ -460,7 +474,7 @@ impl Render for GitDiffView {
                                         .items_center()
                                         .child(
                                             div()
-                                                .text_color(rgb(0x61afef))
+                                                .text_color(rgb(diff.header_text))
                                                 .text_size(px(FONT_SIZE))
                                                 .child(content.clone()),
                                         )
@@ -491,7 +505,7 @@ impl Render for GitDiffView {
                                             .items_center()
                                             .justify_end()
                                             .pr_2()
-                                            .text_color(rgb(0x404040))
+                                            .text_color(rgb(diff.gutter_text))
                                             .text_size(px(GUTTER_FONT_SIZE))
                                             .child(gutter_text),
                                     )

--- a/crates/zedra/src/editor/git_sidebar.rs
+++ b/crates/zedra/src/editor/git_sidebar.rs
@@ -342,12 +342,12 @@ impl GitSidebar {
                                 "icons/chevron-right.svg"
                             })
                             .size(px(theme::FONT_DETAIL))
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .left(px(-2.0)),
                     )
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .text_size(px(theme::FONT_DETAIL))
                             .font_weight(FontWeight::MEDIUM)
                             .child(title),
@@ -356,7 +356,7 @@ impl GitSidebar {
             .child(
                 div()
                     .px_1()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_DETAIL))
                     .child(count.to_string()),
             )
@@ -374,14 +374,14 @@ impl GitSidebar {
             .as_ref()
             .is_some_and(|active| active.path == file.path && active.section == file.section);
         let status_color = if is_active {
-            theme::TEXT_SECONDARY
+            theme::text_secondary(cx)
         } else {
-            theme::TEXT_MUTED
+            theme::text_muted(cx)
         };
         let filename_color = if is_active {
-            theme::TEXT_PRIMARY
+            theme::text_primary(cx)
         } else {
-            theme::TEXT_SECONDARY
+            theme::text_secondary(cx)
         };
 
         let mut row = div()
@@ -452,21 +452,21 @@ impl GitSidebar {
                     .when(insertions > 0, |s| {
                         s.child(
                             div()
-                                .text_color(rgb(theme::TEXT_MUTED))
+                                .text_color(rgb(theme::text_muted(cx)))
                                 .child(format!("+{}", insertions)),
                         )
                     })
                     .when(deletions > 0, |s| {
                         s.child(
                             div()
-                                .text_color(rgb(theme::TEXT_MUTED))
+                                .text_color(rgb(theme::text_muted(cx)))
                                 .child(format!("-{}", deletions)),
                         )
                     }),
             );
 
         if is_active {
-            row = row.bg(hsla(0.0, 0.0, 1.0, 0.10));
+            row = row.bg(theme::row_pressed_bg(cx));
         }
 
         row
@@ -480,9 +480,9 @@ impl GitSidebar {
             "icons/check.svg"
         };
         let icon_color = if is_enabled || self.committing {
-            theme::TEXT_SECONDARY
+            theme::text_secondary(cx)
         } else {
-            theme::TEXT_MUTED
+            theme::text_muted(cx)
         };
         let icon_size = if self.committing { px(14.0) } else { px(20.0) };
 
@@ -600,7 +600,7 @@ impl Render for GitSidebar {
             .flex()
             .flex_col()
             .size_full()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .child(self.render_commit_composer(cx))
             // File sections (scrollable)
             .child(

--- a/crates/zedra/src/editor/markdown.rs
+++ b/crates/zedra/src/editor/markdown.rs
@@ -231,7 +231,8 @@ impl InlineRenderBuffer {
 }
 
 impl Render for MarkdownView {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let _theme = theme::palette(cx);
         let blocks = Arc::clone(&self.document.blocks);
         let block_count = blocks.len();
         let bottom_inset = f32::max(
@@ -240,7 +241,7 @@ impl Render for MarkdownView {
         );
         let focus_handle = self
             .focus_handle
-            .get_or_insert_with(|| _cx.focus_handle())
+            .get_or_insert_with(|| cx.focus_handle())
             .clone();
         let press_focus_handle = focus_handle.clone();
         // Keep each top-level markdown block as one variable-height list row.
@@ -1102,21 +1103,21 @@ fn parse_inline_event(events: &[Event<'_>], cursor: &mut usize) -> Vec<Inline> {
 
 fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -> AnyElement {
     match block {
-        Block::Paragraph(content) => render_inline_block(content, InlineBlockStyle::Body, key),
+        Block::Paragraph(content) => render_inline_block(content, InlineBlockStyle::Body, key, cx),
         Block::Heading { level, content } => {
             let style = match level {
                 HeadingLevel::H1 => InlineBlockStyle::Title,
                 HeadingLevel::H2 => InlineBlockStyle::Section,
                 _ => InlineBlockStyle::Heading,
             };
-            render_inline_block(content, style, key)
+            render_inline_block(content, style, key, cx)
         }
         Block::BlockQuote(children) => {
             div()
                 .w_full()
                 .pl(px(theme::SPACING_MD))
                 .border_l_1()
-                .border_color(rgb(theme::BORDER_DEFAULT))
+                .border_color(rgb(theme::border_default(cx)))
                 .flex()
                 .flex_col()
                 .gap(px(10.0))
@@ -1149,7 +1150,7 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
                         div()
                             .flex_shrink_0()
                             .min_w(px(16.0))
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .text_size(px(theme::FONT_BODY))
                             .line_height(px(theme::FONT_BODY + 6.0))
                             .font_family(fonts::MONO_FONT_FAMILY)
@@ -1190,7 +1191,7 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
                     };
                     div()
                         .w_full()
-                        .text_color(rgb(theme::TEXT_PRIMARY))
+                        .text_color(rgb(theme::text_primary(cx)))
                         .text_size(px(CODE_BLOCK_FONT_SIZE))
                         .line_height(px(CODE_BLOCK_LINE_HEIGHT))
                         .font_family(fonts::MONO_FONT_FAMILY)
@@ -1201,9 +1202,9 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
             let mut container = div()
                 .id(format!("{key}-code-scroll"))
                 .w_full()
-                .bg(rgb(theme::BG_CARD))
+                .bg(rgb(theme::bg_card(cx)))
                 .border_1()
-                .border_color(rgb(theme::BORDER_DEFAULT))
+                .border_color(rgb(theme::border_default(cx)))
                 .rounded(px(6.0))
                 .overflow_x_scroll()
                 .child(code_lines);
@@ -1211,14 +1212,17 @@ fn render_block(block: &Block, key: String, window: &mut Window, cx: &mut App) -
 
             container.into_any_element()
         }
-        Block::Table(table) => render_table(table, key),
-        Block::Html(text) => {
-            render_inline_block(&[Inline::Html(text.clone())], InlineBlockStyle::Html, key)
-        }
+        Block::Table(table) => render_table(table, key, cx),
+        Block::Html(text) => render_inline_block(
+            &[Inline::Html(text.clone())],
+            InlineBlockStyle::Html,
+            key,
+            cx,
+        ),
         Block::Rule => div()
             .w_full()
             .h(px(1.0))
-            .bg(rgb(theme::BORDER_SUBTLE))
+            .bg(rgb(theme::border_subtle(cx)))
             .into_any_element(),
     }
 }
@@ -1245,7 +1249,7 @@ fn code_block_display_columns(line: &str) -> usize {
     columns
 }
 
-fn render_table(table: &TableBlock, key: String) -> AnyElement {
+fn render_table(table: &TableBlock, key: String, cx: &App) -> AnyElement {
     let column_widths = table_column_widths(table);
     let table_width = column_widths.iter().sum::<f32>().max(TABLE_CELL_MIN_WIDTH);
     let rows = (!table.headers.is_empty())
@@ -1269,9 +1273,9 @@ fn render_table(table: &TableBlock, key: String) -> AnyElement {
                         .flex()
                         .border_b_1()
                         .when(is_last_row, |this| {
-                            this.border_color(rgb(theme::BORDER_SUBTLE))
+                            this.border_color(rgb(theme::border_subtle(cx)))
                         })
-                        .border_color(rgb(theme::BORDER_SUBTLE))
+                        .border_color(rgb(theme::border_subtle(cx)))
                         .children(row.iter().enumerate().map(|(cell_ix, cell)| {
                             let cell_width = column_widths
                                 .get(cell_ix)
@@ -1285,7 +1289,7 @@ fn render_table(table: &TableBlock, key: String) -> AnyElement {
                                 .px(px(TABLE_CELL_PADDING_X))
                                 .py(px(TABLE_CELL_PADDING_Y))
                                 .border_r_1()
-                                .border_color(rgb(theme::BORDER_SUBTLE))
+                                .border_color(rgb(theme::border_subtle(cx)))
                                 .child(render_inline_block(
                                     &cell,
                                     if is_header {
@@ -1294,6 +1298,7 @@ fn render_table(table: &TableBlock, key: String) -> AnyElement {
                                         InlineBlockStyle::TableCell
                                     },
                                     format!("{key}-row-{row_ix}-cell-{cell_ix}"),
+                                    cx,
                                 ))
                         }))
                 }),
@@ -1302,9 +1307,9 @@ fn render_table(table: &TableBlock, key: String) -> AnyElement {
     let mut container = div()
         .id(format!("{key}-table-scroll"))
         .w_full()
-        .bg(rgb(theme::BG_CARD))
+        .bg(rgb(theme::bg_card(cx)))
         .border_1()
-        .border_color(rgb(theme::BORDER_DEFAULT))
+        .border_color(rgb(theme::border_default(cx)))
         .rounded(px(6.0))
         .overflow_x_scroll()
         .child(table_body);
@@ -1405,11 +1410,16 @@ enum InlineBlockStyle {
     Html,
 }
 
-fn render_inline_block(content: &[Inline], style: InlineBlockStyle, key: String) -> AnyElement {
+fn render_inline_block(
+    content: &[Inline],
+    style: InlineBlockStyle,
+    key: String,
+    cx: &App,
+) -> AnyElement {
     let mut buffer = InlineRenderBuffer::default();
-    flatten_inlines(content, &mut buffer, InlineMarks::default());
+    flatten_inlines(content, &mut buffer, InlineMarks::default(), cx);
 
-    let base = block_style(style);
+    let base = block_style(style, cx);
     let styled = StyledText::new(buffer.text.clone()).with_highlights(merge_highlights(
         buffer
             .highlights
@@ -1464,47 +1474,47 @@ struct InlineMarks {
     html: bool,
 }
 
-fn flatten_inlines(content: &[Inline], out: &mut InlineRenderBuffer, marks: InlineMarks) {
+fn flatten_inlines(content: &[Inline], out: &mut InlineRenderBuffer, marks: InlineMarks, cx: &App) {
     for inline in content {
         match inline {
-            Inline::Text(text) => push_text_with_marks(out, text, marks),
+            Inline::Text(text) => push_text_with_marks(out, text, marks, cx),
             Inline::Code(text) => {
                 let mut next = marks;
                 next.code = true;
-                push_text_with_marks(out, text, next);
+                push_text_with_marks(out, text, next, cx);
             }
             Inline::Html(text) => {
                 let mut next = marks;
                 next.html = true;
-                push_text_with_marks(out, text, next);
+                push_text_with_marks(out, text, next, cx);
             }
             Inline::Emphasis(children) => {
                 let mut next = marks;
                 next.emphasis = true;
-                flatten_inlines(children, out, next);
+                flatten_inlines(children, out, next, cx);
             }
             Inline::Strong(children) => {
                 let mut next = marks;
                 next.strong = true;
-                flatten_inlines(children, out, next);
+                flatten_inlines(children, out, next, cx);
             }
             Inline::Strikethrough(children) => {
                 let mut next = marks;
                 next.strike = true;
-                flatten_inlines(children, out, next);
+                flatten_inlines(children, out, next, cx);
             }
             Inline::Link { url, content } => {
                 let start = out.text.len();
-                flatten_inlines(content, out, marks);
+                flatten_inlines(content, out, marks, cx);
                 let end = out.text.len();
                 if start != end {
                     let range = start..end;
                     out.highlights.push(StyledRun {
                         range: range.clone(),
                         style: HighlightStyle {
-                            color: Some(rgb(theme::ACCENT_BLUE).into()),
+                            color: Some(rgb(theme::accent_blue(cx)).into()),
                             underline: Some(UnderlineStyle {
-                                color: Some(rgb(theme::ACCENT_BLUE).into()),
+                                color: Some(rgb(theme::accent_blue(cx)).into()),
                                 thickness: px(1.0),
                                 wavy: false,
                             }),
@@ -1530,7 +1540,7 @@ fn flatten_inlines(content: &[Inline], out: &mut InlineRenderBuffer, marks: Inli
     }
 }
 
-fn push_text_with_marks(out: &mut InlineRenderBuffer, text: &str, marks: InlineMarks) {
+fn push_text_with_marks(out: &mut InlineRenderBuffer, text: &str, marks: InlineMarks, cx: &App) {
     if text.is_empty() {
         return;
     }
@@ -1548,19 +1558,19 @@ fn push_text_with_marks(out: &mut InlineRenderBuffer, text: &str, marks: InlineM
     }
     if marks.strike {
         style.strikethrough = Some(StrikethroughStyle {
-            color: Some(rgb(theme::TEXT_SECONDARY).into()),
+            color: Some(rgb(theme::text_secondary(cx)).into()),
             thickness: px(1.0),
         });
         has_style = true;
     }
     if marks.code {
-        style.background_color = Some(rgb(theme::BG_CARD).into());
-        style.color = Some(rgb(theme::TEXT_PRIMARY).into());
+        style.background_color = Some(rgb(theme::bg_card(cx)).into());
+        style.color = Some(rgb(theme::text_primary(cx)).into());
         has_style = true;
     }
     if marks.html {
-        style.background_color = Some(rgb(theme::BG_CARD).into());
-        style.color = Some(rgb(theme::TEXT_MUTED).into());
+        style.background_color = Some(rgb(theme::bg_card(cx)).into());
+        style.color = Some(rgb(theme::text_muted(cx)).into());
         has_style = true;
     }
 
@@ -1577,47 +1587,47 @@ struct BlockStyleSpec {
     weight: Option<FontWeight>,
 }
 
-fn block_style(style: InlineBlockStyle) -> BlockStyleSpec {
+fn block_style(style: InlineBlockStyle, cx: &App) -> BlockStyleSpec {
     match style {
         InlineBlockStyle::Title => BlockStyleSpec {
             size: theme::FONT_TITLE,
             line_height: theme::FONT_TITLE + 8.0,
-            color: rgb(theme::TEXT_PRIMARY).into(),
+            color: rgb(theme::text_primary(cx)).into(),
             font_family: fonts::HEADING_FONT_FAMILY,
             weight: Some(FontWeight::MEDIUM),
         },
         InlineBlockStyle::Section => BlockStyleSpec {
             size: theme::FONT_HEADING + 2.0,
             line_height: theme::FONT_HEADING + 8.0,
-            color: rgb(theme::TEXT_PRIMARY).into(),
+            color: rgb(theme::text_primary(cx)).into(),
             font_family: fonts::HEADING_FONT_FAMILY,
             weight: Some(FontWeight::MEDIUM),
         },
         InlineBlockStyle::Heading => BlockStyleSpec {
             size: theme::FONT_HEADING,
             line_height: theme::FONT_HEADING + 6.0,
-            color: rgb(theme::TEXT_PRIMARY).into(),
+            color: rgb(theme::text_primary(cx)).into(),
             font_family: fonts::HEADING_FONT_FAMILY,
             weight: Some(FontWeight::MEDIUM),
         },
         InlineBlockStyle::TableHeader => BlockStyleSpec {
             size: theme::FONT_BODY,
             line_height: theme::FONT_BODY + 6.0,
-            color: rgb(theme::TEXT_PRIMARY).into(),
+            color: rgb(theme::text_primary(cx)).into(),
             font_family: fonts::MONO_FONT_FAMILY,
             weight: Some(FontWeight::MEDIUM),
         },
         InlineBlockStyle::TableCell | InlineBlockStyle::Body => BlockStyleSpec {
             size: theme::FONT_BODY,
             line_height: theme::FONT_BODY + 6.0,
-            color: rgb(theme::TEXT_SECONDARY).into(),
+            color: rgb(theme::text_secondary(cx)).into(),
             font_family: fonts::MONO_FONT_FAMILY,
             weight: None,
         },
         InlineBlockStyle::Html => BlockStyleSpec {
             size: theme::FONT_DETAIL,
             line_height: theme::FONT_DETAIL + 5.0,
-            color: rgb(theme::TEXT_MUTED).into(),
+            color: rgb(theme::text_muted(cx)).into(),
             font_family: fonts::MONO_FONT_FAMILY,
             weight: None,
         },

--- a/crates/zedra/src/editor/syntax_theme.rs
+++ b/crates/zedra/src/editor/syntax_theme.rs
@@ -1,5 +1,4 @@
 use gpui::HighlightStyle;
-use serde::{Deserialize, Serialize};
 
 /// Maps tree-sitter capture names to highlight styles.
 /// Lookup uses longest prefix match so e.g. `"function.method"` matches `"function"`.

--- a/crates/zedra/src/editor/syntax_theme.rs
+++ b/crates/zedra/src/editor/syntax_theme.rs
@@ -1,34 +1,63 @@
 use gpui::HighlightStyle;
+use serde::{Deserialize, Serialize};
 
 /// Maps tree-sitter capture names to highlight styles.
 /// Lookup uses longest prefix match so e.g. `"function.method"` matches `"function"`.
+#[derive(Clone, Debug, PartialEq)]
 pub struct SyntaxTheme {
     styles: Vec<(String, HighlightStyle)>,
 }
 
 impl SyntaxTheme {
-    /// A dark theme inspired by One Dark.
-    pub fn default_dark() -> Self {
+    pub fn dark() -> Self {
         use gpui::rgb;
 
         let entries = vec![
-            ("keyword", rgb(0xc678dd)),     // purple
-            ("function", rgb(0x61afef)),    // blue
-            ("type", rgb(0xe5c07b)),        // yellow
-            ("string", rgb(0x98c379)),      // green
-            ("comment", rgb(0x5c6370)),     // gray
-            ("number", rgb(0xd19a66)),      // orange
-            ("constant", rgb(0xd19a66)),    // orange
-            ("property", rgb(0x56b6c2)),    // cyan
-            ("operator", rgb(0xc678dd)),    // purple
-            ("variable", rgb(0xabb2bf)),    // foreground
-            ("punctuation", rgb(0x636d83)), // dim gray
-            ("attribute", rgb(0xd19a66)),   // orange
-            ("label", rgb(0xe06c75)),       // red
-            ("constructor", rgb(0x61afef)), // blue
-            ("tag", rgb(0xe06c75)),         // red
+            ("keyword", rgb(0xc678dd)),
+            ("function", rgb(0x61afef)),
+            ("type", rgb(0xe5c07b)),
+            ("string", rgb(0x98c379)),
+            ("comment", rgb(0x5c6370)),
+            ("number", rgb(0xd19a66)),
+            ("constant", rgb(0xd19a66)),
+            ("property", rgb(0x56b6c2)),
+            ("operator", rgb(0xc678dd)),
+            ("variable", rgb(0xabb2bf)),
+            ("punctuation", rgb(0x636d83)),
+            ("attribute", rgb(0xd19a66)),
+            ("label", rgb(0xe06c75)),
+            ("constructor", rgb(0x61afef)),
+            ("tag", rgb(0xe06c75)),
         ];
 
+        Self::from_entries(entries)
+    }
+
+    pub fn light() -> Self {
+        use gpui::rgb;
+
+        let entries = vec![
+            ("keyword", rgb(0xcf222e)),
+            ("function", rgb(0x8250df)),
+            ("type", rgb(0x953800)),
+            ("string", rgb(0x0a3069)),
+            ("comment", rgb(0x6e7781)),
+            ("number", rgb(0x0550ae)),
+            ("constant", rgb(0x0550ae)),
+            ("property", rgb(0x116329)),
+            ("operator", rgb(0xcf222e)),
+            ("variable", rgb(0x24292f)),
+            ("punctuation", rgb(0x57606a)),
+            ("attribute", rgb(0x0550ae)),
+            ("label", rgb(0xcf222e)),
+            ("constructor", rgb(0x8250df)),
+            ("tag", rgb(0xcf222e)),
+        ];
+
+        Self::from_entries(entries)
+    }
+
+    fn from_entries(entries: Vec<(&str, gpui::Rgba)>) -> Self {
         let styles = entries
             .into_iter()
             .map(|(name, color)| {
@@ -68,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_prefix_match() {
-        let theme = SyntaxTheme::default_dark();
+        let theme = SyntaxTheme::dark();
         assert!(theme.get("keyword").is_some());
         assert!(theme.get("function").is_some());
         assert!(theme.get("function.method").is_some());

--- a/crates/zedra/src/file_explorer.rs
+++ b/crates/zedra/src/file_explorer.rs
@@ -729,9 +729,9 @@ impl FileExplorer {
         let entry_depth = entry.depth;
         let indent = entry_depth as f32 * 16.0;
         let text_color = if entry.is_dir {
-            rgb(0xffffff)
+            rgb(theme::text_primary(cx))
         } else {
-            rgb(0xcacaca)
+            rgb(theme::text_secondary(cx))
         };
         let index_path = entry.index_path.clone();
         let is_dir = entry.is_dir;
@@ -760,7 +760,7 @@ impl FileExplorer {
                         .flex_1()
                         .min_w_0()
                         .truncate()
-                        .text_color(rgb(theme::TEXT_MUTED))
+                        .text_color(rgb(theme::text_muted(cx)))
                         .text_size(px(theme::FONT_BODY))
                         .child(name),
                 )
@@ -769,7 +769,7 @@ impl FileExplorer {
 
         let icon_element: AnyElement = if loading {
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_BODY))
                 .child("...")
                 .into_any_element()
@@ -782,13 +782,13 @@ impl FileExplorer {
             svg()
                 .path(icon_path)
                 .size(icon_size)
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .into_any_element()
         } else {
             svg()
                 .path("icons/file.svg")
                 .size(px(theme::ICON_FILE))
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .into_any_element()
         };
 
@@ -836,7 +836,7 @@ impl FileExplorer {
                     .child(name),
             );
         if is_selected {
-            row = row.bg(hsla(0.0, 0.0, 1.0, 0.10));
+            row = row.bg(theme::row_pressed_bg(cx));
         }
         row.into_any_element()
     }

--- a/crates/zedra/src/home_view.rs
+++ b/crates/zedra/src/home_view.rs
@@ -273,12 +273,12 @@ impl Render for HomeView {
                 svg()
                     .path("icons/logo.svg")
                     .size(px(60.0))
-                    .text_color(rgb(theme::TEXT_PRIMARY))
+                    .text_color(rgb(theme::text_primary(cx)))
                     .mb(px(theme::SPACING_LG)),
             )
             .child(
                 div()
-                    .text_color(rgb(theme::TEXT_PRIMARY))
+                    .text_color(rgb(theme::text_primary(cx)))
                     .text_size(px(theme::FONT_APP_TITLE))
                     .font_family(fonts::HEADING_FONT_FAMILY)
                     .font_weight(FontWeight::EXTRA_BOLD)
@@ -288,7 +288,7 @@ impl Render for HomeView {
                 div()
                     .flex()
                     .items_center()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child("Code from anywhere. ")
                     .child(
@@ -305,7 +305,6 @@ impl Render for HomeView {
             )
             .mb(px(theme::SPACING_LG));
 
-        #[cfg(debug_assertions)]
         let settings_button = div()
             .id("home-settings-button")
             .absolute()
@@ -322,7 +321,7 @@ impl Render for HomeView {
                 svg()
                     .path("icons/settings.svg")
                     .size(px(theme::ICON_LG))
-                    .text_color(rgb(theme::TEXT_MUTED)),
+                    .text_color(rgb(theme::text_muted(cx))),
             );
 
         let mut content = div()
@@ -350,8 +349,8 @@ impl Render for HomeView {
 
                 let connect_phase = state.connect_phase.clone();
                 let status_color = match connect_phase.as_ref() {
-                    Some(p) => phase_indicator_color(p),
-                    None => theme::ACCENT_DIM,
+                    Some(p) => phase_indicator_color(&theme::palette(cx), p),
+                    None => theme::accent_dim(cx),
                 };
                 let status_label = match connect_phase.as_ref() {
                     Some(ConnectPhase::Connected) => "Connected",
@@ -393,7 +392,7 @@ impl Render for HomeView {
         }
 
         content = content.child(
-            outline_button("home-scan-qr", "Scan QR Code")
+            outline_button(cx, "home-scan-qr", "Scan QR Code")
                 .w(px(theme::HOME_CARD_WIDTH))
                 .on_press(cx.listener(|this, _event, _window, _cx| {
                     this.handle_scan_qr();
@@ -441,7 +440,7 @@ impl Render for HomeView {
             )
             .child(
                 div()
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_DETAIL))
                     .child(app_version_text()),
             );
@@ -450,16 +449,16 @@ impl Render for HomeView {
             .id("home-view")
             .track_focus(&self.focus_handle)
             .size_full()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .flex_col()
             .items_center()
             .justify_center();
 
-        #[cfg(debug_assertions)]
-        let root = root.child(settings_button);
-
-        root.child(header).child(content).child(footer)
+        root.child(settings_button)
+            .child(header)
+            .child(content)
+            .child(footer)
     }
 }
 
@@ -748,9 +747,9 @@ fn install_guide(selected_tab: GuideTab, cx: &mut Context<HomeView>) -> impl Int
                 .w_full()
                 .max_h(px(184.0))
                 .rounded(px(8.0))
-                .bg(rgb(theme::BG_CARD))
+                .bg(rgb(theme::bg_card(cx)))
                 .border_1()
-                .border_color(rgb(theme::BORDER_SUBTLE))
+                .border_color(rgb(theme::border_subtle(cx)))
                 .px(px(theme::SPACING_SM))
                 .pb(px(theme::SPACING_SM))
                 .child(tab_list)
@@ -773,9 +772,9 @@ fn guide_tab_button(
         .cursor_pointer()
         .border_b_1()
         .border_color(rgb(if selected {
-            theme::BORDER_HIGHLIGHT
+            theme::border_highlight(cx)
         } else {
-            theme::BG_CARD
+            theme::bg_card(cx)
         }))
         .hit_slop(px(10.0))
         .on_press(cx.listener(move |this, _event, _window, cx| {
@@ -786,9 +785,9 @@ fn guide_tab_button(
                 .path(spec.icon)
                 .size(px(spec.icon_size))
                 .text_color(rgb(if selected {
-                    theme::TEXT_SECONDARY
+                    theme::text_secondary(cx)
                 } else {
-                    theme::TEXT_MUTED
+                    theme::text_muted(cx)
                 })),
         )
 }
@@ -800,7 +799,7 @@ fn guide_line(
     line: &'static GuideLine,
     selection_order: u64,
     is_last_line: bool,
-    _cx: &mut Context<HomeView>,
+    cx: &mut Context<HomeView>,
 ) -> AnyElement {
     let text = StyledText::new(line.text)
         .selectable()
@@ -814,9 +813,9 @@ fn guide_line(
         )))
         .w_full()
         .text_color(rgb(if line.comment {
-            theme::TEXT_MUTED
+            theme::text_muted(cx)
         } else {
-            theme::TEXT_SECONDARY
+            theme::text_secondary(cx)
         }))
         .text_size(px(theme::FONT_DETAIL))
         .child(text);
@@ -850,9 +849,9 @@ fn workspace_card(
         .id(SharedString::from(format!("ws-card-{}", index)))
         .w_full()
         .rounded(px(8.0))
-        .bg(rgb(theme::BG_CARD))
+        .bg(rgb(theme::bg_card(cx)))
         .border_1()
-        .border_color(rgb(theme::BORDER_SUBTLE))
+        .border_color(rgb(theme::border_subtle(cx)))
         .p(px(12.0))
         .cursor_pointer()
         .on_press(cx.listener(move |this, _event, window, cx| {
@@ -872,11 +871,12 @@ fn workspace_card(
                 .child(ConnectionStatusIndicator::from_phase(
                     ("home-connect-status", index),
                     connect_phase.as_ref(),
+                    &theme::palette(cx),
                 ))
                 .child(
                     div()
                         .flex_1()
-                        .text_color(rgb(theme::TEXT_PRIMARY))
+                        .text_color(rgb(theme::text_primary(cx)))
                         .text_size(px(theme::FONT_BODY))
                         .font_weight(FontWeight::MEDIUM)
                         .child(project_name),
@@ -894,7 +894,7 @@ fn workspace_card(
             Some(
                 div()
                     .mt(px(4.0))
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_DETAIL))
                     .text_overflow(TextOverflow::Truncate(SharedString::new("...")))
                     .child(subtitle),
@@ -923,6 +923,6 @@ fn social_button(
             svg()
                 .path(icon)
                 .size(px(size))
-                .text_color(rgb(theme::TEXT_MUTED)),
+                .text_color(rgb(theme::text_muted(cx))),
         )
 }

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -6,7 +6,7 @@ use crate::deeplink;
 use crate::platform_bridge::{
     self, AlertButton, AlertButtonStyle, CustomSheetOptions, HapticFeedback,
     NativeDictationPreviewOptions, NativeEditMenuItem, NativeFloatingButtonOptions,
-    NativeNotificationOptions, PlatformBridge,
+    NativeNotificationOptions, PlatformBridge, SystemTheme,
 };
 
 /// Screen scale factor (e.g. 3.0 for @3x), stored as f32 bits.
@@ -157,6 +157,10 @@ unsafe extern "C" {
         placeholder: *const std::ffi::c_char,
         initial_value: *const std::ffi::c_char,
     );
+    /// Returns 1 for dark, 0 for light, -1 when unavailable.
+    fn ios_system_prefers_dark_theme() -> i32;
+    /// Apply the app appearance to the native keyboard accessory bar.
+    fn ios_set_keyboard_accessory_theme(is_dark: bool);
 }
 
 impl PlatformBridge for IosBridge {
@@ -444,6 +448,20 @@ impl PlatformBridge for IosBridge {
                 placeholder.as_ptr(),
                 initial_value.as_ptr(),
             );
+        }
+    }
+
+    fn system_prefers_theme(&self) -> SystemTheme {
+        match unsafe { ios_system_prefers_dark_theme() } {
+            1 => SystemTheme::Dark,
+            0 => SystemTheme::Light,
+            _ => SystemTheme::Unknown,
+        }
+    }
+
+    fn set_keyboard_accessory_theme(&self, is_dark: bool) {
+        unsafe {
+            ios_set_keyboard_accessory_theme(is_dark);
         }
     }
 }

--- a/crates/zedra/src/ios_stub.c
+++ b/crates/zedra/src/ios_stub.c
@@ -79,6 +79,8 @@ __attribute__((weak)) void ios_present_text_input(
     const char *title,
     const char *placeholder,
     const char *initial_value) {}
+__attribute__((weak)) int ios_system_prefers_dark_theme(void) { return -1; }
+__attribute__((weak)) void ios_set_keyboard_accessory_theme(_Bool is_dark) {}
 
 // Firebase Analytics + Crashlytics stubs.
 // Real implementations live in ios/Zedra/ZedraFirebase.m and override at Xcode link time.

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -16,6 +16,7 @@ pub mod editor;
 pub mod fonts;
 pub mod placeholder;
 pub mod theme;
+pub mod theme_state;
 pub mod ui;
 
 // Sceens

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -15,8 +15,8 @@ pub mod docs_tree;
 pub mod editor;
 pub mod fonts;
 pub mod placeholder;
+pub mod settings;
 pub mod theme;
-pub mod theme_state;
 pub mod ui;
 
 // Sceens

--- a/crates/zedra/src/placeholder.rs
+++ b/crates/zedra/src/placeholder.rs
@@ -2,7 +2,7 @@ use gpui::*;
 
 use crate::theme;
 
-pub fn render_placeholder(message: impl Into<String>) -> Div {
+pub fn render_placeholder(cx: &App, message: impl Into<String>) -> Div {
     div()
         .size_full()
         .flex()
@@ -13,7 +13,7 @@ pub fn render_placeholder(message: impl Into<String>) -> Div {
             div()
                 // Magic! It's more balance with this
                 .top(px(-32.0))
-                .text_color(rgb(theme::TEXT_SECONDARY))
+                .text_color(rgb(theme::text_secondary(cx)))
                 .text_size(px(theme::FONT_BODY))
                 .text_align(TextAlign::Center)
                 .child(message.into()),

--- a/crates/zedra/src/platform_bridge.rs
+++ b/crates/zedra/src/platform_bridge.rs
@@ -609,6 +609,14 @@ pub fn trigger_haptic(feedback: HapticFeedback) {
     bridge().trigger_haptic(feedback);
 }
 
+/// OS color scheme reported by the platform bridge.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SystemTheme {
+    Dark,
+    Light,
+    Unknown,
+}
+
 // ---------------------------------------------------------------------------
 // PlatformBridge trait
 // ---------------------------------------------------------------------------
@@ -671,6 +679,10 @@ pub trait PlatformBridge: Send + Sync + 'static {
     /// The platform should call `dispatch_text_input_result(id, value)` on confirm,
     /// or `dispatch_text_input_dismiss(id)` on cancel.
     fn present_text_input(&self, _id: u32, _title: &str, _placeholder: &str, _initial_value: &str) {
+    }
+    /// OS appearance: `dark`, `light`, or `unknown` when unavailable.
+    fn system_prefers_theme(&self) -> SystemTheme {
+        SystemTheme::Unknown
     }
 }
 

--- a/crates/zedra/src/platform_bridge.rs
+++ b/crates/zedra/src/platform_bridge.rs
@@ -684,6 +684,8 @@ pub trait PlatformBridge: Send + Sync + 'static {
     fn system_prefers_theme(&self) -> SystemTheme {
         SystemTheme::Unknown
     }
+    /// Sync native keyboard accessory chrome with the selected app appearance.
+    fn set_keyboard_accessory_theme(&self, _is_dark: bool) {}
 }
 
 static BRIDGE: OnceLock<Box<dyn PlatformBridge>> = OnceLock::new();

--- a/crates/zedra/src/quick_action_panel.rs
+++ b/crates/zedra/src/quick_action_panel.rs
@@ -108,9 +108,9 @@ impl Render for QuickActionPanel {
         let panel = div()
             .w_full()
             .h(viewport_h)
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .border_l_1()
-            .border_color(rgb(theme::BORDER_SUBTLE))
+            .border_color(rgb(theme::border_subtle(cx)))
             .flex()
             .flex_col()
             .child(div().h(px(top_inset)))
@@ -121,7 +121,7 @@ impl Render for QuickActionPanel {
                     .flex_row()
                     .items_center()
                     .border_b_1()
-                    .border_color(rgb(theme::BORDER_SUBTLE))
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .child(
                         div()
                             .id("quick-action-home-icon")
@@ -141,13 +141,13 @@ impl Render for QuickActionPanel {
                                 svg()
                                     .path("icons/logo.svg")
                                     .size(px(theme::ICON_LOGO))
-                                    .text_color(rgb(theme::TEXT_SECONDARY)),
+                                    .text_color(rgb(theme::text_secondary(cx))),
                             ),
                     )
                     .child(
                         div().flex_1().flex().flex_col().child(
                             div()
-                                .text_color(rgb(theme::TEXT_SECONDARY))
+                                .text_color(rgb(theme::text_secondary(cx)))
                                 .text_size(px(theme::FONT_BODY))
                                 .text_center()
                                 .font_weight(FontWeight::MEDIUM)
@@ -172,7 +172,7 @@ impl Render for QuickActionPanel {
                                 svg()
                                     .path("icons/x.svg")
                                     .size(px(16.0))
-                                    .text_color(rgb(theme::TEXT_SECONDARY)),
+                                    .text_color(rgb(theme::text_secondary(cx))),
                             ),
                     ),
             );
@@ -225,11 +225,12 @@ impl Render for QuickActionPanel {
                                     .child(ConnectionStatusIndicator::from_phase(
                                         ("quick-action-connect-status", index),
                                         connect_phase.as_ref(),
+                                        &theme::palette(cx),
                                     ))
                                     .child(
                                         div()
                                             .flex_1()
-                                            .text_color(rgb(theme::TEXT_PRIMARY))
+                                            .text_color(rgb(theme::text_primary(cx)))
                                             .text_size(px(theme::FONT_BODY))
                                             .font_weight(FontWeight::MEDIUM)
                                             .min_w_0()
@@ -239,7 +240,7 @@ impl Render for QuickActionPanel {
                             )
                             .child(
                                 div()
-                                    .text_color(rgb(theme::TEXT_MUTED))
+                                    .text_color(rgb(theme::text_muted(cx)))
                                     .text_size(px(theme::FONT_BODY))
                                     .min_w_0()
                                     .truncate()
@@ -269,7 +270,7 @@ impl Render for QuickActionPanel {
                                 svg()
                                     .path("icons/plus.svg")
                                     .size(px(16.0))
-                                    .text_color(rgb(theme::TEXT_MUTED)),
+                                    .text_color(rgb(theme::text_muted(cx))),
                             ),
                     ),
             );
@@ -291,22 +292,23 @@ impl Render for QuickActionPanel {
                         this.handle_terminal_delete(index, tid_del.clone(), cx);
                     }));
 
-                    let card = render_terminal_card(TerminalCardProps {
-                        id: format!("{}-{}", index, tid),
-                        index: i + 1,
-                        is_active,
-                        title: meta.title,
-                        cwd: meta.cwd,
-                        agent_icon: meta.agent_icon,
-                        shell_state: meta.shell_state,
-                        last_exit_code: meta.last_exit_code,
-                        on_close: Some(on_close),
-                    })
-                    .on_press(cx.listener(
-                        move |this, _event, _window, cx| {
-                            this.handle_switch_terminal(index, tid_click.clone(), cx);
+                    let card = render_terminal_card(
+                        cx,
+                        TerminalCardProps {
+                            id: format!("{}-{}", index, tid),
+                            index: i + 1,
+                            is_active,
+                            title: meta.title,
+                            cwd: meta.cwd,
+                            agent_icon: meta.agent_icon,
+                            shell_state: meta.shell_state,
+                            last_exit_code: meta.last_exit_code,
+                            on_close: Some(on_close),
                         },
-                    ));
+                    )
+                    .on_press(cx.listener(move |this, _event, _window, cx| {
+                        this.handle_switch_terminal(index, tid_click.clone(), cx);
+                    }));
 
                     content = content.child(card);
                 }
@@ -317,7 +319,7 @@ impl Render for QuickActionPanel {
                     .h(px(1.0))
                     .mx(px(16.0))
                     .mt(px(6.0))
-                    .bg(rgb(theme::BORDER_SUBTLE)),
+                    .bg(rgb(theme::border_subtle(cx))),
             );
         }
 
@@ -326,14 +328,14 @@ impl Render for QuickActionPanel {
                 div()
                     .px(px(16.0))
                     .py(px(16.0))
-                    .text_color(rgb(theme::TEXT_MUTED))
+                    .text_color(rgb(theme::text_muted(cx)))
                     .text_size(px(theme::FONT_BODY))
                     .child("No active workspaces"),
             );
         }
 
         content = content.child(
-            crate::button::outline_button("quick-action-scan-qr", "Scan QR Code")
+            crate::button::outline_button(cx, "quick-action-scan-qr", "Scan QR Code")
                 .mx(px(16.0))
                 .mt(px(12.0))
                 .on_press(cx.listener(|this, _event, _window, cx| {

--- a/crates/zedra/src/session_panel.rs
+++ b/crates/zedra/src/session_panel.rs
@@ -51,7 +51,7 @@ impl Render for SessionPanel {
                 .flex()
                 .items_center()
                 .justify_center()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_BODY))
                 .child("No active session");
         }
@@ -63,35 +63,36 @@ impl Render for SessionPanel {
 
         if !snap.username.is_empty() && !snap.hostname.is_empty() {
             let host = format!("{}@{}", snap.username, snap.hostname);
-            info = info.child(info_row("Host", host));
+            info = info.child(info_row(cx, "Host", host));
         }
 
         if let Some(os) = snap.os_version.as_deref()
             && let Some(arch) = snap.arch.as_deref()
         {
             let platform = format!("{} / {}", os, arch,);
-            info = info.child(info_row("Platform", platform));
+            info = info.child(info_row(cx, "Platform", platform));
         }
 
         if let Some(host_info) = host_info.as_ref() {
-            info = info.child(render_host_info(host_info));
+            info = info.child(render_host_info(cx, host_info));
         }
 
         if !snap.strip_path.is_empty() {
-            info = info.child(info_row("Directory", snap.strip_path.clone()));
+            info = info.child(info_row(cx, "Directory", snap.strip_path.clone()));
         }
 
         if let Some(alpn) = snap.alpn.clone() {
-            info = info.child(info_row("Protocol", alpn));
+            info = info.child(info_row(cx, "Protocol", alpn));
         }
 
         if let Some(version) = snap.host_version.as_deref() {
             let daemon_version = format!("v{}", version);
-            info = info.child(info_row("Daemon version", daemon_version));
+            info = info.child(info_row(cx, "Daemon version", daemon_version));
         }
 
         // --- Connection badge ---
-        let (badge_label, badge_color) = transport_badge(&phase, snap.transport.as_ref());
+        let (badge_label, badge_color) =
+            transport_badge(&theme::palette(cx), &phase, snap.transport.as_ref());
         info = info.child(
             div()
                 .id("session-connection-section")
@@ -116,7 +117,7 @@ impl Render for SessionPanel {
                         .flex_col()
                         .child(
                             div()
-                                .text_color(rgb(theme::TEXT_MUTED))
+                                .text_color(rgb(theme::text_muted(cx)))
                                 .text_size(px(theme::FONT_DETAIL))
                                 .child("Connection"),
                         )
@@ -132,7 +133,7 @@ impl Render for SessionPanel {
                         svg()
                             .path("icons/chevron-right.svg")
                             .size(px(theme::ICON_SM))
-                            .text_color(rgb(theme::TEXT_MUTED)),
+                            .text_color(rgb(theme::text_muted(cx))),
                     ),
                 ),
         );
@@ -140,9 +141,10 @@ impl Render for SessionPanel {
         // --- Transport details ---
         if let Some(t) = &snap.transport {
             let remote_addr_label = format!("{} ({})", t.remote_addr, t.num_paths);
-            info = info.child(info_row("Remote Address", remote_addr_label));
+            info = info.child(info_row(cx, "Remote Address", remote_addr_label));
 
             info = info.child(info_row(
+                cx,
                 "Data",
                 format!(
                     "{} sent / {} recv",
@@ -154,11 +156,11 @@ impl Render for SessionPanel {
 
         // --- Session section ---
         if let Some(sid) = &snap.session_id {
-            info = info.child(info_row("Session ID", sid.clone()));
+            info = info.child(info_row(cx, "Session ID", sid.clone()));
         }
 
         // --- Phase timing section ---
-        info = info.child(render_timing(&snap));
+        info = info.child(render_timing(cx, &snap));
 
         // --- Disconnect button ---
         let disconnect_button = div()
@@ -168,8 +170,8 @@ impl Render for SessionPanel {
             .py(px(8.0))
             .rounded(px(6.0))
             .border_1()
-            .border_color(rgb(theme::ACCENT_RED))
-            .text_color(rgb(theme::ACCENT_RED))
+            .border_color(rgb(theme::accent_red(cx)))
+            .text_color(rgb(theme::accent_red(cx)))
             .text_size(px(theme::FONT_BODY))
             .cursor_pointer()
             .on_press(cx.listener(|_this, _event, window, cx| {
@@ -181,7 +183,7 @@ impl Render for SessionPanel {
     }
 }
 
-fn render_host_info(host_info: &HostInfoSnapshot) -> Div {
+fn render_host_info(cx: &App, host_info: &HostInfoSnapshot) -> Div {
     let mut parts = vec![
         format!("CPU {:.0}%", host_info.cpu_usage_percent),
         format!(
@@ -194,7 +196,7 @@ fn render_host_info(host_info: &HostInfoSnapshot) -> Div {
         parts.push(format!("Batteries {batteries}"));
     }
 
-    info_row("System Stats", parts.join(" \u{00b7} "))
+    info_row(cx, "System Stats", parts.join(" \u{00b7} "))
 }
 
 fn format_percent(used: u64, total: u64) -> String {
@@ -222,7 +224,7 @@ fn format_batteries(batteries: &[HostBatteryInfo]) -> Option<String> {
 }
 
 /// Render phase timing summary row.
-fn render_timing(snap: &zedra_session::ConnectSnapshot) -> Div {
+fn render_timing(cx: &App, snap: &zedra_session::ConnectSnapshot) -> Div {
     let mut timing_parts: Vec<String> = Vec::new();
     if let Some(ms) = snap.binding_ms {
         timing_parts.push(format!("Bind {ms}ms"));
@@ -249,40 +251,40 @@ fn render_timing(snap: &zedra_session::ConnectSnapshot) -> Div {
         return div();
     }
 
-    muted_info_row("Timing", timing_parts.join(" \u{00b7} "))
+    muted_info_row(cx, "Timing", timing_parts.join(" \u{00b7} "))
 }
 
-fn info_row(label: &'static str, value: String) -> Div {
+fn info_row(cx: &App, label: &'static str, value: String) -> Div {
     div()
         .py(px(4.0))
         .child(
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(label),
         )
         .child(
             div()
                 .mt(px(1.0))
-                .text_color(rgb(theme::TEXT_SECONDARY))
+                .text_color(rgb(theme::text_secondary(cx)))
                 .text_size(px(theme::FONT_BODY))
                 .child(value),
         )
 }
 
-fn muted_info_row(label: &'static str, value: String) -> Div {
+fn muted_info_row(cx: &App, label: &'static str, value: String) -> Div {
     div()
         .py(px(4.0))
         .child(
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(label),
         )
         .child(
             div()
                 .mt(px(1.0))
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_BODY))
                 .child(value),
         )

--- a/crates/zedra/src/settings.rs
+++ b/crates/zedra/src/settings.rs
@@ -11,8 +11,9 @@ const SETTINGS_FILE: &str = "settings.json";
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 struct AppSettings {
-    #[serde(default)]
-    theme_preference: ThemePreference,
+    /// Set when the user picks a theme in Settings; `None` follows the system on next launch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    theme_preference: Option<ThemePreference>,
 }
 
 pub enum ThemeStateEvent {
@@ -62,19 +63,29 @@ impl ThemeState {
 
     fn load_preference() -> ThemePreference {
         match read_settings() {
-            Ok(settings) => settings.theme_preference,
+            Ok(settings) => settings
+                .theme_preference
+                .unwrap_or_else(Self::preference_from_system),
             Err(err) => {
-                debug!(err = %err, "theme: using default preference");
-                ThemePreference::default()
+                debug!(err = %err, "settings: using system theme preference");
+                Self::preference_from_system()
             }
+        }
+    }
+
+    pub(crate) fn preference_from_system() -> ThemePreference {
+        match crate::platform_bridge::bridge().system_prefers_theme() {
+            crate::platform_bridge::SystemTheme::Dark => ThemePreference::Dark,
+            crate::platform_bridge::SystemTheme::Light => ThemePreference::Light,
+            crate::platform_bridge::SystemTheme::Unknown => ThemePreference::default(),
         }
     }
 
     fn save_preference(preference: ThemePreference) {
         let mut settings = read_settings().unwrap_or_default();
-        settings.theme_preference = preference;
+        settings.theme_preference = Some(preference);
         if let Err(err) = write_settings(&settings) {
-            warn!(err = %err, "theme: failed to save preference");
+            warn!(err = %err, "settings: failed to save theme preference");
         }
     }
 }
@@ -84,19 +95,19 @@ pub struct ThemeStateHandle(WeakEntity<ThemeState>);
 
 impl Global for ThemeStateHandle {}
 
-pub fn entity(cx: &App) -> Option<Entity<ThemeState>> {
+pub fn theme_state(cx: &App) -> Option<Entity<ThemeState>> {
     cx.try_global::<ThemeStateHandle>()
         .and_then(|handle| handle.0.upgrade())
 }
 
 pub fn palette(cx: &App) -> crate::theme::ThemePalette {
-    entity(cx)
+    theme_state(cx)
         .map(|theme| theme.read(cx).palette().clone())
         .unwrap_or_else(|| ThemeBundle::dark().ui)
 }
 
 pub fn bundle(cx: &App) -> ThemeBundle {
-    entity(cx)
+    theme_state(cx)
         .map(|theme| theme.read(cx).bundle().clone())
         .unwrap_or_else(ThemeBundle::dark)
 }
@@ -132,11 +143,18 @@ fn write_settings(settings: &AppSettings) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
+    use super::ThemeState;
     use crate::theme::{ThemeBundle, ThemePalette, ThemePreference};
 
     #[test]
     fn default_preference_is_dark() {
         assert_eq!(ThemePreference::default(), ThemePreference::Dark);
+    }
+
+    #[test]
+    fn preference_from_system_falls_back_to_dark_when_unknown() {
+        // StubBridge returns Unknown for system_prefers_theme.
+        assert_eq!(ThemeState::preference_from_system(), ThemePreference::Dark);
     }
 
     #[test]

--- a/crates/zedra/src/settings.rs
+++ b/crates/zedra/src/settings.rs
@@ -31,6 +31,7 @@ impl ThemeState {
     pub fn new(_cx: &mut Context<Self>) -> Self {
         let preference = Self::load_preference();
         let bundle = ThemeBundle::for_preference(preference);
+        Self::sync_native_theme(preference);
         Self { preference, bundle }
     }
 
@@ -52,6 +53,7 @@ impl ThemeState {
         }
         self.preference = preference;
         self.bundle = ThemeBundle::for_preference(preference);
+        Self::sync_native_theme(preference);
         Self::save_preference(preference);
         cx.emit(ThemeStateEvent::Changed);
         cx.notify();
@@ -87,6 +89,11 @@ impl ThemeState {
         if let Err(err) = write_settings(&settings) {
             warn!(err = %err, "settings: failed to save theme preference");
         }
+    }
+
+    fn sync_native_theme(preference: ThemePreference) {
+        crate::platform_bridge::bridge()
+            .set_keyboard_accessory_theme(preference == ThemePreference::Dark);
     }
 }
 

--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -5,10 +5,10 @@ use crate::platform_bridge::{
     self, AlertButton, CustomSheetDetent, CustomSheetOptions, HapticFeedback,
     NativeNotificationKind, NativeNotificationOptions,
 };
+use crate::settings::ThemeState;
 use crate::sheet_demo_state::SheetDemoState;
 use crate::telemetry::view_telemetry;
 use crate::theme::{self, ThemePreference};
-use crate::theme_state::ThemeState;
 
 #[derive(Clone, Debug)]
 pub enum SettingsEvent {
@@ -138,6 +138,8 @@ impl Render for SettingsView {
             .id("settings-view")
             .track_focus(&self.focus_handle)
             .size_full()
+            .min_h_0()
+            .min_w_0()
             .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .flex_col()
@@ -201,49 +203,16 @@ impl Render for SettingsView {
                             .flex_col()
                             .gap(px(theme::SPACING_MD))
                             .child(section_header(cx, "Appearance"))
-                            .child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(px(8.0))
-                                    .child(
-                                        div()
-                                            .text_color(rgb(theme::text_secondary(cx)))
-                                            .text_size(px(theme::FONT_BODY))
-                                            .font_family(fonts::MONO_FONT_FAMILY)
-                                            .child("Theme"),
-                                    )
-                                    .child(
-                                        div()
-                                            .flex()
-                                            .flex_row()
-                                            .gap(px(8.0))
-                                            .child(theme_option_button(
-                                                cx,
-                                                "settings-theme-dark",
-                                                ThemePreference::Dark,
-                                                preference == ThemePreference::Dark,
-                                                cx.listener(|this, _event, _window, cx| {
-                                                    this.set_theme_preference(
-                                                        ThemePreference::Dark,
-                                                        cx,
-                                                    );
-                                                }),
-                                            ))
-                                            .child(theme_option_button(
-                                                cx,
-                                                "settings-theme-light",
-                                                ThemePreference::Light,
-                                                preference == ThemePreference::Light,
-                                                cx.listener(|this, _event, _window, cx| {
-                                                    this.set_theme_preference(
-                                                        ThemePreference::Light,
-                                                        cx,
-                                                    );
-                                                }),
-                                            )),
-                                    ),
-                            )
+                            .child(appearance_theme_toggle(
+                                cx,
+                                preference,
+                                cx.listener(|this, _event, _window, cx| {
+                                    this.set_theme_preference(ThemePreference::Dark, cx);
+                                }),
+                                cx.listener(|this, _event, _window, cx| {
+                                    this.set_theme_preference(ThemePreference::Light, cx);
+                                }),
+                            ))
                             .child(
                                 div()
                                     .text_color(rgb(theme::text_muted(cx)))
@@ -329,42 +298,106 @@ fn section_header(cx: &App, title: &'static str) -> Div {
         )
 }
 
-fn theme_option_button(
+/// Settings row with a compact segmented appearance control.
+fn appearance_theme_toggle(
+    cx: &App,
+    preference: ThemePreference,
+    on_dark: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+    on_light: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    let is_dark = preference == ThemePreference::Dark;
+
+    div()
+        .id("settings-appearance-toggle")
+        .w_full()
+        .min_w_0()
+        .min_h(px(32.0))
+        .py(px(2.0))
+        .flex()
+        .flex_row()
+        .items_center()
+        .justify_between()
+        .gap(px(theme::SPACING_MD))
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .flex()
+                .flex_row()
+                .items_center()
+                .child(
+                    div()
+                        .text_color(rgb(theme::text_secondary(cx)))
+                        .text_size(px(theme::FONT_BODY))
+                        .font_family(fonts::MONO_FONT_FAMILY)
+                        .font_weight(FontWeight::MEDIUM)
+                        .child("Theme"),
+                ),
+        )
+        .child(
+            div()
+                .flex_none()
+                .rounded(px(8.0))
+                .border_1()
+                .border_color(rgb(theme::border_default(cx)))
+                .bg(rgb(theme::bg_surface(cx)))
+                .flex()
+                .flex_row()
+                .child(theme_toggle_segment(
+                    cx,
+                    "settings-theme-dark",
+                    "icons/moon.svg",
+                    is_dark,
+                    on_dark,
+                ))
+                .child(
+                    div()
+                        .w(px(1.0))
+                        .h(px(22.0))
+                        .bg(rgb(theme::border_subtle(cx))),
+                )
+                .child(theme_toggle_segment(
+                    cx,
+                    "settings-theme-light",
+                    "icons/sun.svg",
+                    !is_dark,
+                    on_light,
+                )),
+        )
+}
+
+fn theme_toggle_segment(
     cx: &App,
     id: &'static str,
-    preference: ThemePreference,
+    icon_path: &'static str,
     selected: bool,
     on_press: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
 ) -> Stateful<Div> {
-    div()
+    let mut segment = div()
         .id(id)
-        .flex_1()
-        .h(px(36.0))
+        .min_w(px(42.0))
+        .h(px(24.0))
         .flex()
         .items_center()
         .justify_center()
-        .rounded(px(8.0))
-        .border_1()
-        .border_color(rgb(if selected {
-            theme::border_highlight(cx)
-        } else {
-            theme::border_default(cx)
-        }))
-        .bg(rgb(if selected {
-            theme::bg_card(cx)
-        } else {
-            theme::bg_primary(cx)
-        }))
         .cursor_pointer()
-        .text_color(rgb(if selected {
-            theme::text_primary(cx)
-        } else {
-            theme::text_secondary(cx)
-        }))
-        .text_size(px(theme::FONT_BODY))
-        .font_family(fonts::MONO_FONT_FAMILY)
-        .on_press(on_press)
-        .child(preference.label())
+        .hit_slop(px(6.0))
+        .on_press(on_press);
+
+    if selected {
+        segment = segment.bg(rgb(theme::bg_card(cx)));
+    }
+
+    segment.child(
+        svg()
+            .path(icon_path)
+            .size(px(theme::ICON_XS))
+            .text_color(rgb(if selected {
+                theme::text_primary(cx)
+            } else {
+                theme::text_muted(cx)
+            })),
+    )
 }
 
 fn action_row(

--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -1,4 +1,4 @@
-use gpui::*;
+use gpui::{prelude::FluentBuilder as _, *};
 
 use crate::fonts;
 use crate::platform_bridge::{
@@ -7,7 +7,8 @@ use crate::platform_bridge::{
 };
 use crate::sheet_demo_state::SheetDemoState;
 use crate::telemetry::view_telemetry;
-use crate::theme;
+use crate::theme::{self, ThemePreference};
+use crate::theme_state::ThemeState;
 
 #[derive(Clone, Debug)]
 pub enum SettingsEvent {
@@ -18,20 +19,29 @@ impl EventEmitter<SettingsEvent> for SettingsView {}
 
 pub struct SettingsView {
     focus_handle: FocusHandle,
+    theme_state: Entity<ThemeState>,
     sheet_state: Entity<SheetDemoState>,
     sheet_view: Entity<crate::sheet_demo_view::SheetDemoView>,
 }
 
 impl SettingsView {
-    pub fn new(cx: &mut Context<Self>) -> Self {
+    pub fn new(theme_state: Entity<ThemeState>, cx: &mut Context<Self>) -> Self {
         let sheet_state = cx.new(|cx| SheetDemoState::new(cx));
         let sheet_view =
             cx.new(|cx| crate::sheet_demo_view::SheetDemoView::new(sheet_state.clone(), cx));
         Self {
             focus_handle: cx.focus_handle(),
+            theme_state,
             sheet_state,
             sheet_view,
         }
+    }
+
+    fn set_theme_preference(&self, preference: ThemePreference, cx: &mut Context<Self>) {
+        platform_bridge::trigger_haptic(HapticFeedback::SelectionChanged);
+        self.theme_state.update(cx, |state, cx| {
+            state.set_preference(preference, cx);
+        });
     }
 
     fn show_test_alert(&self) {
@@ -122,12 +132,13 @@ impl Render for SettingsView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let top_inset = platform_bridge::status_bar_inset();
         let bottom_inset = platform_bridge::home_indicator_inset();
+        let preference = self.theme_state.read(cx).preference();
 
         div()
             .id("settings-view")
             .track_focus(&self.focus_handle)
             .size_full()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .flex_col()
             .child(
@@ -141,6 +152,7 @@ impl Render for SettingsView {
                     .items_center()
                     .justify_between()
                     .border_b_1()
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .child(
                         div()
                             .flex()
@@ -159,24 +171,17 @@ impl Render for SettingsView {
                                         svg()
                                             .path("icons/chevron-left.svg")
                                             .size(px(theme::ICON_SM))
-                                            .text_color(rgb(theme::TEXT_MUTED))
-                                            .into_any_element()
-                                    )
+                                            .text_color(rgb(theme::text_muted(cx)))
+                                            .into_any_element(),
+                                    ),
                             )
                             .child(
                                 div()
-                                    .flex()
-                                    .flex_row()
-                                    .items_center()
-                                    .gap(px(8.0))
-                                    .child(
-                                        div()
-                                            .text_color(rgb(theme::TEXT_PRIMARY))
-                                            .text_size(px(theme::FONT_TITLE))
-                                            .font_family(fonts::HEADING_FONT_FAMILY)
-                                            .font_weight(FontWeight::MEDIUM)
-                                            .child("Settings"),
-                                    )
+                                    .text_color(rgb(theme::text_primary(cx)))
+                                    .text_size(px(theme::FONT_TITLE))
+                                    .font_family(fonts::HEADING_FONT_FAMILY)
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .child("Settings"),
                             ),
                     ),
             )
@@ -194,95 +199,180 @@ impl Render for SettingsView {
                             .mx_auto()
                             .flex()
                             .flex_col()
+                            .gap(px(theme::SPACING_MD))
+                            .child(section_header(cx, "Appearance"))
                             .child(
                                 div()
-                                    .pt(px(12.0))
-                                    .pb(px(10.0))
-                                    .border_b_1()
-                                    .border_color(rgb(theme::BORDER_SUBTLE))
                                     .flex()
                                     .flex_col()
-                                    .gap(px(4.0))
+                                    .gap(px(8.0))
                                     .child(
                                         div()
-                                            .text_color(rgb(theme::TEXT_PRIMARY))
-                                            .text_size(px(theme::FONT_HEADING))
+                                            .text_color(rgb(theme::text_secondary(cx)))
+                                            .text_size(px(theme::FONT_BODY))
                                             .font_family(fonts::MONO_FONT_FAMILY)
-                                            .font_weight(FontWeight::MEDIUM)
-                                            .child("Developer"),
+                                            .child("Theme"),
                                     )
+                                    .child(
+                                        div()
+                                            .flex()
+                                            .flex_row()
+                                            .gap(px(8.0))
+                                            .child(theme_option_button(
+                                                cx,
+                                                "settings-theme-dark",
+                                                ThemePreference::Dark,
+                                                preference == ThemePreference::Dark,
+                                                cx.listener(|this, _event, _window, cx| {
+                                                    this.set_theme_preference(
+                                                        ThemePreference::Dark,
+                                                        cx,
+                                                    );
+                                                }),
+                                            ))
+                                            .child(theme_option_button(
+                                                cx,
+                                                "settings-theme-light",
+                                                ThemePreference::Light,
+                                                preference == ThemePreference::Light,
+                                                cx.listener(|this, _event, _window, cx| {
+                                                    this.set_theme_preference(
+                                                        ThemePreference::Light,
+                                                        cx,
+                                                    );
+                                                }),
+                                            )),
+                                    ),
                             )
-                            .child(
-                                action_row(
-                                    "settings-test-alert",
-                                    "Native Alert",
-                                    "Native confirmation/failure prompts",
-                                )
-                                .on_press(cx.listener(|this, _event, _window, _cx| {
-                                    this.show_test_alert();
-                                })),
-                            )
-                            .child(
-                                action_row(
-                                    "settings-test-selection",
-                                    "Native Selection",
-                                    "Action sheet selection and behavior",
-                                )
-                                .on_press(cx.listener(|this, _event, _window, _cx| {
-                                    this.show_test_selection();
-                                })),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .w_full()
-                            .max_w(px(520.0))
-                            .mx_auto()
-                            .child(
-                                action_row(
-                                    "settings-test-native-notification",
-                                    "Native Notification",
-                                    "In-app glass banner presentation",
-                                )
-                                .on_press(cx.listener(|this, _event, _window, _cx| {
-                                    this.show_test_native_notification();
-                                })),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .w_full()
-                            .max_w(px(520.0))
-                            .mx_auto()
-                            .child(
-                                action_row(
-                                    "settings-test-custom-sheet",
-                                    "Custom Sheet",
-                                    "Native sheet with GPUI-rendered content",
-                                )
-                                .on_press(cx.listener(|this, _event, _window, cx| {
-                                    this.show_test_custom_sheet(cx);
-                                })),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .w_full()
-                            .max_w(px(520.0))
-                            .mx_auto()
                             .child(
                                 div()
-                                    .text_color(rgb(theme::TEXT_MUTED))
+                                    .text_color(rgb(theme::text_muted(cx)))
                                     .text_size(px(theme::FONT_DETAIL))
                                     .font_family(fonts::MONO_FONT_FAMILY)
-                                    .child("QR scanner and dictation preview remain separate native flows."),
-                            ),
+                                    .child("Custom themes will be supported in a future update."),
+                            )
+                            .when(cfg!(debug_assertions), |section| {
+                                section
+                                    .child(section_header(cx, "Developer"))
+                                    .child(
+                                        action_row(
+                                            cx,
+                                            "settings-test-alert",
+                                            "Native Alert",
+                                            "Native confirmation/failure prompts",
+                                        )
+                                        .on_press(cx.listener(|this, _event, _window, _cx| {
+                                            this.show_test_alert();
+                                        })),
+                                    )
+                                    .child(
+                                        action_row(
+                                            cx,
+                                            "settings-test-selection",
+                                            "Native Selection",
+                                            "Action sheet selection and behavior",
+                                        )
+                                        .on_press(cx.listener(|this, _event, _window, _cx| {
+                                            this.show_test_selection();
+                                        })),
+                                    )
+                                    .child(
+                                        action_row(
+                                            cx,
+                                            "settings-test-native-notification",
+                                            "Native Notification",
+                                            "In-app glass banner presentation",
+                                        )
+                                        .on_press(cx.listener(|this, _event, _window, _cx| {
+                                            this.show_test_native_notification();
+                                        })),
+                                    )
+                                    .child(
+                                        action_row(
+                                            cx,
+                                            "settings-test-custom-sheet",
+                                            "Custom Sheet",
+                                            "Native sheet with GPUI-rendered content",
+                                        )
+                                        .on_press(cx.listener(|this, _event, _window, cx| {
+                                            this.show_test_custom_sheet(cx);
+                                        })),
+                                    )
+                                    .child(
+                                        div()
+                                            .text_color(rgb(theme::text_muted(cx)))
+                                            .text_size(px(theme::FONT_DETAIL))
+                                            .font_family(fonts::MONO_FONT_FAMILY)
+                                            .child(
+                                                "QR scanner and dictation preview remain separate native flows.",
+                                            ),
+                                    )
+                            }),
                     ),
             )
     }
 }
 
-fn action_row(id: &'static str, title: &'static str, description: &'static str) -> Stateful<Div> {
+fn section_header(cx: &App, title: &'static str) -> Div {
+    div()
+        .pt(px(12.0))
+        .pb(px(10.0))
+        .border_b_1()
+        .border_color(rgb(theme::border_subtle(cx)))
+        .child(
+            div()
+                .text_color(rgb(theme::text_primary(cx)))
+                .text_size(px(theme::FONT_HEADING))
+                .font_family(fonts::MONO_FONT_FAMILY)
+                .font_weight(FontWeight::MEDIUM)
+                .child(title),
+        )
+}
+
+fn theme_option_button(
+    cx: &App,
+    id: &'static str,
+    preference: ThemePreference,
+    selected: bool,
+    on_press: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+) -> Stateful<Div> {
+    div()
+        .id(id)
+        .flex_1()
+        .h(px(36.0))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(8.0))
+        .border_1()
+        .border_color(rgb(if selected {
+            theme::border_highlight(cx)
+        } else {
+            theme::border_default(cx)
+        }))
+        .bg(rgb(if selected {
+            theme::bg_card(cx)
+        } else {
+            theme::bg_primary(cx)
+        }))
+        .cursor_pointer()
+        .text_color(rgb(if selected {
+            theme::text_primary(cx)
+        } else {
+            theme::text_secondary(cx)
+        }))
+        .text_size(px(theme::FONT_BODY))
+        .font_family(fonts::MONO_FONT_FAMILY)
+        .on_press(on_press)
+        .child(preference.label())
+}
+
+fn action_row(
+    cx: &App,
+    id: &'static str,
+    title: &'static str,
+    description: &'static str,
+) -> Stateful<Div> {
     div()
         .id(id)
         .w_full()
@@ -304,7 +394,7 @@ fn action_row(id: &'static str, title: &'static str, description: &'static str) 
                 .overflow_hidden()
                 .child(
                     div()
-                        .text_color(rgb(theme::TEXT_SECONDARY))
+                        .text_color(rgb(theme::text_secondary(cx)))
                         .text_size(px(theme::FONT_BODY))
                         .font_family(fonts::MONO_FONT_FAMILY)
                         .font_weight(FontWeight::MEDIUM)
@@ -312,7 +402,7 @@ fn action_row(id: &'static str, title: &'static str, description: &'static str) 
                 )
                 .child(
                     div()
-                        .text_color(rgb(theme::TEXT_MUTED))
+                        .text_color(rgb(theme::text_muted(cx)))
                         .text_size(px(theme::FONT_DETAIL))
                         .font_family(fonts::MONO_FONT_FAMILY)
                         .child(description),
@@ -323,7 +413,7 @@ fn action_row(id: &'static str, title: &'static str, description: &'static str) 
                 svg()
                     .path("icons/chevron-right.svg")
                     .size(px(theme::ICON_SM))
-                    .text_color(rgb(theme::TEXT_MUTED)),
+                    .text_color(rgb(theme::text_muted(cx))),
             ),
         )
 }

--- a/crates/zedra/src/sheet_demo_view.rs
+++ b/crates/zedra/src/sheet_demo_view.rs
@@ -19,7 +19,7 @@ impl Render for SheetDemoView {
         div()
             .id("sheet-demo")
             .size_full()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .justify_center()
             .px(px(18.0))
@@ -30,8 +30,8 @@ impl Render for SheetDemoView {
                     .max_w(px(680.0))
                     .rounded(px(14.0))
                     .border_1()
-                    .border_color(rgb(theme::BORDER_DEFAULT))
-                    .bg(rgb(theme::BG_CARD))
+                    .border_color(rgb(theme::border_default(cx)))
+                    .bg(rgb(theme::bg_card(cx)))
                     .px(px(20.0))
                     .py(px(18.0))
                     .flex()
@@ -39,7 +39,7 @@ impl Render for SheetDemoView {
                     .gap(px(theme::SPACING_MD))
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_PRIMARY))
+                            .text_color(rgb(theme::text_primary(cx)))
                             .text_size(px(theme::FONT_BODY))
                             .font_family(fonts::MONO_FONT_FAMILY)
                             .font_weight(FontWeight::MEDIUM)
@@ -47,7 +47,7 @@ impl Render for SheetDemoView {
                     )
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .text_size(px(theme::FONT_DETAIL))
                             .font_family(fonts::MONO_FONT_FAMILY)
                             .child(state.subtitle.clone()),
@@ -57,8 +57,8 @@ impl Render for SheetDemoView {
                             .w_full()
                             .rounded(px(8.0))
                             .border_1()
-                            .border_color(rgb(theme::BORDER_SUBTLE))
-                            .bg(rgb(theme::BG_SURFACE))
+                            .border_color(rgb(theme::border_subtle(cx)))
+                            .bg(rgb(theme::bg_surface(cx)))
                             .px(px(14.0))
                             .py(px(12.0))
                             .flex()
@@ -66,14 +66,14 @@ impl Render for SheetDemoView {
                             .gap(px(6.0))
                             .child(
                                 div()
-                                    .text_color(rgb(theme::ACCENT_BLUE))
+                                    .text_color(rgb(theme::accent_blue(cx)))
                                     .text_size(px(theme::FONT_DETAIL))
                                     .font_family(fonts::MONO_FONT_FAMILY)
                                     .child("// Mock presentation entrypoint"),
                             )
                             .children(state.mock_code.iter().cloned().map(|line| {
                                 div()
-                                    .text_color(rgb(theme::TEXT_SECONDARY))
+                                    .text_color(rgb(theme::text_secondary(cx)))
                                     .text_size(px(theme::FONT_DETAIL))
                                     .font_family(fonts::MONO_FONT_FAMILY)
                                     .child(line)
@@ -81,7 +81,7 @@ impl Render for SheetDemoView {
                     )
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .text_size(px(theme::FONT_DETAIL))
                             .font_family(fonts::MONO_FONT_FAMILY)
                             .child(format!(

--- a/crates/zedra/src/terminal_card.rs
+++ b/crates/zedra/src/terminal_card.rs
@@ -29,13 +29,13 @@ pub struct TerminalCardProps {
 }
 
 /// Colour of the status dot based on shell state and last exit code.
-fn dot_color(shell_state: &ShellState, last_exit_code: Option<i32>) -> u32 {
+fn dot_color(cx: &App, shell_state: &ShellState, last_exit_code: Option<i32>) -> u32 {
     match shell_state {
-        ShellState::Unknown => theme::TEXT_MUTED,
-        ShellState::Running => theme::ACCENT_YELLOW,
+        ShellState::Unknown => theme::text_muted(cx),
+        ShellState::Running => theme::accent_yellow(cx),
         ShellState::Idle => match last_exit_code {
-            None | Some(0) => theme::ACCENT_GREEN,
-            _ => theme::ACCENT_RED,
+            None | Some(0) => theme::accent_green(cx),
+            _ => theme::accent_red(cx),
         },
     }
 }
@@ -67,7 +67,7 @@ pub fn strip_ps1_prefix(title: &str) -> &str {
 ///
 /// Returns a `Div` — chain `.on_press()` and `.on_long_press()` for tap and
 /// long-press actions respectively.
-pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
+pub fn render_terminal_card(cx: &App, props: TerminalCardProps) -> Stateful<Div> {
     // Primary label: OSC 2 title (stripped of user@host: prefix) — the most
     // dynamic source, updated each prompt and with each command via preexec.
     // Falls back to cwd last component, then to the numbered placeholder.
@@ -94,7 +94,7 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
         .unwrap_or_default();
     let has_subtitle = !subtitle.is_empty();
 
-    let status_color = dot_color(&props.shell_state, props.last_exit_code);
+    let status_color = dot_color(cx, &props.shell_state, props.last_exit_code);
     let card_id = SharedString::from(format!("term-card-{}", props.id));
     let close_btn_id = SharedString::from(format!("term-close-{}", props.id));
     let is_active = props.is_active;
@@ -120,7 +120,7 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
                 svg()
                     .path("icons/x.svg")
                     .size(px(14.0))
-                    .text_color(rgb(theme::TEXT_MUTED)),
+                    .text_color(rgb(theme::text_muted(cx))),
             )
             .into_any_element()
     } else {
@@ -144,9 +144,9 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
         .px(px(12.0))
         .py(px(8.0))
         .rounded(px(6.0))
-        .bg(rgb(theme::BG_CARD))
+        .bg(rgb(theme::bg_card(cx)))
         .border_1()
-        .border_color(rgb(theme::BORDER_SUBTLE))
+        .border_color(rgb(theme::border_subtle(cx)))
         .cursor_pointer()
         // Icon — brand icon for known AI agents, terminal icon otherwise.
         // Colour tied to active state only for visual consistency.
@@ -156,9 +156,9 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
                 .size(px(theme::ICON_TERMINAL))
                 .flex_shrink_0()
                 .text_color(if is_active {
-                    rgb(theme::TEXT_PRIMARY)
+                    rgb(theme::text_primary(cx))
                 } else {
-                    rgb(theme::TEXT_MUTED)
+                    rgb(theme::text_muted(cx))
                 }),
         )
         // Text column: always two rows for a fixed card height.
@@ -178,9 +178,9 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
                         .whitespace_nowrap()
                         .font_family(fonts::MONO_FONT_FAMILY)
                         .text_color(if is_active {
-                            rgb(theme::TEXT_PRIMARY)
+                            rgb(theme::text_primary(cx))
                         } else {
-                            rgb(theme::TEXT_SECONDARY)
+                            rgb(theme::text_secondary(cx))
                         })
                         .text_size(px(theme::FONT_BODY))
                         .when(is_active, |s| s.font_weight(FontWeight::MEDIUM))
@@ -193,7 +193,7 @@ pub fn render_terminal_card(props: TerminalCardProps) -> Stateful<Div> {
                         .overflow_hidden()
                         .whitespace_nowrap()
                         .font_family(fonts::MONO_FONT_FAMILY)
-                        .text_color(rgb(theme::TEXT_MUTED))
+                        .text_color(rgb(theme::text_muted(cx)))
                         .text_size(px(theme::FONT_BODY - 1.0))
                         .when(!has_subtitle, |s| s.invisible())
                         .child(subtitle),

--- a/crates/zedra/src/terminal_panel.rs
+++ b/crates/zedra/src/terminal_panel.rs
@@ -58,17 +58,20 @@ impl Render for TerminalPanel {
                 }));
 
                 let tid_tap = tid.clone();
-                let card = render_terminal_card(TerminalCardProps {
-                    id: tid,
-                    index: index + 1,
-                    is_active,
-                    title: meta.title,
-                    cwd: meta.cwd,
-                    agent_icon: meta.agent_icon,
-                    shell_state: meta.shell_state,
-                    last_exit_code: meta.last_exit_code,
-                    on_close: Some(on_close),
-                })
+                let card = render_terminal_card(
+                    cx,
+                    TerminalCardProps {
+                        id: tid,
+                        index: index + 1,
+                        is_active,
+                        title: meta.title,
+                        cwd: meta.cwd,
+                        agent_icon: meta.agent_icon,
+                        shell_state: meta.shell_state,
+                        last_exit_code: meta.last_exit_code,
+                        on_close: Some(on_close),
+                    },
+                )
                 .on_press(cx.listener(move |_this, _event, window, cx| {
                     window.dispatch_action(
                         workspace_action::OpenTerminal {
@@ -96,7 +99,7 @@ impl Render for TerminalPanel {
                 }))
                 .child(
                     div()
-                        .text_color(rgb(theme::TEXT_MUTED))
+                        .text_color(rgb(theme::text_muted(cx)))
                         .text_size(px(theme::FONT_BODY))
                         .text_center()
                         .child("+ New Terminal"),

--- a/crates/zedra/src/terminal_preview_view.rs
+++ b/crates/zedra/src/terminal_preview_view.rs
@@ -254,17 +254,17 @@ fn preview_content_for_path(path: &str) -> PreviewContent {
 }
 
 impl Render for TerminalPreviewView {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let body: AnyElement = match &self.state {
             PreviewState::Idle => {
-                render_placeholder("Tap a file path in the terminal").into_any_element()
+                render_placeholder(cx, "Tap a file path in the terminal").into_any_element()
             }
-            PreviewState::Loading => render_placeholder("Loading ...").into_any_element(),
+            PreviewState::Loading => render_placeholder(cx, "Loading ...").into_any_element(),
             PreviewState::TooLarge => {
-                render_placeholder("File too large (>500 KB)").into_any_element()
+                render_placeholder(cx, "File too large (>500 KB)").into_any_element()
             }
             PreviewState::Error(error) => {
-                render_placeholder(format!("Error: {error}")).into_any_element()
+                render_placeholder(cx, format!("Error: {error}")).into_any_element()
             }
             PreviewState::Loaded => match self.content {
                 PreviewContent::Editor => self.editor_view.clone().into_any_element(),
@@ -282,7 +282,7 @@ impl Render for TerminalPreviewView {
         div()
             .id("terminal-preview-sheet")
             .size_full()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .flex_col()
             .child(
@@ -292,13 +292,13 @@ impl Render for TerminalPreviewView {
                     .pt(px(8.0))
                     .pb(px(8.0))
                     .border_b_1()
-                    .border_color(rgb(theme::BORDER_SUBTLE))
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_PRIMARY))
+                            .text_color(rgb(theme::text_primary(cx)))
                             .text_size(px(theme::FONT_HEADING))
                             .font_family(fonts::HEADING_FONT_FAMILY)
                             .font_weight(FontWeight::MEDIUM)
@@ -306,7 +306,7 @@ impl Render for TerminalPreviewView {
                     )
                     .child(
                         div()
-                            .text_color(rgb(theme::TEXT_MUTED))
+                            .text_color(rgb(theme::text_muted(cx)))
                             .text_size(px(theme::FONT_DETAIL))
                             .font_family(fonts::MONO_FONT_FAMILY)
                             .child(self.subtitle.clone()),
@@ -321,7 +321,7 @@ impl Render for TerminalPreviewView {
                     .flex_col()
                     // The custom sheet owns native handoff state; the active
                     // content view only reports whether its scroll is at top.
-                    .on_scroll_wheel(_cx.listener(|this, _event, _window, cx| {
+                    .on_scroll_wheel(cx.listener(|this, _event, _window, cx| {
                         this.update_sheet_scroll_boundary(cx);
                     }))
                     .child(body),

--- a/crates/zedra/src/theme.rs
+++ b/crates/zedra/src/theme.rs
@@ -1,37 +1,18 @@
 use gpui::Hsla;
+use zedra_terminal::element::TerminalTheme;
 
-// Background colors
-pub const BG_PRIMARY: u32 = 0x0e0c0c;
-pub const BG_CARD: u32 = 0x131313;
-pub const BG_OVERLAY: u32 = 0x131313;
-pub const BG_SURFACE: u32 = 0x0e0c0c; // Terminal / input field background (matches BG_PRIMARY)
+use crate::editor::syntax_theme::SyntaxTheme;
 
-// Text colors
-pub const TEXT_PRIMARY: u32 = 0xffffff;
-pub const TEXT_SECONDARY: u32 = 0xcacaca;
-pub const TEXT_MUTED: u32 = 0x505050;
+// ---------------------------------------------------------------------------
+// Layout and typography (theme-independent)
+// ---------------------------------------------------------------------------
 
-// Border colors
-pub const BORDER_HIGHLIGHT: u32 = 0xcacaca;
-pub const BORDER_DEFAULT: u32 = 0x2c2c2c;
-pub const BORDER_ACTIVE: u32 = 0x505050;
-pub const BORDER_SUBTLE: u32 = 0x1a1a1a;
-
-// Accent / button colors
-pub const ACCENT_GREEN: u32 = 0x98c379;
-pub const ACCENT_BLUE: u32 = 0x61afef;
-pub const ACCENT_YELLOW: u32 = 0xe5c07b;
-pub const ACCENT_RED: u32 = 0xe06c75;
-pub const ACCENT_DIM: u32 = 0x505050;
-
-// Spacing
-pub const DRAWER_PADDING: f32 = 12.0; // Horizontal padding for drawer tab content
+pub const DRAWER_PADDING: f32 = 12.0;
 pub const SPACING_XS: f32 = 4.0;
 pub const SPACING_SM: f32 = 8.0;
 pub const SPACING_MD: f32 = 12.0;
 pub const SPACING_LG: f32 = 16.0;
 
-// Layout dimensions
 pub const HEADER_HEIGHT: f32 = 48.0;
 pub const HOME_CARD_WIDTH: f32 = 300.0;
 pub const HOME_GUIDE_WIDTH: f32 = 300.0;
@@ -41,7 +22,6 @@ pub const DRAWER_ICON_ZONE: f32 = 38.0;
 pub const TERMINAL_LINE_HEIGHT: f32 = 16.0;
 pub const PANEL_ITEM_HEIGHT: f32 = 28.0;
 
-// Drawer gesture thresholds
 #[cfg(target_os = "android")]
 pub const DRAWER_EDGE_ZONE: f32 = 72.0;
 #[cfg(not(target_os = "android"))]
@@ -52,41 +32,269 @@ pub const DRAWER_DEFAULT_WIDTH: f32 = 295.0;
 pub const DRAWER_OPEN_ANIMATION_DURATION_MS: u64 = 160;
 pub const DRAWER_CLOSE_ANIMATION_DURATION_MS: u64 = 100;
 
-// Font sizes (pixels) — change these to scale all UI text
-pub const FONT_APP_TITLE: f32 = 28.0; // App main title ("Zedra")
-pub const FONT_TITLE: f32 = 20.0; // Screen title
-pub const FONT_HEADING: f32 = 13.0; // Section headings, dialog titles
-pub const FONT_BODY: f32 = 12.0; // Standard UI text: labels, buttons, file names, values
-pub const FONT_DETAIL: f32 = 12.0; // Small metadata, code previews, badges
+pub const FONT_APP_TITLE: f32 = 28.0;
+pub const FONT_TITLE: f32 = 20.0;
+pub const FONT_HEADING: f32 = 13.0;
+pub const FONT_BODY: f32 = 12.0;
+pub const FONT_DETAIL: f32 = 12.0;
 
-// Icon sizes (pixels)
 pub const ICON_LOGO: f32 = 20.0;
 pub const ICON_LG: f32 = 24.0;
 pub const ICON_MD: f32 = 18.0;
 pub const ICON_SM: f32 = 16.0;
 pub const ICON_XS: f32 = 14.0;
-pub const ICON_FILE: f32 = 12.0; // File tree icons
-pub const ICON_FILE_DIR: f32 = 14.0; // Directory icons (slightly larger than file)
-pub const ICON_STATUS: f32 = 6.0; // Status dots (connected/disconnected)
-pub const ICON_TERMINAL: f32 = 16.0; // Terminal icon
+pub const ICON_FILE: f32 = 12.0;
+pub const ICON_FILE_DIR: f32 = 14.0;
+pub const ICON_STATUS: f32 = 6.0;
+pub const ICON_TERMINAL: f32 = 16.0;
 
-// Editor / diff code view constants
-pub const EDITOR_FONT_SIZE: f32 = 12.0; // Code text in editor and diff views
-pub const EDITOR_GUTTER_FONT_SIZE: f32 = 11.0; // Line numbers in gutter
-pub const EDITOR_LINE_HEIGHT: f32 = 15.0; // Row height for code lines
-pub const EDITOR_GUTTER_WIDTH: f32 = 36.0; // Gutter column width
+pub const EDITOR_FONT_SIZE: f32 = 12.0;
+pub const EDITOR_GUTTER_FONT_SIZE: f32 = 11.0;
+pub const EDITOR_LINE_HEIGHT: f32 = 15.0;
+pub const EDITOR_GUTTER_WIDTH: f32 = 36.0;
 
-// Line number color (white at 30% opacity)
-pub fn line_number_color() -> Hsla {
-    gpui::hsla(0.0, 0.0, 0.83, 0.3)
+// ---------------------------------------------------------------------------
+// Theme preference
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThemePreference {
+    #[default]
+    Dark,
+    Light,
 }
 
-// Backdrop overlay
-pub fn backdrop_color() -> Hsla {
-    gpui::hsla(0.0, 0.0, 0.075, 0.6)
+impl ThemePreference {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Dark => "Dark",
+            Self::Light => "Light",
+        }
+    }
 }
 
-// Transport badge background
-pub fn badge_bg() -> Hsla {
-    gpui::hsla(0.0, 0.0, 0.08, 0.8)
+// ---------------------------------------------------------------------------
+// UI palette
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+pub struct ThemePalette {
+    pub bg_primary: u32,
+    pub bg_card: u32,
+    pub bg_overlay: u32,
+    pub bg_surface: u32,
+    pub text_primary: u32,
+    pub text_secondary: u32,
+    pub text_muted: u32,
+    pub border_highlight: u32,
+    pub border_default: u32,
+    pub border_active: u32,
+    pub border_subtle: u32,
+    pub accent_green: u32,
+    pub accent_blue: u32,
+    pub accent_yellow: u32,
+    pub accent_red: u32,
+    pub accent_dim: u32,
+    pub git_added: u32,
+    pub git_removed: u32,
+    pub row_pressed_bg: Hsla,
+    pub overlay_backdrop: Hsla,
+}
+
+impl ThemePalette {
+    pub fn dark() -> Self {
+        Self {
+            bg_primary: 0x0e0c0c,
+            bg_card: 0x131313,
+            bg_overlay: 0x131313,
+            bg_surface: 0x0e0c0c,
+            text_primary: 0xffffff,
+            text_secondary: 0xcacaca,
+            text_muted: 0x505050,
+            border_highlight: 0xcacaca,
+            border_default: 0x2c2c2c,
+            border_active: 0x505050,
+            border_subtle: 0x1a1a1a,
+            accent_green: 0x98c379,
+            accent_blue: 0x61afef,
+            accent_yellow: 0xe5c07b,
+            accent_red: 0xe06c75,
+            accent_dim: 0x505050,
+            git_added: 0x6fc17a,
+            git_removed: 0xd57a7a,
+            row_pressed_bg: gpui::hsla(0.0, 0.0, 1.0, 0.10),
+            overlay_backdrop: gpui::hsla(0.0, 0.0, 0.0, 1.0),
+        }
+    }
+
+    pub fn light() -> Self {
+        Self {
+            bg_primary: 0xf5f5f5,
+            bg_card: 0xffffff,
+            bg_overlay: 0xffffff,
+            bg_surface: 0xffffff,
+            text_primary: 0x1a1a1a,
+            text_secondary: 0x4a4a4a,
+            text_muted: 0x8a8a8a,
+            border_highlight: 0x4a4a4a,
+            border_default: 0xd8d8d8,
+            border_active: 0x8a8a8a,
+            border_subtle: 0xe8e8e8,
+            accent_green: 0x1a7f37,
+            accent_blue: 0x0969da,
+            accent_yellow: 0x9a6700,
+            accent_red: 0xcf222e,
+            accent_dim: 0x8a8a8a,
+            git_added: 0x1a7f37,
+            git_removed: 0xcf222e,
+            row_pressed_bg: gpui::hsla(0.0, 0.0, 0.0, 0.06),
+            overlay_backdrop: gpui::hsla(0.0, 0.0, 0.0, 1.0),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Editor + diff
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DiffTheme {
+    pub header_bg: u32,
+    pub added_bg: u32,
+    pub removed_bg: u32,
+    pub header_text: u32,
+    pub gutter_text: u32,
+    pub body_text: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct EditorTheme {
+    pub background: u32,
+    pub foreground: u32,
+    pub pending_syntax: u32,
+    pub gutter: Hsla,
+    pub syntax: SyntaxTheme,
+    pub diff: DiffTheme,
+}
+
+impl EditorTheme {
+    pub fn dark() -> Self {
+        Self {
+            background: 0x0e0c0c,
+            foreground: 0xabb2bf,
+            pending_syntax: 0x7b8494,
+            gutter: gpui::hsla(0.0, 0.0, 0.83, 0.3),
+            syntax: SyntaxTheme::dark(),
+            diff: DiffTheme {
+                header_bg: 0x131313,
+                added_bg: 0x162016,
+                removed_bg: 0x201616,
+                header_text: 0x61afef,
+                gutter_text: 0x404040,
+                body_text: 0xcacaca,
+            },
+        }
+    }
+
+    pub fn light() -> Self {
+        Self {
+            background: 0xfafafa,
+            foreground: 0x24292f,
+            pending_syntax: 0x8b949e,
+            gutter: gpui::hsla(0.0, 0.0, 0.45, 0.6),
+            syntax: SyntaxTheme::light(),
+            diff: DiffTheme {
+                header_bg: 0xf6f8fa,
+                added_bg: 0xdafbe1,
+                removed_bg: 0xffebe9,
+                header_text: 0x0969da,
+                gutter_text: 0x8b949e,
+                body_text: 0x24292f,
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Full bundle
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub struct ThemeBundle {
+    pub ui: ThemePalette,
+    pub editor: EditorTheme,
+    pub terminal: TerminalTheme,
+}
+
+impl ThemeBundle {
+    pub fn dark() -> Self {
+        Self {
+            ui: ThemePalette::dark(),
+            editor: EditorTheme::dark(),
+            terminal: TerminalTheme::dark(),
+        }
+    }
+
+    pub fn light() -> Self {
+        Self {
+            ui: ThemePalette::light(),
+            editor: EditorTheme::light(),
+            terminal: TerminalTheme::light(),
+        }
+    }
+
+    pub fn for_preference(preference: ThemePreference) -> Self {
+        match preference {
+            ThemePreference::Dark => Self::dark(),
+            ThemePreference::Light => Self::light(),
+        }
+    }
+}
+
+pub fn palette(cx: &gpui::App) -> ThemePalette {
+    crate::theme_state::palette(cx)
+}
+
+pub fn bundle(cx: &gpui::App) -> ThemeBundle {
+    crate::theme_state::bundle(cx)
+}
+
+macro_rules! palette_accessor {
+    ($name:ident, $field:ident) => {
+        pub fn $name(cx: &gpui::App) -> u32 {
+            palette(cx).$field
+        }
+    };
+}
+
+palette_accessor!(bg_primary, bg_primary);
+palette_accessor!(bg_card, bg_card);
+palette_accessor!(bg_overlay, bg_overlay);
+palette_accessor!(bg_surface, bg_surface);
+palette_accessor!(text_primary, text_primary);
+palette_accessor!(text_secondary, text_secondary);
+palette_accessor!(text_muted, text_muted);
+palette_accessor!(border_highlight, border_highlight);
+palette_accessor!(border_default, border_default);
+palette_accessor!(border_active, border_active);
+palette_accessor!(border_subtle, border_subtle);
+palette_accessor!(accent_green, accent_green);
+palette_accessor!(accent_blue, accent_blue);
+palette_accessor!(accent_yellow, accent_yellow);
+palette_accessor!(accent_red, accent_red);
+palette_accessor!(accent_dim, accent_dim);
+palette_accessor!(git_added, git_added);
+palette_accessor!(git_removed, git_removed);
+
+pub fn row_pressed_bg(cx: &gpui::App) -> Hsla {
+    palette(cx).row_pressed_bg
+}
+
+pub fn overlay_backdrop(cx: &gpui::App) -> Hsla {
+    palette(cx).overlay_backdrop
+}
+
+pub fn overlay_backdrop_with_opacity(base: Hsla, opacity: f32) -> Hsla {
+    gpui::hsla(base.h, base.s, base.l, opacity)
 }

--- a/crates/zedra/src/theme.rs
+++ b/crates/zedra/src/theme.rs
@@ -1,5 +1,10 @@
+//! Theme tokens for Zedra UI, editor, and terminal.
+//!
+//! New product UI must use these tokens (via `theme::palette(cx)` and accessors below),
+//! not hardcoded colors in views. See `docs/THEMING.md`.
+
 use gpui::Hsla;
-use zedra_terminal::element::TerminalTheme;
+use zedra_terminal::TerminalTheme;
 
 use crate::editor::syntax_theme::SyntaxTheme;
 
@@ -253,11 +258,11 @@ impl ThemeBundle {
 }
 
 pub fn palette(cx: &gpui::App) -> ThemePalette {
-    crate::theme_state::palette(cx)
+    crate::settings::palette(cx)
 }
 
 pub fn bundle(cx: &gpui::App) -> ThemeBundle {
-    crate::theme_state::bundle(cx)
+    crate::settings::bundle(cx)
 }
 
 macro_rules! palette_accessor {

--- a/crates/zedra/src/theme.rs
+++ b/crates/zedra/src/theme.rs
@@ -27,10 +27,11 @@ pub const DRAWER_ICON_ZONE: f32 = 38.0;
 pub const TERMINAL_LINE_HEIGHT: f32 = 16.0;
 pub const PANEL_ITEM_HEIGHT: f32 = 28.0;
 
-#[cfg(target_os = "android")]
-pub const DRAWER_EDGE_ZONE: f32 = 72.0;
-#[cfg(not(target_os = "android"))]
-pub const DRAWER_EDGE_ZONE: f32 = 56.0;
+pub const DRAWER_EDGE_ZONE: f32 = if cfg!(target_os = "android") {
+    72.0
+} else {
+    56.0
+};
 pub const DRAWER_VELOCITY_THRESHOLD: f32 = 12.0;
 pub const DRAWER_BACKDROP_OPACITY: f32 = 0.4;
 pub const DRAWER_DEFAULT_WIDTH: f32 = 295.0;

--- a/crates/zedra/src/theme_state.rs
+++ b/crates/zedra/src/theme_state.rs
@@ -1,0 +1,151 @@
+use std::path::PathBuf;
+
+use gpui::{App, Context, Entity, EventEmitter, Global, WeakEntity};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::theme::{ThemeBundle, ThemePreference};
+
+const STORE_DIR: &str = "zedra";
+const SETTINGS_FILE: &str = "settings.json";
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct AppSettings {
+    #[serde(default)]
+    theme_preference: ThemePreference,
+}
+
+pub enum ThemeStateEvent {
+    Changed,
+}
+
+impl EventEmitter<ThemeStateEvent> for ThemeState {}
+
+pub struct ThemeState {
+    preference: ThemePreference,
+    bundle: ThemeBundle,
+}
+
+impl ThemeState {
+    pub fn new(_cx: &mut Context<Self>) -> Self {
+        let preference = Self::load_preference();
+        let bundle = ThemeBundle::for_preference(preference);
+        Self { preference, bundle }
+    }
+
+    pub fn preference(&self) -> ThemePreference {
+        self.preference
+    }
+
+    pub fn bundle(&self) -> &ThemeBundle {
+        &self.bundle
+    }
+
+    pub fn palette(&self) -> &crate::theme::ThemePalette {
+        &self.bundle.ui
+    }
+
+    pub fn set_preference(&mut self, preference: ThemePreference, cx: &mut Context<Self>) {
+        if self.preference == preference {
+            return;
+        }
+        self.preference = preference;
+        self.bundle = ThemeBundle::for_preference(preference);
+        Self::save_preference(preference);
+        cx.emit(ThemeStateEvent::Changed);
+        cx.notify();
+    }
+
+    pub fn register_global(entity: WeakEntity<Self>, cx: &mut App) {
+        cx.set_global(ThemeStateHandle(entity));
+    }
+
+    fn load_preference() -> ThemePreference {
+        match read_settings() {
+            Ok(settings) => settings.theme_preference,
+            Err(err) => {
+                debug!(err = %err, "theme: using default preference");
+                ThemePreference::default()
+            }
+        }
+    }
+
+    fn save_preference(preference: ThemePreference) {
+        let mut settings = read_settings().unwrap_or_default();
+        settings.theme_preference = preference;
+        if let Err(err) = write_settings(&settings) {
+            warn!(err = %err, "theme: failed to save preference");
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ThemeStateHandle(WeakEntity<ThemeState>);
+
+impl Global for ThemeStateHandle {}
+
+pub fn entity(cx: &App) -> Option<Entity<ThemeState>> {
+    cx.try_global::<ThemeStateHandle>()
+        .and_then(|handle| handle.0.upgrade())
+}
+
+pub fn palette(cx: &App) -> crate::theme::ThemePalette {
+    entity(cx)
+        .map(|theme| theme.read(cx).palette().clone())
+        .unwrap_or_else(|| ThemeBundle::dark().ui)
+}
+
+pub fn bundle(cx: &App) -> ThemeBundle {
+    entity(cx)
+        .map(|theme| theme.read(cx).bundle().clone())
+        .unwrap_or_else(ThemeBundle::dark)
+}
+
+fn data_directory() -> Option<PathBuf> {
+    crate::platform_bridge::bridge()
+        .data_directory()
+        .map(PathBuf::from)
+}
+
+fn settings_path() -> Option<PathBuf> {
+    let dir = data_directory()?.join(STORE_DIR);
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir).ok()?;
+    }
+    Some(dir.join(SETTINGS_FILE))
+}
+
+fn read_settings() -> Result<AppSettings, String> {
+    let path = settings_path().ok_or_else(|| "settings path unavailable".to_string())?;
+    if !path.exists() {
+        return Ok(AppSettings::default());
+    }
+    let contents = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&contents).map_err(|e| e.to_string())
+}
+
+fn write_settings(settings: &AppSettings) -> Result<(), String> {
+    let path = settings_path().ok_or_else(|| "settings path unavailable".to_string())?;
+    let contents = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
+    std::fs::write(path, contents).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::theme::{ThemeBundle, ThemePalette, ThemePreference};
+
+    #[test]
+    fn default_preference_is_dark() {
+        assert_eq!(ThemePreference::default(), ThemePreference::Dark);
+    }
+
+    #[test]
+    fn bundle_matches_preference() {
+        assert_eq!(
+            ThemeBundle::for_preference(ThemePreference::Light)
+                .ui
+                .bg_primary,
+            ThemePalette::light().bg_primary
+        );
+    }
+}

--- a/crates/zedra/src/transport_badge.rs
+++ b/crates/zedra/src/transport_badge.rs
@@ -4,16 +4,17 @@ use std::time::Duration;
 use gpui::*;
 use zedra_session::{ConnectPhase, TransportSnapshot};
 
-use crate::theme;
+use crate::theme::{self, ThemePalette};
 
 /// Compute badge label and dot color from phase and transport.
 /// Returns `(label, dot_color)`.
 pub(crate) fn transport_badge(
+    palette: &ThemePalette,
     phase: &ConnectPhase,
     transport: Option<&TransportSnapshot>,
 ) -> (String, u32) {
     match phase {
-        ConnectPhase::Init => ("Initializing".into(), theme::ACCENT_YELLOW),
+        ConnectPhase::Init => ("Initializing".into(), palette.accent_yellow),
         ConnectPhase::Connected => {
             let (conn_type, relay): (String, Option<&str>) = match transport {
                 Some(t) if t.is_direct => {
@@ -34,13 +35,13 @@ pub(crate) fn transport_badge(
                 _ => conn_type.to_string(),
             };
             let color = match transport {
-                Some(t) if t.is_direct => theme::ACCENT_GREEN,
-                Some(_) => theme::ACCENT_GREEN,
-                None => theme::ACCENT_GREEN,
+                Some(t) if t.is_direct => palette.accent_green,
+                Some(_) => palette.accent_green,
+                None => palette.accent_green,
             };
             (label, color)
         }
-        ConnectPhase::Disconnected => ("Tap refresh to reconnect.".into(), theme::ACCENT_RED),
+        ConnectPhase::Disconnected => ("Tap refresh to reconnect.".into(), palette.accent_red),
         ConnectPhase::Reconnecting {
             attempt,
             next_retry_secs,
@@ -51,36 +52,36 @@ pub(crate) fn transport_badge(
             } else {
                 format!("Reconnecting ({attempt})")
             };
-            (label, theme::ACCENT_RED)
+            (label, palette.accent_red)
         }
-        ConnectPhase::Failed(err) => (err.user_message(), theme::ACCENT_RED),
-        ConnectPhase::BindingEndpoint => ("Binding endpoint".into(), theme::ACCENT_YELLOW),
-        ConnectPhase::HolePunching => ("Hole punching".into(), theme::ACCENT_YELLOW),
-        ConnectPhase::Registering => ("Registering device".into(), theme::ACCENT_YELLOW),
-        ConnectPhase::Authenticating => ("Authenticating".into(), theme::ACCENT_YELLOW),
-        ConnectPhase::Proving => ("Auth challenge".into(), theme::ACCENT_YELLOW),
-        ConnectPhase::Sync => ("Syncing state".into(), theme::ACCENT_YELLOW),
+        ConnectPhase::Failed(err) => (err.user_message(), palette.accent_red),
+        ConnectPhase::BindingEndpoint => ("Binding endpoint".into(), palette.accent_yellow),
+        ConnectPhase::HolePunching => ("Hole punching".into(), palette.accent_yellow),
+        ConnectPhase::Registering => ("Registering device".into(), palette.accent_yellow),
+        ConnectPhase::Authenticating => ("Authenticating".into(), palette.accent_yellow),
+        ConnectPhase::Proving => ("Auth challenge".into(), palette.accent_yellow),
+        ConnectPhase::Sync => ("Syncing state".into(), palette.accent_yellow),
         ConnectPhase::Idle { idle_since } => (
             format!("Idle {}s", idle_since.elapsed().as_secs()),
-            theme::ACCENT_YELLOW,
+            palette.accent_yellow,
         ),
     }
 }
 
-pub(crate) fn phase_indicator_color(phase: &ConnectPhase) -> u32 {
+pub(crate) fn phase_indicator_color(palette: &ThemePalette, phase: &ConnectPhase) -> u32 {
     if phase.is_connected() {
-        theme::ACCENT_GREEN
+        palette.accent_green
     } else if phase.is_idle() || phase.is_connecting() || phase.is_reconnecting() {
-        theme::ACCENT_YELLOW
+        palette.accent_yellow
     } else if phase.is_failed() {
-        theme::ACCENT_RED
+        palette.accent_red
     } else {
-        theme::ACCENT_DIM
+        palette.accent_dim
     }
 }
 
-fn phase_indicator_blinks(phase: &ConnectPhase) -> bool {
-    phase_indicator_color(phase) == theme::ACCENT_YELLOW
+fn phase_indicator_blinks(palette: &ThemePalette, phase: &ConnectPhase) -> bool {
+    phase_indicator_color(palette, phase) == palette.accent_yellow
 }
 
 const STATUS_PULSE_MS: u64 = 1800;
@@ -95,11 +96,17 @@ pub(crate) struct ConnectionStatusIndicator {
 }
 
 impl ConnectionStatusIndicator {
-    pub(crate) fn from_phase(id: impl Into<ElementId>, phase: Option<&ConnectPhase>) -> Self {
+    pub(crate) fn from_phase(
+        id: impl Into<ElementId>,
+        phase: Option<&ConnectPhase>,
+        palette: &ThemePalette,
+    ) -> Self {
         let color = phase
-            .map(phase_indicator_color)
-            .unwrap_or(theme::ACCENT_DIM);
-        let blink = phase.map(phase_indicator_blinks).unwrap_or(false);
+            .map(|phase| phase_indicator_color(palette, phase))
+            .unwrap_or(palette.accent_dim);
+        let blink = phase
+            .map(|phase| phase_indicator_blinks(palette, phase))
+            .unwrap_or(false);
 
         Self {
             id: id.into(),
@@ -165,7 +172,7 @@ pub fn format_bytes(bytes: u64) -> String {
 mod tests {
     use std::time::Instant;
 
-    use crate::theme;
+    use crate::theme::ThemePalette;
     use crate::transport_badge::{
         ConnectionStatusIndicator, phase_indicator_color, transport_badge,
     };
@@ -173,15 +180,18 @@ mod tests {
 
     #[test]
     fn disconnected_badge_uses_manual_reconnect_hint() {
-        let (label, color) = transport_badge(&ConnectPhase::Disconnected, None);
+        let palette = ThemePalette::dark();
+        let (label, color) = transport_badge(&palette, &ConnectPhase::Disconnected, None);
 
         assert_eq!(label, "Tap refresh to reconnect.");
-        assert_eq!(color, theme::ACCENT_RED);
+        assert_eq!(color, palette.accent_red);
     }
 
     #[test]
     fn reconnecting_badge_includes_retry_countdown() {
+        let palette = ThemePalette::dark();
         let (label, color) = transport_badge(
+            &palette,
             &ConnectPhase::Reconnecting {
                 attempt: 2,
                 reason: zedra_session::ReconnectReason::ConnectionLost,
@@ -191,11 +201,12 @@ mod tests {
         );
 
         assert_eq!(label, "Reconnecting (2) \u{00b7} 3s");
-        assert_eq!(color, theme::ACCENT_RED);
+        assert_eq!(color, palette.accent_red);
     }
 
     #[test]
     fn warning_status_indicator_blinks() {
+        let palette = ThemePalette::dark();
         let idle = ConnectPhase::Idle {
             idle_since: Instant::now(),
         };
@@ -208,20 +219,29 @@ mod tests {
         let failed = ConnectPhase::Failed(ConnectError::HostUnreachable);
 
         for phase in [&idle, &reconnecting] {
-            let indicator = ConnectionStatusIndicator::from_phase("test-dot", Some(phase));
-            assert_eq!(phase_indicator_color(phase), theme::ACCENT_YELLOW);
+            let indicator =
+                ConnectionStatusIndicator::from_phase("test-dot", Some(phase), &palette);
+            assert_eq!(
+                phase_indicator_color(&palette, phase),
+                palette.accent_yellow
+            );
             assert!(indicator.blink);
         }
 
         for phase in [&connected, &failed] {
-            let indicator = ConnectionStatusIndicator::from_phase("test-dot", Some(phase));
-            assert_ne!(phase_indicator_color(phase), theme::ACCENT_YELLOW);
+            let indicator =
+                ConnectionStatusIndicator::from_phase("test-dot", Some(phase), &palette);
+            assert_ne!(
+                phase_indicator_color(&palette, phase),
+                palette.accent_yellow
+            );
             assert!(!indicator.blink);
         }
     }
 
     #[test]
     fn failed_badge_uses_friendly_error_message() {
+        let palette = ThemePalette::dark();
         let cases = [
             (
                 ConnectError::AlpnMismatch,
@@ -246,10 +266,10 @@ mod tests {
         ];
 
         for (error, message) in cases {
-            let (label, color) = transport_badge(&ConnectPhase::Failed(error), None);
+            let (label, color) = transport_badge(&palette, &ConnectPhase::Failed(error), None);
 
             assert_eq!(label, message);
-            assert_eq!(color, theme::ACCENT_RED);
+            assert_eq!(color, palette.accent_red);
         }
     }
 }

--- a/crates/zedra/src/ui/drawer_host.rs
+++ b/crates/zedra/src/ui/drawer_host.rs
@@ -445,6 +445,7 @@ impl Render for DrawerHost {
         let animating = self.is_snap_animating() && !is_dragging;
         let side = self.drawer_side;
         let edge_inset = self.edge_inset;
+        let backdrop_base_color = theme::overlay_backdrop(cx);
 
         let show_overlay = drawer_offset > 0.0 || snap_target.is_some() || is_dragging;
 
@@ -492,7 +493,7 @@ impl Render for DrawerHost {
                         .top_0()
                         .bottom_0()
                         .w(px(drawer_width))
-                        .bg(rgb(0x0e0c0c))
+                        .bg(rgb(theme::bg_primary(cx)))
                         .flex()
                         .flex_col()
                         .overflow_hidden()
@@ -523,10 +524,8 @@ impl Render for DrawerHost {
                                 ),
                                 anim.clone(),
                                 move |el, delta| {
-                                    el.bg(hsla(
-                                        0.0,
-                                        0.0,
-                                        0.0,
+                                    el.bg(theme::overlay_backdrop_with_opacity(
+                                        backdrop_base_color,
                                         from_opacity + (target_opacity - from_opacity) * delta,
                                     ))
                                 },
@@ -550,7 +549,10 @@ impl Render for DrawerHost {
                     let opacity = (drawer_offset / drawer_width).clamp(0.0, 1.0) * max_opacity;
                     (
                         backdrop_base
-                            .bg(hsla(0.0, 0.0, 0.0, opacity))
+                            .bg(theme::overlay_backdrop_with_opacity(
+                                backdrop_base_color,
+                                opacity,
+                            ))
                             .into_any_element(),
                         match side {
                             DrawerSide::Left => panel_base

--- a/crates/zedra/src/ui/input.rs
+++ b/crates/zedra/src/ui/input.rs
@@ -94,7 +94,7 @@ impl Element for MultilineInputText {
         };
         let caret = fill(
             Bounds::new(origin, size(px(2.0), line_height)),
-            rgb(theme::TEXT_SECONDARY),
+            rgb(theme::text_secondary(cx)),
         );
         window.paint_quad(caret);
     }
@@ -694,7 +694,7 @@ impl Input {
         div()
             .w(px(2.0))
             .h(px(if self.compact { 14.0 } else { 18.0 }))
-            .bg(rgb(theme::TEXT_SECONDARY))
+            .bg(rgb(theme::text_secondary(cx)))
             .rounded(px(1.0))
             .with_animation(
                 cursor_id,
@@ -1143,15 +1143,15 @@ impl Render for Input {
         let show_placeholder = self.value.is_empty() && !is_focused;
 
         let text_color = if show_placeholder {
-            rgb(theme::TEXT_MUTED)
+            rgb(theme::text_muted(cx))
         } else {
-            rgb(theme::TEXT_SECONDARY)
+            rgb(theme::text_secondary(cx))
         };
 
         let border_color = if is_focused {
-            rgb(theme::BORDER_ACTIVE)
+            rgb(theme::border_active(cx))
         } else {
-            rgb(theme::BORDER_DEFAULT)
+            rgb(theme::border_default(cx))
         };
         let text_size = if self.compact {
             theme::FONT_DETAIL
@@ -1189,7 +1189,7 @@ impl Render for Input {
             .py(px(vertical_padding))
             .w_full()
             .min_h(px(min_height))
-            .bg(rgb(theme::BG_SURFACE))
+            .bg(rgb(theme::bg_surface(cx)))
             .rounded(px(6.0))
             .border_1()
             .border_color(border_color)

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -2376,20 +2376,25 @@ enum WorkspaceSubtitle {
     },
 }
 
-fn render_subtitle(text: impl IntoElement) -> AnyElement {
+fn render_subtitle(cx: &App, text: impl IntoElement) -> AnyElement {
     div()
         .w_full()
         .min_w_0()
         .truncate()
         .text_center()
-        .text_color(rgb(theme::TEXT_SECONDARY))
+        .text_color(rgb(theme::text_secondary(cx)))
         .text_size(px(theme::FONT_BODY))
         .font_weight(FontWeight::MEDIUM)
         .child(text)
         .into_any_element()
 }
 
-fn render_gitdiff_subtitle(filename: SharedString, added: usize, removed: usize) -> AnyElement {
+fn render_gitdiff_subtitle(
+    cx: &App,
+    filename: SharedString,
+    added: usize,
+    removed: usize,
+) -> AnyElement {
     div()
         .w_full()
         .min_w_0()
@@ -2407,14 +2412,14 @@ fn render_gitdiff_subtitle(filename: SharedString, added: usize, removed: usize)
                 .flex_shrink()
                 .truncate()
                 .text_center()
-                .text_color(rgb(theme::TEXT_SECONDARY))
+                .text_color(rgb(theme::text_secondary(cx)))
                 .child(filename),
         )
         .when(added > 0, |this| {
             this.child(
                 div()
                     .flex_shrink_0()
-                    .text_color(rgb(0x6fc17a))
+                    .text_color(rgb(theme::git_added(cx)))
                     .child(format!("+{}", added)),
             )
         })
@@ -2422,7 +2427,7 @@ fn render_gitdiff_subtitle(filename: SharedString, added: usize, removed: usize)
             this.child(
                 div()
                     .flex_shrink_0()
-                    .text_color(rgb(0xd57a7a))
+                    .text_color(rgb(theme::git_removed(cx)))
                     .child(format!("-{}", removed)),
             )
         })
@@ -2517,8 +2522,8 @@ impl WorkspaceContent {
 
     fn render_subtitle(&self, default_subtitle: &str, cx: &mut Context<Self>) -> AnyElement {
         match &self.subtitle {
-            WorkspaceSubtitle::Default => render_subtitle(default_subtitle.to_owned()),
-            WorkspaceSubtitle::File { path } => render_subtitle(path.clone()),
+            WorkspaceSubtitle::Default => render_subtitle(cx, default_subtitle.to_owned()),
+            WorkspaceSubtitle::File { path } => render_subtitle(cx, path.clone()),
             WorkspaceSubtitle::Terminal { id } => {
                 let meta = self.terminal_state.read(cx).meta(id);
                 let subtitle = meta
@@ -2528,13 +2533,13 @@ impl WorkspaceContent {
                     .filter(|title| !title.is_empty())
                     .unwrap_or(default_subtitle)
                     .to_owned();
-                render_subtitle(subtitle)
+                render_subtitle(cx, subtitle)
             }
             WorkspaceSubtitle::GitDiff {
                 filename,
                 added,
                 removed,
-            } => render_gitdiff_subtitle(filename.clone(), *added, *removed),
+            } => render_gitdiff_subtitle(cx, filename.clone(), *added, *removed),
         }
     }
 
@@ -2564,7 +2569,7 @@ struct NoActiveTerminalView;
 
 impl Render for NoActiveTerminalView {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        render_placeholder("No active terminal")
+        render_placeholder(_cx, "No active terminal")
     }
 }
 
@@ -2600,7 +2605,7 @@ impl Render for WorkspaceContent {
             .flex()
             .flex_col()
             .min_h_0()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .child(div().h(px(top_inset)))
             .child(
                 div()
@@ -2609,7 +2614,7 @@ impl Render for WorkspaceContent {
                     .flex_row()
                     .items_center()
                     .border_b_1()
-                    .border_color(rgb(theme::BORDER_SUBTLE))
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .child(
                         div()
                             .id("drawer-toggle-btn")
@@ -2631,7 +2636,7 @@ impl Render for WorkspaceContent {
                                 svg()
                                     .path("icons/menu.svg")
                                     .size(px(16.0))
-                                    .text_color(rgb(theme::TEXT_SECONDARY)),
+                                    .text_color(rgb(theme::text_secondary(cx))),
                             ),
                     )
                     .child(
@@ -2660,6 +2665,7 @@ impl Render for WorkspaceContent {
                                                 ConnectionStatusIndicator::from_phase(
                                                     "workspace-connect-status",
                                                     connect_phase.as_ref(),
+                                                    &theme::palette(cx),
                                                 )
                                                 .size(6.0),
                                             )
@@ -2667,7 +2673,7 @@ impl Render for WorkspaceContent {
                                                 div()
                                                     .min_w_0()
                                                     .truncate()
-                                                    .text_color(rgb(theme::TEXT_MUTED))
+                                                    .text_color(rgb(theme::text_muted(cx)))
                                                     .text_size(px(theme::FONT_DETAIL))
                                                     .child(title),
                                             ),
@@ -2696,7 +2702,7 @@ impl Render for WorkspaceContent {
                                 svg()
                                     .path("icons/package.svg")
                                     .size(px(16.0))
-                                    .text_color(rgb(theme::TEXT_SECONDARY)),
+                                    .text_color(rgb(theme::text_secondary(cx))),
                             ),
                     ),
             )

--- a/crates/zedra/src/workspace_connecting.rs
+++ b/crates/zedra/src/workspace_connecting.rs
@@ -36,7 +36,7 @@ impl Render for WorkspaceConnecting {
             .id("connecting-view")
             .size_full()
             .relative()
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .flex()
             .flex_col()
             .justify_start()
@@ -59,7 +59,7 @@ impl Render for WorkspaceConnecting {
                     ))
                     .child(render_details_toggle(expanded, cx))
                     .when(expanded, |d| {
-                        d.child(render_detail(&state.phase, &state.snapshot))
+                        d.child(render_detail(cx, &state.phase, &state.snapshot))
                     }),
             )
             .child(render_close_button(cx))
@@ -86,7 +86,7 @@ fn render_close_button(cx: &mut Context<WorkspaceConnecting>) -> Stateful<Div> {
             svg()
                 .path("icons/x.svg")
                 .size(px(16.0))
-                .text_color(rgb(theme::TEXT_MUTED)),
+                .text_color(rgb(theme::text_muted(cx))),
         )
 }
 
@@ -117,14 +117,14 @@ fn render_details_toggle(expanded: bool, cx: &mut Context<WorkspaceConnecting>) 
         .child(
             div()
                 .text_size(px(theme::FONT_DETAIL))
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .child(label),
         )
         .child(
             svg()
                 .path(chevron)
                 .size(px(12.0))
-                .text_color(rgb(theme::TEXT_MUTED)),
+                .text_color(rgb(theme::text_muted(cx))),
         )
 }
 
@@ -134,7 +134,7 @@ fn render_phase_title(
     restart_animation_id: u64,
     cx: &mut Context<WorkspaceConnecting>,
 ) -> Div {
-    let (label, color) = transport_badge(phase, snap.transport.as_ref());
+    let (label, color) = transport_badge(&theme::palette(cx), phase, snap.transport.as_ref());
 
     let title = match phase {
         ConnectPhase::BindingEndpoint | ConnectPhase::HolePunching => "Connect",
@@ -166,7 +166,7 @@ fn render_phase_title(
                         .min_w_0()
                         .truncate()
                         .text_align(TextAlign::Center)
-                        .text_color(rgb(theme::TEXT_PRIMARY))
+                        .text_color(rgb(theme::text_primary(cx)))
                         .text_size(px(theme::FONT_HEADING))
                         .font_weight(FontWeight::MEDIUM)
                         .child(title),
@@ -208,14 +208,14 @@ fn render_restart_button(
             window.dispatch_action(workspace_action::RestartConnection.boxed_clone(), cx);
             cx.notify();
         }))
-        .child(render_restart_icon(restart_animation_id))
+        .child(render_restart_icon(cx, restart_animation_id))
 }
 
-fn render_restart_icon(restart_animation_id: u64) -> AnyElement {
+fn render_restart_icon(cx: &App, restart_animation_id: u64) -> AnyElement {
     let icon = svg()
         .path("icons/refresh-ccw.svg")
         .size(px(14.0))
-        .text_color(rgb(theme::TEXT_MUTED));
+        .text_color(rgb(theme::text_muted(cx)));
 
     if restart_animation_id == 0 {
         icon.into_any_element()
@@ -239,7 +239,7 @@ fn has_discovery_data(snap: &ConnectSnapshot) -> bool {
         || snap.relay_latency_ms.is_some()
 }
 
-fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
+fn render_discovery_rows(cx: &App, snap: &ConnectSnapshot) -> Div {
     let mut d = div().flex().flex_col().gap(px(2.0));
 
     let relay_status = if snap.relay_connected {
@@ -250,7 +250,7 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
     } else {
         "Connecting\u{2026}".into()
     };
-    d = d.child(kv_row("Relay", &relay_status));
+    d = d.child(kv_row(cx, "Relay", &relay_status));
 
     if !snap.direct_addrs.is_empty() {
         let count = snap.direct_addrs.len();
@@ -283,7 +283,7 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
                     div()
                         .w(px(60.0))
                         .flex_shrink_0()
-                        .text_color(rgb(theme::TEXT_MUTED))
+                        .text_color(rgb(theme::text_muted(cx)))
                         .text_size(px(theme::FONT_DETAIL))
                         .child("Direct"),
                 )
@@ -292,7 +292,7 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
                         .flex_1()
                         .min_w_0()
                         .truncate()
-                        .text_color(rgb(theme::TEXT_SECONDARY))
+                        .text_color(rgb(theme::text_secondary(cx)))
                         .text_size(px(theme::FONT_DETAIL))
                         .child(direct_label),
                 ),
@@ -305,7 +305,7 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
         (false, true) => "IPv6 only",
         (false, false) => "probing\u{2026}",
     };
-    d = d.child(kv_row("UDP", ip_status));
+    d = d.child(kv_row(cx, "UDP", ip_status));
 
     if let Some(varies) = snap.mapping_varies {
         let nat = if varies {
@@ -313,11 +313,11 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
         } else {
             "Cone / direct"
         };
-        d = d.child(kv_row("NAT", nat));
+        d = d.child(kv_row(cx, "NAT", nat));
     }
 
     if snap.captive_portal == Some(true) {
-        d = d.child(kv_row("Portal", "Captive portal detected"));
+        d = d.child(kv_row(cx, "Portal", "Captive portal detected"));
     }
 
     d
@@ -325,7 +325,7 @@ fn render_discovery_rows(snap: &ConnectSnapshot) -> Div {
 
 // ─── Vertical detail panel ───────────────────────────────────────────────────
 
-fn render_detail(phase: &ConnectPhase, snap: &ConnectSnapshot) -> Div {
+fn render_detail(cx: &App, phase: &ConnectPhase, snap: &ConnectSnapshot) -> Div {
     let mut col = div()
         .w(px(theme::CONNECT_DETAIL_WIDTH))
         .min_w_0()
@@ -334,30 +334,42 @@ fn render_detail(phase: &ConnectPhase, snap: &ConnectSnapshot) -> Div {
         .gap(px(theme::SPACING_SM));
 
     if snap.local_node_id.is_some() || snap.remote_node_id.is_some() || snap.relay_url.is_some() {
-        col = col.child(render_section("Endpoint", render_endpoint_rows(snap)));
+        col = col.child(render_section(
+            cx,
+            "Endpoint",
+            render_endpoint_rows(cx, snap),
+        ));
     }
 
     if has_discovery_data(snap) {
-        col = col.child(render_section("Discovery", render_discovery_rows(snap)));
+        col = col.child(render_section(
+            cx,
+            "Discovery",
+            render_discovery_rows(cx, snap),
+        ));
     }
 
     if let Some(t) = &snap.transport {
-        col = col.child(render_section("Transport", render_transport_rows(t)));
+        col = col.child(render_section(
+            cx,
+            "Transport",
+            render_transport_rows(cx, t),
+        ));
     }
 
     if snap.session_id.is_some() || snap.auth_outcome.is_some() {
-        col = col.child(render_section("Auth", render_auth_rows(snap)));
+        col = col.child(render_section(cx, "Auth", render_auth_rows(cx, snap)));
     }
 
     if !snap.hostname.is_empty() {
-        col = col.child(render_section("Daemon", render_host_rows(snap)));
+        col = col.child(render_section(cx, "Daemon", render_host_rows(cx, snap)));
     }
 
     let timing = build_timing_string(snap);
     if !timing.is_empty() {
         col = col.child(
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(timing),
         );
@@ -372,7 +384,7 @@ fn render_detail(phase: &ConnectPhase, snap: &ConnectSnapshot) -> Div {
     {
         col = col.child(
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(format!(
                     "Attempt {} · retry in {}s",
@@ -384,14 +396,14 @@ fn render_detail(phase: &ConnectPhase, snap: &ConnectSnapshot) -> Div {
     col
 }
 
-fn render_section(title: &'static str, rows: Div) -> Div {
+fn render_section(cx: &App, title: &'static str, rows: Div) -> Div {
     div()
         .flex()
         .flex_col()
         .gap(px(2.0))
         .child(
             div()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .mb(px(2.0))
                 .child(title),
@@ -399,24 +411,24 @@ fn render_section(title: &'static str, rows: Div) -> Div {
         .child(rows)
 }
 
-fn render_endpoint_rows(snap: &ConnectSnapshot) -> Div {
+fn render_endpoint_rows(cx: &App, snap: &ConnectSnapshot) -> Div {
     let mut d = div().flex().flex_col().gap(px(2.0));
     if let Some(id) = &snap.local_node_id {
-        d = d.child(kv_row("Local", id));
+        d = d.child(kv_row(cx, "Local", id));
     }
     if let Some(id) = &snap.remote_node_id {
-        d = d.child(kv_row("Remote", id));
+        d = d.child(kv_row(cx, "Remote", id));
     }
     if let Some(relay) = &snap.relay_url {
-        d = d.child(kv_row("Relay", relay));
+        d = d.child(kv_row(cx, "Relay", relay));
     }
     if let Some(alpn) = &snap.alpn {
-        d = d.child(kv_row("Protocol", alpn));
+        d = d.child(kv_row(cx, "Protocol", alpn));
     }
     d
 }
 
-fn render_transport_rows(t: &TransportSnapshot) -> Div {
+fn render_transport_rows(cx: &App, t: &TransportSnapshot) -> Div {
     let conn_type = if t.is_direct {
         match &t.network_hint {
             Some(h) => format!("P2P \u{00b7} {}", h.label()),
@@ -430,14 +442,15 @@ fn render_transport_rows(t: &TransportSnapshot) -> Div {
         .flex()
         .flex_col()
         .gap(px(2.0))
-        .child(kv_row("Type", &conn_type))
+        .child(kv_row(cx, "Type", &conn_type))
         .child(kv_row(
+            cx,
             "Address",
             &format!("{} ({})", t.remote_addr, t.num_paths),
         ));
 
     if let Some(relay) = &t.relay_url {
-        d = d.child(kv_row("Relay", relay));
+        d = d.child(kv_row(cx, "Relay", relay));
     }
     let net = format!(
         "{}ms - {} \u{2191} / {} \u{2193}",
@@ -445,44 +458,44 @@ fn render_transport_rows(t: &TransportSnapshot) -> Div {
         format_bytes(t.bytes_sent),
         format_bytes(t.bytes_recv)
     );
-    d = d.child(kv_row("Net", &net));
+    d = d.child(kv_row(cx, "Net", &net));
     d
 }
 
-fn render_auth_rows(snap: &ConnectSnapshot) -> Div {
+fn render_auth_rows(cx: &App, snap: &ConnectSnapshot) -> Div {
     let mut d = div().flex().flex_col().gap(px(2.0));
     if let Some(sid) = &snap.session_id {
-        d = d.child(kv_row("Session", sid));
+        d = d.child(kv_row(cx, "Session", sid));
     }
     if let Some(outcome) = &snap.auth_outcome {
         let label = match outcome {
             zedra_session::AuthOutcome::Registered => "Registered (first pairing)",
             zedra_session::AuthOutcome::Authenticated => "Authorized",
         };
-        d = d.child(kv_row("Status", label));
+        d = d.child(kv_row(cx, "Status", label));
     }
     d
 }
 
-fn render_host_rows(snap: &ConnectSnapshot) -> Div {
+fn render_host_rows(cx: &App, snap: &ConnectSnapshot) -> Div {
     let mut d = div().flex().flex_col().gap(px(2.0));
     if !snap.hostname.is_empty() && !snap.username.is_empty() {
         let host_label = format!("{}@{}", snap.username, snap.hostname);
-        d = d.child(kv_row("Host", &host_label));
+        d = d.child(kv_row(cx, "Host", &host_label));
     }
     if let Some(os) = &snap.os {
         let label = match &snap.arch {
             Some(arch) if !arch.is_empty() => format!("{os} / {arch}"),
             _ => os.clone(),
         };
-        d = d.child(kv_row("OS", &label));
+        d = d.child(kv_row(cx, "OS", &label));
     }
     if !snap.workdir.is_empty() {
-        d = d.child(kv_row("Workdir", &snap.workdir));
+        d = d.child(kv_row(cx, "Workdir", &snap.workdir));
     }
     if let Some(v) = &snap.host_version {
         if !v.is_empty() {
-            d = d.child(kv_row("Version", v));
+            d = d.child(kv_row(cx, "Version", v));
         }
     }
     d
@@ -513,7 +526,7 @@ fn build_timing_string(snap: &ConnectSnapshot) -> String {
     parts.join(" \u{00b7} ")
 }
 
-fn kv_row(key: &'static str, value: &str) -> Div {
+fn kv_row(cx: &App, key: &'static str, value: &str) -> Div {
     div()
         .flex()
         .flex_row()
@@ -522,7 +535,7 @@ fn kv_row(key: &'static str, value: &str) -> Div {
             div()
                 .w(px(60.0))
                 .flex_shrink_0()
-                .text_color(rgb(theme::TEXT_MUTED))
+                .text_color(rgb(theme::text_muted(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(key),
         )
@@ -531,7 +544,7 @@ fn kv_row(key: &'static str, value: &str) -> Div {
                 .flex_1()
                 .min_w_0()
                 .truncate()
-                .text_color(rgb(theme::TEXT_SECONDARY))
+                .text_color(rgb(theme::text_secondary(cx)))
                 .text_size(px(theme::FONT_DETAIL))
                 .child(value.to_string()),
         )

--- a/crates/zedra/src/workspace_drawer.rs
+++ b/crates/zedra/src/workspace_drawer.rs
@@ -188,7 +188,7 @@ impl WorkspaceDrawer {
                     .clone()
                     .unwrap_or_else(|| session_state.phase());
                 let transport = session_state.snapshot().transport;
-                let (label, _) = transport_badge(&phase, transport.as_ref());
+                let (label, _) = transport_badge(&theme::palette(cx), &phase, transport.as_ref());
                 label
             }
         };
@@ -225,14 +225,14 @@ impl WorkspaceDrawer {
     fn nav_icon(&self, tab: DrawerTab, cx: &mut Context<Self>) -> impl IntoElement {
         let is_active = self.current_tab == tab;
         let color = if is_active {
-            rgb(theme::TEXT_PRIMARY)
+            rgb(theme::text_primary(cx))
         } else {
-            rgb(theme::TEXT_MUTED)
+            rgb(theme::text_muted(cx))
         };
         let fill = if is_active {
-            rgb(theme::BG_CARD)
+            rgb(theme::bg_card(cx))
         } else {
-            rgb(theme::BG_PRIMARY)
+            rgb(theme::bg_primary(cx))
         };
 
         div()
@@ -268,9 +268,9 @@ impl WorkspaceDrawer {
     fn file_mode_button(&self, mode: FileDisplayMode, cx: &mut Context<Self>) -> impl IntoElement {
         let is_active = self.file_display_mode == mode;
         let color = if is_active {
-            rgb(theme::TEXT_SECONDARY)
+            rgb(theme::text_secondary(cx))
         } else {
-            rgb(theme::TEXT_MUTED)
+            rgb(theme::text_muted(cx))
         };
 
         div()
@@ -305,13 +305,13 @@ impl WorkspaceDrawer {
             .top(px(0.0))
             .right(px(0.0))
             .pb_1()
-            .bg(rgb(theme::BG_SURFACE))
+            .bg(rgb(theme::bg_surface(cx)))
             .occlude()
             .on_pointer_down(|_, _, cx| cx.stop_propagation())
             .rounded_bl(px(6.0))
             .border_b_1()
             .border_l_1()
-            .border_color(rgb(theme::BORDER_SUBTLE))
+            .border_color(rgb(theme::border_subtle(cx)))
             .flex()
             .flex_col()
             .child(self.file_mode_button(FileDisplayMode::Explorer, cx))
@@ -351,7 +351,7 @@ impl Render for WorkspaceDrawer {
             .flex_col()
             .w_full()
             .h(viewport_h)
-            .bg(rgb(theme::BG_PRIMARY))
+            .bg(rgb(theme::bg_primary(cx)))
             .child(div().h(px(top_inset)))
             // Header
             .child(
@@ -361,7 +361,7 @@ impl Render for WorkspaceDrawer {
                     .flex_row()
                     .items_center()
                     .border_b_1()
-                    .border_color(rgb(theme::BORDER_SUBTLE))
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .child(
                         div()
                             .id("drawer-home-icon")
@@ -379,7 +379,7 @@ impl Render for WorkspaceDrawer {
                                 svg()
                                     .path("icons/logo.svg")
                                     .size(px(theme::ICON_LOGO))
-                                    .text_color(rgb(theme::TEXT_PRIMARY)),
+                                    .text_color(rgb(theme::text_primary(cx))),
                             ),
                     )
                     .child(
@@ -395,7 +395,7 @@ impl Render for WorkspaceDrawer {
                                     .min_w_0()
                                     .truncate()
                                     .text_center()
-                                    .text_color(rgb(theme::TEXT_SECONDARY))
+                                    .text_color(rgb(theme::text_secondary(cx)))
                                     .text_size(px(theme::FONT_BODY))
                                     .font_weight(FontWeight::MEDIUM)
                                     .child(title),
@@ -406,7 +406,7 @@ impl Render for WorkspaceDrawer {
                                     .min_w_0()
                                     .truncate()
                                     .text_center()
-                                    .text_color(rgb(theme::TEXT_MUTED))
+                                    .text_color(rgb(theme::text_muted(cx)))
                                     .text_size(px(theme::FONT_BODY))
                                     .font_weight(FontWeight::MEDIUM)
                                     .child(subtitle),
@@ -422,6 +422,7 @@ impl Render for WorkspaceDrawer {
                                 ConnectionStatusIndicator::from_phase(
                                     "drawer-connect-status",
                                     connect_phase.as_ref(),
+                                    &theme::palette(cx),
                                 )
                                 .size(6.0),
                             ),
@@ -451,7 +452,7 @@ impl Render for WorkspaceDrawer {
                     .justify_center()
                     .gap(px(36.0))
                     .border_t_1()
-                    .border_color(rgb(theme::BORDER_SUBTLE))
+                    .border_color(rgb(theme::border_subtle(cx)))
                     .child(self.nav_icon(DrawerTab::FileExplorer, cx))
                     .child(self.nav_icon(DrawerTab::GitDiff, cx))
                     .child(self.nav_icon(DrawerTab::Terminals, cx))

--- a/crates/zedra/src/workspace_editor.rs
+++ b/crates/zedra/src/workspace_editor.rs
@@ -6,6 +6,7 @@ use crate::editor::markdown::{
     MARKDOWN_SELECTION_AREA_ID, MarkdownView, is_markdown_path, parse_markdown_source,
 };
 use crate::placeholder::render_placeholder;
+use crate::theme;
 
 #[derive(Clone, Debug)]
 enum FileState {
@@ -64,7 +65,6 @@ impl WorkspaceEditor {
         self.state = FileState::Loading;
         cx.notify();
 
-        // Drop any previous task before starting a new one.
         let prev_task = self.read_task.take();
         drop(prev_task);
 
@@ -212,11 +212,11 @@ pub struct EditorSelection {
 }
 
 impl Render for WorkspaceEditor {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         match self.state.clone() {
-            FileState::Loading => render_placeholder("Loading ..."),
-            FileState::TooLarge => render_placeholder("File too large (>500 KB)"),
-            FileState::Error { error } => render_placeholder(format!("Error: {}", error)),
+            FileState::Loading => render_placeholder(cx, "Loading ..."),
+            FileState::TooLarge => render_placeholder(cx, "File too large (>500 KB)"),
+            FileState::Error { error } => render_placeholder(cx, format!("Error: {}", error)),
             FileState::Loaded => match self.content {
                 EditorContent::Code => div().size_full().child(self.editor_view.clone()),
                 EditorContent::Markdown => div()

--- a/crates/zedra/src/workspace_editor.rs
+++ b/crates/zedra/src/workspace_editor.rs
@@ -6,7 +6,6 @@ use crate::editor::markdown::{
     MARKDOWN_SELECTION_AREA_ID, MarkdownView, is_markdown_path, parse_markdown_source,
 };
 use crate::placeholder::render_placeholder;
-use crate::theme;
 
 #[derive(Clone, Debug)]
 enum FileState {

--- a/crates/zedra/src/workspace_gitdiff.rs
+++ b/crates/zedra/src/workspace_gitdiff.rs
@@ -121,11 +121,11 @@ impl WorkspaceGitdiff {
 }
 
 impl Render for WorkspaceGitdiff {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         match self.state.clone() {
-            GitdiffState::Loading => render_placeholder("Loading ..."),
-            GitdiffState::TooLarge => render_placeholder("Diff too large (>200 KB)"),
-            GitdiffState::Error { error } => render_placeholder(&format!("Error: {}", error)),
+            GitdiffState::Loading => render_placeholder(cx, "Loading ..."),
+            GitdiffState::TooLarge => render_placeholder(cx, "Diff too large (>200 KB)"),
+            GitdiffState::Error { error } => render_placeholder(cx, &format!("Error: {}", error)),
             GitdiffState::Loaded => div().size_full().child(self.diff_view.clone()),
         }
     }

--- a/crates/zedra/src/workspace_terminal.rs
+++ b/crates/zedra/src/workspace_terminal.rs
@@ -19,6 +19,7 @@ use crate::platform_bridge::{
 use crate::telemetry::view_telemetry;
 use crate::terminal_preview_view::TerminalPreviewView;
 use crate::terminal_state::TerminalState;
+use crate::theme_state::{ThemeStateEvent, entity as theme_entity};
 use crate::workspace_state::{WorkspaceState, WorkspaceStateEvent};
 
 pub const TERMINAL_PENDING_ID: &str = "___PENDING___";
@@ -55,6 +56,13 @@ pub struct WorkspaceTerminal {
 }
 
 impl WorkspaceTerminal {
+    fn sync_terminal_theme(&mut self, cx: &mut Context<Self>) {
+        let terminal_theme = crate::theme::bundle(cx).terminal;
+        self.terminal_view.update(cx, |terminal_view, cx| {
+            terminal_view.set_terminal_theme(terminal_theme, cx);
+        });
+    }
+
     fn keyboard_inset() -> Pixels {
         let bridge = platform_bridge::bridge();
         let density = bridge.density();
@@ -378,7 +386,16 @@ impl WorkspaceTerminal {
             },
         );
 
-        Self {
+        let mut subscriptions = vec![attach_sub, terminal_events_sub, keyboard_offset_hook];
+        if let Some(theme_state) = theme_entity(cx) {
+            subscriptions.push(
+                cx.subscribe(&theme_state, |this, _, _: &ThemeStateEvent, cx| {
+                    this.sync_terminal_theme(cx);
+                }),
+            );
+        }
+
+        let mut this = Self {
             terminal_id,
             workspace_state,
             terminal_state,
@@ -392,8 +409,10 @@ impl WorkspaceTerminal {
             scroll_to_bottom_button_visible: false,
             scroll_to_bottom_button_hide_pending: false,
             scroll_to_bottom_button_hide_generation: 0,
-            _subscriptions: vec![attach_sub, terminal_events_sub, keyboard_offset_hook],
-        }
+            _subscriptions: subscriptions,
+        };
+        this.sync_terminal_theme(cx);
+        this
     }
 
     pub fn register_as_active_input(&mut self, cx: &mut Context<Self>) {

--- a/crates/zedra/src/workspace_terminal.rs
+++ b/crates/zedra/src/workspace_terminal.rs
@@ -16,10 +16,10 @@ use crate::platform_bridge::{
     self, CustomSheetDetent, CustomSheetOptions, HapticFeedback, NativeDictationPreviewOptions,
     NativeEditMenuItem,
 };
+use crate::settings::{ThemeStateEvent, theme_state as theme_entity};
 use crate::telemetry::view_telemetry;
 use crate::terminal_preview_view::TerminalPreviewView;
 use crate::terminal_state::TerminalState;
-use crate::theme_state::{ThemeStateEvent, entity as theme_entity};
 use crate::workspace_state::{WorkspaceState, WorkspaceStateEvent};
 
 pub const TERMINAL_PENDING_ID: &str = "___PENDING___";

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -135,6 +135,10 @@ and git status are refreshed before the initial terminal is opened or created.
 On reconnect, the same drawer refresh is triggered in the background so terminal
 reattach and user interaction are not blocked by file/git refresh latency.
 
+### Appearance / theming
+
+App settings live in `crates/zedra/src/settings.rs`. `ThemeState` is the appearance-specific part of those settings: it owns the user’s `ThemePreference` and a `ThemeBundle` (UI palette, editor theme, terminal theme). GPUI views read tokens through `theme::palette(cx)`; editor and terminal entities sync their sub-bundles on `ThemeStateEvent::Changed`. New UI must follow `docs/THEMING.md`—do not hardcode colors in views.
+
 ## Security
 
 | Layer | Mechanism |

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -152,7 +152,17 @@ Always `platform_bridge::bridge()`. Never call platform APIs directly from UI co
 Read `docs/DESIGN.md` before creating or redesigning UI.
 
 - Treat it as the visual source of truth for tone, density, spacing, typography, and component styling.
-- New product UI should match the repo's dark, flat, quiet, tool-like direction.
+- New product UI should match the repo's flat, quiet, tool-like direction in both dark and light appearance.
+
+## Theming
+
+Read `docs/THEMING.md` before adding or changing product UI colors.
+
+- **Workspace GPUI**: use `theme::palette(cx)` or `theme::bg_primary(cx)` (and related accessors) in `render()`. Layout sizes use constants in `theme.rs` (`SPACING_*`, `FONT_*`, `ICON_*`).
+- **Editor**: sync `theme::bundle(cx).editor` into editor entities on create and on `ThemeStateEvent::Changed`.
+- **Terminal**: sync `theme::bundle(cx).terminal` through `WorkspaceTerminal` / `TerminalView::set_terminal_theme`; do not map terminal ANSI colors from `ThemePalette`.
+- **Do not** hardcode `0xRRGGBB` or inline light/dark branches in views. Add tokens in `crates/zedra/src/theme.rs` or `crates/zedra-terminal/src/theme.rs` when a new color is needed.
+- Subscribe to `ThemeStateEvent::Changed` on the owning entity when the subtree is not refreshed by a parent that already notifies on theme change.
 
 ## Swift Native Integration
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -14,24 +14,28 @@ The UI should read like a native code workspace on mobile: calm surfaces, compac
 
 ## Color System
 
-Primary references live in `crates/zedra/src/theme.rs`.
+Canonical tokens and wiring live in `docs/THEMING.md`. Definitions are in `crates/zedra/src/theme.rs` (`ThemePalette`, dark/light pairs) and `crates/zedra-terminal/src/theme.rs` for the embedded terminal.
 
-- Base background: `BG_PRIMARY` / `BG_SURFACE`
-- Raised surface: `BG_CARD`
-- Quiet structure: `BORDER_SUBTLE`
-- Stronger control edge: `BORDER_DEFAULT`
-- Primary text: `TEXT_PRIMARY`
-- Standard text: `TEXT_SECONDARY`
-- Muted metadata and inactive states: `TEXT_MUTED`
+New UI must read colors from `theme::palette(cx)` or the `theme::bg_primary(cx)`-style accessors at render time. Do not hardcode hex values in views.
+
+| Role | Token (via `theme::`) |
+|------|------------------------|
+| Base background | `bg_primary`, `bg_surface` |
+| Raised surface | `bg_card`, `bg_overlay` |
+| Quiet structure | `border_subtle` |
+| Control edge | `border_default`, `border_active` |
+| Primary text | `text_primary` |
+| Standard text | `text_secondary` |
+| Muted metadata | `text_muted` |
 
 Accent colors are semantic only.
 
-- Green: healthy / connected / success
-- Yellow: connecting / warning
-- Red: failure / destructive
-- Blue: focus and active input state
+- Green: healthy / connected / success (`accent_green`)
+- Yellow: connecting / warning (`accent_yellow`)
+- Red: failure / destructive (`accent_red`)
+- Blue: focus and active input state (`accent_blue`)
 
-Do not use accent color as decoration.
+Do not use accent color as decoration. Light and dark palettes are paired in `ThemePalette::dark()` / `light()`; keep new tokens in sync in both.
 
 ## Layout And Spacing
 
@@ -88,7 +92,7 @@ If a component feels busy, remove a line before adding a new one.
 
 ### Cards
 
-- Use `BG_CARD`
+- Use `bg_card` from the active palette
 - Use a subtle 1px border
 - Keep padding tight
 - Avoid decorative fills and badges unless they carry state
@@ -127,8 +131,8 @@ Recommended direction for commit UI:
 
 ## Do
 
-- Use neutral dark surfaces
-- Reuse `theme.rs` tokens
+- Use neutral surfaces from the active palette (dark or light)
+- Reuse `theme.rs` tokens; follow `docs/THEMING.md` for editor and terminal
 - Reuse existing GPUI controls
 - Prefer subtraction over embellishment
 - Make state visible with text, opacity, and spacing

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -948,3 +948,16 @@ Expected:
 1. Install a **Release** build on device (not Xcode Run with debugger attached)
 2. Connect via **Scan QR**; optional: `scripts/log-ios.sh --grep connect`
 3. Expected: no burst of per-packet iroh/quinn trace lines (`tracing-subscriber` requires `debug-logs`)
+
+## 22. Terminal appearance (light/dark)
+
+1. Connect to a workspace and open a terminal running `ls` with color
+2. Open Settings → Appearance → **Light**
+3. Expected: terminal background is light; directory names and ANSI colors are readable (not washed out)
+4. Run `claude` (or another session already showing Claude output) and scroll to file-reference lines such as `L123 (file.rs):`
+5. Expected: highlighted paths are readable on the light background (not pale lavender)
+6. Open **Codex** in the same terminal (or a dedicated Codex session)
+7. Expected: the composer / user-message background pill matches the light theme (not missing or using a dark gray from stale palette)
+8. Toggle back to **Dark**
+9. Expected: terminal colors, Claude highlights, and Codex pill update without restarting the app
+10. Optional: from the host, run `printf '\e[10;?\e[11;?\e\\'` inside the Zedra session and confirm replies report the current fg/bg (light: `fafafa` background). Zedra answers OSC queries on the session PTY via `ColorRequest` and the active `TerminalTheme`; it does not inject palette setup bytes into scrollback on toggle.

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -952,7 +952,7 @@ Expected:
 ## 22. Terminal appearance (light/dark)
 
 1. Connect to a workspace and open a terminal running `ls` with color
-2. Open Settings → Appearance → **Light**
+2. Open Settings → Appearance and tap the **sun** segment (light mode)
 3. Expected: terminal background is light; directory names and ANSI colors are readable (not washed out)
 4. Run `claude` (or another session already showing Claude output) and scroll to file-reference lines such as `L123 (file.rs):`
 5. Expected: highlighted paths are readable on the light background (not pale lavender)

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -1,0 +1,140 @@
+# Theming
+
+Zedra supports **dark** and **light** appearance. New product UI must use the shared theme tokens so colors stay consistent and update when the user toggles appearance or when the app follows the system theme on launch.
+
+Read `docs/DESIGN.md` for visual tone (density, typography, when to use accent color). This doc covers **where tokens live** and **how to wire them in code**.
+
+## Source Of Truth
+
+| Layer | Location | Role |
+|-------|----------|------|
+| App settings + appearance | `crates/zedra/src/settings.rs` | Loads/saves app settings; `ThemeState` manages `ThemePreference`, builds `ThemeBundle`, emits `ThemeStateEvent::Changed` |
+| Token definitions | `crates/zedra/src/theme.rs` | `ThemePalette`, `EditorTheme`, `ThemeBundle`, layout constants, `theme::palette(cx)` accessors |
+| Terminal palette | `crates/zedra-terminal/src/theme.rs` | `TerminalTheme`, ANSI + xterm-256 table, truecolor rules for light mode |
+| User control | Settings → Appearance | Calls `ThemeState::set_preference` |
+
+`ThemeState` is registered as a GPUI global at app startup (`ZedraApp` in `crates/zedra/src/app.rs`). It is the appearance-specific state inside the settings module. Views read the active bundle through `theme::palette(cx)` / `theme::bundle(cx)`, which delegate to the global entity.
+
+```
+Settings / system on launch
+        ↓
+   ThemeState (preference + ThemeBundle)
+        ↓
+   ┌────┴────┬──────────────┐
+   │         │              │
+GPUI views  Editor        Terminal (zedra-terminal)
+theme::*    EditorTheme   TerminalTheme
+```
+
+## Rules For New UI
+
+**Required**
+
+- Read **UI colors** from `theme::palette(cx)` or the `theme::bg_primary(cx)`-style accessors in `crates/zedra/src/theme.rs`. Wrap hex tokens with `rgb(...)` (or `Hsla` fields on the palette) in `render()`.
+- Use **layout and typography constants** from `theme.rs` (`SPACING_*`, `FONT_*`, `ICON_*`, `DRAWER_*`, etc.). Those are appearance-independent; do not duplicate magic numbers in views.
+- Use **semantic accents** only for meaning (connected, warning, destructive, focus)—see `docs/DESIGN.md`.
+- If a surface must react to a theme toggle, subscribe to `ThemeStateEvent::Changed` and call `cx.notify()` on the owning entity (see `ZedraApp::on_theme_changed` and `WorkspaceTerminal`).
+
+**Forbidden in view `render()` and leaf components**
+
+- Hardcoded `0xRRGGBB` / `rgb(0x...)` for product chrome, text, borders, or backgrounds.
+- Per-component light/dark branches (`if light { ... } else { ... }`) unless you are implementing theme infrastructure itself.
+- Render-time hacks that only fix contrast for one screen (tint overlays, one-off HSLA nudges). Add or adjust a token in `theme.rs` (or terminal `theme.rs`) instead.
+
+**Exceptions**
+
+- Illustrations, third-party assets, or platform-provided colors outside GPUI control.
+- Editor syntax highlighting: use `EditorTheme` / `SyntaxTheme` from `theme::bundle(cx).editor`, not `ThemePalette`.
+- Terminal cell colors: use `TerminalTheme` via `TerminalView::set_terminal_theme`, not `ThemePalette`. The emulator answers OSC color queries from `TerminalTheme` and paints through `convert_color`.
+
+## Workspace UI (GPUI)
+
+During `render`, pass `cx` and use accessors:
+
+```rust
+use crate::theme;
+
+div()
+    .bg(rgb(theme::bg_primary(cx)))
+    .child(
+        Label::new("Title")
+            .text_color(rgb(theme::text_primary(cx)))
+            .text_size(px(theme::FONT_BODY)),
+    )
+```
+
+When several fields are needed together (e.g. badges), take `let palette = theme::palette(cx);` once.
+
+`ThemePalette` fields:
+
+| Field | Typical use |
+|-------|-------------|
+| `bg_primary`, `bg_surface` | Full-height shells, workspace background |
+| `bg_card`, `bg_overlay` | Raised panels, sheets, overlays |
+| `text_primary`, `text_secondary`, `text_muted` | Labels, body, metadata |
+| `border_subtle`, `border_default`, `border_active`, `border_highlight` | 1px separators and control edges |
+| `accent_green`, `accent_blue`, `accent_yellow`, `accent_red`, `accent_dim` | Status and semantic emphasis only |
+| `git_added`, `git_removed` | Git diff marks |
+| `row_pressed_bg`, `overlay_backdrop` | Pressed rows, modal backdrops (`Hsla`) |
+
+Adding a new UI color: extend `ThemePalette` in `theme.rs` for both `dark()` and `light()`, add an accessor if it will be used widely, then use it from views. Do not add parallel constants outside `theme.rs`.
+
+## Editor
+
+Editor views take `EditorTheme` from `theme::bundle(cx).editor` and push it into the editor entity:
+
+- `CodeEditor::sync_editor_theme`
+- `GitDiffView::sync_editor_theme`
+
+Subscribe to `ThemeStateEvent::Changed` on the same entity that owns the editor (or a parent that can reach it) and re-sync after `theme::bundle(cx)` updates.
+
+Syntax colors live in `crates/zedra/src/editor/syntax_theme.rs` and are selected inside `EditorTheme::dark()` / `light()`.
+
+## Terminal
+
+Terminal colors are **not** `ThemePalette`. They flow through `ThemeBundle::terminal` (`TerminalTheme` in `crates/zedra-terminal/src/theme.rs`).
+
+- `WorkspaceTerminal::sync_terminal_theme` calls `TerminalView::set_terminal_theme`.
+- GPUI painting uses `TerminalTheme::convert_color` in `zedra-terminal`’s element layer.
+- OSC 10/11/12 and palette queries are answered from `TerminalTheme` via `ColorRequest` (see `docs/MANUAL_TEST.md` §22).
+
+To tune light terminal contrast, edit tokens and derived tables in `crates/zedra-terminal/src/theme.rs` only—not in `element.rs` or `terminal.rs` render paths.
+
+## Subscribing To Theme Changes
+
+**App shell** — `ZedraApp` subscribes to `ThemeState` and calls `cx.notify()` so top-level screens re-render.
+
+**Feature-owned surfaces** — subscribe where the entity owns the subtree that must update:
+
+```rust
+cx.subscribe(&theme_state, |this, _, _: &ThemeStateEvent, cx| {
+    this.sync_terminal_theme(cx); // or sync_editor_theme, or cx.notify()
+});
+```
+
+Call the sync helper once after subscribe setup so the initial preference is applied.
+
+Changing preference:
+
+```rust
+theme_state.update(cx, |state, cx| {
+    state.set_preference(ThemePreference::Light, cx);
+});
+```
+
+Persistence is handled inside `ThemeState`. `None` in settings means “follow system on next launch.”
+
+## Checklist For New Screens
+
+1. All backgrounds, text, and borders use `theme::` accessors (or `theme::palette(cx)` fields).
+2. Spacing and font sizes use `theme::` layout constants.
+3. Parent entity subscribes to `ThemeStateEvent::Changed` if the screen is not under `ZedraApp`’s notify path.
+4. Editor or terminal child, if any, has a `sync_*_theme` on create and on theme change.
+5. Manual steps added to `docs/MANUAL_TEST.md` if the change is visible on device (toggle light/dark).
+
+## Related Docs
+
+- `docs/DESIGN.md` — visual tone and component patterns
+- `docs/CONVENTIONS.md` — GPUI `render()` purity and UI design pointer
+- `docs/MANUAL_TEST.md` §22 — terminal appearance verification
+- `crates/zedra/AGENTS.md` — crate-level UI rules

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -6,38 +6,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define BG_PRIMARY 920588
-
-#define BG_CARD 1250067
-
-#define BG_OVERLAY 1250067
-
-#define BG_SURFACE 920588
-
-#define TEXT_PRIMARY 16777215
-
-#define TEXT_SECONDARY 13290186
-
-#define TEXT_MUTED 5263440
-
-#define BORDER_HIGHLIGHT 13290186
-
-#define BORDER_DEFAULT 2894892
-
-#define BORDER_ACTIVE 5263440
-
-#define BORDER_SUBTLE 1710618
-
-#define ACCENT_GREEN 10011513
-
-#define ACCENT_BLUE 6402031
-
-#define ACCENT_YELLOW 15057019
-
-#define ACCENT_RED 14707829
-
-#define ACCENT_DIM 5263440
-
 #define DRAWER_PADDING 12.0
 
 #define SPACING_XS 4.0
@@ -63,6 +31,8 @@
 #define TERMINAL_LINE_HEIGHT 16.0
 
 #define PANEL_ITEM_HEIGHT 28.0
+
+#define DRAWER_EDGE_ZONE 72.0
 
 #define DRAWER_EDGE_ZONE 56.0
 
@@ -321,6 +291,16 @@ extern void ios_present_text_input(uint32_t callback_id,
                                    const char *title,
                                    const char *placeholder,
                                    const char *initial_value);
+
+/**
+ * Returns 1 for dark, 0 for light, -1 when unavailable.
+ */
+extern int32_t ios_system_prefers_dark_theme(void);
+
+/**
+ * Apply the app appearance to the native keyboard accessory bar.
+ */
+extern void ios_set_keyboard_accessory_theme(bool is_dark);
 
 /**
  * Called from the native alert handler after the user taps a button.

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -6,95 +6,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define DRAWER_PADDING 12.0
-
-#define SPACING_XS 4.0
-
-#define SPACING_SM 8.0
-
-#define SPACING_MD 12.0
-
-#define SPACING_LG 16.0
-
-#define HEADER_HEIGHT 48.0
-
-#define HOME_CARD_WIDTH 300.0
-
-#define HOME_GUIDE_WIDTH 300.0
-
-#define CONNECT_DETAIL_WIDTH 300.0
-
-#define HEADER_BUTTON_SIZE 42.0
-
-#define DRAWER_ICON_ZONE 38.0
-
-#define TERMINAL_LINE_HEIGHT 16.0
-
-#define PANEL_ITEM_HEIGHT 28.0
-
-#define DRAWER_EDGE_ZONE 72.0
-
-#define DRAWER_EDGE_ZONE 56.0
-
-#define DRAWER_VELOCITY_THRESHOLD 12.0
-
-#define DRAWER_BACKDROP_OPACITY 0.4
-
-#define DRAWER_DEFAULT_WIDTH 295.0
-
-#define DRAWER_OPEN_ANIMATION_DURATION_MS 160
-
-#define DRAWER_CLOSE_ANIMATION_DURATION_MS 100
-
-#define FONT_APP_TITLE 28.0
-
-#define FONT_TITLE 20.0
-
-#define FONT_HEADING 13.0
-
-#define FONT_BODY 12.0
-
-#define FONT_DETAIL 12.0
-
-#define ICON_LOGO 20.0
-
-#define ICON_LG 24.0
-
-#define ICON_MD 18.0
-
-#define ICON_SM 16.0
-
-#define ICON_XS 14.0
-
-#define ICON_FILE 12.0
-
-#define ICON_FILE_DIR 14.0
-
-#define ICON_STATUS 6.0
-
-#define ICON_TERMINAL 16.0
-
-#define EDITOR_FONT_SIZE 12.0
-
-#define EDITOR_GUTTER_FONT_SIZE 11.0
-
-#define EDITOR_LINE_HEIGHT 15.0
-
-#define EDITOR_GUTTER_WIDTH 36.0
-
-typedef struct AgentCaps AgentCaps;
-
-
-
-
-
-
-
 extern void gpui_ios_set_next_embedded_parent(void *parent_view_ptr,
                                               float width_pts,
                                               float height_pts);
-
-extern void *gpui_ios_get_window(void);
 
 extern void gpui_ios_attach_embedded_view(void *window_ptr,
                                           void *parent_view_ptr,
@@ -157,16 +71,7 @@ void zedra_ios_set_keyboard_height(uint32_t height_px);
  */
 void zedra_ios_set_safe_area_insets(float top, float bottom, float _left, float _right);
 
-extern void *gpui_ios_get_window(void);
-
 extern bool gpui_ios_is_keyboard_visible(void *window_ptr);
-
-extern void gpui_ios_hide_keyboard(void *window_ptr);
-
-/**
- * Present the AVFoundation QR scanner (defined in QRScanner.swift).
- */
-extern void ios_present_qr_scanner(void);
 
 /**
  * Returns the app's Documents directory path (from NSSearchPathForDirectoriesInDomains).
@@ -373,8 +278,6 @@ void zedra_deeplink_received(const char *url);
  * Routes through the unified deeplink path (same as system URL intents).
  */
 void zedra_qr_scanner_result(const char *qr_string);
-
-extern void zedra_nslog(const char *msg);
 
 extern void zedra_log_event(const char *name,
                             const char *const *keys,

--- a/ios/Zedra/GPUIRuntimeController.swift
+++ b/ios/Zedra/GPUIRuntimeController.swift
@@ -25,12 +25,15 @@ private func zedra_ios_send_key_input(_ key: UnsafePointer<CChar>)
 private func zedra_ios_app_will_terminate()
 
 final class GPUIRuntimeController: NSObject {
+    private static weak var activeController: GPUIRuntimeController?
+
     private var gpuiApp: UnsafeMutableRawPointer?
     private var gpuiWindow: UnsafeMutableRawPointer?
     private var displayLink: CADisplayLink?
     private let keyboardAccessoryController = KeyboardSupporter()
 
     func launch() {
+        Self.activeController = self
         zedra_firebase_initialize()
 
         gpuiApp = gpui_ios_initialize()
@@ -179,6 +182,12 @@ final class GPUIRuntimeController: NSObject {
             self?.sendKeyboardAccessoryKey(key)
         }
         gpui_ios_set_keyboard_accessory_view(Unmanaged.passUnretained(bar).toOpaque())
+    }
+
+    static func setKeyboardAccessoryTheme(isDark: Bool) {
+        DispatchQueue.main.async {
+            activeController?.keyboardAccessoryController.applyTheme(isDark: isDark)
+        }
     }
 
     private func startDisplayLink() {

--- a/ios/Zedra/KeyboardSupporter.swift
+++ b/ios/Zedra/KeyboardSupporter.swift
@@ -22,24 +22,45 @@ final class KeyboardSupporter: NSObject {
     private let repeatInterval: TimeInterval = 0.06
 
     private(set) var accessoryView: UIView?
+    private weak var topBorder: UIView?
+    private weak var leftKeyboardCornerFill: UIView?
+    private weak var rightKeyboardCornerFill: UIView?
+    private var buttons: [UIButton] = []
     private var sendKey: ((String) -> Void)?
     private var repeatTimer: Timer?
     private var repeatingKey: String?
+    private var isDarkTheme = true
 
     func makeAccessoryView(width: CGFloat, sendKey: @escaping (String) -> Void) -> UIView {
         stopRepeating()
         self.sendKey = sendKey
+        buttons.removeAll()
 
         let height: CGFloat = 44.0
         let bar = UIView(frame: CGRect(x: 0, y: 0, width: width, height: height))
-        bar.backgroundColor = UIColor(red: 0.055, green: 0.047, blue: 0.047, alpha: 0.96)
-        if #available(iOS 13.0, *) {
-            bar.overrideUserInterfaceStyle = .dark
-        }
+        bar.clipsToBounds = false
 
         let border = UIView(frame: CGRect(x: 0, y: 0, width: width, height: 0.33))
-        border.backgroundColor = UIColor(white: 1.0, alpha: 0.12)
         bar.addSubview(border)
+        topBorder = border
+
+        // The system keyboard has rounded top corners, which can expose the window
+        // background beside an inputAccessoryView. Fill only those side gaps.
+        let cornerFillWidth: CGFloat = 18.0
+        let cornerFillHeight: CGFloat = 12.0
+        let leftFill = UIView(frame: CGRect(x: 0, y: height, width: cornerFillWidth, height: cornerFillHeight))
+        let rightFill = UIView(
+            frame: CGRect(
+                x: width - cornerFillWidth,
+                y: height,
+                width: cornerFillWidth,
+                height: cornerFillHeight
+            )
+        )
+        bar.addSubview(leftFill)
+        bar.addSubview(rightFill)
+        leftKeyboardCornerFill = leftFill
+        rightKeyboardCornerFill = rightFill
 
         let buttonWidth = width / CGFloat(keySpecs.count)
 
@@ -48,12 +69,6 @@ final class KeyboardSupporter: NSObject {
             button.frame = CGRect(x: buttonWidth * CGFloat(index), y: 0, width: buttonWidth, height: height)
             button.setTitle(spec.label, for: .normal)
             button.titleLabel?.font = .systemFont(ofSize: 16.0)
-            let color = UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.0)
-            button.setTitleColor(color, for: .normal)
-            button.tintColor = color
-            if #available(iOS 13.0, *) {
-                button.overrideUserInterfaceStyle = .dark
-            }
             button.tag = index
             button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
             button.addTarget(self, action: #selector(buttonTouchUpInside(_:)), for: .touchUpInside)
@@ -61,10 +76,43 @@ final class KeyboardSupporter: NSObject {
             button.addTarget(self, action: #selector(stopRepeating), for: .touchCancel)
             button.addTarget(self, action: #selector(stopRepeating), for: .touchDragExit)
             bar.addSubview(button)
+            buttons.append(button)
         }
 
         accessoryView = bar
+        applyTheme(isDark: isDarkTheme)
         return bar
+    }
+
+    func applyTheme(isDark: Bool) {
+        isDarkTheme = isDark
+
+        let backgroundColor = isDark
+            ? UIColor(red: 0.055, green: 0.047, blue: 0.047, alpha: 0.96)
+            : UIColor(red: 0.961, green: 0.961, blue: 0.961, alpha: 0.98)
+        let foregroundColor = isDark
+            ? UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.0)
+            : UIColor(red: 0.102, green: 0.102, blue: 0.102, alpha: 1.0)
+        let borderColor = isDark
+            ? UIColor(white: 1.0, alpha: 0.12)
+            : UIColor(white: 0.0, alpha: 0.10)
+
+        accessoryView?.backgroundColor = backgroundColor
+        topBorder?.backgroundColor = borderColor
+        leftKeyboardCornerFill?.backgroundColor = backgroundColor
+        rightKeyboardCornerFill?.backgroundColor = backgroundColor
+
+        let interfaceStyle: UIUserInterfaceStyle = isDark ? .dark : .light
+        if #available(iOS 13.0, *) {
+            accessoryView?.overrideUserInterfaceStyle = interfaceStyle
+        }
+        for button in buttons {
+            button.setTitleColor(foregroundColor, for: .normal)
+            button.tintColor = foregroundColor
+            if #available(iOS 13.0, *) {
+                button.overrideUserInterfaceStyle = interfaceStyle
+            }
+        }
     }
 
     func stopRepeating() {

--- a/ios/Zedra/NativeBridge.swift
+++ b/ios/Zedra/NativeBridge.swift
@@ -77,6 +77,24 @@ func ios_get_documents_directory() -> UnsafePointer<CChar>? {
     return CStringStorage.shared.pointer(for: "documents_directory", value: path)
 }
 
+/// Returns 1 for dark, 0 for light, -1 when unavailable.
+@_cdecl("ios_system_prefers_dark_theme")
+func ios_system_prefers_dark_theme() -> Int32 {
+    switch UITraitCollection.current.userInterfaceStyle {
+    case .dark:
+        return 1
+    case .light:
+        return 0
+    default:
+        return -1
+    }
+}
+
+@_cdecl("ios_set_keyboard_accessory_theme")
+func ios_set_keyboard_accessory_theme(_ isDark: Bool) {
+    GPUIRuntimeController.setKeyboardAccessoryTheme(isDark: isDark)
+}
+
 @_cdecl("zedra_firebase_initialize")
 func zedra_firebase_initialize_bridge() {
     _ = ZedraFirebase.configureIfAvailable()

--- a/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
@@ -6,38 +6,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define BG_PRIMARY 920588
-
-#define BG_CARD 1250067
-
-#define BG_OVERLAY 1250067
-
-#define BG_SURFACE 920588
-
-#define TEXT_PRIMARY 16777215
-
-#define TEXT_SECONDARY 13290186
-
-#define TEXT_MUTED 5263440
-
-#define BORDER_HIGHLIGHT 13290186
-
-#define BORDER_DEFAULT 2894892
-
-#define BORDER_ACTIVE 5263440
-
-#define BORDER_SUBTLE 1710618
-
-#define ACCENT_GREEN 10011513
-
-#define ACCENT_BLUE 6402031
-
-#define ACCENT_YELLOW 15057019
-
-#define ACCENT_RED 14707829
-
-#define ACCENT_DIM 5263440
-
 #define DRAWER_PADDING 12.0
 
 #define SPACING_XS 4.0
@@ -63,6 +31,8 @@
 #define TERMINAL_LINE_HEIGHT 16.0
 
 #define PANEL_ITEM_HEIGHT 28.0
+
+#define DRAWER_EDGE_ZONE 72.0
 
 #define DRAWER_EDGE_ZONE 56.0
 
@@ -321,6 +291,16 @@ extern void ios_present_text_input(uint32_t callback_id,
                                    const char *title,
                                    const char *placeholder,
                                    const char *initial_value);
+
+/**
+ * Returns 1 for dark, 0 for light, -1 when unavailable.
+ */
+extern int32_t ios_system_prefers_dark_theme(void);
+
+/**
+ * Apply the app appearance to the native keyboard accessory bar.
+ */
+extern void ios_set_keyboard_accessory_theme(bool is_dark);
 
 /**
  * Called from the native alert handler after the user taps a button.

--- a/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
@@ -6,95 +6,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define DRAWER_PADDING 12.0
-
-#define SPACING_XS 4.0
-
-#define SPACING_SM 8.0
-
-#define SPACING_MD 12.0
-
-#define SPACING_LG 16.0
-
-#define HEADER_HEIGHT 48.0
-
-#define HOME_CARD_WIDTH 300.0
-
-#define HOME_GUIDE_WIDTH 300.0
-
-#define CONNECT_DETAIL_WIDTH 300.0
-
-#define HEADER_BUTTON_SIZE 42.0
-
-#define DRAWER_ICON_ZONE 38.0
-
-#define TERMINAL_LINE_HEIGHT 16.0
-
-#define PANEL_ITEM_HEIGHT 28.0
-
-#define DRAWER_EDGE_ZONE 72.0
-
-#define DRAWER_EDGE_ZONE 56.0
-
-#define DRAWER_VELOCITY_THRESHOLD 12.0
-
-#define DRAWER_BACKDROP_OPACITY 0.4
-
-#define DRAWER_DEFAULT_WIDTH 295.0
-
-#define DRAWER_OPEN_ANIMATION_DURATION_MS 160
-
-#define DRAWER_CLOSE_ANIMATION_DURATION_MS 100
-
-#define FONT_APP_TITLE 28.0
-
-#define FONT_TITLE 20.0
-
-#define FONT_HEADING 13.0
-
-#define FONT_BODY 12.0
-
-#define FONT_DETAIL 12.0
-
-#define ICON_LOGO 20.0
-
-#define ICON_LG 24.0
-
-#define ICON_MD 18.0
-
-#define ICON_SM 16.0
-
-#define ICON_XS 14.0
-
-#define ICON_FILE 12.0
-
-#define ICON_FILE_DIR 14.0
-
-#define ICON_STATUS 6.0
-
-#define ICON_TERMINAL 16.0
-
-#define EDITOR_FONT_SIZE 12.0
-
-#define EDITOR_GUTTER_FONT_SIZE 11.0
-
-#define EDITOR_LINE_HEIGHT 15.0
-
-#define EDITOR_GUTTER_WIDTH 36.0
-
-typedef struct AgentCaps AgentCaps;
-
-
-
-
-
-
-
 extern void gpui_ios_set_next_embedded_parent(void *parent_view_ptr,
                                               float width_pts,
                                               float height_pts);
-
-extern void *gpui_ios_get_window(void);
 
 extern void gpui_ios_attach_embedded_view(void *window_ptr,
                                           void *parent_view_ptr,
@@ -157,16 +71,7 @@ void zedra_ios_set_keyboard_height(uint32_t height_px);
  */
 void zedra_ios_set_safe_area_insets(float top, float bottom, float _left, float _right);
 
-extern void *gpui_ios_get_window(void);
-
 extern bool gpui_ios_is_keyboard_visible(void *window_ptr);
-
-extern void gpui_ios_hide_keyboard(void *window_ptr);
-
-/**
- * Present the AVFoundation QR scanner (defined in QRScanner.swift).
- */
-extern void ios_present_qr_scanner(void);
 
 /**
  * Returns the app's Documents directory path (from NSSearchPathForDirectoriesInDomains).
@@ -373,8 +278,6 @@ void zedra_deeplink_received(const char *url);
  * Routes through the unified deeplink path (same as system URL intents).
  */
 void zedra_qr_scanner_result(const char *qr_string);
-
-extern void zedra_nslog(const char *msg);
 
 extern void zedra_log_event(const char *name,
                             const char *const *keys,

--- a/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
@@ -6,38 +6,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define BG_PRIMARY 920588
-
-#define BG_CARD 1250067
-
-#define BG_OVERLAY 1250067
-
-#define BG_SURFACE 920588
-
-#define TEXT_PRIMARY 16777215
-
-#define TEXT_SECONDARY 13290186
-
-#define TEXT_MUTED 5263440
-
-#define BORDER_HIGHLIGHT 13290186
-
-#define BORDER_DEFAULT 2894892
-
-#define BORDER_ACTIVE 5263440
-
-#define BORDER_SUBTLE 1710618
-
-#define ACCENT_GREEN 10011513
-
-#define ACCENT_BLUE 6402031
-
-#define ACCENT_YELLOW 15057019
-
-#define ACCENT_RED 14707829
-
-#define ACCENT_DIM 5263440
-
 #define DRAWER_PADDING 12.0
 
 #define SPACING_XS 4.0
@@ -63,6 +31,8 @@
 #define TERMINAL_LINE_HEIGHT 16.0
 
 #define PANEL_ITEM_HEIGHT 28.0
+
+#define DRAWER_EDGE_ZONE 72.0
 
 #define DRAWER_EDGE_ZONE 56.0
 
@@ -321,6 +291,16 @@ extern void ios_present_text_input(uint32_t callback_id,
                                    const char *title,
                                    const char *placeholder,
                                    const char *initial_value);
+
+/**
+ * Returns 1 for dark, 0 for light, -1 when unavailable.
+ */
+extern int32_t ios_system_prefers_dark_theme(void);
+
+/**
+ * Apply the app appearance to the native keyboard accessory bar.
+ */
+extern void ios_set_keyboard_accessory_theme(bool is_dark);
 
 /**
  * Called from the native alert handler after the user taps a button.


### PR DESCRIPTION
## Summary

- Add `ThemeState` / `ThemeBundle` with GPUI global access and persistence to `data_directory()/zedra/settings.json`
- Settings → Appearance toggle for Dark/Light; editor, terminal, and UI views read active palette via `theme::*(cx)` accessors
- Distinct light syntax palette (GitHub Light–style); terminal theme synced via `ThemeStateEvent` subscription
- Async syntax highlighting rebuilds colors on apply using the current theme to avoid stale highlights after toggling mid-load

## Notes

- Cherry-picked onto `main` (excludes agent-management-only files)
- Replaces #101 which targeted `feat/agent-management`

Made with [Cursor](https://cursor.com)