### PR TITLE
fix(workspace): reliable QR rescan via fresh restart path

### DIFF
--- a/crates/zedra-session/src/session.rs
+++ b/crates/zedra-session/src/session.rs
@@ -3,6 +3,7 @@ use tracing::*;
 
 use iroh::EndpointAddr;
 use tokio::sync::{Notify, broadcast, mpsc};
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use zedra_rpc::ZedraPairingTicket;
 use zedra_rpc::proto::{
@@ -31,6 +32,10 @@ pub struct Session {
     abort_signal: Arc<Mutex<CancellationToken>>,
     /// Notify when the session connection is closed.
     closed_notify: Arc<Notify>,
+    /// JoinHandle of the connect loop task. Used to serialize re-entry: a new
+    /// `connect()` awaits the previous loop's exit before running so old/new
+    /// loops never race on the same `event_tx` or `SessionHandle`.
+    connect_task: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 impl Session {
@@ -52,6 +57,7 @@ impl Session {
             closed_notify,
             host_event_tx,
             host_info_tx,
+            connect_task: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -115,7 +121,15 @@ impl Session {
         }
         handle.set_session_id(session_id.clone());
 
-        session_runtime().spawn(async move {
+        // Take ownership of the previous connect-loop handle (if any); the new
+        // task awaits its exit before running so we never have two loops
+        // writing to the same `event_tx`/`SessionHandle` simultaneously.
+        let previous_task = self.connect_task.lock().unwrap().take();
+        let task_slot = self.connect_task.clone();
+        let new_task = session_runtime().spawn(async move {
+            if let Some(prev) = previous_task {
+                let _ = prev.await;
+            }
             let mut connector = Connector::new(event_tx);
             let mut ticket = ticket;
             let mut session_id = session_id;
@@ -297,6 +311,14 @@ impl Session {
                 }
             }
         });
+        *task_slot.lock().unwrap() = Some(new_task);
+    }
+
+    /// Abort the in-flight connect attempt without marking the session as
+    /// manually disconnected. Used when restarting with fresh credentials
+    /// (e.g. QR rescan) so the entry stays alive for the new attempt.
+    pub fn abort_in_flight(&self) {
+        self.cancel_abort_signal();
     }
 
     /// Disconnect and clear session state.

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -1009,6 +1009,47 @@ impl Workspace {
         self.record_current_view(cx);
     }
 
+    /// Restart this workspace's connection with a fresh pairing ticket
+    /// (e.g. QR rescan). Aborts any in-flight attempt, clears stale auth
+    /// material on the SessionHandle, and starts a new connect with the
+    /// new ticket. The entry stays alive across the restart.
+    pub fn restart_with_ticket(
+        &mut self,
+        addr: iroh::EndpointAddr,
+        ticket: ZedraPairingTicket,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(signer) = self.connection_request.as_ref().map(|r| r.signer.clone()) else {
+            warn!("restart_with_ticket called without a prior signer");
+            return;
+        };
+
+        // Stop the current connect loop; the new spawn will await its exit
+        // before running, so no two loops race on the same handle/event_tx.
+        self.session.abort_in_flight();
+
+        // Drop stale auth material so the new ticket drives a fresh Register/Auth.
+        let handle = self.session.handle();
+        handle.set_session_token(None);
+        handle.set_session_id(Some(ticket.session_id.clone()));
+
+        let session_id = Some(ticket.session_id.clone());
+        let request = ConnectionRequest {
+            addr,
+            ticket: Some(ticket),
+            signer,
+            session_id,
+        };
+        self.connection_request = Some(request.clone());
+        self.seen_reconnect = false;
+        self.active_reconnect_reason = None;
+        self.latency_sampler.reset();
+        self.start_connection(request);
+        self.content.update(cx, |c, cx| c.show_connecting_view(cx));
+        self.record_current_view(cx);
+        info!("restarted workspace connection with fresh ticket");
+    }
+
     pub fn session_handle(&self) -> &SessionHandle {
         self.session.handle()
     }

--- a/crates/zedra/src/workspaces.rs
+++ b/crates/zedra/src/workspaces.rs
@@ -179,9 +179,11 @@ impl Workspaces {
             }
         };
 
-        // Existing entry just needs to switch into, triggers reconnect if it's failed/disconencted
+        // Existing entry: if healthy (Connected/Idle), just switch to it.
+        // Otherwise (Failed, Disconnected, or any in-flight phase) restart
+        // with the fresh ticket so a rescan always overrides stale auth.
         if let Some(index) = self.entry_index_by_endpoint_addr(&encoded_addr, cx) {
-            self.open_existing_entry(index, cx);
+            self.open_existing_entry_with_ticket(index, addr, ticket, cx);
             return;
         }
 
@@ -249,20 +251,27 @@ impl Workspaces {
         }
     }
 
-    fn open_existing_entry(&mut self, index: usize, cx: &mut Context<Self>) {
+    fn open_existing_entry_with_ticket(
+        &mut self,
+        index: usize,
+        addr: iroh::EndpointAddr,
+        ticket: ZedraPairingTicket,
+        cx: &mut Context<Self>,
+    ) {
         let Some(entry) = self.entries.get(index).cloned() else {
             return;
         };
 
         let phase = entry.read(cx).workspace_state(cx).connect_phase.clone();
-        if matches!(
+        let healthy = matches!(
             phase,
-            Some(ConnectPhase::Disconnected) | Some(ConnectPhase::Failed(_))
-        ) {
-            info!("Reconnecting existing workspace for endpoint.");
-            entry.update(cx, |ws, cx| ws.restart_connection(cx));
+            Some(ConnectPhase::Connected) | Some(ConnectPhase::Idle { .. })
+        );
+        if healthy {
+            info!("Workspace for this endpoint already connected; switching to it.");
         } else {
-            info!("Workspace for this endpoint already exists; switching to it.");
+            info!("Restarting existing workspace for endpoint with fresh ticket.");
+            entry.update(cx, |ws, cx| ws.restart_with_ticket(addr, ticket, cx));
         }
 
         self.activate_entry(index, cx);

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -264,6 +264,28 @@
 8. Expected: the old static QR no longer works; the app says the QR expired or was replaced
 9. Restart the daemon and generate a fresh static QR if needed
 
+## 2b. QR Rescan Restarts Existing Entry
+
+Covers the rescan path through `Workspaces::connect_ticket` →
+`Workspace::restart_with_ticket`. Every scenario must end with the same
+entry index (no duplicate) and the entry transitioning into `BindingEndpoint`
+or beyond.
+
+1. Start host: `zedra start --workdir .`
+2. Scan QR, let StaleTimestamp or any auth failure land the entry in `Failed`
+3. Refresh the QR on the host, rescan from the same device
+4. Expected: existing entry restarts and reaches `Connected`; no new entry is created
+5. Repeat with a deliberately stuck Authenticating phase (e.g. pause network for
+   ~10s mid-auth, then rescan a fresh QR before the entry times out)
+6. Expected: in-flight attempt is aborted and the fresh ticket drives a new
+   Register/Authenticate round on the same entry
+7. While the entry is `Connected`, rescan a still-valid QR for the same endpoint
+8. Expected: just switches to the entry; no restart, no flicker of the connecting view
+9. Rescan twice in rapid succession (two fresh QRs back-to-back)
+10. Expected: only the last attempt is alive; no overlapping connect loops
+    (`grep` logs for `start connect to` — two entries are fine, but the first
+    one must be followed by abort/cancel before the second's `Connected`)
+
 ## 2a. Protocol Version Mismatch
 
 1. Run an app build and CLI/host build that use different `ZEDRA_ALPN` versions


### PR DESCRIPTION
## Summary

- Replaces in-place `ConnectionRequest` mutation with `Workspace::restart_with_ticket`: aborts the in-flight connect, clears stale `session_token`/`session_id` on the SessionHandle, and starts a new connect with the fresh ticket.
- `Session` now serializes connect re-entry via a stored `JoinHandle` so old and new connect loops never race on the same `event_tx` or `SessionHandle`.
- `Workspaces::connect_ticket` existing-entry branch covers Failed, Disconnected, and any in-flight phase (Connecting/Authenticating/etc.); Connected/Idle entries just switch.

## Notes

- Removed the tautological tests from the previous rescan attempt; new manual test scenarios added in `docs/MANUAL_TEST.md` §2b covering Failed-state rescan, mid-Authenticate rescan, Connected no-op switch, and rapid double-rescan.
- No `SessionState::reset` needed — the connect loop's `apply_event` overwrites phase naturally; the new restart path bypasses `restart_connection`'s `register_attempted` guard by calling `start_connection` directly.