### PR TITLE
feat: show settings in release builds

### DIFF
--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -27,11 +27,13 @@
 
 ## 0b. Home Settings Button
 
-1. Run a Debug build and open the Home screen
+1. Run a Debug or Release build and open the Home screen
 2. Tap the top-right settings icon
-3. Expected: a light haptic feedback fires and the Settings screen opens
-4. Run a Release build and open the Home screen
-5. Expected: the settings icon is not visible and the developer Settings screen is not reachable from Home
+3. Expected: a light haptic feedback fires and the Settings screen opens with the Appearance section
+4. Run a Release build, open Settings from Home, and inspect the scroll content
+5. Expected: only the Appearance section is visible; the Developer section is absent
+6. Run a Debug build, open Settings from Home, and inspect the scroll content
+7. Expected: Appearance and Developer sections are both visible
 
 ## 0c. Developer Native Notification (iOS)
 


### PR DESCRIPTION
## Summary

- Release builds already show the Home settings button and Appearance settings (`2fb4e763f4`); the Developer section stays debug-only via `cfg!(debug_assertions)` in `settings_view.rs`.
- Update `docs/MANUAL_TEST.md` section **0b** so release verification matches that behavior.

## Notes

Worktree: `zedra-feat-release-settings` on branch `feat/release-settings-button` from `origin/main`. No Rust changes were required on current `main`; this PR documents the intended release vs debug Settings behavior for QA.


Made with [Cursor](https://cursor.com)