### PR TITLE
chore: bump iOS to 1.3 (build 11) and Android to 0.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,8 +38,8 @@ android {
         applicationId = "dev.zedra.app"
         minSdk = 23
         targetSdk = 35
-        versionCode = 2
-        versionName = "0.2"
+        versionCode = 3
+        versionName = "0.3"
         manifestPlaceholders = [
             appLabel: "@string/app_name",
             firebaseAnalyticsCollectionEnabled: "false",

--- a/ios/Zedra.xcodeproj/project.pbxproj
+++ b/ios/Zedra.xcodeproj/project.pbxproj
@@ -440,7 +440,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = GHV27CNR5U;
@@ -462,7 +462,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
@@ -487,7 +487,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = YES;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 11;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_POSTPROCESSING = YES;
@@ -512,7 +512,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -96,8 +96,8 @@ targets:
     settings:
       base:
         GENERATE_INFOPLIST_FILE: YES
-        MARKETING_VERSION: "1.2"
-        CURRENT_PROJECT_VERSION: "10"
+        MARKETING_VERSION: "1.3"
+        CURRENT_PROJECT_VERSION: "11"
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: GHV27CNR5U
         INFOPLIST_KEY_CFBundleDisplayName: Zedra


### PR DESCRIPTION
## Summary
- iOS `MARKETING_VERSION` 1.2 → 1.3, `CURRENT_PROJECT_VERSION` 10 → 11
- Android `versionName` 0.2 → 0.3, `versionCode` 2 → 3

## Notes
Synced `ios/project.yml` and `ios/Zedra.xcodeproj/project.pbxproj` together.