### PR TITLE
fix(agent): open pending terminals immediately

### DIFF
--- a/crates/zedra/src/agent_picker.rs
+++ b/crates/zedra/src/agent_picker.rs
@@ -93,8 +93,15 @@ impl AgentPicker {
             })
             .collect();
 
-        let launch_cmds: Vec<Option<String>> =
-            agents.iter().map(|a| a.launch_cmd.clone()).collect();
+        let launch_targets: Vec<(String, Option<String>)> = agents
+            .iter()
+            .map(|a| {
+                (
+                    format!("Launching {}...", a.display_name),
+                    a.launch_cmd.clone(),
+                )
+            })
+            .collect();
 
         let pending = self.pending_action.clone();
         platform_bridge::show_list_picker(
@@ -103,10 +110,13 @@ impl AgentPicker {
             picker_items,
             move |selection| {
                 let Some(index) = selection else { return };
-                let Some(cmd) = launch_cmds.get(index).and_then(|c| c.clone()) else {
+                let Some((initial_title, Some(cmd))) = launch_targets.get(index).cloned() else {
                     return;
                 };
-                pending.set(PendingWorkspaceAction::SpawnAgentTerminal { launch_cmd: cmd });
+                pending.set(PendingWorkspaceAction::SpawnAgentTerminal {
+                    launch_cmd: cmd,
+                    initial_title,
+                });
             },
         );
     }

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -19,6 +19,7 @@ use crate::agent_detail::AgentDetail;
 use crate::agent_manage::AgentManage;
 use crate::agent_picker::AgentPicker;
 use crate::agent_sessions::AgentSessions;
+use crate::agent_ui::managed_agent_name;
 use crate::editor::git_sidebar::GitFileSection;
 use crate::pending::{SharedPendingSlot, shared_pending_slot, spawn_periodic_task};
 use crate::placeholder::render_placeholder;
@@ -96,6 +97,7 @@ pub(crate) enum PendingWorkspaceAction {
     },
     SpawnAgentTerminal {
         launch_cmd: String,
+        initial_title: String,
     },
 }
 
@@ -576,6 +578,27 @@ fn seed_host_created_terminal_meta(
     }
 
     changed
