### PR TITLE
feat(ios): make connection status indicator tappable

### DIFF
--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -13,6 +13,7 @@ use crate::settings::{ThemeState, ThemeStateEvent};
 use crate::settings_view::{SettingsEvent, SettingsView};
 use crate::telemetry::view_telemetry::{self, ViewDescriptor};
 use crate::ui::{DrawerHost, DrawerSide};
+use crate::workspace_action::ShowConnecting;
 use crate::workspaces::{Workspaces, WorkspacesEvent};
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -215,6 +216,24 @@ impl ZedraApp {
         }
     }
 
+    fn close_quick_action_drawer(&self, cx: &mut Context<Self>) {
+        self.quick_action_drawer.update(cx, |host, cx| host.close(cx));
+    }
+
+    fn handle_show_connecting(
+        &mut self,
+        _: &ShowConnecting,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(entry_index) = self.workspaces.read(cx).active_index() {
+            self.workspaces.update(cx, |ws, cx| {
+                ws.open_connecting_for_entry(entry_index, window, cx);
+            });
+        }
+        self.close_quick_action_drawer(cx);
+    }
+
     fn open_terminal_from_quick_action(
         &self,
         ws_index: usize,
@@ -405,6 +424,7 @@ impl Render for ZedraApp {
         div()
             .size_full()
             .on_action(cx.listener(Self::handle_system_back_action))
+            .on_action(cx.listener(Self::handle_show_connecting))
             .font_family(fonts::MONO_FONT_FAMILY)
             .child(self.quick_action_drawer.clone())
     }

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -217,7 +217,8 @@ impl ZedraApp {
     }
 
     fn close_quick_action_drawer(&self, cx: &mut Context<Self>) {
-        self.quick_action_drawer.update(cx, |host, cx| host.close(cx));
+        self.quick_action_drawer
+            .update(cx, |host, cx| host.close(cx));
     }
 
     fn handle_show_connecting(

--- a/crates/zedra/src/home_view.rs
+++ b/crates/zedra/src/home_view.rs
@@ -10,7 +10,7 @@ use crate::fonts;
 use crate::platform_bridge::{self, AlertButton, HapticFeedback};
 use crate::theme;
 use crate::transport_badge::{ConnectionStatusIndicator, phase_indicator_color};
-use crate::workspaces::Workspaces;
+use crate::workspaces::{OpenConnectingForState, Workspaces};
 
 const WEBSITE_URL: &str = "https://www.zedra.dev";
 const GITHUB_URL: &str = "https://github.com/tanlethanh/zedra";
@@ -114,6 +114,28 @@ impl HomeView {
             });
         }
         cx.emit(HomeEvent::NavigateToWorkspace);
