### PR TITLE
fix(ios): fix layout regressions from android merge

### DIFF
--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -190,7 +190,7 @@ impl Render for SettingsView {
             .child(
                 div()
                     .id("settings-scroll")
-                    .overflow_scroll()
+                    .overflow_y_scroll()
                     .flex_1()
                     .px(px(theme::SPACING_LG))
                     .pb(px(bottom_inset + 18.0))
@@ -198,7 +198,6 @@ impl Render for SettingsView {
                         div()
                             .w_full()
                             .max_w(px(520.0))
-                            .mx_auto()
                             .flex()
                             .flex_col()
                             .gap(px(theme::SPACING_MD))
@@ -309,14 +308,12 @@ fn appearance_theme_toggle(
 
     div()
         .id("settings-appearance-toggle")
-        .w_full()
         .min_w_0()
         .min_h(px(32.0))
         .py(px(2.0))
         .flex()
         .flex_row()
         .items_center()
-        .justify_between()
         .gap(px(theme::SPACING_MD))
         .child(
             div()
@@ -408,14 +405,12 @@ fn action_row(
 ) -> Stateful<Div> {
     div()
         .id(id)
-        .w_full()
         .min_w_0()
         .min_h(px(56.0))
         .py(px(10.0))
         .flex()
         .flex_row()
         .items_center()
-        .justify_between()
         .gap(px(theme::SPACING_MD))
         .cursor_pointer()
         .child(

--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -153,8 +153,6 @@ impl Render for SettingsView {
                     .flex_row()
                     .items_center()
                     .justify_between()
-                    .border_b_1()
-                    .border_color(rgb(theme::border_subtle(cx)))
                     .child(
                         div()
                             .flex()
@@ -212,13 +210,6 @@ impl Render for SettingsView {
                                     this.set_theme_preference(ThemePreference::Light, cx);
                                 }),
                             ))
-                            .child(
-                                div()
-                                    .text_color(rgb(theme::text_muted(cx)))
-                                    .text_size(px(theme::FONT_DETAIL))
-                                    .font_family(fonts::MONO_FONT_FAMILY)
-                                    .child("Custom themes will be supported in a future update."),
-                            )
                             .when(cfg!(debug_assertions), |section| {
                                 section
                                     .child(section_header(cx, "Developer"))

--- a/crates/zedra/src/sheet_demo_view.rs
+++ b/crates/zedra/src/sheet_demo_view.rs
@@ -21,7 +21,8 @@ impl Render for SheetDemoView {
             .size_full()
             .bg(rgb(theme::bg_primary(cx)))
             .flex()
-            .justify_center()
+            .flex_col()
+            .items_center()
             .px(px(18.0))
             .py(px(20.0))
             .child(

--- a/crates/zedra/src/terminal_preview_view.rs
+++ b/crates/zedra/src/terminal_preview_view.rs
@@ -289,7 +289,7 @@ impl Render for TerminalPreviewView {
                 div()
                     .w_full()
                     .px(px(theme::SPACING_LG))
-                    .pt(px(8.0))
+                    .pt(px(if cfg!(target_os = "ios") { 18.0 } else { 8.0 }))
                     .pb(px(8.0))
                     .border_b_1()
                     .border_color(rgb(theme::BORDER_SUBTLE))

--- a/crates/zedra/src/workspace_terminal.rs
+++ b/crates/zedra/src/workspace_terminal.rs
@@ -561,7 +561,7 @@ impl Render for WorkspaceTerminal {
                             });
                         },
                     )
-                    .icon_size(22.0)
+                    .icon_size(if cfg!(target_os = "ios") { 16.0 } else { 22.0 })
                     .absolute()
                     .right(px(24.0))
                     .bottom(px(24.0 + bottom_offset))

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -240,6 +240,28 @@ When the scroll area lives inside nested flex layouts, the parent chain must als
 
 See `docs/GPUI_NATIVE_PRESENTATIONS.md` for the native sheet gesture bridge and ownership split.
 
+## GPUI Flex Layout — Width Resolution in Column Containers
+
+Do not use `w_full()` (`width: 100%`) on flex items inside a `flex_col()` container to make them fill the container's width. Taffy only resolves percentage widths against a definite size. When a flex container's width comes from cross-axis stretch (the default), it is not considered definite for percentage resolution, so `width: 100%` on children resolves against a higher ancestor and produces wrong widths.
+
+**Use instead**: omit the explicit width and let the default `align-self: stretch` fill the cross axis.
+
+```rust
+// Wrong — w_full() resolves against the wrong ancestor
+div().flex_col()
+    .child(div().w_full().flex().flex_row()...)
+
+// Correct — stretch is the default and uses the definite container width
+div().flex_col()
+    .child(div().min_w_0().flex().flex_row()...)
+```
+
+Keep `min_w_0()` on flex items that contain truncated text or overflow content to prevent them from overflowing their container.
+
+For the column container itself to have a definite width (so its children can use stretch reliably), give it an explicit `w_full()` or absolute pixel width. Do not rely solely on cross-axis stretch being inherited transitively through multiple flex levels.
+
+Do not combine `justify_between()` with `flex_1()` on a sibling to push a right-hand element to the far edge. With `flex_1()` consuming all free space, `justify-content: space-between` has no remaining space to distribute and behaves identically to `flex-start`. Use `flex_1()` on the left child alone — it naturally pushes the right child to the far edge without `justify_between`.
+
 ## WorkspaceState as Single Source of Truth
 
 All display reads from `WorkspaceState`, never `SessionHandle`.


### PR DESCRIPTION
## Summary

- Restore scroll-to-bottom icon size (16pt iOS, 22pt Android) and sheet header top padding (18pt iOS, 8pt Android) overridden by the Android merge, using `cfg!(target_os = "ios")` conditionals
- Fix settings screen layout: remove `w_full()` from flex items inside `flex_col` containers and drop `mx_auto()` from the content column — Taffy only resolves percentage widths against definite sizes, and cross-axis stretch is not definite; removing these lets `align-self: stretch` do the correct job
- Fix `justify_between` + `flex_1` misuse in row items: `flex_1` consumes all free space so `space-between` has nothing to distribute; use `flex_1` on the left child alone to push the right child to the far edge
- Fix sheet demo embedded window layout: change root from `flex-row + justify_center` to `flex_col + items_center` so the card's `w_full()` resolves against the correct axis
- Clean up settings chrome: remove placeholder text and border below screen title
- Document Taffy flex width-resolution and `justify_between + flex_1` pitfalls in `docs/CONVENTIONS.md`