### PR TITLE
fix(host): prevent iroh-quinn drain panic on connection teardown

### DIFF
--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -18,9 +18,9 @@ use crate::metrics;
 use crate::paths;
 use crate::pty::{ShellSession, SpawnOptions};
 use crate::session_registry::{
-    ActiveClientConnection, AttachResult, ConsumeSlotResult, HostShellState, HostTermMeta,
-    OutputSenderSlot, PairingSlotMode, ServerSession, SessionRegistry, TermBacklog, TermSession,
-    MAX_WATCHED_PATHS_PER_SESSION,
+    finish_host_connection, ActiveClientConnection, AttachResult, ConsumeSlotResult, HostShellState,
+    HostTermMeta, OutputSenderSlot, PairingSlotMode,
+    ServerSession, SessionRegistry, TermBacklog, TermSession, MAX_WATCHED_PATHS_PER_SESSION,
 };
 use crate::utils;
 use anyhow::Result;
@@ -550,10 +550,7 @@ pub async fn handle_connection(
                 path_type,
             });
             tracing::warn!("auth failed from {}: {}", remote.fmt_short(), e);
-            // Wait for the client to close the connection (up to 500ms) so any
-            // error response we sent has time to be delivered before CONNECTION_CLOSE.
-            let _ =
-                tokio::time::timeout(std::time::Duration::from_millis(500), conn.closed()).await;
+            finish_host_connection(&conn).await;
             return Ok(());
         }
     };
@@ -572,7 +569,7 @@ pub async fn handle_connection(
         &client_pubkey[..4],
         session.id,
     );
-    active_connection.spawn_monitor();
+    let monitor_task = active_connection.spawn_monitor();
     let metrics_connection_open = match metrics::record_connection_opened(&state.workdir) {
         Ok(()) => true,
         Err(e) => {
@@ -589,7 +586,7 @@ pub async fn handle_connection(
     let session_start = std::time::Instant::now();
 
     // Spawn bandwidth sampler: reads iroh path stats every 60s while connected.
-    {
+    let bandwidth_task = {
         use iroh::Watcher;
         let conn_for_bw = conn.clone();
         tokio::spawn(async move {
@@ -602,6 +599,9 @@ pub async fn handle_connection(
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
+                        if conn_for_bw.close_reason().is_some() {
+                            break;
+                        }
                         let path_list = paths.get();
                         let mut cur_tx = 0u64;
                         let mut cur_rx = 0u64;
@@ -640,8 +640,8 @@ pub async fn handle_connection(
                     _ = conn_for_bw.closed() => break,
                 }
             }
-        });
-    }
+        })
+    };
 
     // RPC dispatch loop
     loop {
@@ -693,6 +693,12 @@ pub async fn handle_connection(
             tracing::warn!("Failed to record connection metrics: {}", e);
         }
     }
+
+    if let Some(monitor_task) = monitor_task {
+        monitor_task.abort();
+    }
+    bandwidth_task.abort();
+    finish_host_connection(&conn).await;
 
     tracing::info!(
         "Connection closed: session={} (session stays alive in registry)",

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -18,8 +18,8 @@ use crate::metrics;
 use crate::paths;
 use crate::pty::{ShellSession, SpawnOptions};
 use crate::session_registry::{
-    finish_host_connection, ActiveClientConnection, AttachResult, ConsumeSlotResult, HostShellState,
-    HostTermMeta, OutputSenderSlot, PairingSlotMode,
+    finish_auth_failed_connection, finish_host_connection, ActiveClientConnection, AttachResult,
+    ConsumeSlotResult, HostShellState, HostTermMeta, OutputSenderSlot, PairingSlotMode,
     ServerSession, SessionRegistry, TermBacklog, TermSession, MAX_WATCHED_PATHS_PER_SESSION,
 };
 use crate::utils;
@@ -550,7 +550,7 @@ pub async fn handle_connection(
                 path_type,
             });
             tracing::warn!("auth failed from {}: {}", remote.fmt_short(), e);
-            finish_host_connection(&conn).await;
+            finish_auth_failed_connection(&conn).await;
             return Ok(());
         }
     };

--- a/crates/zedra-host/src/session_registry.rs
+++ b/crates/zedra-host/src/session_registry.rs
@@ -21,7 +21,8 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 use zedra_osc::{OscEvent, OscScanner};
 use zedra_rpc::proto::{
-    BacklogEntry, FsDocsTreeError, FsDocsTreeResult, HostEvent, TermOutput, TerminalSyncEntry,
+    BacklogEntry, FsDocsTreeError, FsDocsTreeResult, HostEvent, SessionCloseReason, TermOutput,
+    TerminalSyncEntry,
 };
 use zedra_rpc::verify_registration_hmac;
 