+}
+
+fn seed_pending_launch_terminal_meta(
+    terminal_state: &mut TerminalState,
+    terminal_id: &str,
+    title: String,
+    launch_cmd: Option<&str>,
+) {
+    terminal_state.set_title(terminal_id, Some(title));
+    if let Some(command) = launch_cmd.filter(|command| !command.is_empty()) {
+        terminal_state.set_current_command(terminal_id, command.to_owned());
+        terminal_state.set_shell_running(terminal_id);
+    }
+}
+
+fn managed_agent_command_hint(kind: ManagedAgentKind) -> &'static str {
+    match kind {
+        ManagedAgentKind::Claude => "claude",
+        ManagedAgentKind::Codex => "codex",
+        ManagedAgentKind::OpenCode => "opencode",
+    }
 }
 
 fn terminal_ids_after_close(closed_id: &str, terminal_ids: &[String]) -> Vec<String> {
@@ -1242,6 +1265,23 @@ impl Workspace {
         self.apply_route(route, prev_terminal_id, cx);
     }
 
+    fn replace_current_route(&mut self, route: WorkspaceMainView, cx: &mut Context<Self>) {
+        let prev_terminal_id = self.workspace_state.read(cx).active_terminal_id.clone();
+        self.workspace_state.update(cx, |state, cx| {
+            state.replace_current_route(route.clone(), cx);
+        });
+        self.apply_route(route, prev_terminal_id, cx);
+    }
+
+    fn remove_terminal_route(&mut self, id: &str, cx: &mut Context<Self>) {
+        self.workspace_state
+            .update(cx, |state, cx| state.remove_terminal_route(id, cx));
+    }
+
+    fn active_route_is_pending_terminal(&self, cx: &App) -> bool {
+        self.workspace_state.read(cx).active_main_view_terminal_id() == Some(TERMINAL_PENDING_ID)
+    }
+
     /// Back navigation: pop the nav stack and apply the revealed route. Returns false if
     /// already at the bottom of the stack.
     fn navigate_back(&mut self, cx: &mut Context<Self>) -> bool {
@@ -1590,7 +1630,7 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.spawn_terminal("user_action", None, window, cx);
+        self.spawn_terminal("user_action", None, None, window, cx);
     }
 
     fn handle_create_agent(
@@ -1612,13 +1652,20 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.spawn_terminal("create_agent", Some(action.launch_cmd.clone()), window, cx);
+        self.spawn_terminal(
+            "create_agent",
+            Some(action.launch_cmd.clone()),
+            Some(action.initial_title.clone()),
+            window,
+            cx,
+        );
     }
 
     fn spawn_terminal(
         &mut self,
         telemetry_source: &'static str,
         launch_cmd: Option<String>,
+        initial_title: Option<String>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -1635,6 +1682,23 @@ impl Workspace {
         let workspace_terminal =
             self.create_terminal_entity(TERMINAL_PENDING_ID.to_string(), window, cx);
         let pending_entity_id = workspace_terminal.entity_id();
+        if let Some(title) = initial_title.clone() {
+            self.terminal_state.update(cx, |state, cx| {
+                seed_pending_launch_terminal_meta(
+                    state,
+                    TERMINAL_PENDING_ID,
+                    title,
+                    launch_cmd.as_deref(),
+                );
+                cx.notify();
+            });
+            self.navigate_to(
+                WorkspaceMainView::Terminal {
+                    id: TERMINAL_PENDING_ID.to_string(),
+                },
+                cx,
+            );
+        }
 
         let color_scheme = if crate::theme::bundle(cx).terminal.is_light() {
             zedra_rpc::proto::TerminalColorScheme::Light
@@ -1643,6 +1707,7 @@ impl Workspace {
         };
 
         cx.spawn(async move |workspace, cx| {
+            let launch_cmd_for_meta = launch_cmd.clone();
             let terminal_id = match session_handle
                 .terminal_create_with_cmd(cols as u16, rows as u16, launch_cmd, Some(color_scheme))
                 .await
@@ -1651,8 +1716,17 @@ impl Workspace {
                 Err(e) => {
                     tracing::error!("terminal_create failed: {}", e);
                     let message = e.to_string();
-                    let _ = workspace.update(cx, |ws, _cx| {
+                    let _ = workspace.update(cx, |ws, cx| {
                         ws.terminals.retain(|t| t.entity_id() != pending_entity_id);
+                        ws.terminal_state.update(cx, |state, cx| {
+                            state.remove(TERMINAL_PENDING_ID);
+                            cx.notify();
+                        });
+                        if ws.active_route_is_pending_terminal(cx) {
+                            ws.navigate_to(WorkspaceMainView::Default, cx);
+                        } else {
+                            ws.remove_terminal_route(TERMINAL_PENDING_ID, cx);
+                        }
                         platform_bridge::show_alert(
                             "Open Terminal",
                             &message,
@@ -1665,6 +1739,18 @@ impl Workspace {
             };
 
             let _ = workspace.update(cx, |ws, cx| {
+                if let Some(title) = initial_title {
+                    ws.terminal_state.update(cx, |state, cx| {
+                        seed_pending_launch_terminal_meta(
+                            state,
+                            &terminal_id,
+                            title,
+                            launch_cmd_for_meta.as_deref(),
+                        );
+                        state.remove(TERMINAL_PENDING_ID);
+                        cx.notify();
+                    });
+                }
                 workspace_terminal.update(cx, |terminal, cx| {
                     terminal.set_terminal_id(terminal_id.clone(), cx);
                 });
@@ -1675,7 +1761,12 @@ impl Workspace {
                     });
                 });
 
-                ws.navigate_to(WorkspaceMainView::Terminal { id: terminal_id }, cx);
+                if ws.active_route_is_pending_terminal(cx) {
+                    ws.replace_current_route(WorkspaceMainView::Terminal { id: terminal_id }, cx);
+                } else {
+                    ws.remove_terminal_route(TERMINAL_PENDING_ID, cx);
+                    ws.navigate_to(WorkspaceMainView::Terminal { id: terminal_id }, cx);
+                }
                 let terminal_count = ws.workspace_state.read(cx).terminal_ids.len();
                 zedra_telemetry::send(zedra_telemetry::Event::TerminalOpened {
                     source: telemetry_source,
@@ -1692,7 +1783,7 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.spawn_terminal(telemetry_source, None, window, cx);
+        self.spawn_terminal(telemetry_source, None, None, window, cx);
     }
 
     fn handle_navigate_back(
@@ -1769,6 +1860,23 @@ impl Workspace {
         let workspace_terminal =
             self.create_terminal_entity(TERMINAL_PENDING_ID.to_string(), window, cx);
         let pending_entity_id = workspace_terminal.entity_id();
+        let pending_title = format!("Resuming {}...", managed_agent_name(kind));
+        let command_hint = managed_agent_command_hint(kind);
+        self.terminal_state.update(cx, |state, cx| {
+            seed_pending_launch_terminal_meta(
+                state,
+                TERMINAL_PENDING_ID,
+                pending_title.clone(),
+                Some(command_hint),
+            );
+            cx.notify();
+        });
+        self.navigate_to(
+            WorkspaceMainView::Terminal {
+                id: TERMINAL_PENDING_ID.to_string(),
+            },
+            cx,
+        );
 
         cx.spawn(async move |workspace, cx| {
             let terminal_id = match session_handle
@@ -1778,8 +1886,17 @@ impl Workspace {
                 Ok(id) => id,
                 Err(e) => {
                     tracing::error!(?kind, "agent session resume failed: {}", e);
-                    let _ = workspace.update(cx, |ws, _cx| {
+                    let _ = workspace.update(cx, |ws, cx| {
                         ws.terminals.retain(|t| t.entity_id() != pending_entity_id);
+                        ws.terminal_state.update(cx, |state, cx| {
+                            state.remove(TERMINAL_PENDING_ID);
+                            cx.notify();
+                        });
+                        if ws.active_route_is_pending_terminal(cx) {
+                            ws.navigate_to(WorkspaceMainView::Default, cx);
+                        } else {
+                            ws.remove_terminal_route(TERMINAL_PENDING_ID, cx);
+                        }
                         platform_bridge::show_alert(
                             "Resume Agent",
                             "Failed to resume the agent session.",
@@ -1792,6 +1909,16 @@ impl Workspace {
             };
 
             let _ = workspace.update(cx, |ws, cx| {
+                ws.terminal_state.update(cx, |state, cx| {
+                    seed_pending_launch_terminal_meta(
+                        state,
+                        &terminal_id,
+                        pending_title,
+                        Some(command_hint),
+                    );
+                    state.remove(TERMINAL_PENDING_ID);
+                    cx.notify();
+                });
                 workspace_terminal.update(cx, |terminal, cx| {
                     terminal.set_terminal_id(terminal_id.clone(), cx);
                 });
@@ -1800,7 +1927,12 @@ impl Workspace {
                         id: terminal_id.clone(),
                     });
                 });
-                ws.navigate_to(WorkspaceMainView::Terminal { id: terminal_id }, cx);
+                if ws.active_route_is_pending_terminal(cx) {
+                    ws.replace_current_route(WorkspaceMainView::Terminal { id: terminal_id }, cx);
+                } else {
+                    ws.remove_terminal_route(TERMINAL_PENDING_ID, cx);
+                    ws.navigate_to(WorkspaceMainView::Terminal { id: terminal_id }, cx);
+                }
                 let terminal_count = ws.workspace_state.read(cx).terminal_ids.len();
                 zedra_telemetry::send(zedra_telemetry::Event::TerminalOpened {
                     source: "resume_agent",
@@ -1993,10 +2125,19 @@ impl Workspace {
                 self.activate_existing_terminal(target.terminal_id.clone(), cx);
                 self.schedule_add_to_chat_after_activation(target, input, cx);
             }
-            PendingWorkspaceAction::SpawnAgentTerminal { launch_cmd } => {
+            PendingWorkspaceAction::SpawnAgentTerminal {
+                launch_cmd,
+                initial_title,
+            } => {
                 cx.spawn(async move |this, cx| {
                     let _ = this.update_in(cx, |workspace, window, cx| {
-                        workspace.spawn_terminal("create_agent", Some(launch_cmd), window, cx);
+                        workspace.spawn_terminal(
+                            "create_agent",
+                            Some(launch_cmd),
+                            Some(initial_title),
+                            window,
+                            cx,
+                        );
                     });
                 })
                 .detach();
@@ -2366,6 +2507,24 @@ mod tests {
             meta.current_command.as_deref(),
             Some("claude --resume session")
         );
+    }
+
+    #[::core::prelude::v1::test]
+    fn pending_launch_terminal_seeds_title_and_agent_icon() {
+        let mut terminal_state = TerminalState::new();
+
+        seed_pending_launch_terminal_meta(
+            &mut terminal_state,
+            TERMINAL_PENDING_ID,
+            "Launching Codex...".to_string(),
+            Some("codex"),
+        );
+
+        let meta = terminal_state.meta(TERMINAL_PENDING_ID);
+        assert_eq!(meta.title.as_deref(), Some("Launching Codex..."));
+        assert_eq!(meta.agent_icon, Some("icons/openai.svg"));
+        assert_eq!(meta.agent_kind, Some(agent::Kind::Codex));
+        assert_eq!(meta.shell_state, crate::terminal_state::ShellState::Running);
     }
 
     #[::core::prelude::v1::test]

--- a/crates/zedra/src/workspace_action.rs
+++ b/crates/zedra/src/workspace_action.rs
@@ -112,6 +112,7 @@ pub struct CreateAgent;
 #[action(namespace = workspace, no_json)]
 pub struct SpawnAgentTerminal {
     pub launch_cmd: String,
+    pub initial_title: String,
 }
 
 #[derive(Clone, PartialEq, Action)]

--- a/crates/zedra/src/workspace_state.rs
+++ b/crates/zedra/src/workspace_state.rs
@@ -130,6 +130,10 @@ impl WorkspaceNavigationStack {
                 .is_none_or(|id| terminal_ids.iter().any(|terminal_id| terminal_id == id))
         });
     }
+
+    pub fn remove_terminal(&mut self, id: &str) {
+        self.routes.retain(|route| route.terminal_id() != Some(id));
+    }
 }
 
 /// Shareable workspace state. Clone copies the Arc only. Read via methods (non-blocking).
@@ -355,6 +359,10 @@ impl WorkspaceState {
         cx.notify();
     }
 
+    pub fn active_main_view_terminal_id(&self) -> Option<&str> {
+        self.active_main_view.terminal_id()
+    }
+
     pub fn navigate(&mut self, route: WorkspaceMainView, cx: &mut Context<Self>) {
         self.main_view_stack.open(route.clone());
         if let WorkspaceMainView::Terminal { ref id } = route {
@@ -362,6 +370,20 @@ impl WorkspaceState {
             cx.emit(WorkspaceStateEvent::TerminalOpened { id: id.clone() });
         }
         self.set_active_main_view(route, cx);
+    }
+
+    pub fn replace_current_route(&mut self, route: WorkspaceMainView, cx: &mut Context<Self>) {
+        self.main_view_stack.replace(route.clone());
+        if let WorkspaceMainView::Terminal { ref id } = route {
+            self.active_terminal_id = Some(id.clone());
+            cx.emit(WorkspaceStateEvent::TerminalOpened { id: id.clone() });
+        }
+        self.set_active_main_view(route, cx);
+    }
+
+    pub fn remove_terminal_route(&mut self, id: &str, cx: &mut Context<Self>) {
+        self.main_view_stack.remove_terminal(id);
+        cx.notify();
     }
 
     pub fn go_back(&mut self, cx: &mut Context<Self>) -> Option<WorkspaceMainView> {
@@ -656,6 +678,42 @@ mod tests {
                 id: "terminal-1".into()
             })
         );
+    }
+
+    #[test]
+    fn navigation_stack_removes_buried_terminal_route() {
+        let mut stack = WorkspaceNavigationStack::default();
+        let file = WorkspaceMainView::File {
+            path: "src/main.rs".into(),
+        };
+        let diff = WorkspaceMainView::GitDiff {
+            path: "src/lib.rs".into(),
+            section: 0,
+        };
+
+        stack.open(WorkspaceMainView::Terminal {
+            id: "terminal-pending".into(),
+        });
+        stack.open(file.clone());
+        stack.open(diff.clone());
+
+        stack.remove_terminal("terminal-pending");
+
+        assert_eq!(stack.active(), diff);
+        assert_eq!(stack.go_back(), Some(file));
+        assert_eq!(stack.go_back(), None);
+    }
+
+    #[test]
+    fn active_main_view_terminal_id_ignores_last_active_terminal() {
+        let mut state = WorkspaceState::default();
+        state.active_terminal_id = Some("terminal-pending".into());
+        state.active_main_view = WorkspaceMainView::GitDiff {
+            path: "src/lib.rs".into(),
+            section: 0,
+        };
+
+        assert_eq!(state.active_main_view_terminal_id(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Open a pending terminal immediately when launching or resuming an agent.
- Seed the pending terminal title and agent identity, then retarget it to the real terminal when the host responds.
- Remove stale pending terminal routes if the user navigates away while the request is in flight.

## Notes
None