### PR TITLE
fix(rpc): guard new RPCs against older hosts

### DIFF
--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -897,7 +897,9 @@ pub async fn handle_connection(
         })
     };
 
-    // RPC dispatch loop
+    // RPC dispatch loop. Treat decode failures (newer-client variant /
+    // extended struct) as per-stream, not connection-level: breaking here
+    // would brick every other in-flight RPC on the same QUIC connection.
     loop {
         match irpc_iroh::read_request::<ZedraProto>(&conn).await {
             Ok(Some(msg)) => {
@@ -913,6 +915,10 @@ pub async fn handle_connection(
                 });
             }
             Ok(None) => break,
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                tracing::warn!("ignoring undecodable request: {}", e);
+                continue;
+            }
             Err(e) => {
                 tracing::debug!("read_request error: {}", e);
                 break;
@@ -2210,7 +2216,7 @@ async fn dispatch(
                 SpawnOptions {
                     workdir,
                     launch_cmd,
-                    color_scheme: msg.color_scheme,
+                    color_scheme: None,
                     env: Vec::new(),
                 },
             )
@@ -2227,6 +2233,49 @@ async fn dispatch(
                 }
                 Err(e) => {
                     tracing::warn!("TermCreate failed: {}", e);
+                    let _ = msg
+                        .tx
+                        .send(TermCreateResult {
+                            id: String::new(),
+                            error: Some(e.to_string()),
+                        })
+                        .await;
+                }
+            }
+        }
+
+        ZedraMessage::TermCreateV2(msg) => {
+            session.touch().await;
+            let workdir = session
+                .workdir
+                .clone()
+                .or_else(|| Some(state.workdir.clone()));
+            let has_launch_cmd = msg.launch_cmd.is_some();
+            let launch_cmd = msg.launch_cmd.clone();
+            match create_terminal(
+                &session,
+                msg.cols,
+                msg.rows,
+                SpawnOptions {
+                    workdir,
+                    launch_cmd,
+                    color_scheme: msg.color_scheme,
+                    env: Vec::new(),
+                },
+            )
+            .await
+            {
+                Ok(id) => {
+                    zedra_telemetry::send(Event::HostTerminalOpen { has_launch_cmd });
+                    let terminal_count = session.terminals.lock().await.len();
+                    if let Err(e) = metrics::record_terminal_created(&state.workdir, terminal_count)
+                    {
+                        tracing::warn!("Failed to record terminal metrics: {}", e);
+                    }
+                    let _ = msg.tx.send(TermCreateResult { id, error: None }).await;
+                }
+                Err(e) => {
+                    tracing::warn!("TermCreateV2 failed: {}", e);
                     let _ = msg
                         .tx
                         .send(TermCreateResult {

--- a/crates/zedra-host/tests/integration.rs
+++ b/crates/zedra-host/tests/integration.rs
@@ -590,7 +590,6 @@ async fn test_rpc_terminal_over_relay() {
             cols: 80,
             rows: 24,
             launch_cmd: None,
-            color_scheme: None,
         })
         .await
         .unwrap();
@@ -672,7 +671,6 @@ async fn test_terminal_reorder_updates_host_list_and_sync_order() {
                 cols: 80,
                 rows: 24,
                 launch_cmd: None,
-                color_scheme: None,
             })
             .await
             .unwrap();

--- a/crates/zedra-rpc/src/proto.rs
+++ b/crates/zedra-rpc/src/proto.rs
@@ -184,6 +184,12 @@ pub enum ZedraProto {
     /// Kept at enum tail because protocol variants are append-only.
     #[rpc(tx = oneshot::Sender<AgentInstalledListResult>)]
     AgentInstalledList(AgentInstalledListReq),
+
+    /// `TermCreate` + client appearance. Separate variant (not a tail field
+    /// on `TermCreateReq`) so old hosts can still decode the legacy shape;
+    /// gated on the client by `host_version`.
+    #[rpc(tx = oneshot::Sender<TermCreateResult>)]
+    TermCreateV2(TermCreateReqV2),
 }
 
 // ---------------------------------------------------------------------------
@@ -727,8 +733,14 @@ pub struct TermCreateReq {
     /// If `None`, the host's default launch command (if any) is used.
     /// Example: `"claude --resume"` to drop straight into a Claude session.
     pub launch_cmd: Option<String>,
-    /// Client appearance used for host-side terminal color query replies.
-    #[serde(default)]
+}
+
+/// `TermCreateReq` + `color_scheme` for host-side OSC 10/11/12 replies.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TermCreateReqV2 {
+    pub cols: u16,
+    pub rows: u16,
+    pub launch_cmd: Option<String>,
     pub color_scheme: Option<TerminalColorScheme>,
 }
 

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -11,6 +11,20 @@ use crate::{
     unregister_active_connection,
 };
 
+/// Minimum host CLI version for agent-management RPCs and `TermCreateV2`.
+///
+/// TEMPORARY: workspace-version gate, to be replaced by capability
+/// negotiation in `SyncSessionResult`. Until then, every new post-baseline
+/// variant must either bump this constant or add its own gate.
+const HOST_VERSION_AGENT_MGMT: (u32, u32, u32) = (0, 2, 5);
+
+/// Public so views can show the same message when they short-circuit at the
+/// app layer instead of letting each per-kind RPC produce its own copy.
+pub const AGENT_MGMT_UNSUPPORTED_MSG: &str =
+    "Requires host CLI 0.2.5+. Please update your host to match the version.";
+
+const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[derive(Clone)]
 pub struct SessionHandle(Arc<SessionHandleInner>);
 
@@ -27,6 +41,9 @@ struct SessionHandleInner {
     user_disconnect: AtomicBool,
     observer_rpc_supported: AtomicBool,
     docs_tree_rpc_supported: AtomicBool,
+    /// Parsed from `SyncSessionResult.host_version`; gates post-baseline
+    /// RPCs so old hosts never receive an undecodable variant.
+    host_version: Mutex<Option<(u32, u32, u32)>>,
 }
 
 impl Drop for SessionHandleInner {
@@ -61,6 +78,7 @@ impl SessionHandle {
             user_disconnect: AtomicBool::new(false),
             observer_rpc_supported: AtomicBool::new(true),
             docs_tree_rpc_supported: AtomicBool::new(true),
+            host_version: Mutex::new(None),
         }))
     }
 