@@ -84,6 +85,34 @@ const MAX_SUPERSEDED_PAIRING_SLOTS_PER_SESSION: usize = 8;
 
 static NEXT_ACTIVE_CONNECTION_ID: AtomicU64 = AtomicU64::new(1);
 
+/// Close the QUIC connection if it is still open.
+///
+/// iroh-quinn's driver panics if the last handle drops while the connection is
+/// drained but `State::error` was never set. Always call this before releasing
+/// the final `Connection` clone in a handler task.
+pub fn close_connection_if_open(
+    conn: &iroh::endpoint::Connection,
+    reason: SessionCloseReason,
+    detail: &[u8],
+) {
+    if conn.close_reason().is_none() {
+        conn.close((reason as u32).into(), detail);
+    }
+}
+
+/// Wait for the QUIC driver to finish after a close.
+pub async fn wait_connection_drained(conn: &iroh::endpoint::Connection) {
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), conn.closed()).await;
+}
+
+/// Close a handler-owned connection and wait for the QUIC driver to drain.
+pub async fn finish_host_connection(conn: &iroh::endpoint::Connection) {
+    if conn.close_reason().is_none() {
+        conn.close(0u32.into(), b"");
+    }
+    wait_connection_drained(conn).await;
+}
+
 /// Host-side lease for the active client connection.
 #[derive(Clone)]
 pub struct ActiveClientConnection {
@@ -128,15 +157,15 @@ impl ActiveClientConnection {
         self.client_pubkey
     }
 
-    pub fn spawn_monitor(&self) {
+    pub fn spawn_monitor(&self) -> Option<tokio::task::JoinHandle<()>> {
         let Some(conn) = self.conn.clone() else {
-            return;
+            return None;
         };
         let last_rx_bytes = self.last_rx_bytes.clone();
         let last_rx_at = self.last_rx_at.clone();
         let closed = self.closed.clone();
 
-        tokio::spawn(async move {
+        Some(tokio::spawn(async move {
             let mut interval = tokio::time::interval(ACTIVE_CLIENT_PROBE_INTERVAL);
             loop {
                 tokio::select! {
@@ -160,7 +189,7 @@ impl ActiveClientConnection {
                     }
                 }
             }
-        });
+        }))
     }
 
     pub fn is_stale(&self, now: Instant) -> bool {
@@ -181,7 +210,11 @@ impl ActiveClientConnection {
 
     pub fn close_for_takeover(&self) {
         if let Some(conn) = &self.conn {
-            conn.close(0u32.into(), b"replaced by new client");
+            close_connection_if_open(
+                conn,
+                SessionCloseReason::SessionTakenOver,
+                b"replaced by new client",
+            );
         }
         self.closed.store(true, Ordering::Release);
     }
@@ -1066,7 +1099,10 @@ impl SessionRegistry {
     pub async fn force_detach(&self, session_id: &str) -> bool {
         let sessions = self.sessions.lock().await;
         if let Some(session) = sessions.get(session_id) {
-            *session.active_client.lock().await = None;
+            let previous = session.active_client.lock().await.take();
+            if let Some(previous) = previous {
+                previous.close_for_takeover();
+            }
             true
         } else {
             false

--- a/crates/zedra-host/src/session_registry.rs
+++ b/crates/zedra-host/src/session_registry.rs
@@ -113,6 +113,17 @@ pub async fn finish_host_connection(conn: &iroh::endpoint::Connection) {
     wait_connection_drained(conn).await;
 }
 
+/// Tear down a connection after auth failed.
+///
+/// Wait briefly for the client to close first so any typed auth error response
+/// can be delivered before we send CONNECTION_CLOSE. If the client is still
+/// connected, close explicitly so iroh-quinn always sees a close reason before
+/// the handler drops its last handle.
+pub async fn finish_auth_failed_connection(conn: &iroh::endpoint::Connection) {
+    let _ = tokio::time::timeout(std::time::Duration::from_millis(500), conn.closed()).await;
+    finish_host_connection(conn).await;
+}
+
 /// Host-side lease for the active client connection.
 #[derive(Clone)]
 pub struct ActiveClientConnection {


### PR DESCRIPTION
## Summary

- Close QUIC connections with an explicit reason and wait for the driver to drain before `handle_connection` drops its last handle, avoiding the iroh-quinn `drained connections always have an error` panic.
- Send `SessionCloseReason::SessionTakenOver` on session takeover, close active connections on `force_detach`, and abort monitor/bandwidth background tasks before teardown.

## Notes

Typical trigger was client reconnect or second attach replacing the active connection while the old handler still held `Connection` clones. The follow-on `PoisonError` was a secondary failure from the poisoned quinn mutex after the initial panic.

Made with [Cursor](https://cursor.com)