+    }
+
+    fn show_connecting_for_state(
+        &self,
+        state_index: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let outcome = self.workspaces.update(cx, |ws, cx| {
+            ws.open_connecting_for_state(state_index, window, cx)
+        });
+        match outcome {
+            OpenConnectingForState::ActiveEntry => {
+                zedra_telemetry::send(Event::WorkspaceSelected { source: "active" });
+                cx.emit(HomeEvent::NavigateToWorkspace);
+            }
+            OpenConnectingForState::StartedConnect => {
+                zedra_telemetry::send(Event::WorkspaceSelected { source: "saved" });
+                cx.emit(HomeEvent::NavigateToWorkspace);
+            }
+            OpenConnectingForState::InvalidState => {}
+        }
     }
 
     fn handle_workspace_long_press(&self, item_idx: usize, cx: &mut Context<Self>) {
@@ -868,11 +890,16 @@ fn workspace_card(
                 .flex_row()
                 .items_center()
                 .gap(px(6.0))
-                .child(ConnectionStatusIndicator::from_phase(
-                    ("home-connect-status", index),
-                    connect_phase.as_ref(),
-                    &theme::palette(cx),
-                ))
+                .child(
+                    ConnectionStatusIndicator::from_phase(
+                        ("home-connect-status", index),
+                        connect_phase.as_ref(),
+                        &theme::palette(cx),
+                    )
+                    .on_press(cx.listener(move |this, _event, window, cx| {
+                        this.show_connecting_for_state(index, window, cx);
+                    })),
+                )
                 .child(
                     div()
                         .flex_1()

--- a/crates/zedra/src/quick_action_panel.rs
+++ b/crates/zedra/src/quick_action_panel.rs
@@ -241,9 +241,11 @@ impl Render for QuickActionPanel {
                                             connect_phase.as_ref(),
                                             &theme::palette(cx),
                                         )
-                                        .on_press(cx.listener(move |this, _event, window, cx| {
-                                            this.show_connecting_for_entry(index, window, cx);
-                                        })),
+                                        .on_press(
+                                            cx.listener(move |this, _event, window, cx| {
+                                                this.show_connecting_for_entry(index, window, cx);
+                                            }),
+                                        ),
                                     )
                                     .child(
                                         div()

--- a/crates/zedra/src/quick_action_panel.rs
+++ b/crates/zedra/src/quick_action_panel.rs
@@ -53,6 +53,19 @@ impl QuickActionPanel {
         cx.emit(QuickActionEvent::NavigateToWorkspace);
     }
 
+    fn show_connecting_for_entry(
+        &self,
+        entry_index: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.workspaces.update(cx, |ws, cx| {
+            ws.open_connecting_for_entry(entry_index, window, cx);
+        });
+        cx.emit(QuickActionEvent::Close);
+        cx.emit(QuickActionEvent::NavigateToWorkspace);
+    }
+
     fn handle_switch_terminal(&self, ws_index: usize, tid: String, cx: &mut Context<Self>) {
         self.workspaces
             .update(cx, |ws, cx| ws.switch_to(ws_index, cx));
@@ -222,11 +235,16 @@ impl Render for QuickActionPanel {
                                     .flex_row()
                                     .items_center()
                                     .gap(px(6.0))
-                                    .child(ConnectionStatusIndicator::from_phase(
-                                        ("quick-action-connect-status", index),
-                                        connect_phase.as_ref(),
-                                        &theme::palette(cx),
-                                    ))
+                                    .child(
+                                        ConnectionStatusIndicator::from_phase(
+                                            ("quick-action-connect-status", index),
+                                            connect_phase.as_ref(),
+                                            &theme::palette(cx),
+                                        )
+                                        .on_press(cx.listener(move |this, _event, window, cx| {
+                                            this.show_connecting_for_entry(index, window, cx);
+                                        })),
+                                    )
                                     .child(
                                         div()
                                             .flex_1()

--- a/crates/zedra/src/transport_badge.rs
+++ b/crates/zedra/src/transport_badge.rs
@@ -91,8 +91,7 @@ const STATUS_PULSE_MIN_OPACITY: f32 = 0.35;
 const STATUS_PULSE_MAX_SCALE: f32 = 1.3;
 const STATUS_HIT_SLOP: f32 = 20.0;
 
-type ConnectionStatusPressHandler =
-    Arc<dyn Fn(&PressEvent, &mut Window, &mut App) + 'static>;
+type ConnectionStatusPressHandler = Arc<dyn Fn(&PressEvent, &mut Window, &mut App) + 'static>;
 
 #[derive(Clone, IntoElement)]
 pub(crate) struct ConnectionStatusIndicator {

--- a/crates/zedra/src/transport_badge.rs
+++ b/crates/zedra/src/transport_badge.rs
@@ -1,9 +1,11 @@
 /// Transport badge: connection type indicator (P2P / Relay / Reconnecting).
+use std::sync::Arc;
 use std::time::Duration;
 
 use gpui::*;
 use zedra_session::{ConnectPhase, TransportSnapshot};
 
+use crate::platform_bridge::{self, HapticFeedback};
 use crate::theme::{self, ThemePalette};
 
 /// Compute badge label and dot color from phase and transport.
@@ -86,6 +88,11 @@ fn phase_indicator_blinks(palette: &ThemePalette, phase: &ConnectPhase) -> bool 
 
 const STATUS_PULSE_MS: u64 = 1800;
 const STATUS_PULSE_MIN_OPACITY: f32 = 0.35;
+const STATUS_PULSE_MAX_SCALE: f32 = 1.3;
+const STATUS_HIT_SLOP: f32 = 20.0;
+
+type ConnectionStatusPressHandler =
+    Arc<dyn Fn(&PressEvent, &mut Window, &mut App) + 'static>;
 
 #[derive(Clone, IntoElement)]
 pub(crate) struct ConnectionStatusIndicator {
@@ -93,6 +100,7 @@ pub(crate) struct ConnectionStatusIndicator {
     color: u32,
     size: f32,
     blink: bool,
+    on_press: Option<ConnectionStatusPressHandler>,
 }
 
 impl ConnectionStatusIndicator {
@@ -113,6 +121,7 @@ impl ConnectionStatusIndicator {
             color,
             size: theme::ICON_STATUS,
             blink,
+            on_press: None,
         }
     }
 
@@ -120,31 +129,70 @@ impl ConnectionStatusIndicator {
         self.size = size;
         self
     }
+
+    /// Press handler compatible with [`Context::listener`].
+    pub(crate) fn on_press(
+        mut self,
+        handler: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_press = Some(Arc::new(handler));
+        self
+    }
+}
+
+fn status_pulse_wave(delta: f32) -> f32 {
+    0.5 - 0.5 * (delta * std::f32::consts::TAU).cos()
+}
+
+fn render_status_dot(id: ElementId, color: u32, dot_size: f32, blink: bool) -> AnyElement {
+    let dot = svg()
+        .path("icons/dot.svg")
+        .size(px(dot_size))
+        .flex_shrink_0()
+        .text_color(rgb(color));
+
+    if blink {
+        dot.with_animation(
+            id,
+            Animation::new(Duration::from_millis(STATUS_PULSE_MS)).repeat(),
+            move |dot, delta| {
+                let wave = status_pulse_wave(delta);
+                let opacity = STATUS_PULSE_MIN_OPACITY + wave * (1.0 - STATUS_PULSE_MIN_OPACITY);
+                let scale = 1.0 + wave * (STATUS_PULSE_MAX_SCALE - 1.0);
+                dot.opacity(opacity)
+                    .with_transformation(Transformation::scale(gpui::size(scale, scale)))
+            },
+        )
+        .into_any_element()
+    } else {
+        dot.into_any_element()
+    }
 }
 
 impl RenderOnce for ConnectionStatusIndicator {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
-        let dot = div()
-            .w(px(self.size))
-            .h(px(self.size))
-            .rounded(px(self.size / 2.0))
-            .flex_shrink_0()
-            .bg(rgb(self.color));
+        let indicator = render_status_dot(self.id.clone(), self.color, self.size, self.blink);
 
-        if self.blink {
-            dot.with_animation(
-                self.id,
-                Animation::new(Duration::from_millis(STATUS_PULSE_MS)).repeat(),
-                |dot, delta| {
-                    let wave = 0.5 - 0.5 * (delta * std::f32::consts::TAU).cos();
-                    let opacity =
-                        STATUS_PULSE_MIN_OPACITY + wave * (1.0 - STATUS_PULSE_MIN_OPACITY);
-                    dot.opacity(opacity)
-                },
-            )
-            .into_any_element()
+        if let Some(on_press) = self.on_press {
+            let button_id = (self.id, "press");
+            div()
+                .id(button_id)
+                .flex()
+                .items_center()
+                .justify_center()
+                .flex_shrink_0()
+                .cursor_pointer()
+                .hit_slop(px(STATUS_HIT_SLOP))
+                .on_pointer_down(|_, _, cx| cx.stop_propagation())
+                .on_press(move |event, window, cx| {
+                    cx.stop_propagation();
+                    platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
+                    on_press(event, window, cx);
+                })
+                .child(indicator)
+                .into_any_element()
         } else {
-            dot.into_any_element()
+            indicator
         }
     }
 }

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -2676,9 +2676,11 @@ impl Render for WorkspaceContent {
                                                     &theme::palette(cx),
                                                 )
                                                 .size(6.0)
-                                                .on_press(cx.listener(|this, _event, window, cx| {
-                                                    this.open_connecting_view(window, cx);
-                                                })),
+                                                .on_press(cx.listener(
+                                                    |this, _event, window, cx| {
+                                                        this.open_connecting_view(window, cx);
+                                                    },
+                                                )),
                                             )
                                             .child(
                                                 div()

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -1148,8 +1148,12 @@ impl Workspace {
         cx: &mut Context<Self>,
     ) {
         info!("handle ShowConnecting from workspace");
+        self.reveal_connecting_view(window, cx);
+    }
+
+    pub(crate) fn reveal_connecting_view(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.drawer_host
-            .update(cx, |host, cx| host.close_with_window(&mut *window, cx));
+            .update(cx, |host, cx| host.close_with_window(window, cx));
         self.content.update(cx, |c, cx| c.show_connecting_view(cx));
         self.record_current_view(cx);
     }
@@ -2520,6 +2524,10 @@ impl WorkspaceContent {
         self.show_connecting
     }
 
+    fn open_connecting_view(&self, window: &mut Window, cx: &mut Context<Self>) {
+        window.dispatch_action(workspace_action::ShowConnecting.boxed_clone(), cx);
+    }
+
     fn render_subtitle(&self, default_subtitle: &str, cx: &mut Context<Self>) -> AnyElement {
         match &self.subtitle {
             WorkspaceSubtitle::Default => render_subtitle(cx, default_subtitle.to_owned()),
@@ -2667,7 +2675,10 @@ impl Render for WorkspaceContent {
                                                     connect_phase.as_ref(),
                                                     &theme::palette(cx),
                                                 )
-                                                .size(6.0),
+                                                .size(6.0)
+                                                .on_press(cx.listener(|this, _event, window, cx| {
+                                                    this.open_connecting_view(window, cx);
+                                                })),
                                             )
                                             .child(
                                                 div()

--- a/crates/zedra/src/workspace_drawer.rs
+++ b/crates/zedra/src/workspace_drawer.rs
@@ -424,7 +424,13 @@ impl Render for WorkspaceDrawer {
                                     connect_phase.as_ref(),
                                     &theme::palette(cx),
                                 )
-                                .size(6.0),
+                                .size(6.0)
+                                .on_press(cx.listener(|_this, _event, window, cx| {
+                                    window.dispatch_action(
+                                        workspace_action::ShowConnecting.boxed_clone(),
+                                        cx,
+                                    );
+                                })),
                             ),
                     ),
             )

--- a/crates/zedra/src/workspace_drawer.rs
+++ b/crates/zedra/src/workspace_drawer.rs
@@ -425,12 +425,14 @@ impl Render for WorkspaceDrawer {
                                     &theme::palette(cx),
                                 )
                                 .size(6.0)
-                                .on_press(cx.listener(|_this, _event, window, cx| {
-                                    window.dispatch_action(
-                                        workspace_action::ShowConnecting.boxed_clone(),
-                                        cx,
-                                    );
-                                })),
+                                .on_press(cx.listener(
+                                    |_this, _event, window, cx| {
+                                        window.dispatch_action(
+                                            workspace_action::ShowConnecting.boxed_clone(),
+                                            cx,
+                                        );
+                                    },
+                                )),
                             ),
                     ),
             )

--- a/crates/zedra/src/workspaces.rs
+++ b/crates/zedra/src/workspaces.rs
@@ -23,6 +23,13 @@ pub enum WorkspacesEvent {
 
 impl EventEmitter<WorkspacesEvent> for Workspaces {}
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OpenConnectingForState {
+    ActiveEntry,
+    StartedConnect,
+    InvalidState,
+}
+
 pub struct Workspaces {
     /// Workspace entries, one per state.
     /// The entry is lazily loaded from the state when first opened,
@@ -115,6 +122,44 @@ impl Workspaces {
             cx.notify();
         } else {
             warn!("Index {index} out of range. Cannot switch to workspace.");
+        }
+    }
+
+    pub fn open_connecting_for_entry(
+        &mut self,
+        entry_index: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if entry_index >= self.entries.len() {
+            warn!("Index {entry_index} out of range. Cannot open connecting view.");
+            return;
+        }
+        self.switch_to(entry_index, cx);
+        let Some(workspace) = self.entries.get(entry_index).cloned() else {
+            return;
+        };
+        workspace.update(cx, |ws, cx| ws.reveal_connecting_view(window, cx));
+    }
+
+    pub fn open_connecting_for_state(
+        &mut self,
+        state_index: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> OpenConnectingForState {
+        let Some(state) = self.states.get(state_index) else {
+            warn!("Index {state_index} out of range. Cannot open connecting view.");
+            return OpenConnectingForState::InvalidState;
+        };
+
+        let endpoint_addr = state.read(cx).endpoint_addr.clone();
+        if let Some(entry_index) = self.entry_index_by_endpoint_addr(&endpoint_addr, cx) {
+            self.open_connecting_for_entry(entry_index, window, cx);
+            OpenConnectingForState::ActiveEntry
+        } else {
+            self.connect_saved(state_index, window, cx);
+            OpenConnectingForState::StartedConnect
         }
     }
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -17,7 +17,7 @@
 ## 0a. Home Install Guide Tabs
 
 1. Open the app with no saved workspaces visible on the Home screen
-2. Switch between the `mac/linux`, `windows`, `claude`, `codex`, and `opencode` guide tabs
+2. Switch between the `curl`, `claude`, `codex`, `opencode`, and `gemini` guide tabs
 3. Expected: each tab shows the same install commands as the landing page
 4. Tap a command line in each tab
 5. Expected: the tapped command line is copied to the system clipboard without navigating away from Home
@@ -25,15 +25,27 @@
 7. Expected: native text selection handles appear, command and comment lines are selectable, and `Copy` copies the selected text
 8. Expected: switching tabs or scrolling the guide does not leave stale selection handles on screen
 
+## 0b-Status. Connection Status Indicator
+
+1. From Home, tap the status dot on a saved workspace card without tapping the card body
+2. Expected: light haptic, the app navigates to that workspace, and the connecting view opens
+3. Tap the card body outside the dot
+4. Expected: the workspace still opens, but the card tap path is unchanged from before
+5. In a connected workspace, tap the status dot beside the header title
+6. Expected: the connecting view opens and any open workspace drawer closes
+7. Open the workspace drawer and tap the status dot in the drawer header
+8. Expected: the connecting view opens and the drawer closes
+9. Open Quick Actions and tap the status dot on a workspace row, not the row body or `+` button
+10. Expected: Quick Actions closes, that workspace becomes active, and the connecting view opens
+11. While a workspace is idle or reconnecting, confirm the status dot pulses opacity and scale without shifting header layout
+
 ## 0b. Home Settings Button
 
-1. Run a Debug or Release build and open the Home screen
+1. Run a Debug build and open the Home screen
 2. Tap the top-right settings icon
-3. Expected: a light haptic feedback fires and the Settings screen opens with the Appearance section
-4. Run a Release build, open Settings from Home, and inspect the scroll content
-5. Expected: only the Appearance section is visible; the Developer section is absent
-6. Run a Debug build, open Settings from Home, and inspect the scroll content
-7. Expected: Appearance and Developer sections are both visible
+3. Expected: a light haptic feedback fires and the Settings screen opens
+4. Run a Release build and open the Home screen
+5. Expected: the settings icon is not visible and the developer Settings screen is not reachable from Home
 
 ## 0c. Developer Native Notification (iOS)
 
@@ -106,7 +118,7 @@
 1. Run an iOS build with Firebase Analytics enabled, or add `android/google-services.json` with the `dev.zedra.app` client and run `./scripts/run-android.sh --release --target arm64-v8a`
 2. Open Home, Settings, Quick Actions, then connect to a workspace
 3. Open the workspace drawer and switch through Files, Documents, Git Diff, Terminals, and Session
-4. Open a non-markdown file, a markdown file, a git diff, and a terminal as the main workspace view
+4. Open a non-markdown file, a markdown file, a git diff, a terminal, and the managed-agent view as the main workspace view
 5. Tap terminal file links for both a source file and a markdown file so the native custom sheet opens
 6. Expected: manual `screen_view` events include `screen_name` and `screen_class` for `Home`, `Settings`, `Quick Actions`, `Workspace Connecting`, `Workspace Editor`, `Workspace Markdown`, `Workspace Git Diff`, `Workspace Terminal`, each drawer tab, `Custom Sheet Editor`, and `Custom Sheet Markdown`
 7. Expected: native automatic rows such as `UIViewController`, `CustomSheetViewController`, `UIAlertController`, and `ZedraQRScannerVC` on iOS or Android activity rows on Android are still present because native Firebase screen reporting remains enabled
@@ -921,6 +933,53 @@ Expected:
   `launch_cmd` path such as `claude --resume <session_id>`. Expected: while
   Claude is running, the terminal card shows the Claude icon even before a shell
   prompt emits fresh OSC metadata.
+
+## 18b. Agent Toolbar, Sessions, and Manage Views
+
+1. Open a connected workspace and open the workspace drawer Terminals tab.
+2. Expected: the top toolbar shows four icon actions: Create agent, Create
+   terminal, View sessions, and Manage agents.
+3. Tap `Create terminal`.
+4. Expected: the drawer closes, a new shell terminal opens in the main view,
+   and the terminal card appears in the drawer.
+5. Tap `Create agent`.
+6. Expected: a scrollable native list picker shows installed host agents with
+   icon and version subtitle; unavailable agents are omitted.
+7. Pick an installed agent such as Claude or Codex.
+8. Expected: Zedra creates a new terminal using the host-owned launch command,
+   opens it as the active main view, and the terminal card shows the matching
+   agent icon once OSC metadata arrives.
+9. Tap `View sessions`.
+10. Expected: the drawer closes and the main view shows a unified session list
+    grouped by day across Claude, Codex, and OpenCode for the current
+    workspace. Each row shows agent icon, title, datetime, branch/worktree,
+    transcript size, and model when available.
+11. Tap a resumable session row.
+12. Expected: Zedra immediately resumes the session in a new terminal and opens
+    it as the active main view.
+13. Tap `Manage agents`.
+14. Expected: the main view shows managed agents as a list with setup/session
+    counts. Tapping an agent opens detail with CLI/setup/account fields and a
+    session list below.
+15. In manage detail, verify discovered account fields:
+    - Claude: model, effort, permission mode, total sessions/messages/cost when
+      `stats-cache.json` exists
+    - Codex: logged in, last refresh, model/personality from `config.toml`
+    - OpenCode: config dir presence
+16. Tap `Resume` on a session from manage detail.
+17. Expected: same immediate resume behavior as the unified sessions view.
+18. Re-open `View sessions` or `Manage agents` without tapping Refresh.
+19. Expected: lists load quickly from the host startup cache (default limit 50
+    sessions per agent).
+20. Tap Refresh in either view.
+21. Expected: the host rescans synchronous managed-agent metadata and session
+    lists immediately; CLI versions may arrive a moment later (one
+    `AgentInfoChanged` host event per agent) and update manage detail without
+    another refresh.
+22. In manage detail for an available agent, wait a few seconds after opening
+    or refreshing.
+23. Expected: the version line updates from `Checking…` to the real `--version`
+    string when the host finishes that agent’s async version probe.
 
 ## 19. Xcode Rust Build Target
 


### PR DESCRIPTION
## Summary

- Make the connection status dot a pressable control with generous hit slop and light haptic feedback.
- Pulse idle/reconnecting states with SVG transform scaling (1.0x–1.3x) so layout stays fixed.
- Wire `on_press` callbacks at each call site (Home, workspace header, drawer, Quick Actions) and add `Workspaces::open_connecting_for_entry` / `open_connecting_for_state` helpers to open the connecting view.

## Notes

- Manual verification steps are in `docs/MANUAL_TEST.md` under **0b-Status. Connection Status Indicator**.
- Worktree for this branch: `/Users/thomasle/projects/zedra-feat-connection-status-indicator`.


Made with [Cursor](https://cursor.com)