@@ -116,6 +134,71 @@ impl SessionHandle {
 
     pub fn set_rpc_client(&self, client: irpc::Client<ZedraProto>) {
         *self.0.rpc_client.lock().unwrap() = Some(client);
+    }
+
+    /// Accepts strings like `"0.2.5"` or `"0.2.5-pre-1"`; unparseable → `None`.
+    pub fn set_host_version(&self, raw: Option<String>) {
+        *self.0.host_version.lock().unwrap() = raw.as_deref().and_then(parse_semver_triplet);
+    }
+
+    pub fn host_version(&self) -> Option<(u32, u32, u32)> {
+        self.0.host_version.lock().ok().and_then(|g| *g)
+    }
+
+    /// False when the version is unknown (treat as "old, don't risk it").
+    pub fn host_at_least(&self, want: (u32, u32, u32)) -> bool {
+        match self.host_version() {
+            Some(v) => v >= want,
+            None => false,
+        }
+    }
+
+    /// Single source of truth for agent-management capability. Views call
+    /// this and short-circuit so the user sees one message, not one per
+    /// kind (`agent_sessions` fans out across Claude / Codex / OpenCode).
+    pub fn supports_agent_mgmt(&self) -> bool {
+        self.host_at_least(HOST_VERSION_AGENT_MGMT)
+    }
+
+    /// Names both sides for the user when an RPC fails because the host
+    /// can't decode it. ALPN match means the baseline surface still works;
+    /// only this specific call is unsupported.
+    fn version_mismatch_notice(&self) -> String {
+        let host = self
+            .0
+            .host_version
+            .lock()
+            .ok()
+            .and_then(|g| *g)
+            .map(|(a, b, c)| format!("{a}.{b}.{c}"))
+            .unwrap_or_else(|| "unknown".to_string());
+        format!(
+            "This action is not supported by host CLI {host} (client {CLIENT_VERSION}). \
+             Update the host or client so the versions match."
+        )
+    }
+
+    /// Rewrite "host can't decode this variant" errors to a version-skew
+    /// notice. Requires either an unambiguous decode keyword or an
+    /// older-than-client host, so benign transport closes (idle timeout,
+    /// reconnect race, host crash) on a same-version peer pass through raw.
+    fn map_rpc_error(&self, err: irpc::Error) -> anyhow::Error {
+        let raw = err.to_string();
+        let lower = raw.to_lowercase();
+        let definite_decode = lower.contains("unknown variant")
+            || lower.contains("invalid type")
+            || lower.contains("decode")
+            || lower.contains("deserialize");
+        let ambiguous_close = lower.contains("oneshot recv") || lower.contains("sender closed");
+        let host_older = match (self.host_version(), parse_semver_triplet(CLIENT_VERSION)) {
+            (Some(host), Some(client)) => host < client,
+            _ => false,
+        };
+        if definite_decode || (ambiguous_close && host_older) {
+            anyhow::anyhow!(self.version_mismatch_notice())
+        } else {
+            anyhow::anyhow!(raw)
+        }
     }
 
     pub fn set_active_connection(&self, conn: iroh::endpoint::Connection) {
@@ -525,14 +608,30 @@ impl SessionHandle {
         color_scheme: Option<TerminalColorScheme>,
     ) -> Result<String> {
         let client = self.client()?;
-        let result: TermCreateResult = client
-            .rpc(TermCreateReq {
-                cols,
-                rows,
-                launch_cmd,
-                color_scheme,
-            })
-            .await?;
+        // Host < 0.2.5: send legacy V1 to keep its dispatch loop alive.
+        let result: TermCreateResult = if self.host_at_least(HOST_VERSION_AGENT_MGMT) {
+            client
+                .rpc(TermCreateReqV2 {
+                    cols,
+                    rows,
+                    launch_cmd,
+                    color_scheme,
+                })
+                .await
+                .map_err(|e| self.map_rpc_error(e))?
+        } else {
+            if color_scheme.is_some() {
+                tracing::warn!("host < 0.2.5: color scheme dropped, using host defaults");
+            }
+            client
+                .rpc(TermCreateReq {
+                    cols,
+                    rows,
+                    launch_cmd,
+                })
+                .await
+                .map_err(|e| self.map_rpc_error(e))?
+        };
         if let Some(e) = result.error {
             return Err(anyhow::anyhow!(e));
         }
@@ -548,10 +647,14 @@ impl SessionHandle {
     }
 
     pub async fn agent_installed_list(&self, refresh: bool) -> Result<Vec<InstalledAgentEntry>> {
+        if !self.host_at_least(HOST_VERSION_AGENT_MGMT) {
+            return Err(anyhow::anyhow!(AGENT_MGMT_UNSUPPORTED_MSG));
+        }
         let result: AgentInstalledListResult = self
             .client()?
             .rpc(AgentInstalledListReq { refresh })
-            .await?;
+            .await
+            .map_err(|e| self.map_rpc_error(e))?;
         if let Some(e) = result.error {
             return Err(anyhow::anyhow!(e));
         }
@@ -559,7 +662,14 @@ impl SessionHandle {
     }
 
     pub async fn agent_list(&self, refresh: bool) -> Result<Vec<AgentSummary>> {
-        let result: AgentListResult = self.client()?.rpc(AgentListReq { refresh }).await?;
+        if !self.host_at_least(HOST_VERSION_AGENT_MGMT) {
+            return Err(anyhow::anyhow!(AGENT_MGMT_UNSUPPORTED_MSG));
+        }
+        let result: AgentListResult = self
+            .client()?
+            .rpc(AgentListReq { refresh })
+            .await
+            .map_err(|e| self.map_rpc_error(e))?;
         if let Some(e) = result.error {
             return Err(anyhow::anyhow!(e));
         }
@@ -572,6 +682,9 @@ impl SessionHandle {
         refresh: bool,
         limit: u32,
     ) -> Result<Vec<AgentSessionSummary>> {
+        if !self.host_at_least(HOST_VERSION_AGENT_MGMT) {
+            return Err(anyhow::anyhow!(AGENT_MGMT_UNSUPPORTED_MSG));
+        }
         let result: AgentSessionsResult = self
             .client()?
             .rpc(AgentSessionsReq {
@@ -579,7 +692,8 @@ impl SessionHandle {
                 refresh,
                 limit,
             })
-            .await?;
+            .await
+            .map_err(|e| self.map_rpc_error(e))?;
         if let Some(e) = result.error {
             return Err(anyhow::anyhow!(e));
         }
@@ -593,6 +707,9 @@ impl SessionHandle {
         cols: u16,
         rows: u16,
     ) -> Result<String> {
+        if !self.host_at_least(HOST_VERSION_AGENT_MGMT) {
+            return Err(anyhow::anyhow!(AGENT_MGMT_UNSUPPORTED_MSG));
+        }
         let client = self.client()?;
         let result: AgentResumeResult = client
             .rpc(AgentResumeReq {
@@ -601,7 +718,8 @@ impl SessionHandle {
                 cols,
                 rows,
             })
-            .await?;
+            .await
+            .map_err(|e| self.map_rpc_error(e))?;
         if let Some(e) = result.error {
             return Err(anyhow::anyhow!(e));
         }
@@ -670,9 +788,43 @@ fn git_checkout_result(result: GitCheckoutResult, branch: &str) -> Result<()> {
     }
 }
 
+/// Parse leading `major.minor.patch`, ignoring `-pre-N` / `+build` suffix.
+fn parse_semver_triplet(raw: &str) -> Option<(u32, u32, u32)> {
+    let core = raw
+        .split(|c: char| c == '-' || c == '+')
+        .next()
+        .unwrap_or(raw);
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse::<u32>().ok()?;
+    let minor = parts.next()?.parse::<u32>().ok()?;
+    let patch = parts.next()?.parse::<u32>().ok()?;
+    Some((major, minor, patch))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_semver_triplet_handles_release_and_prerelease() {
+        assert_eq!(parse_semver_triplet("0.2.5"), Some((0, 2, 5)));
+        assert_eq!(parse_semver_triplet("0.2.5-pre-1"), Some((0, 2, 5)));
+        assert_eq!(parse_semver_triplet("1.0.0+build.7"), Some((1, 0, 0)));
+        assert_eq!(parse_semver_triplet("0.2"), None);
+        assert_eq!(parse_semver_triplet("garbage"), None);
+    }
+
+    #[test]
+    fn host_at_least_returns_false_when_version_unknown() {
+        let handle = SessionHandle::new();
+        assert!(!handle.host_at_least((0, 2, 5)));
+        handle.set_host_version(Some("0.2.4".into()));
+        assert!(!handle.host_at_least((0, 2, 5)));
+        handle.set_host_version(Some("0.2.5".into()));
+        assert!(handle.host_at_least((0, 2, 5)));
+        handle.set_host_version(Some("0.3.0".into()));
+        assert!(handle.host_at_least((0, 2, 5)));
+    }
 
     #[test]
     fn add_terminal_replaces_existing_id() {

--- a/crates/zedra-session/src/session.rs
+++ b/crates/zedra-session/src/session.rs
@@ -173,6 +173,7 @@ impl Session {
                         handle.set_rpc_client(client.clone());
                         handle.set_session_id(Some(sync.session_id.clone()));
                         handle.set_session_token(Some(sync.session_token));
+                        handle.set_host_version(sync.host_version.clone());
                         handle.set_terminals(terminals);
                         on_connected(&handle);
 

--- a/crates/zedra/src/agent_detail.rs
+++ b/crates/zedra/src/agent_detail.rs
@@ -2,7 +2,7 @@ use gpui::prelude::FluentBuilder;
 use gpui::*;
 use tracing::error;
 use zedra_rpc::proto::{AgentSummary, HostEvent, ManagedAgentKind};
-use zedra_session::{Session, SessionHandle};
+use zedra_session::{AGENT_MGMT_UNSUPPORTED_MSG, Session, SessionHandle};
 
 use crate::agent_ui::{
     AgentSessionListProps, cli_version_display, group_sessions_by_day, managed_agent_name,
@@ -93,6 +93,12 @@ impl AgentDetail {
     fn reload(&mut self, refresh: bool, cx: &mut Context<Self>) {
         self.loading_epoch = self.loading_epoch.wrapping_add(1);
         let epoch = self.loading_epoch;
+        if !self.session_handle.supports_agent_mgmt() {
+            self.agent_state = LoadState::Error(AGENT_MGMT_UNSUPPORTED_MSG.into());
+            self.session_state = LoadState::Error(AGENT_MGMT_UNSUPPORTED_MSG.into());
+            cx.notify();
+            return;
+        }
         self.agent_state = LoadState::Loading;
         self.session_state = LoadState::Loading;
         cx.notify();
@@ -168,11 +174,10 @@ impl Render for AgentDetail {
 
         let body: AnyElement = match (&agent_state, agent.as_ref()) {
             (LoadState::Loading, _) => {
-                subscreen_padded_body(empty_text("Loading agent…", cx)).into_any_element()
+                subscreen_padded_body(empty_text("Loading…", cx)).into_any_element()
             }
             (LoadState::Error(message), _) => {
-                subscreen_padded_body(empty_text(format!("Failed to load agent: {message}"), cx))
-                    .into_any_element()
+                subscreen_padded_body(empty_text(message.clone(), cx)).into_any_element()
             }
             (LoadState::Ready, Some(agent)) => {
                 let (sessions_loading, sessions_error) = match &session_state {

--- a/crates/zedra/src/agent_manage.rs
+++ b/crates/zedra/src/agent_manage.rs
@@ -1,7 +1,7 @@
 use gpui::*;
 use tracing::error;
 use zedra_rpc::proto::{AgentSummary, HostEvent};
-use zedra_session::{Session, SessionHandle};
+use zedra_session::{AGENT_MGMT_UNSUPPORTED_MSG, Session, SessionHandle};
 
 use crate::agent_ui::{AgentCardProps, render_agent_card};
 use crate::fonts;
@@ -84,6 +84,11 @@ impl AgentManage {
     fn load_agents(&mut self, refresh: bool, cx: &mut Context<Self>) {
         self.loading_epoch = self.loading_epoch.wrapping_add(1);
         let epoch = self.loading_epoch;
+        if !self.session_handle.supports_agent_mgmt() {
+            self.agent_state = LoadState::Error(AGENT_MGMT_UNSUPPORTED_MSG.into());
+            cx.notify();
+            return;
+        }
         self.agent_state = LoadState::Loading;
         cx.notify();
 
@@ -123,14 +128,11 @@ impl Render for AgentManage {
 
         let body: AnyElement = match agent_state {
             LoadState::Loading => {
-                subscreen_padded_body(empty_text("Loading managed agents...", cx))
-                    .into_any_element()
+                subscreen_padded_body(empty_text("Loading…", cx)).into_any_element()
             }
-            LoadState::Error(message) => subscreen_padded_body(empty_text(
-                format!("Failed to load managed agents: {message}"),
-                cx,
-            ))
-            .into_any_element(),
+            LoadState::Error(message) => {
+                subscreen_padded_body(empty_text(message, cx)).into_any_element()
+            }
             LoadState::Ready => render_list_body(&agents, cx).into_any_element(),
         };
 

--- a/crates/zedra/src/agent_picker.rs
+++ b/crates/zedra/src/agent_picker.rs
@@ -1,10 +1,10 @@
 use gpui::*;
 use tracing::error;
 use zedra_rpc::proto::InstalledAgentEntry;
-use zedra_session::SessionHandle;
+use zedra_session::{AGENT_MGMT_UNSUPPORTED_MSG, SessionHandle};
 
 use crate::pending::SharedPendingSlot;
-use crate::platform_bridge::{self, AlertButton, ListPickerItem};
+use crate::platform_bridge::{self, ListPickerItem};
 use crate::workspace::PendingWorkspaceAction;
 
 enum State {
@@ -36,6 +36,10 @@ impl AgentPicker {
     /// Called when the user taps "Create Agent". Shows the native picker
     /// immediately with cached items if available, otherwise fetches first.
     pub fn trigger(&mut self, cx: &mut Context<Self>) {
+        if !self.session_handle.supports_agent_mgmt() {
+            self.present_placeholder(AGENT_MGMT_UNSUPPORTED_MSG);
+            return;
+        }
         match &self.state {
             State::Ready(agents) => {
                 self.present(agents.clone());
@@ -55,19 +59,12 @@ impl AgentPicker {
         let task = cx.spawn(
             async move |this, cx| match handle.agent_installed_list(false).await {
                 Ok(agents) => {
-                    let _ = this.update(cx, |this, cx| {
+                    let _ = this.update(cx, |this, _cx| {
                         let available: Vec<_> =
                             agents.into_iter().filter(|a| a.available).collect();
                         if available.is_empty() {
+                            this.present_placeholder("No agents installed on the host.");
                             this.state = State::Idle;
-                            cx.defer(|_| {
-                                platform_bridge::show_alert(
-                                    "Create Agent",
-                                    "No supported agent CLIs are installed on the host.",
-                                    vec![AlertButton::default("OK")],
-                                    |_| {},
-                                );
-                            });
                         } else {
                             this.present(available.clone());
                             this.state = State::Ready(available);
@@ -78,12 +75,7 @@ impl AgentPicker {
                     error!("agent picker: fetch failed: {}", err);
                     let _ = this.update(cx, |this, _cx| {
                         this.state = State::Idle;
-                        platform_bridge::show_alert(
-                            "Create Agent",
-                            "Failed to load installed agents.",
-                            vec![AlertButton::default("OK")],
-                            |_| {},
-                        );
+                        this.present_placeholder(&err.to_string());
                     });
                 }
             },
@@ -116,6 +108,23 @@ impl AgentPicker {
                 };
                 pending.set(PendingWorkspaceAction::SpawnAgentTerminal { launch_cmd: cmd });
             },
+        );
+    }
+
+    /// Picker with one "Dismiss" row carrying the reason in its subtitle.
+    /// `show_list_picker` has no disabled-row affordance, so naming the
+    /// label "Dismiss" keeps the tap unambiguous.
+    fn present_placeholder(&self, message: &str) {
+        let items = vec![ListPickerItem {
+            label: "Dismiss".to_string(),
+            subtitle: Some(message.to_string()),
+            image_name: None,
+        }];
+        platform_bridge::show_list_picker(
+            "Create Agent",
+            "Agent management is unavailable right now.",
+            items,
+            move |_selection| {},
         );
     }
 }

--- a/crates/zedra/src/agent_sessions.rs
+++ b/crates/zedra/src/agent_sessions.rs
@@ -1,7 +1,7 @@
 use gpui::*;
 use tracing::error;
 use zedra_rpc::proto::ManagedAgentKind;
-use zedra_session::SessionHandle;
+use zedra_session::{AGENT_MGMT_UNSUPPORTED_MSG, SessionHandle};
 
 use crate::agent_ui::{
     AgentSessionListProps, AgentSessionSection, group_sessions_by_day, render_agent_session_list,
@@ -43,8 +43,13 @@ impl AgentSessions {
     fn load(&mut self, refresh: bool, cx: &mut Context<Self>) {
         self.loading_epoch = self.loading_epoch.wrapping_add(1);
         let epoch = self.loading_epoch;
-        self.load_state = LoadState::Loading;
         self.sections.clear();
+        if !self.session_handle.supports_agent_mgmt() {
+            self.load_state = LoadState::Error(AGENT_MGMT_UNSUPPORTED_MSG.into());
+            cx.notify();
+            return;
+        }
+        self.load_state = LoadState::Loading;
         cx.notify();
 
         let handle = self.session_handle.clone();

--- a/crates/zedra/src/agent_ui.rs
+++ b/crates/zedra/src/agent_ui.rs
@@ -682,13 +682,10 @@ pub fn render_agent_session_list<C: 'static>(
     list = list.flex().flex_col().gap(px(theme::SPACING_SM));
 
     if props.loading {
-        return list.child(list_empty_text("Loading sessions...", cx));
+        return list.child(list_empty_text("Loading…", cx));
     }
     if let Some(error) = props.error {
-        return list.child(list_empty_text(
-            format!("Failed to load sessions: {error}"),
-            cx,
-        ));
+        return list.child(list_empty_text(error, cx));
     }
     if props.sections.is_empty() {
         return list.child(list_empty_text(props.empty_message, cx));

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -1650,11 +1650,12 @@ impl Workspace {
                 Ok(id) => id,
                 Err(e) => {
                     tracing::error!("terminal_create failed: {}", e);
+                    let message = e.to_string();
                     let _ = workspace.update(cx, |ws, _cx| {
                         ws.terminals.retain(|t| t.entity_id() != pending_entity_id);
                         platform_bridge::show_alert(
                             "Open Terminal",
-                            "Failed to create the terminal.",
+                            &message,
                             vec![AlertButton::default("OK")],
                             |_| {},
                         );


### PR DESCRIPTION
## Summary

- Gate post-baseline RPCs (`AgentList` / `AgentInstalledList` / `AgentSessions` / `AgentResume`, and `TermCreate` with `color_scheme`) behind `host_version >= 0.2.5` so old hosts never receive an undecodable variant.
- Add `TermCreateV2(TermCreateReqV2)` instead of mutating `TermCreateReq`, preserving the legacy shape byte-for-byte.
- Harden the new host's RPC dispatch loop: `InvalidData` is per-stream, not connection-level.
- `map_rpc_error` rewrites decode / older-host stream-close errors into a `"host X / client Y"` notice; same/newer-version transport errors pass through.
- UI: terser loading/error copy, `Create Agent` picker opens with an explicit "Dismiss" row when unavailable, terminal-create alert shows the real error.

## Notes

- Root cause: postcard is schema-positional — appending a tail byte (`color_scheme` on `TermCreateReq`) or a new enum variant breaks old hosts' decode, their loop hits `break`, and every later RPC on the connection silently hangs (the "Loading…" file/git view).
- `HOST_VERSION_AGENT_MGMT` is a stopgap; capability negotiation tracked in #112.