### PR TITLE
feat(landing): update Android CTA, update UIs

### DIFF
--- a/packages/landing/src/pages/index.astro
+++ b/packages/landing/src/pages/index.astro
@@ -80,13 +80,13 @@ const storeLinks = [
     subtitle: "iOS",
   },
   {
-    href: "#",
-    className: "store-btn secondary",
-    ariaLabel: "Zedra on Android coming soon",
+    href: "https://groups.google.com/g/zedra-beta",
+    className: "store-btn",
+    ariaLabel: "Join Zedra Android closed testing",
     analyticsName: "android",
     icon: `<svg class="store-icon" fill="currentColor" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Google Play</title><path d="M22.018 13.298l-3.919 2.218-3.515-3.493 3.543-3.521 3.891 2.202a1.49 1.49 0 0 1 0 2.594zM1.337.924a1.486 1.486 0 0 0-.112.568v21.017c0 .217.045.419.124.6l11.155-11.087L1.337.924zm12.207 10.065l3.258-3.238L3.45.195a1.466 1.466 0 0 0-.946-.179l11.04 10.973zm0 2.067l-11 10.933c.298.036.612-.016.906-.183l13.324-7.54-3.23-3.21z"/></svg>`,
-    title: "Google Play",
-    subtitle: "Coming soon",
+    title: "Android Beta",
+    subtitle: "Closed testing",
   },
 ];
 
@@ -253,7 +253,7 @@ const canonicalUrl = "https://zedra.dev/";
         display: flex;
         flex-direction: column;
         justify-content: center;
-        gap: 28px;
+        gap: 40px;
       }
 
       .hero-copy {
@@ -263,7 +263,7 @@ const canonicalUrl = "https://zedra.dev/";
 
       .hero-intro {
         display: grid;
-        gap: 14px;
+        gap: 20px;
       }
 
       h1 {
@@ -608,6 +608,9 @@ const canonicalUrl = "https://zedra.dev/";
       }
 
       footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
         padding: 24px 0 8px;
         border-top: 1px solid var(--border);
       }
@@ -627,6 +630,10 @@ const canonicalUrl = "https://zedra.dev/";
 
       footer a:hover {
         color: var(--text);
+      }
+
+      footer .social-links {
+        margin-top: 0;
       }
 
       @media (max-width: 640px) {
@@ -673,6 +680,14 @@ const canonicalUrl = "https://zedra.dev/";
           line-height: 1.65;
         }
 
+        .left {
+          gap: 28px;
+        }
+
+        .hero-intro {
+          gap: 14px;
+        }
+
         .store-copy strong {
           font-size: 0.82rem;
         }
@@ -691,13 +706,17 @@ const canonicalUrl = "https://zedra.dev/";
           justify-content: center;
         }
 
-        .ph-badge {
-          display: block;
-          text-align: center;
+        footer {
+          flex-direction: column;
+          gap: 16px;
+        }
+
+        footer nav {
+          justify-content: center;
         }
 
         .social-links {
-          margin-top: 16px;
+          margin-top: 0;
           justify-content: center;
           gap: 28px;
         }
@@ -886,36 +905,7 @@ const canonicalUrl = "https://zedra.dev/";
               }
             </div>
 
-            <a
-              class="ph-badge"
-              href="https://www.producthunt.com/products/zedra-mobile-ide-for-ai?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-zedra"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <img
-                alt="Zedra - Code from anywhere | Product Hunt"
-                width="250"
-                height="54"
-                src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1097175&theme=dark&t=1774597535210"
-              />
-            </a>
 
-            <div class="social-links" aria-label="Zedra social links">
-              {
-                socialLinks.map((link) => (
-                  <a
-                    class="social-btn"
-                    href={link.href}
-                    aria-label={link.ariaLabel}
-                    data-analytics-social={link.analyticsName}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Fragment set:html={link.icon} />
-                  </a>
-                ))
-              }
-            </div>
           </section>
         </section>
 
@@ -933,14 +923,26 @@ const canonicalUrl = "https://zedra.dev/";
         </aside>
       </main>
       <footer>
+        <div class="social-links" aria-label="Zedra social links">
+          {
+            socialLinks.map((link) => (
+              <a
+                class="social-btn"
+                href={link.href}
+                aria-label={link.ariaLabel}
+                data-analytics-social={link.analyticsName}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Fragment set:html={link.icon} />
+              </a>
+            ))
+          }
+        </div>
+
         <nav aria-label="Site links">
           <a href="/privacy">Privacy Policy</a>
           <a href="/support">Support</a>
-          <a
-            href="https://github.com/tanlethanh/zedra"
-            target="_blank"
-            rel="noopener noreferrer">GitHub</a
-          >
         </nav>
       </footer>
     </div>


### PR DESCRIPTION
## Summary

Updates the landing page with several layout and CTA changes:

- **Android CTA**: Replaced disabled 'Coming soon' button with active 'Android Beta / Closed testing' link to the Google Group for closed testing signup.
- **Removed Product Hunt badge** from the hero section.
- **Moved social icons** (X, GitHub, Discord) from hero to the footer, bottom-right.
- **Removed 'GitHub' text link** from footer nav — already covered by the social icon.
- **Reversed footer layout**: social icons on the left, site links on the right.
- **Increased spacing** between title, description, and install container on desktop; tightened back to original values on mobile for better responsiveness.