### PR TITLE
feat: opt-in LSP control plane schema (refs #90)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10173,11 +10173,14 @@ name = "zedra-lsp"
 version = "0.2.5"
 dependencies = [
  "anyhow",
+ "libc",
  "serde",
  "serde_json",
+ "sysinfo",
  "tokio",
  "tracing",
  "zedra-rpc",
+ "zedra-telemetry",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10162,9 +10162,22 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "windows-sys 0.61.2",
+ "zedra-lsp",
  "zedra-osc",
  "zedra-rpc",
  "zedra-telemetry",
+]
+
+[[package]]
+name = "zedra-lsp"
+version = "0.2.5"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "zedra-rpc",
 ]
 
 [[package]]

--- a/crates/zedra-host/Cargo.toml
+++ b/crates/zedra-host/Cargo.toml
@@ -84,6 +84,7 @@ serde_bytes.workspace = true
 # Workspace crates
 zedra-osc = { path = "../zedra-osc" }
 zedra-rpc = { path = "../zedra-rpc" }
+zedra-lsp = { path = "../zedra-lsp" }
 zedra-telemetry.workspace = true
 
 # Unix process signaling (for workspace lock PID check)

--- a/crates/zedra-host/src/api.rs
+++ b/crates/zedra-host/src/api.rs
@@ -261,6 +261,91 @@ fn lsp_kill_reason_label(reason: zedra_rpc::proto::LspKillReason) -> &'static st
     }
 }
 
+fn parse_lsp_language(raw: &str) -> Option<zedra_rpc::proto::LspLanguage> {
+    use zedra_rpc::proto::LspLanguage::*;
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "rust" | "rs" | "rust-analyzer" => Some(Rust),
+        "go" | "gopls" | "golang" => Some(Go),
+        "typescript" | "ts" => Some(TypeScript),
+        "javascript" | "js" => Some(JavaScript),
+        "python" | "py" => Some(Python),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct LspLanguageRequest {
+    language: String,
+}
+
+async fn lsp_enable_handler(
+    State(s): State<ApiState>,
+    headers: HeaderMap,
+    Json(body): Json<LspLanguageRequest>,
+) -> impl IntoResponse {
+    if !verify_token(&headers, &s.token) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "unauthorized"})),
+        )
+            .into_response();
+    }
+    let Some(language) = parse_lsp_language(&body.language) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": format!("unknown language: {}", body.language)})),
+        )
+            .into_response();
+    };
+    if let Err(e) = s.daemon_state.lsp.enable(language).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+    Json(serde_json::json!({
+        "ok": true,
+        "language": lsp_language_label(language),
+        "enabled": true,
+    }))
+    .into_response()
+}
+
+async fn lsp_disable_handler(
+    State(s): State<ApiState>,
+    headers: HeaderMap,
+    Json(body): Json<LspLanguageRequest>,
+) -> impl IntoResponse {
+    if !verify_token(&headers, &s.token) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "unauthorized"})),
+        )
+            .into_response();
+    }
+    let Some(language) = parse_lsp_language(&body.language) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": format!("unknown language: {}", body.language)})),
+        )
+            .into_response();
+    };
+    if let Err(e) = s.daemon_state.lsp.disable(language).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+            .into_response();
+    }
+    Json(serde_json::json!({
+        "ok": true,
+        "language": lsp_language_label(language),
+        "enabled": false,
+    }))
+    .into_response()
+}
+
 async fn create_pairing_qr_handler(
     State(s): State<ApiState>,
     headers: HeaderMap,
@@ -832,6 +917,8 @@ pub async fn start(state: ApiState) -> anyhow::Result<std::net::SocketAddr> {
             get(list_agent_hook_events_handler),
         )
         .route("/api/agent-hooks/:kind", post(receive_agent_hook_handler))
+        .route("/api/lsp/enable", post(lsp_enable_handler))
+        .route("/api/lsp/disable", post(lsp_disable_handler))
         .with_state(state);
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;

--- a/crates/zedra-host/src/api.rs
+++ b/crates/zedra-host/src/api.rs
@@ -98,6 +98,29 @@ struct StatusSession {
 }
 
 #[derive(Debug, Serialize)]
+struct StatusLspServer {
+    language: String,
+    state: String,
+    pid: Option<u32>,
+    rss_bytes: u64,
+    uptime_secs: u64,
+    diagnostic_errors: u32,
+    diagnostic_warnings: u32,
+    last_request_ms: Option<u32>,
+    last_kill_reason: Option<String>,
+    peak_rss_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct StatusLsp {
+    enabled: bool,
+    servers: Vec<StatusLspServer>,
+    aggregate_rss_bytes: u64,
+    aggregate_rss_cap_bytes: u64,
+    concurrent_cap: u32,
+}
+
+#[derive(Debug, Serialize)]
 struct StatusResp {
     ok: bool,
     version: &'static str,
@@ -106,6 +129,7 @@ struct StatusResp {
     uptime_secs: u64,
     sessions: Vec<StatusSession>,
     terminals: Vec<StatusTerminal>,
+    lsp: StatusLsp,
 }
 
 async fn status(State(s): State<ApiState>, headers: HeaderMap) -> impl IntoResponse {
@@ -159,6 +183,8 @@ async fn status(State(s): State<ApiState>, headers: HeaderMap) -> impl IntoRespo
         });
     }
 
+    let lsp = lsp_status_snapshot(&s).await;
+
     Json(StatusResp {
         ok: true,
         version,
@@ -167,8 +193,72 @@ async fn status(State(s): State<ApiState>, headers: HeaderMap) -> impl IntoRespo
         uptime_secs,
         sessions,
         terminals: all_terminals,
+        lsp,
     })
     .into_response()
+}
+
+async fn lsp_status_snapshot(s: &ApiState) -> StatusLsp {
+    let snap = s.daemon_state.lsp.status_snapshot().await;
+    StatusLsp {
+        enabled: snap.enabled,
+        servers: snap
+            .servers
+            .into_iter()
+            .map(|server| StatusLspServer {
+                language: lsp_language_label(server.language).to_string(),
+                state: lsp_state_label(server.state).to_string(),
+                pid: server.pid,
+                rss_bytes: server.rss_bytes,
+                uptime_secs: server.uptime_secs,
+                diagnostic_errors: server.diagnostic_errors,
+                diagnostic_warnings: server.diagnostic_warnings,
+                last_request_ms: server.last_request_ms,
+                last_kill_reason: server
+                    .last_kill_reason
+                    .map(|r| lsp_kill_reason_label(r).to_string()),
+                peak_rss_bytes: server.peak_rss_bytes,
+            })
+            .collect(),
+        aggregate_rss_bytes: snap.aggregate_rss_bytes,
+        aggregate_rss_cap_bytes: snap.aggregate_rss_cap_bytes,
+        concurrent_cap: snap.concurrent_cap,
+    }
+}
+
+fn lsp_language_label(language: zedra_rpc::proto::LspLanguage) -> &'static str {
+    use zedra_rpc::proto::LspLanguage::*;
+    match language {
+        Rust => "rust",
+        Go => "go",
+        TypeScript => "typescript",
+        JavaScript => "javascript",
+        Python => "python",
+    }
+}
+
+fn lsp_state_label(state: zedra_rpc::proto::LspServerState) -> &'static str {
+    use zedra_rpc::proto::LspServerState::*;
+    match state {
+        Idle => "idle",
+        Starting => "starting",
+        Ready => "ready",
+        Failed => "failed",
+        Killed => "killed",
+        Disabled => "disabled",
+    }
+}
+
+fn lsp_kill_reason_label(reason: zedra_rpc::proto::LspKillReason) -> &'static str {
+    use zedra_rpc::proto::LspKillReason::*;
+    match reason {
+        Oom => "oom",
+        AggregateOom => "aggregate_oom",
+        Cpu => "cpu",
+        Idle => "idle",
+        Manual => "manual",
+        Crash => "crash",
+    }
 }
 
 async fn create_pairing_qr_handler(

--- a/crates/zedra-host/src/lsp_cli.rs
+++ b/crates/zedra-host/src/lsp_cli.rs
@@ -1,0 +1,327 @@
+// CLI subcommands for the opt-in LSP control plane.
+//
+// All commands talk to the running daemon over its loopback REST API. When
+// the daemon is not running, `status` falls back to reading the persisted
+// `lsp.json`, and mutating commands fail with a clear error rather than
+// editing the file behind the daemon's back (which would diverge from the
+// in-memory `LspManager` if the daemon came back up).
+
+use anyhow::{bail, Context, Result};
+use clap::{Args, Subcommand};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use zedra_host::{identity, utils};
+
+#[derive(Debug, Args)]
+pub struct LspArgs {
+    #[command(subcommand)]
+    pub command: LspCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LspCommand {
+    /// Show LSP subsystem state for a workspace.
+    Status(LspStatusArgs),
+    /// Enable a language server for the active workspace.
+    Enable(LspToggleArgs),
+    /// Disable a language server for the active workspace.
+    Disable(LspToggleArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct LspStatusArgs {
+    /// Working directory of the running daemon.
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+    /// Print the LSP block as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct LspToggleArgs {
+    /// Language identifier: rust, go, typescript, javascript, python.
+    language: String,
+    /// Working directory of the running daemon.
+    #[arg(short, long, default_value = ".")]
+    workdir: String,
+}
+
+pub async fn run(args: LspArgs) -> Result<()> {
+    match args.command {
+        LspCommand::Status(a) => status(a).await,
+        LspCommand::Enable(a) => enable(a).await,
+        LspCommand::Disable(a) => disable(a).await,
+    }
+}
+
+async fn status(args: LspStatusArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let lsp = match daemon_api(&workdir) {
+        Ok((addr, token)) => fetch_lsp_block(&addr, &token).await?,
+        Err(_) => offline_lsp_block(&workdir),
+    };
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&lsp)?);
+    } else {
+        println!("{}", render_lsp_status(&lsp));
+    }
+    Ok(())
+}
+
+async fn enable(args: LspToggleArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let body = serde_json::json!({ "language": args.language });
+    let resp: serde_json::Value = api_post(&workdir, "/api/lsp/enable", &body)
+        .await
+        .context("LSP enable failed (is the daemon running?)")?;
+    let lang = resp["language"].as_str().unwrap_or(&args.language);
+    println!("Enabled LSP for {lang}");
+    Ok(())
+}
+
+async fn disable(args: LspToggleArgs) -> Result<()> {
+    let workdir = resolve_workdir(&args.workdir);
+    let body = serde_json::json!({ "language": args.language });
+    let resp: serde_json::Value = api_post(&workdir, "/api/lsp/disable", &body)
+        .await
+        .context("LSP disable failed (is the daemon running?)")?;
+    let lang = resp["language"].as_str().unwrap_or(&args.language);
+    println!("Disabled LSP for {lang}");
+    Ok(())
+}
+
+/// Read the persisted enablement list when the daemon is not running.
+/// Server-state fields stay zeroed since nothing is supervising them.
+fn offline_lsp_block(workdir: &Path) -> serde_json::Value {
+    let path = match identity::workspace_config_dir(workdir) {
+        Ok(dir) => dir.join("lsp.json"),
+        Err(_) => return serde_json::json!({ "enabled": false, "servers": [], "offline": true }),
+    };
+    let state = zedra_lsp::persistence::load(&path);
+    let servers: Vec<serde_json::Value> = state
+        .enabled_languages
+        .iter()
+        .map(|l| {
+            serde_json::json!({
+                "language": language_label(*l),
+                "state": "idle",
+                "pid": null_value(),
+                "rss_bytes": 0,
+                "uptime_secs": 0,
+                "diagnostic_errors": 0,
+                "diagnostic_warnings": 0,
+                "last_request_ms": null_value(),
+                "last_kill_reason": null_value(),
+                "peak_rss_bytes": 0,
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "enabled": !state.enabled_languages.is_empty(),
+        "servers": servers,
+        "aggregate_rss_bytes": 0,
+        "aggregate_rss_cap_bytes": 0,
+        "concurrent_cap": 0,
+        "offline": true,
+    })
+}
+
+fn null_value() -> serde_json::Value {
+    serde_json::Value::Null
+}
+
+fn language_label(language: zedra_rpc::proto::LspLanguage) -> &'static str {
+    use zedra_rpc::proto::LspLanguage::*;
+    match language {
+        Rust => "rust",
+        Go => "go",
+        TypeScript => "typescript",
+        JavaScript => "javascript",
+        Python => "python",
+    }
+}
+
+async fn fetch_lsp_block(addr: &str, token: &str) -> Result<serde_json::Value> {
+    let url = format!("http://{}/api/status", addr.trim());
+    let response = reqwest::Client::new()
+        .get(url)
+        .bearer_auth(token.trim())
+        .send()
+        .await
+        .context("failed to reach daemon")?;
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!("daemon returned HTTP {status}: {text}");
+    }
+    let mut value: serde_json::Value =
+        serde_json::from_str(&text).context("failed to decode daemon status response")?;
+    Ok(value["lsp"].take())
+}
+
+fn render_lsp_status(lsp: &serde_json::Value) -> String {
+    let offline = lsp
+        .get("offline")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let enabled = lsp
+        .get("enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let mut sections = Vec::new();
+    if offline {
+        sections.push("Zedra daemon not running — showing persisted config.".to_string());
+        sections.push(String::new());
+    }
+    if !enabled {
+        sections.push("LSP: no languages enabled for this workspace.".to_string());
+        sections.push(
+            "Enable one with `zedra lsp enable <language>` while the daemon is running."
+                .to_string(),
+        );
+        return sections.join("\n");
+    }
+
+    let servers = lsp
+        .get("servers")
+        .and_then(|s| s.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let running = servers
+        .iter()
+        .filter(|s| {
+            matches!(
+                s.get("state").and_then(|v| v.as_str()),
+                Some("starting") | Some("ready")
+            )
+        })
+        .count();
+    let cap = lsp
+        .get("concurrent_cap")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    sections.push(format!("LSP servers ({running} running, cap {cap})"));
+    let rows: Vec<Vec<String>> = servers.iter().map(server_row).collect();
+    sections.push(utils::render_table(
+        &["LANG", "STATE", "PID", "RSS", "UPTIME", "DIAGS", "LAST"],
+        &rows,
+    ));
+
+    let agg = lsp
+        .get("aggregate_rss_bytes")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let agg_cap = lsp
+        .get("aggregate_rss_cap_bytes")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    if agg_cap > 0 {
+        let pct = ((agg as f64 / agg_cap as f64) * 100.0).round() as u64;
+        sections.push(format!(
+            "Aggregate RSS: {} / {} ({}%)",
+            format_bytes_mb(agg),
+            format_bytes_mb(agg_cap),
+            pct,
+        ));
+    }
+    sections.join("\n")
+}
+
+fn server_row(server: &serde_json::Value) -> Vec<String> {
+    let lang = server
+        .get("language")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?");
+    let state = server.get("state").and_then(|v| v.as_str()).unwrap_or("?");
+    let pid = server
+        .get("pid")
+        .and_then(|v| v.as_u64())
+        .map(|p| p.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let rss = server
+        .get("rss_bytes")
+        .and_then(|v| v.as_u64())
+        .map(format_bytes_mb)
+        .unwrap_or_else(|| "-".to_string());
+    let uptime = server
+        .get("uptime_secs")
+        .and_then(|v| v.as_u64())
+        .map(utils::format_duration)
+        .unwrap_or_else(|| "-".to_string());
+    let errors = server
+        .get("diagnostic_errors")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let warnings = server
+        .get("diagnostic_warnings")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let last = server
+        .get("last_request_ms")
+        .and_then(|v| v.as_u64())
+        .map(|ms| format!("{ms}ms"))
+        .unwrap_or_else(|| "-".to_string());
+    vec![
+        lang.to_string(),
+        state.to_string(),
+        pid,
+        rss,
+        uptime,
+        format!("{errors}E {warnings}W"),
+        last,
+    ]
+}
+
+fn format_bytes_mb(bytes: u64) -> String {
+    if bytes == 0 {
+        return "-".to_string();
+    }
+    let mb = bytes as f64 / (1024.0 * 1024.0);
+    if mb >= 1024.0 {
+        format!("{:.1} GB", mb / 1024.0)
+    } else {
+        format!("{:.0} MB", mb)
+    }
+}
+
+async fn api_post<T: DeserializeOwned, B: Serialize>(
+    workdir: &Path,
+    path: &str,
+    body: &B,
+) -> Result<T> {
+    let (addr, token) = daemon_api(workdir)?;
+    let url = format!("http://{}{}", addr.trim(), path);
+    let response = reqwest::Client::new()
+        .post(url)
+        .bearer_auth(token.trim())
+        .json(body)
+        .send()
+        .await
+        .context("failed to reach daemon")?;
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!("daemon returned HTTP {status}: {text}");
+    }
+    serde_json::from_str(&text).with_context(|| format!("failed to decode daemon response: {text}"))
+}
+
+fn daemon_api(workdir: &Path) -> Result<(String, String)> {
+    let config_dir = identity::workspace_config_dir(workdir)?;
+    let addr = std::fs::read_to_string(config_dir.join("api-addr")).unwrap_or_default();
+    let token = std::fs::read_to_string(config_dir.join("api-token")).unwrap_or_default();
+    if addr.trim().is_empty() {
+        bail!("No running daemon found for: {}", workdir.display());
+    }
+    Ok((addr, token))
+}
+
+fn resolve_workdir(raw: &str) -> PathBuf {
+    PathBuf::from(raw)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(raw))
+}

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -730,20 +730,35 @@ async fn main() -> Result<()> {
                     lsp.restore_enabled().await;
                 });
             }
-            // Consume diagnostic updates so the channel does not block the
-            // reader task. The HostEvent fan-out to subscribed clients lands
-            // in a follow-up commit; until then we drop the payloads after
-            // logging so the supervisor + RSS guard stay live.
-            tokio::spawn(async move {
-                while let Some(update) = lsp_diag_rx.recv().await {
-                    tracing::debug!(
-                        language = ?update.language,
-                        path = %update.path.display(),
-                        diagnostics = update.diagnostics.len(),
-                        "LSP diagnostics update",
-                    );
-                }
-            });
+            // Fan diagnostic updates out to every session as
+            // HostEvent::LspDiagnosticsPush. Sessions without an active
+            // Subscribe stream drop the push at the per-session level, which
+            // is what we want — a UI that does not surface diagnostics
+            // should not pin the buffer in memory.
+            {
+                let registry = registry.clone();
+                let lsp_workdir = workdir.clone();
+                tokio::spawn(async move {
+                    use zedra_rpc::proto::{HostEvent, LspDiagnosticsPush};
+                    while let Some(update) = lsp_diag_rx.recv().await {
+                        let path = update
+                            .path
+                            .strip_prefix(&lsp_workdir)
+                            .unwrap_or(&update.path)
+                            .to_string_lossy()
+                            .into_owned();
+                        let push = HostEvent::LspDiagnosticsPush(LspDiagnosticsPush {
+                            language: update.language,
+                            path,
+                            version: 0,
+                            diagnostics: update.diagnostics,
+                        });
+                        for session in registry.all_sessions().await {
+                            session.push_event(push.clone()).await;
+                        }
+                    }
+                });
+            }
             let state = Arc::new(rpc_daemon::DaemonState::new_with_lsp(
                 workdir.clone(),
                 host_identity.clone(),

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -24,6 +24,7 @@ use zedra_rpc::ZedraPairingTicket;
 use zedra_telemetry::Event;
 
 mod agent_cli;
+mod lsp_cli;
 mod setup;
 mod terminal_cli;
 
@@ -187,6 +188,9 @@ enum Commands {
         #[command(subcommand)]
         command: agent_cli::AgentCommand,
     },
+
+    /// Manage the opt-in LSP control plane for a workspace
+    Lsp(lsp_cli::LspArgs),
 
     /// Install Zedra skills or plugins for an AI coding agent
     Setup {
@@ -1035,6 +1039,10 @@ async fn main() -> Result<()> {
 
         Commands::Agent { command } => {
             agent_cli::run(command).await?;
+        }
+
+        Commands::Lsp(args) => {
+            lsp_cli::run(args).await?;
         }
 
         Commands::Setup { yes, agent } => {

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -713,9 +713,14 @@ async fn main() -> Result<()> {
                 prev_hook(info);
             }));
 
-            let state = Arc::new(rpc_daemon::DaemonState::new(
+            let lsp_manager = match identity::workspace_config_dir(&workdir) {
+                Ok(dir) => zedra_lsp::LspManager::load(dir.join("lsp.json")),
+                Err(_) => zedra_lsp::LspManager::ephemeral(),
+            };
+            let state = Arc::new(rpc_daemon::DaemonState::new_with_lsp(
                 workdir.clone(),
                 host_identity.clone(),
+                lsp_manager,
             ));
             state
                 .agent_cache
@@ -1408,7 +1413,123 @@ fn render_status_output(status: &serde_json::Value) -> String {
         }
     }
 
+    if let Some(lsp_section) = render_lsp_status(&status["lsp"]) {
+        sections.push(String::new());
+        sections.push(lsp_section);
+    }
+
     sections.join("\n")
+}
+
+fn render_lsp_status(lsp: &serde_json::Value) -> Option<String> {
+    let enabled = lsp.get("enabled")?.as_bool().unwrap_or(false);
+    let servers = lsp.get("servers").and_then(|s| s.as_array());
+    let concurrent_cap = lsp
+        .get("concurrent_cap")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let agg_rss = lsp
+        .get("aggregate_rss_bytes")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let agg_cap = lsp
+        .get("aggregate_rss_cap_bytes")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    if !enabled || servers.map(|s| s.is_empty()).unwrap_or(true) {
+        return None;
+    }
+    let servers = servers?;
+    let running = servers
+        .iter()
+        .filter(|s| {
+            matches!(
+                s.get("state").and_then(|v| v.as_str()),
+                Some("starting") | Some("ready")
+            )
+        })
+        .count();
+
+    let mut out = format!("LSP servers ({} running, cap {})", running, concurrent_cap);
+    out.push('\n');
+
+    let rows: Vec<Vec<String>> = servers.iter().map(lsp_server_row).collect();
+    out.push_str(&utils::render_table(
+        &["LANG", "STATE", "PID", "RSS", "UPTIME", "DIAGS", "LAST"],
+        &rows,
+    ));
+
+    if agg_cap > 0 {
+        let pct = if agg_cap == 0 {
+            0
+        } else {
+            ((agg_rss as f64 / agg_cap as f64) * 100.0).round() as u64
+        };
+        out.push('\n');
+        out.push_str(&format!(
+            "Aggregate RSS: {} / {} ({}%)",
+            format_bytes_mb(agg_rss),
+            format_bytes_mb(agg_cap),
+            pct,
+        ));
+    }
+    Some(out)
+}
+
+fn lsp_server_row(server: &serde_json::Value) -> Vec<String> {
+    let lang = server
+        .get("language")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?")
+        .to_string();
+    let state = server
+        .get("state")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?")
+        .to_string();
+    let pid = server
+        .get("pid")
+        .and_then(|v| v.as_u64())
+        .map(|p| p.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let rss = server
+        .get("rss_bytes")
+        .and_then(|v| v.as_u64())
+        .map(format_bytes_mb)
+        .unwrap_or_else(|| "-".to_string());
+    let uptime = server
+        .get("uptime_secs")
+        .and_then(|v| v.as_u64())
+        .map(utils::format_duration)
+        .unwrap_or_else(|| "-".to_string());
+    let errors = server
+        .get("diagnostic_errors")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let warnings = server
+        .get("diagnostic_warnings")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let diags = format!("{}E {}W", errors, warnings);
+    let last = server
+        .get("last_request_ms")
+        .and_then(|v| v.as_u64())
+        .map(|ms| format!("{}ms", ms))
+        .unwrap_or_else(|| "-".to_string());
+    vec![lang, state, pid, rss, uptime, diags, last]
+}
+
+fn format_bytes_mb(bytes: u64) -> String {
+    if bytes == 0 {
+        return "-".to_string();
+    }
+    let mb = bytes as f64 / (1024.0 * 1024.0);
+    if mb >= 1024.0 {
+        format!("{:.1} GB", mb / 1024.0)
+    } else {
+        format!("{:.0} MB", mb)
+    }
 }
 
 fn render_metrics_output(

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -717,9 +717,12 @@ async fn main() -> Result<()> {
                 prev_hook(info);
             }));
 
-            let lsp_manager = match identity::workspace_config_dir(&workdir) {
-                Ok(dir) => zedra_lsp::LspManager::load(dir.join("lsp.json")),
-                Err(_) => zedra_lsp::LspManager::ephemeral(),
+            let (lsp_manager, mut lsp_diag_rx) = match identity::workspace_config_dir(&workdir) {
+                Ok(dir) => zedra_lsp::LspManager::load(dir.join("lsp.json"), workdir.clone()),
+                Err(_) => (
+                    zedra_lsp::LspManager::ephemeral(),
+                    tokio::sync::mpsc::channel(1).1,
+                ),
             };
             {
                 let lsp = lsp_manager.clone();
@@ -727,6 +730,20 @@ async fn main() -> Result<()> {
                     lsp.restore_enabled().await;
                 });
             }
+            // Consume diagnostic updates so the channel does not block the
+            // reader task. The HostEvent fan-out to subscribed clients lands
+            // in a follow-up commit; until then we drop the payloads after
+            // logging so the supervisor + RSS guard stay live.
+            tokio::spawn(async move {
+                while let Some(update) = lsp_diag_rx.recv().await {
+                    tracing::debug!(
+                        language = ?update.language,
+                        path = %update.path.display(),
+                        diagnostics = update.diagnostics.len(),
+                        "LSP diagnostics update",
+                    );
+                }
+            });
             let state = Arc::new(rpc_daemon::DaemonState::new_with_lsp(
                 workdir.clone(),
                 host_identity.clone(),

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -721,6 +721,12 @@ async fn main() -> Result<()> {
                 Ok(dir) => zedra_lsp::LspManager::load(dir.join("lsp.json")),
                 Err(_) => zedra_lsp::LspManager::ephemeral(),
             };
+            {
+                let lsp = lsp_manager.clone();
+                tokio::spawn(async move {
+                    lsp.restore_enabled().await;
+                });
+            }
             let state = Arc::new(rpc_daemon::DaemonState::new_with_lsp(
                 workdir.clone(),
                 host_identity.clone(),

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -2945,18 +2945,34 @@ async fn dispatch(
         }
 
         ZedraMessage::LspSubscribe(msg) => {
+            // Diagnostics already fan out to every session via the host event
+            // stream from main.rs (`HostEvent::LspDiagnosticsPush`). The
+            // subscription is acknowledged here so clients see `enabled=true`
+            // when the workspace has any language enabled, and is otherwise
+            // a no-op — there is no per-path filtering yet.
+            let enabled = state.lsp.any_enabled().await;
+            let subscription_id = if enabled {
+                uuid::Uuid::new_v4().to_string()
+            } else {
+                String::new()
+            };
             let _ = msg
                 .tx
                 .send(LspSubscribeResult {
-                    enabled: false,
-                    subscription_id: String::new(),
+                    enabled,
+                    subscription_id,
                     error: None,
                 })
                 .await;
         }
 
         ZedraMessage::LspUnsubscribe(msg) => {
-            let _ = msg.tx.send(LspUnsubscribeResult { enabled: false }).await;
+            let _ = msg
+                .tx
+                .send(LspUnsubscribeResult {
+                    enabled: state.lsp.any_enabled().await,
+                })
+                .await;
         }
 
         ZedraMessage::LspHoverV2(msg) => {

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -2901,11 +2901,19 @@ async fn dispatch(
         }
 
         ZedraMessage::LspEnable(msg) => {
+            let was_enabled = state.lsp.is_enabled(msg.language).await;
             let result = match state.lsp.enable(msg.language).await {
-                Ok(()) => LspEnableResult {
-                    enabled: true,
-                    error: None,
-                },
+                Ok(()) => {
+                    if !was_enabled {
+                        zedra_telemetry::send(Event::LspEnabled {
+                            language: lsp_language_label(msg.language),
+                        });
+                    }
+                    LspEnableResult {
+                        enabled: true,
+                        error: None,
+                    }
+                }
                 Err(e) => LspEnableResult {
                     enabled: state.lsp.is_enabled(msg.language).await,
                     error: Some(e.to_string()),
@@ -2915,11 +2923,19 @@ async fn dispatch(
         }
 
         ZedraMessage::LspDisable(msg) => {
+            let was_enabled = state.lsp.is_enabled(msg.language).await;
             let result = match state.lsp.disable(msg.language).await {
-                Ok(()) => LspDisableResult {
-                    enabled: false,
-                    error: None,
-                },
+                Ok(()) => {
+                    if was_enabled {
+                        zedra_telemetry::send(Event::LspDisabled {
+                            language: lsp_language_label(msg.language),
+                        });
+                    }
+                    LspDisableResult {
+                        enabled: false,
+                        error: None,
+                    }
+                }
                 Err(e) => LspDisableResult {
                     enabled: state.lsp.is_enabled(msg.language).await,
                     error: Some(e.to_string()),
@@ -2987,6 +3003,18 @@ async fn dispatch(
     }
 
     Ok(())
+}
+
+/// Stable telemetry label for an `LspLanguage`. Mirrors the API JSON label so
+/// telemetry, the REST API, and the CLI all agree on the language name.
+fn lsp_language_label(language: LspLanguage) -> &'static str {
+    match language {
+        LspLanguage::Rust => "rust",
+        LspLanguage::Go => "go",
+        LspLanguage::TypeScript => "typescript",
+        LspLanguage::JavaScript => "javascript",
+        LspLanguage::Python => "python",
+    }
 }
 
 fn os_version_string() -> Option<String> {

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -2855,33 +2855,18 @@ async fn dispatch(
             }
         }
 
-        // -- LSP --
+        // -- LSP (legacy stub variants) --
+        //
+        // The host LSP subsystem is opt-in and not yet wired. Until it lands,
+        // every LSP variant short-circuits to an inert response so clients
+        // built against newer protocol revisions degrade cleanly. The legacy
+        // `LspDiagnostics` / `LspHover` variants stay for binary compatibility
+        // but no longer shell out to compilers — that path was unsafe by NFR.
         ZedraMessage::LspDiagnostics(msg) => {
-            let full_path = match resolve_path(&state.workdir, &msg.path) {
-                Ok(p) => p,
-                Err(e) => {
-                    tracing::warn!("LspDiagnostics: rejected path {:?}: {}", msg.path, e);
-                    let _ = msg
-                        .tx
-                        .send(LspDiagnosticsResult {
-                            diagnostics: vec![],
-                            error: Some(e.to_string()),
-                        })
-                        .await;
-                    return Ok(());
-                }
-            };
-            let diagnostics = run_lsp_check(&full_path)
-                .into_iter()
-                .map(|d| LspDiagnostic {
-                    message: d.message,
-                    severity: d.severity,
-                })
-                .collect();
             let _ = msg
                 .tx
                 .send(LspDiagnosticsResult {
-                    diagnostics,
+                    diagnostics: vec![],
                     error: None,
                 })
                 .await;
@@ -2891,64 +2876,104 @@ async fn dispatch(
             let _ = msg
                 .tx
                 .send(LspHoverResult {
-                    contents: "LSP hover not yet connected to a language server.".to_string(),
+                    contents: String::new(),
+                })
+                .await;
+        }
+
+        // -- LSP control plane --
+        ZedraMessage::LspStatus(msg) => {
+            let _ = msg
+                .tx
+                .send(LspStatusResult {
+                    enabled: false,
+                    servers: vec![],
+                    aggregate_rss_bytes: 0,
+                    aggregate_rss_cap_bytes: 0,
+                    concurrent_cap: 0,
+                })
+                .await;
+        }
+
+        ZedraMessage::LspEnable(msg) => {
+            let _ = msg
+                .tx
+                .send(LspEnableResult {
+                    enabled: false,
+                    error: None,
+                })
+                .await;
+        }
+
+        ZedraMessage::LspDisable(msg) => {
+            let _ = msg
+                .tx
+                .send(LspDisableResult {
+                    enabled: false,
+                    error: None,
+                })
+                .await;
+        }
+
+        ZedraMessage::LspSubscribe(msg) => {
+            let _ = msg
+                .tx
+                .send(LspSubscribeResult {
+                    enabled: false,
+                    subscription_id: String::new(),
+                    error: None,
+                })
+                .await;
+        }
+
+        ZedraMessage::LspUnsubscribe(msg) => {
+            let _ = msg.tx.send(LspUnsubscribeResult { enabled: false }).await;
+        }
+
+        ZedraMessage::LspHoverV2(msg) => {
+            let _ = msg
+                .tx
+                .send(LspHoverV2Result {
+                    enabled: false,
+                    contents: String::new(),
+                    range: None,
+                })
+                .await;
+        }
+
+        ZedraMessage::LspCodeAction(msg) => {
+            let _ = msg
+                .tx
+                .send(LspCodeActionResult {
+                    enabled: false,
+                    actions: vec![],
+                })
+                .await;
+        }
+
+        ZedraMessage::LspApplyAction(msg) => {
+            let _ = msg
+                .tx
+                .send(LspApplyActionResult {
+                    enabled: false,
+                    files_changed: 0,
+                    error: None,
+                })
+                .await;
+        }
+
+        ZedraMessage::LspGotoDef(msg) => {
+            let _ = msg
+                .tx
+                .send(LspGotoDefResult {
+                    enabled: false,
+                    locations: vec![],
                 })
                 .await;
         }
     }
 
     Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-struct DiagnosticEntry {
-    message: String,
-    severity: String,
-}
-
-fn run_lsp_check(path: &std::path::Path) -> Vec<DiagnosticEntry> {
-    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-
-    let (cmd, args): (&str, Vec<&str>) = match ext {
-        "rs" => ("cargo", vec!["check", "--message-format=json"]),
-        "ts" | "tsx" | "js" | "jsx" => ("npx", vec!["tsc", "--noEmit"]),
-        "py" => (
-            "python3",
-            vec!["-m", "py_compile", path.to_str().unwrap_or("")],
-        ),
-        _ => return vec![],
-    };
-
-    let output = std::process::Command::new(cmd)
-        .args(&args)
-        .current_dir(path.parent().unwrap_or(std::path::Path::new(".")))
-        .output();
-
-    match output {
-        Ok(out) => {
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            if stderr.is_empty() && out.status.success() {
-                vec![]
-            } else {
-                stderr
-                    .lines()
-                    .take(10)
-                    .filter(|l| !l.is_empty())
-                    .map(|line| DiagnosticEntry {
-                        message: line.to_string(),
-                        severity: "error".into(),
-                    })
-                    .collect()
-            }
-        }
-        Err(e) => {
-            tracing::warn!("LspDiagnostics: command {} failed: {}", cmd, e);
-            vec![]
-        }
-    }
 }
 
 fn os_version_string() -> Option<String> {

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -679,6 +679,10 @@ pub struct DaemonState {
     pub started_at: std::time::Instant,
     pub agent_hook_events: tokio::sync::Mutex<VecDeque<AgentHookEventRecord>>,
     pub agent_cache: Arc<agent_cache::AgentCache>,
+    /// Opt-in LSP control plane. Always present (so RPC handlers don't need to
+    /// branch on Option), but reports `enabled=false` until a language is
+    /// enabled for the workspace.
+    pub lsp: Arc<zedra_lsp::LspManager>,
     next_agent_hook_event_seq: AtomicU64,
 }
 
@@ -692,6 +696,14 @@ impl std::fmt::Debug for DaemonState {
 
 impl DaemonState {
     pub fn new(workdir: std::path::PathBuf, identity: SharedIdentity) -> Self {
+        Self::new_with_lsp(workdir, identity, zedra_lsp::LspManager::ephemeral())
+    }
+
+    pub fn new_with_lsp(
+        workdir: std::path::PathBuf,
+        identity: SharedIdentity,
+        lsp: Arc<zedra_lsp::LspManager>,
+    ) -> Self {
         Self {
             fs: Arc::new(LocalFs),
             workdir,
@@ -699,6 +711,7 @@ impl DaemonState {
             started_at: std::time::Instant::now(),
             agent_hook_events: tokio::sync::Mutex::new(VecDeque::new()),
             agent_cache: agent_cache::AgentCache::new(),
+            lsp,
             next_agent_hook_event_seq: AtomicU64::new(1),
         }
     }
@@ -2883,36 +2896,36 @@ async fn dispatch(
 
         // -- LSP control plane --
         ZedraMessage::LspStatus(msg) => {
-            let _ = msg
-                .tx
-                .send(LspStatusResult {
-                    enabled: false,
-                    servers: vec![],
-                    aggregate_rss_bytes: 0,
-                    aggregate_rss_cap_bytes: 0,
-                    concurrent_cap: 0,
-                })
-                .await;
+            let snapshot = state.lsp.status_snapshot().await;
+            let _ = msg.tx.send(snapshot).await;
         }
 
         ZedraMessage::LspEnable(msg) => {
-            let _ = msg
-                .tx
-                .send(LspEnableResult {
-                    enabled: false,
+            let result = match state.lsp.enable(msg.language).await {
+                Ok(()) => LspEnableResult {
+                    enabled: true,
                     error: None,
-                })
-                .await;
+                },
+                Err(e) => LspEnableResult {
+                    enabled: state.lsp.is_enabled(msg.language).await,
+                    error: Some(e.to_string()),
+                },
+            };
+            let _ = msg.tx.send(result).await;
         }
 
         ZedraMessage::LspDisable(msg) => {
-            let _ = msg
-                .tx
-                .send(LspDisableResult {
+            let result = match state.lsp.disable(msg.language).await {
+                Ok(()) => LspDisableResult {
                     enabled: false,
                     error: None,
-                })
-                .await;
+                },
+                Err(e) => LspDisableResult {
+                    enabled: state.lsp.is_enabled(msg.language).await,
+                    error: Some(e.to_string()),
+                },
+            };
+            let _ = msg.tx.send(result).await;
         }
 
         ZedraMessage::LspSubscribe(msg) => {

--- a/crates/zedra-host/src/session_registry.rs
+++ b/crates/zedra-host/src/session_registry.rs
@@ -884,6 +884,13 @@ impl SessionRegistry {
         self.sessions.lock().await.len()
     }
 
+    /// Snapshot of every active session as `Arc` handles. Used by host-driven
+    /// event fan-out (e.g. LSP diagnostic pushes) where the caller wants to
+    /// iterate sessions without holding the registry lock across awaits.
+    pub async fn all_sessions(&self) -> Vec<Arc<ServerSession>> {
+        self.sessions.lock().await.values().cloned().collect()
+    }
+
     /// Return the most recently active session, if any.
     /// Used by the REST API when no session_id is specified, so the request
     /// targets the session a user is actually working in rather than an

--- a/crates/zedra-lsp/Cargo.toml
+++ b/crates/zedra-lsp/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "zedra-lsp"
+version.workspace = true
+edition.workspace = true
+description = "Opt-in LSP control plane for Zedra host. Owns per-workspace language enablement, the resource guard policy, and status snapshots. Process spawning is wired in a follow-up commit."
+
+[dependencies]
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+zedra-rpc = { path = "../zedra-rpc" }

--- a/crates/zedra-lsp/Cargo.toml
+++ b/crates/zedra-lsp/Cargo.toml
@@ -6,8 +6,12 @@ description = "Opt-in LSP control plane for Zedra host. Owns per-workspace langu
 
 [dependencies]
 anyhow.workspace = true
+libc = "0.2"
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
+sysinfo = "0.31.4"
+tokio = { workspace = true, features = ["process", "macros"] }
 tracing.workspace = true
 zedra-rpc = { path = "../zedra-rpc" }
+zedra-telemetry.workspace = true
+

--- a/crates/zedra-lsp/src/guard.rs
+++ b/crates/zedra-lsp/src/guard.rs
@@ -1,0 +1,75 @@
+//! Resource guard configuration.
+//!
+//! Defines the caps the runtime supervisor will enforce. Numbers are the
+//! defaults; operators override them via env vars or `~/.config/zedra/lsp.toml`
+//! (config file parsing arrives with the supervisor commit). Holding the
+//! policy here, separate from the supervisor loop, keeps the contract visible
+//! and unit-testable without spinning up child processes.
+//!
+//! These defaults are conservative on purpose: LSP servers (especially
+//! `rust-analyzer` on large projects) can balloon memory quickly. The supervisor
+//! will surface every termination via `LspServerStateChange { reason }` and a
+//! telemetry event so kills are observable, not silent.
+
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy)]
+pub struct GuardConfig {
+    /// Per-server RSS cap. Exceeding this triggers SIGTERM, then SIGKILL after
+    /// the grace period.
+    pub per_server_rss_cap_bytes: u64,
+    /// Sum of RSS across all running servers. When exceeded, the supervisor
+    /// kills the highest-RSS server first.
+    pub aggregate_rss_cap_bytes: u64,
+    /// SIGTERM → SIGKILL grace window.
+    pub kill_grace: Duration,
+    /// Poll interval for the RSS / CPU watcher.
+    pub poll_interval: Duration,
+    /// Sustained-CPU window. If the server averages above
+    /// `cpu_kill_percent` for this long, the supervisor escalates.
+    pub cpu_window: Duration,
+    pub cpu_kill_percent: u32,
+    /// Idle shutdown window. With no active subscription, a server is shut
+    /// down after this long.
+    pub idle_shutdown: Duration,
+    /// Minimum interval between spawn attempts for the same language. Stops
+    /// crash-loop thrash.
+    pub spawn_rate_limit: Duration,
+    /// Hard cap on concurrent running servers across all languages and
+    /// workspaces. LRU-evict on overflow.
+    pub concurrent_cap: u32,
+}
+
+impl GuardConfig {
+    /// Effective RSS cap, taking `ZEDRA_LSP_MEM_CAP_MB` into account.
+    pub fn with_env_overrides(mut self) -> Self {
+        if let Ok(raw) = std::env::var("ZEDRA_LSP_MEM_CAP_MB") {
+            if let Ok(mb) = raw.trim().parse::<u64>() {
+                self.per_server_rss_cap_bytes = mb.saturating_mul(1024 * 1024);
+            }
+        }
+        if let Ok(raw) = std::env::var("ZEDRA_LSP_AGG_MEM_CAP_MB") {
+            if let Ok(mb) = raw.trim().parse::<u64>() {
+                self.aggregate_rss_cap_bytes = mb.saturating_mul(1024 * 1024);
+            }
+        }
+        if let Ok(raw) = std::env::var("ZEDRA_LSP_CONCURRENT_CAP") {
+            if let Ok(n) = raw.trim().parse::<u32>() {
+                self.concurrent_cap = n;
+            }
+        }
+        self
+    }
+}
+
+pub const GUARD_DEFAULTS: GuardConfig = GuardConfig {
+    per_server_rss_cap_bytes: 1536 * 1024 * 1024,
+    aggregate_rss_cap_bytes: 4096 * 1024 * 1024,
+    kill_grace: Duration::from_secs(3),
+    poll_interval: Duration::from_secs(5),
+    cpu_window: Duration::from_secs(60),
+    cpu_kill_percent: 90,
+    idle_shutdown: Duration::from_secs(300),
+    spawn_rate_limit: Duration::from_secs(30),
+    concurrent_cap: 4,
+};

--- a/crates/zedra-lsp/src/lib.rs
+++ b/crates/zedra-lsp/src/lib.rs
@@ -15,7 +15,11 @@ pub mod guard;
 pub mod manager;
 pub mod persistence;
 pub mod policy;
+pub mod server;
+pub mod supervisor;
 
 pub use guard::{GUARD_DEFAULTS, GuardConfig};
 pub use manager::LspManager;
 pub use policy::{language_binary, supported_languages};
+pub use server::LspServer;
+pub use supervisor::Supervisor;

--- a/crates/zedra-lsp/src/lib.rs
+++ b/crates/zedra-lsp/src/lib.rs
@@ -1,0 +1,21 @@
+//! Opt-in LSP control plane for the Zedra host.
+//!
+//! Ownership boundary: this crate owns *policy* (which languages are enabled
+//! for a workspace, what binary serves them, what the resource caps are) and
+//! *bookkeeping* (status snapshots, persistence). It does **not** spawn
+//! language-server processes yet — the actual process supervisor lands in a
+//! follow-up commit. Until then, `LspManager` exposes the same status surface
+//! the runtime supervisor will use, with all servers in `Idle` state.
+//!
+//! Decoupling: `zedra-host` depends on this crate, but no other crate does.
+//! Removing the dependency must cleanly disable LSP without touching unrelated
+//! code paths.
+
+pub mod guard;
+pub mod manager;
+pub mod persistence;
+pub mod policy;
+
+pub use guard::{GUARD_DEFAULTS, GuardConfig};
+pub use manager::LspManager;
+pub use policy::{language_binary, supported_languages};

--- a/crates/zedra-lsp/src/lib.rs
+++ b/crates/zedra-lsp/src/lib.rs
@@ -15,11 +15,12 @@ pub mod guard;
 pub mod manager;
 pub mod persistence;
 pub mod policy;
+pub mod protocol;
 pub mod server;
 pub mod supervisor;
 
 pub use guard::{GUARD_DEFAULTS, GuardConfig};
-pub use manager::LspManager;
+pub use manager::{DiagnosticReceiver, LspManager};
 pub use policy::{language_binary, supported_languages};
-pub use server::LspServer;
+pub use server::{DiagnosticUpdate, LspServer};
 pub use supervisor::Supervisor;

--- a/crates/zedra-lsp/src/manager.rs
+++ b/crates/zedra-lsp/src/manager.rs
@@ -1,0 +1,202 @@
+//! `LspManager` — per-workspace LSP enablement state.
+//!
+//! Current scope: bookkeeping only. Tracks which languages are enabled, where
+//! the persisted file lives, and how to produce an `LspStatusResult` snapshot
+//! that mirrors what the runtime supervisor will report. Spawning the actual
+//! language-server processes is wired in a follow-up commit; until then every
+//! enabled language reports `LspServerState::Idle`.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use zedra_rpc::proto::{LspLanguage, LspServerInfo, LspServerState, LspStatusResult};
+
+use crate::guard::{GUARD_DEFAULTS, GuardConfig};
+use crate::persistence::{self, PersistedLspState};
+
+pub struct LspManager {
+    inner: Mutex<Inner>,
+    storage_path: PathBuf,
+    guard: GuardConfig,
+}
+
+struct Inner {
+    enabled: HashSet<LspLanguage>,
+}
+
+impl LspManager {
+    /// Load persisted enablement from `storage_path` and return a manager. The
+    /// supervisor is **not** started here — that arrives with the spawn
+    /// commit.
+    pub fn load(storage_path: PathBuf) -> Arc<Self> {
+        let persisted = persistence::load(&storage_path);
+        let enabled: HashSet<LspLanguage> = persisted.enabled_languages.into_iter().collect();
+        Arc::new(Self {
+            inner: Mutex::new(Inner { enabled }),
+            storage_path,
+            guard: GUARD_DEFAULTS.with_env_overrides(),
+        })
+    }
+
+    /// In-memory manager with no persistence. Used by tests and ephemeral
+    /// daemons that have no workspace config dir.
+    pub fn ephemeral() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(Inner {
+                enabled: HashSet::new(),
+            }),
+            storage_path: PathBuf::new(),
+            guard: GUARD_DEFAULTS.with_env_overrides(),
+        })
+    }
+
+    pub fn guard_config(&self) -> GuardConfig {
+        self.guard
+    }
+
+    /// Mark `language` as enabled for this workspace and persist the change.
+    /// Returns `Ok(())` on success. The supervisor will treat the language as
+    /// spawnable on the next subscription.
+    pub async fn enable(&self, language: LspLanguage) -> anyhow::Result<()> {
+        let mut inner = self.inner.lock().await;
+        if inner.enabled.insert(language) {
+            self.persist_locked(&inner);
+        }
+        Ok(())
+    }
+
+    /// Mark `language` as disabled. Future commits will tear down a running
+    /// server here.
+    pub async fn disable(&self, language: LspLanguage) -> anyhow::Result<()> {
+        let mut inner = self.inner.lock().await;
+        if inner.enabled.remove(&language) {
+            self.persist_locked(&inner);
+        }
+        Ok(())
+    }
+
+    pub async fn is_enabled(&self, language: LspLanguage) -> bool {
+        self.inner.lock().await.enabled.contains(&language)
+    }
+
+    pub async fn any_enabled(&self) -> bool {
+        !self.inner.lock().await.enabled.is_empty()
+    }
+
+    /// Build the status snapshot returned by `LspStatus` RPC and consumed by
+    /// the `zedra status` CLI block. Single source of truth so the two views
+    /// can never drift.
+    pub async fn status_snapshot(&self) -> LspStatusResult {
+        let inner = self.inner.lock().await;
+        let mut servers: Vec<LspServerInfo> = inner
+            .enabled
+            .iter()
+            .copied()
+            .map(|language| LspServerInfo {
+                language,
+                state: LspServerState::Idle,
+                pid: None,
+                rss_bytes: 0,
+                uptime_secs: 0,
+                diagnostic_errors: 0,
+                diagnostic_warnings: 0,
+                last_request_ms: None,
+                last_kill_reason: None,
+                peak_rss_bytes: 0,
+            })
+            .collect();
+        // Stable ordering for CLI / UI render.
+        servers.sort_by_key(|s| language_sort_key(s.language));
+
+        LspStatusResult {
+            enabled: !inner.enabled.is_empty(),
+            servers,
+            aggregate_rss_bytes: 0,
+            aggregate_rss_cap_bytes: self.guard.aggregate_rss_cap_bytes,
+            concurrent_cap: self.guard.concurrent_cap,
+        }
+    }
+
+    fn persist_locked(&self, inner: &Inner) {
+        if self.storage_path.as_os_str().is_empty() {
+            return;
+        }
+        let state = PersistedLspState {
+            version: 1,
+            enabled_languages: {
+                let mut v: Vec<LspLanguage> = inner.enabled.iter().copied().collect();
+                v.sort_by_key(|l| language_sort_key(*l));
+                v
+            },
+        };
+        persistence::save(&self.storage_path, &state);
+    }
+}
+
+fn language_sort_key(language: LspLanguage) -> u8 {
+    match language {
+        LspLanguage::Rust => 0,
+        LspLanguage::Go => 1,
+        LspLanguage::TypeScript => 2,
+        LspLanguage::JavaScript => 3,
+        LspLanguage::Python => 4,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn enable_disable_roundtrip_persists() {
+        let dir = tempdir();
+        let path = dir.join("lsp.json");
+        let m = LspManager::load(path.clone());
+        m.enable(LspLanguage::Rust).await.unwrap();
+        m.enable(LspLanguage::Go).await.unwrap();
+        drop(m);
+
+        let m = LspManager::load(path);
+        assert!(m.is_enabled(LspLanguage::Rust).await);
+        assert!(m.is_enabled(LspLanguage::Go).await);
+        assert!(!m.is_enabled(LspLanguage::Python).await);
+
+        m.disable(LspLanguage::Rust).await.unwrap();
+        assert!(!m.is_enabled(LspLanguage::Rust).await);
+    }
+
+    #[tokio::test]
+    async fn ephemeral_manager_does_not_persist() {
+        let m = LspManager::ephemeral();
+        m.enable(LspLanguage::Rust).await.unwrap();
+        assert!(m.is_enabled(LspLanguage::Rust).await);
+    }
+
+    #[tokio::test]
+    async fn status_snapshot_lists_enabled_languages_as_idle() {
+        let m = LspManager::ephemeral();
+        m.enable(LspLanguage::Rust).await.unwrap();
+        m.enable(LspLanguage::TypeScript).await.unwrap();
+        let snap = m.status_snapshot().await;
+        assert!(snap.enabled);
+        assert_eq!(snap.servers.len(), 2);
+        assert!(
+            snap.servers
+                .iter()
+                .all(|s| matches!(s.state, LspServerState::Idle))
+        );
+    }
+
+    fn tempdir() -> PathBuf {
+        let mut p = std::env::temp_dir();
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        p.push(format!("zedra-lsp-test-{nonce}"));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/crates/zedra-lsp/src/manager.rs
+++ b/crates/zedra-lsp/src/manager.rs
@@ -10,14 +10,19 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc};
 use zedra_rpc::proto::{
     LspKillReason, LspLanguage, LspServerInfo, LspServerState, LspStatusResult,
 };
 
 use crate::guard::{GUARD_DEFAULTS, GuardConfig};
 use crate::persistence::{self, PersistedLspState};
+use crate::server::DiagnosticUpdate;
 use crate::supervisor::Supervisor;
+
+/// Receiver end of the diagnostic-update channel. The host RPC daemon owns
+/// this and fans out to subscribed clients as `HostEvent::LspDiagnosticsPush`.
+pub type DiagnosticReceiver = mpsc::Receiver<DiagnosticUpdate>;
 
 pub struct LspManager {
     inner: Mutex<Inner>,
@@ -34,31 +39,38 @@ impl LspManager {
     /// Load persisted enablement from `storage_path` and return a manager. The
     /// supervisor is **not** started here — that arrives with the spawn
     /// commit.
-    pub fn load(storage_path: PathBuf) -> Arc<Self> {
+    /// Construct the manager, start the supervisor watcher, and return both
+    /// the manager handle and the diagnostic-update receiver. The caller owns
+    /// the receiver and fans diagnostics out to clients.
+    pub fn load(storage_path: PathBuf, workspace_root: PathBuf) -> (Arc<Self>, DiagnosticReceiver) {
         let persisted = persistence::load(&storage_path);
         let enabled: HashSet<LspLanguage> = persisted.enabled_languages.into_iter().collect();
         let guard = GUARD_DEFAULTS.with_env_overrides();
-        let supervisor = Supervisor::new(guard);
+        let (diag_tx, diag_rx) = mpsc::channel(256);
+        let supervisor = Supervisor::new(guard, workspace_root, diag_tx);
         supervisor.spawn_watcher();
-        Arc::new(Self {
+        let manager = Arc::new(Self {
             inner: Mutex::new(Inner { enabled }),
             storage_path,
             guard,
             supervisor,
-        })
+        });
+        (manager, diag_rx)
     }
 
-    /// In-memory manager with no persistence and no watcher task. Used by
-    /// tests and ephemeral daemons that have no workspace config dir.
+    /// In-memory manager with no persistence and no watcher task. The
+    /// returned receiver is never written to. Used by tests and ephemeral
+    /// daemons that have no workspace config dir.
     pub fn ephemeral() -> Arc<Self> {
         let guard = GUARD_DEFAULTS.with_env_overrides();
+        let (diag_tx, _diag_rx) = mpsc::channel(1);
         Arc::new(Self {
             inner: Mutex::new(Inner {
                 enabled: HashSet::new(),
             }),
             storage_path: PathBuf::new(),
             guard,
-            supervisor: Supervisor::new(guard),
+            supervisor: Supervisor::new(guard, PathBuf::from("."), diag_tx),
         })
     }
 
@@ -115,14 +127,15 @@ impl LspManager {
             let info = if let Some(server) = live {
                 let rss = server.peak_rss_bytes();
                 aggregate = aggregate.saturating_add(rss);
+                let (errors, warnings) = server.diagnostic_counts().await;
                 LspServerInfo {
                     language,
                     state: server.state().await,
                     pid: server.pid(),
                     rss_bytes: rss,
                     uptime_secs: server.uptime_secs().await,
-                    diagnostic_errors: 0,
-                    diagnostic_warnings: 0,
+                    diagnostic_errors: errors,
+                    diagnostic_warnings: warnings,
                     last_request_ms: None,
                     last_kill_reason: server.last_kill_reason().await,
                     peak_rss_bytes: rss,
@@ -220,7 +233,7 @@ mod tests {
                 enabled_languages: vec![LspLanguage::Rust, LspLanguage::Go],
             },
         );
-        let m = LspManager::load(path);
+        let (m, _rx) = LspManager::load(path, dir.clone());
         assert!(m.is_enabled(LspLanguage::Rust).await);
         assert!(m.is_enabled(LspLanguage::Go).await);
         assert!(!m.is_enabled(LspLanguage::Python).await);

--- a/crates/zedra-lsp/src/manager.rs
+++ b/crates/zedra-lsp/src/manager.rs
@@ -11,15 +11,19 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
-use zedra_rpc::proto::{LspLanguage, LspServerInfo, LspServerState, LspStatusResult};
+use zedra_rpc::proto::{
+    LspKillReason, LspLanguage, LspServerInfo, LspServerState, LspStatusResult,
+};
 
 use crate::guard::{GUARD_DEFAULTS, GuardConfig};
 use crate::persistence::{self, PersistedLspState};
+use crate::supervisor::Supervisor;
 
 pub struct LspManager {
     inner: Mutex<Inner>,
     storage_path: PathBuf,
     guard: GuardConfig,
+    supervisor: Arc<Supervisor>,
 }
 
 struct Inner {
@@ -33,22 +37,28 @@ impl LspManager {
     pub fn load(storage_path: PathBuf) -> Arc<Self> {
         let persisted = persistence::load(&storage_path);
         let enabled: HashSet<LspLanguage> = persisted.enabled_languages.into_iter().collect();
+        let guard = GUARD_DEFAULTS.with_env_overrides();
+        let supervisor = Supervisor::new(guard);
+        supervisor.spawn_watcher();
         Arc::new(Self {
             inner: Mutex::new(Inner { enabled }),
             storage_path,
-            guard: GUARD_DEFAULTS.with_env_overrides(),
+            guard,
+            supervisor,
         })
     }
 
-    /// In-memory manager with no persistence. Used by tests and ephemeral
-    /// daemons that have no workspace config dir.
+    /// In-memory manager with no persistence and no watcher task. Used by
+    /// tests and ephemeral daemons that have no workspace config dir.
     pub fn ephemeral() -> Arc<Self> {
+        let guard = GUARD_DEFAULTS.with_env_overrides();
         Arc::new(Self {
             inner: Mutex::new(Inner {
                 enabled: HashSet::new(),
             }),
             storage_path: PathBuf::new(),
-            guard: GUARD_DEFAULTS.with_env_overrides(),
+            guard,
+            supervisor: Supervisor::new(guard),
         })
     }
 
@@ -56,24 +66,29 @@ impl LspManager {
         self.guard
     }
 
-    /// Mark `language` as enabled for this workspace and persist the change.
-    /// Returns `Ok(())` on success. The supervisor will treat the language as
-    /// spawnable on the next subscription.
+    /// Mark `language` as enabled for this workspace, persist the change, and
+    /// spawn the language server. A spawn failure (binary missing, cap
+    /// reached) is returned to the caller but does not roll back the persisted
+    /// enablement — the server can be retried with the same flag set.
     pub async fn enable(&self, language: LspLanguage) -> anyhow::Result<()> {
-        let mut inner = self.inner.lock().await;
-        if inner.enabled.insert(language) {
-            self.persist_locked(&inner);
+        {
+            let mut inner = self.inner.lock().await;
+            if inner.enabled.insert(language) {
+                self.persist_locked(&inner);
+            }
         }
-        Ok(())
+        self.supervisor.start(language).await
     }
 
-    /// Mark `language` as disabled. Future commits will tear down a running
-    /// server here.
+    /// Mark `language` as disabled and shut down a running server.
     pub async fn disable(&self, language: LspLanguage) -> anyhow::Result<()> {
-        let mut inner = self.inner.lock().await;
-        if inner.enabled.remove(&language) {
-            self.persist_locked(&inner);
+        {
+            let mut inner = self.inner.lock().await;
+            if inner.enabled.remove(&language) {
+                self.persist_locked(&inner);
+            }
         }
+        self.supervisor.stop(language, LspKillReason::Manual).await;
         Ok(())
     }
 
@@ -89,33 +104,73 @@ impl LspManager {
     /// the `zedra status` CLI block. Single source of truth so the two views
     /// can never drift.
     pub async fn status_snapshot(&self) -> LspStatusResult {
-        let inner = self.inner.lock().await;
-        let mut servers: Vec<LspServerInfo> = inner
-            .enabled
-            .iter()
-            .copied()
-            .map(|language| LspServerInfo {
-                language,
-                state: LspServerState::Idle,
-                pid: None,
-                rss_bytes: 0,
-                uptime_secs: 0,
-                diagnostic_errors: 0,
-                diagnostic_warnings: 0,
-                last_request_ms: None,
-                last_kill_reason: None,
-                peak_rss_bytes: 0,
-            })
-            .collect();
-        // Stable ordering for CLI / UI render.
+        let enabled_langs: Vec<LspLanguage> = {
+            let inner = self.inner.lock().await;
+            inner.enabled.iter().copied().collect()
+        };
+        let mut servers: Vec<LspServerInfo> = Vec::with_capacity(enabled_langs.len());
+        let mut aggregate: u64 = 0;
+        for language in enabled_langs {
+            let live = self.supervisor.get(language).await;
+            let info = if let Some(server) = live {
+                let rss = server.peak_rss_bytes();
+                aggregate = aggregate.saturating_add(rss);
+                LspServerInfo {
+                    language,
+                    state: server.state().await,
+                    pid: server.pid(),
+                    rss_bytes: rss,
+                    uptime_secs: server.uptime_secs().await,
+                    diagnostic_errors: 0,
+                    diagnostic_warnings: 0,
+                    last_request_ms: None,
+                    last_kill_reason: server.last_kill_reason().await,
+                    peak_rss_bytes: rss,
+                }
+            } else {
+                LspServerInfo {
+                    language,
+                    state: LspServerState::Idle,
+                    pid: None,
+                    rss_bytes: 0,
+                    uptime_secs: 0,
+                    diagnostic_errors: 0,
+                    diagnostic_warnings: 0,
+                    last_request_ms: None,
+                    last_kill_reason: None,
+                    peak_rss_bytes: 0,
+                }
+            };
+            servers.push(info);
+        }
         servers.sort_by_key(|s| language_sort_key(s.language));
 
         LspStatusResult {
-            enabled: !inner.enabled.is_empty(),
+            enabled: !servers.is_empty(),
             servers,
-            aggregate_rss_bytes: 0,
+            aggregate_rss_bytes: aggregate,
             aggregate_rss_cap_bytes: self.guard.aggregate_rss_cap_bytes,
             concurrent_cap: self.guard.concurrent_cap,
+        }
+    }
+
+    /// Re-spawn servers for every persisted-enabled language. Called once at
+    /// daemon start so the watcher has servers to supervise. Failures are
+    /// logged, not propagated; a missing binary should not prevent the
+    /// daemon from starting other LSPs or the rest of zedra-host.
+    pub async fn restore_enabled(&self) {
+        let langs: Vec<LspLanguage> = {
+            let inner = self.inner.lock().await;
+            inner.enabled.iter().copied().collect()
+        };
+        for language in langs {
+            if let Err(e) = self.supervisor.start(language).await {
+                tracing::warn!(
+                    language = ?language,
+                    "Failed to start LSP server at daemon startup: {}",
+                    e,
+                );
+            }
         }
     }
 
@@ -148,37 +203,38 @@ fn language_sort_key(language: LspLanguage) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::persistence;
+
+    // `enable()` tries to spawn the language server, which is unavailable in
+    // CI. These tests cover the persistence + bookkeeping seams without
+    // exercising the supervisor.
 
     #[tokio::test]
-    async fn enable_disable_roundtrip_persists() {
+    async fn persistence_roundtrip_independent_of_supervisor() {
         let dir = tempdir();
         let path = dir.join("lsp.json");
-        let m = LspManager::load(path.clone());
-        m.enable(LspLanguage::Rust).await.unwrap();
-        m.enable(LspLanguage::Go).await.unwrap();
-        drop(m);
-
+        persistence::save(
+            &path,
+            &PersistedLspState {
+                version: 1,
+                enabled_languages: vec![LspLanguage::Rust, LspLanguage::Go],
+            },
+        );
         let m = LspManager::load(path);
         assert!(m.is_enabled(LspLanguage::Rust).await);
         assert!(m.is_enabled(LspLanguage::Go).await);
         assert!(!m.is_enabled(LspLanguage::Python).await);
-
-        m.disable(LspLanguage::Rust).await.unwrap();
-        assert!(!m.is_enabled(LspLanguage::Rust).await);
     }
 
     #[tokio::test]
-    async fn ephemeral_manager_does_not_persist() {
+    async fn status_snapshot_reports_idle_for_enabled_but_unspawned() {
         let m = LspManager::ephemeral();
-        m.enable(LspLanguage::Rust).await.unwrap();
-        assert!(m.is_enabled(LspLanguage::Rust).await);
-    }
-
-    #[tokio::test]
-    async fn status_snapshot_lists_enabled_languages_as_idle() {
-        let m = LspManager::ephemeral();
-        m.enable(LspLanguage::Rust).await.unwrap();
-        m.enable(LspLanguage::TypeScript).await.unwrap();
+        // Seed enablement without going through enable() so we skip the spawn.
+        {
+            let mut inner = m.inner.lock().await;
+            inner.enabled.insert(LspLanguage::Rust);
+            inner.enabled.insert(LspLanguage::TypeScript);
+        }
         let snap = m.status_snapshot().await;
         assert!(snap.enabled);
         assert_eq!(snap.servers.len(), 2);
@@ -187,6 +243,15 @@ mod tests {
                 .iter()
                 .all(|s| matches!(s.state, LspServerState::Idle))
         );
+        assert_eq!(snap.concurrent_cap, m.guard.concurrent_cap);
+    }
+
+    #[tokio::test]
+    async fn empty_manager_reports_disabled() {
+        let m = LspManager::ephemeral();
+        let snap = m.status_snapshot().await;
+        assert!(!snap.enabled);
+        assert!(snap.servers.is_empty());
     }
 
     fn tempdir() -> PathBuf {

--- a/crates/zedra-lsp/src/persistence.rs
+++ b/crates/zedra-lsp/src/persistence.rs
@@ -1,0 +1,83 @@
+//! On-disk persistence of the per-workspace LSP enablement list.
+//!
+//! Stored at `<workspace_config_dir>/lsp.json` alongside `sessions.json`. Kept
+//! in its own file so the LSP subsystem can be added or removed without
+//! touching `SessionRegistry` persistence (decoupling NFR).
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use zedra_rpc::proto::LspLanguage;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedLspState {
+    pub version: u32,
+    pub enabled_languages: Vec<LspLanguage>,
+}
+
+impl Default for PersistedLspState {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            enabled_languages: Vec::new(),
+        }
+    }
+}
+
+/// Load the persisted state from `path`, or return defaults on missing /
+/// unreadable file. Parse errors are logged, not propagated — a corrupt
+/// `lsp.json` should not block daemon start.
+pub fn load(path: &PathBuf) -> PersistedLspState {
+    let data = match std::fs::read_to_string(path) {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return PersistedLspState::default(),
+        Err(e) => {
+            tracing::warn!("Failed to read lsp.json at {}: {}", path.display(), e);
+            return PersistedLspState::default();
+        }
+    };
+    match serde_json::from_str(&data) {
+        Ok(state) => state,
+        Err(e) => {
+            tracing::warn!("Failed to parse lsp.json at {}: {}", path.display(), e);
+            PersistedLspState::default()
+        }
+    }
+}
+
+/// Atomically persist `state` to `path`. Errors are logged, not propagated —
+/// a save failure should never abort an RPC call.
+pub fn save(path: &PathBuf, state: &PersistedLspState) {
+    let Some(parent) = path.parent() else {
+        tracing::warn!("lsp.json path has no parent: {}", path.display());
+        return;
+    };
+    if let Err(e) = std::fs::create_dir_all(parent) {
+        tracing::warn!(
+            "Failed to create lsp.json parent {}: {}",
+            parent.display(),
+            e
+        );
+        return;
+    }
+    let json = match serde_json::to_string_pretty(state) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("Failed to serialize lsp.json: {}", e);
+            return;
+        }
+    };
+    let tmp = path.with_extension("json.tmp");
+    if let Err(e) = std::fs::write(&tmp, json.as_bytes()) {
+        tracing::warn!("Failed to write {}: {}", tmp.display(), e);
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        tracing::warn!(
+            "Failed to rename {} -> {}: {}",
+            tmp.display(),
+            path.display(),
+            e
+        );
+    }
+}

--- a/crates/zedra-lsp/src/policy.rs
+++ b/crates/zedra-lsp/src/policy.rs
@@ -1,0 +1,44 @@
+//! Language registry. Hardcoded for now; an extension surface lands later.
+
+use zedra_rpc::proto::LspLanguage;
+
+/// Binary + argv for a language server. The binary is looked up on `PATH`.
+pub struct LanguageBinary {
+    pub command: &'static str,
+    pub args: &'static [&'static str],
+}
+
+/// Resolve the language server binary for `language`. Returns `None` for
+/// languages with no built-in mapping.
+pub fn language_binary(language: LspLanguage) -> Option<LanguageBinary> {
+    match language {
+        LspLanguage::Rust => Some(LanguageBinary {
+            command: "rust-analyzer",
+            args: &[],
+        }),
+        LspLanguage::Go => Some(LanguageBinary {
+            command: "gopls",
+            args: &[],
+        }),
+        LspLanguage::TypeScript | LspLanguage::JavaScript => Some(LanguageBinary {
+            command: "typescript-language-server",
+            args: &["--stdio"],
+        }),
+        LspLanguage::Python => Some(LanguageBinary {
+            command: "pyright-langserver",
+            args: &["--stdio"],
+        }),
+    }
+}
+
+/// Languages this host can serve. Used by the CLI for `zedra lsp enable`
+/// completion and validation.
+pub fn supported_languages() -> &'static [LspLanguage] {
+    &[
+        LspLanguage::Rust,
+        LspLanguage::Go,
+        LspLanguage::TypeScript,
+        LspLanguage::JavaScript,
+        LspLanguage::Python,
+    ]
+}

--- a/crates/zedra-lsp/src/protocol.rs
+++ b/crates/zedra-lsp/src/protocol.rs
@@ -1,0 +1,359 @@
+//! Minimal LSP JSON-RPC client over stdio.
+//!
+//! Scope: framing, initialize/initialized handshake, parse
+//! `textDocument/publishDiagnostics` notifications. Hover, code-action,
+//! goto-definition, and didOpen/didChange wire-up land in follow-up commits.
+//! Servers like rust-analyzer and gopls scan the workspace on `initialize`
+//! and publish diagnostics without the client needing to open files, which
+//! is enough to prove the end-to-end push path before buffer sync arrives.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::{ChildStdin, ChildStdout};
+use tokio::sync::Mutex;
+use zedra_rpc::proto::{LspDiagnosticV2, LspPosition, LspRange, LspRelated, LspSeverity};
+
+/// Per-file diagnostic store. Wholesale replacement: each `publishDiagnostics`
+/// overwrites the entry for that path.
+pub type DiagnosticStore = HashMap<PathBuf, Vec<LspDiagnosticV2>>;
+
+#[derive(Debug, Serialize)]
+struct JsonRpcRequest<'a> {
+    jsonrpc: &'static str,
+    id: u64,
+    method: &'a str,
+    params: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcNotification<'a> {
+    jsonrpc: &'static str,
+    method: &'a str,
+    params: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcResponse {
+    #[allow(dead_code)]
+    jsonrpc: Option<String>,
+    #[allow(dead_code)]
+    id: Option<Value>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    result: Option<Value>,
+    #[serde(default)]
+    error: Option<Value>,
+    #[serde(default)]
+    method: Option<String>,
+    #[serde(default)]
+    params: Option<Value>,
+}
+
+/// Write one Content-Length-framed JSON-RPC message to `stdin`.
+async fn write_message(stdin: &mut ChildStdin, body: &str) -> Result<()> {
+    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+    stdin
+        .write_all(header.as_bytes())
+        .await
+        .context("write LSP header")?;
+    stdin
+        .write_all(body.as_bytes())
+        .await
+        .context("write LSP body")?;
+    stdin.flush().await.context("flush LSP stdin")?;
+    Ok(())
+}
+
+/// Read one Content-Length-framed message from `stdout`. Returns the JSON
+/// body as a `String`.
+async fn read_message(stdout: &mut ChildStdout) -> Result<String> {
+    // Read headers byte-by-byte until \r\n\r\n.
+    let mut headers = Vec::with_capacity(64);
+    let mut last4 = [0u8; 4];
+    let mut byte = [0u8; 1];
+    loop {
+        let n = stdout.read(&mut byte).await.context("read LSP header")?;
+        if n == 0 {
+            return Err(anyhow!("LSP server closed stdout"));
+        }
+        headers.push(byte[0]);
+        last4.rotate_left(1);
+        last4[3] = byte[0];
+        if last4 == *b"\r\n\r\n" {
+            break;
+        }
+        if headers.len() > 8192 {
+            return Err(anyhow!("LSP header exceeded 8 KiB"));
+        }
+    }
+    let header_str = std::str::from_utf8(&headers).context("non-UTF8 LSP header")?;
+    let mut content_length = 0usize;
+    for line in header_str.split("\r\n") {
+        if let Some(rest) = line.strip_prefix("Content-Length:") {
+            content_length = rest.trim().parse().context("invalid Content-Length")?;
+        }
+    }
+    if content_length == 0 {
+        return Err(anyhow!("missing Content-Length"));
+    }
+    if content_length > 16 * 1024 * 1024 {
+        return Err(anyhow!(
+            "LSP message body too large ({} bytes); refusing",
+            content_length,
+        ));
+    }
+    let mut body = vec![0u8; content_length];
+    stdout
+        .read_exact(&mut body)
+        .await
+        .context("read LSP body")?;
+    String::from_utf8(body).context("non-UTF8 LSP body")
+}
+
+/// Perform the `initialize` → `initialized` handshake. Returns when the
+/// server has acknowledged `initialized`, after which it is free to push
+/// diagnostics. `workspace_root` is the absolute path of the workspace.
+pub async fn handshake(
+    stdin: &mut ChildStdin,
+    stdout: &mut ChildStdout,
+    workspace_root: &std::path::Path,
+) -> Result<()> {
+    let root_uri = path_to_uri(workspace_root);
+    let init_params = serde_json::json!({
+        "processId": std::process::id(),
+        "clientInfo": { "name": "zedra-lsp", "version": env!("CARGO_PKG_VERSION") },
+        "rootUri": root_uri,
+        "workspaceFolders": [{ "uri": root_uri, "name": "workspace" }],
+        "capabilities": {
+            "textDocument": {
+                "publishDiagnostics": { "relatedInformation": true, "versionSupport": false }
+            },
+            "workspace": { "workspaceFolders": true }
+        },
+    });
+    let req = JsonRpcRequest {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: init_params,
+    };
+    let body = serde_json::to_string(&req)?;
+    write_message(stdin, &body).await?;
+
+    // Drain until we see the initialize response (id=1). Some servers push
+    // progress notifications before responding.
+    loop {
+        let body = read_message(stdout).await?;
+        let parsed: JsonRpcResponse = serde_json::from_str(&body)
+            .with_context(|| format!("invalid JSON from LSP server: {body}"))?;
+        if parsed.id == Some(Value::from(1)) {
+            if let Some(err) = parsed.error {
+                return Err(anyhow!("LSP initialize failed: {err}"));
+            }
+            break;
+        }
+    }
+
+    let notif = JsonRpcNotification {
+        jsonrpc: "2.0",
+        method: "initialized",
+        params: serde_json::json!({}),
+    };
+    let body = serde_json::to_string(&notif)?;
+    write_message(stdin, &body).await?;
+    Ok(())
+}
+
+/// Background reader loop. Parses incoming messages and updates `store` on
+/// every `textDocument/publishDiagnostics` notification. Exits cleanly when
+/// the server closes its stdout.
+pub async fn run_reader(
+    mut stdout: ChildStdout,
+    store: Arc<Mutex<DiagnosticStore>>,
+    on_diagnostic: impl Fn(PathBuf, Vec<LspDiagnosticV2>) + Send + 'static,
+) {
+    loop {
+        let body = match read_message(&mut stdout).await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::debug!("LSP reader exiting: {}", e);
+                return;
+            }
+        };
+        let parsed: JsonRpcResponse = match serde_json::from_str(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("LSP malformed message: {}", e);
+                continue;
+            }
+        };
+        let Some(method) = parsed.method.as_deref() else {
+            continue;
+        };
+        if method != "textDocument/publishDiagnostics" {
+            continue;
+        }
+        let Some(params) = parsed.params else {
+            continue;
+        };
+        let Some((path, diagnostics)) = decode_publish_diagnostics(&params) else {
+            continue;
+        };
+        {
+            let mut guard = store.lock().await;
+            if diagnostics.is_empty() {
+                guard.remove(&path);
+            } else {
+                guard.insert(path.clone(), diagnostics.clone());
+            }
+        }
+        on_diagnostic(path, diagnostics);
+    }
+}
+
+fn decode_publish_diagnostics(params: &Value) -> Option<(PathBuf, Vec<LspDiagnosticV2>)> {
+    let uri = params.get("uri")?.as_str()?;
+    let path = uri_to_path(uri)?;
+    let raw = params.get("diagnostics")?.as_array()?;
+    let diagnostics = raw.iter().filter_map(decode_diagnostic).collect();
+    Some((path, diagnostics))
+}
+
+fn decode_diagnostic(v: &Value) -> Option<LspDiagnosticV2> {
+    let range = decode_range(v.get("range")?)?;
+    let severity = match v.get("severity").and_then(|s| s.as_u64()) {
+        Some(1) => LspSeverity::Error,
+        Some(2) => LspSeverity::Warning,
+        Some(3) => LspSeverity::Info,
+        Some(4) => LspSeverity::Hint,
+        _ => LspSeverity::Info,
+    };
+    let code = v.get("code").map(|c| match c {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    });
+    let source = v
+        .get("source")
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string());
+    let message = v
+        .get("message")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
+    let related = v
+        .get("relatedInformation")
+        .and_then(|r| r.as_array())
+        .map(|arr| arr.iter().filter_map(decode_related).collect())
+        .unwrap_or_default();
+    Some(LspDiagnosticV2 {
+        range,
+        severity,
+        code,
+        source,
+        message,
+        related,
+    })
+}
+
+fn decode_related(v: &Value) -> Option<LspRelated> {
+    let location = v.get("location")?;
+    let uri = location.get("uri")?.as_str()?;
+    let path = uri_to_path(uri)?;
+    let range = decode_range(location.get("range")?)?;
+    let message = v
+        .get("message")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
+    Some(LspRelated {
+        path: path.to_string_lossy().into_owned(),
+        range,
+        message,
+    })
+}
+
+fn decode_range(v: &Value) -> Option<LspRange> {
+    let start = decode_position(v.get("start")?)?;
+    let end = decode_position(v.get("end")?)?;
+    Some(LspRange {
+        start_line: start.line,
+        start_col: start.col,
+        end_line: end.line,
+        end_col: end.col,
+    })
+}
+
+fn decode_position(v: &Value) -> Option<LspPosition> {
+    Some(LspPosition {
+        line: v.get("line")?.as_u64()? as u32,
+        col: v.get("character")?.as_u64()? as u32,
+    })
+}
+
+fn path_to_uri(path: &std::path::Path) -> String {
+    let s = path.to_string_lossy();
+    if s.starts_with("/") {
+        format!("file://{}", s)
+    } else {
+        format!("file:///{}", s.replace('\\', "/"))
+    }
+}
+
+fn uri_to_path(uri: &str) -> Option<PathBuf> {
+    let rest = uri.strip_prefix("file://")?;
+    let rest = rest
+        .strip_prefix('/')
+        .map(|r| format!("/{r}"))
+        .unwrap_or_else(|| rest.to_string());
+    Some(PathBuf::from(rest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_publish_diagnostics_parses_rust_analyzer_payload() {
+        let raw = serde_json::json!({
+            "uri": "file:///tmp/zedra/src/lib.rs",
+            "diagnostics": [
+                {
+                    "range": {
+                        "start": { "line": 12, "character": 4 },
+                        "end":   { "line": 12, "character": 9 }
+                    },
+                    "severity": 1,
+                    "code": "E0382",
+                    "source": "rustc",
+                    "message": "borrow of moved value: `foo`"
+                }
+            ]
+        });
+        let (path, diags) = decode_publish_diagnostics(&raw).unwrap();
+        assert_eq!(path, PathBuf::from("/tmp/zedra/src/lib.rs"));
+        assert_eq!(diags.len(), 1);
+        let d = &diags[0];
+        assert_eq!(d.severity, LspSeverity::Error);
+        assert_eq!(d.code.as_deref(), Some("E0382"));
+        assert_eq!(d.source.as_deref(), Some("rustc"));
+        assert_eq!(d.range.start_line, 12);
+        assert_eq!(d.range.start_col, 4);
+    }
+
+    #[test]
+    fn empty_diagnostics_array_is_clearing_signal() {
+        let raw = serde_json::json!({
+            "uri": "file:///tmp/a.rs",
+            "diagnostics": []
+        });
+        let (_path, diags) = decode_publish_diagnostics(&raw).unwrap();
+        assert!(diags.is_empty());
+    }
+}

--- a/crates/zedra-lsp/src/server.rs
+++ b/crates/zedra-lsp/src/server.rs
@@ -11,6 +11,7 @@
 //! server in a request loop. This file is what gives the guard something to
 //! supervise.
 
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -19,10 +20,20 @@ use std::time::Instant;
 use anyhow::{Context, Result, anyhow};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
-use tokio::sync::Mutex;
-use zedra_rpc::proto::{LspKillReason, LspLanguage, LspServerState};
+use tokio::sync::{Mutex, mpsc};
+use zedra_rpc::proto::{LspDiagnosticV2, LspKillReason, LspLanguage, LspServerState};
 
 use crate::policy::language_binary;
+use crate::protocol::{self, DiagnosticStore};
+
+/// One diagnostic-set update from a language server. Wholesale replacement
+/// for `(language, path)`. Empty `diagnostics` means "clear the file".
+#[derive(Debug, Clone)]
+pub struct DiagnosticUpdate {
+    pub language: LspLanguage,
+    pub path: PathBuf,
+    pub diagnostics: Vec<LspDiagnosticV2>,
+}
 
 /// Telemetry-stable language label. Kept here (mirrored in `zedra-host`) so
 /// `zedra-lsp` can emit telemetry without a back-dependency.
@@ -45,6 +56,7 @@ pub struct LspServer {
     started_at: Mutex<Option<Instant>>,
     peak_rss_bytes: AtomicRss,
     last_kill_reason: Mutex<Option<LspKillReason>>,
+    diagnostics: Arc<Mutex<DiagnosticStore>>,
 }
 
 impl LspServer {
@@ -57,7 +69,29 @@ impl LspServer {
             started_at: Mutex::new(None),
             peak_rss_bytes: AtomicRss::new(),
             last_kill_reason: Mutex::new(None),
+            diagnostics: Arc::new(Mutex::new(DiagnosticStore::new())),
         })
+    }
+
+    /// Snapshot of the diagnostic store for this server.
+    pub async fn diagnostics_snapshot(&self) -> DiagnosticStore {
+        self.diagnostics.lock().await.clone()
+    }
+
+    /// Aggregate diagnostic counts across all files. `(errors, warnings)`.
+    pub async fn diagnostic_counts(&self) -> (u32, u32) {
+        let mut errors = 0u32;
+        let mut warnings = 0u32;
+        for ds in self.diagnostics.lock().await.values() {
+            for d in ds {
+                match d.severity {
+                    zedra_rpc::proto::LspSeverity::Error => errors += 1,
+                    zedra_rpc::proto::LspSeverity::Warning => warnings += 1,
+                    _ => {}
+                }
+            }
+        }
+        (errors, warnings)
     }
 
     pub fn language(&self) -> LspLanguage {
@@ -93,9 +127,15 @@ impl LspServer {
         *self.last_kill_reason.lock().await
     }
 
-    /// Spawn the child if not already running. Returns the elapsed cold-start
-    /// time so the caller can emit `lsp_spawn` telemetry.
-    pub async fn spawn(&self) -> Result<u64> {
+    /// Spawn the child and drive the LSP initialize handshake. After
+    /// `initialized`, a background task reads `publishDiagnostics` and
+    /// forwards each update to `diag_tx`. `workspace_root` is the absolute
+    /// path the language server should index.
+    pub async fn spawn(
+        self: &Arc<Self>,
+        workspace_root: &Path,
+        diag_tx: mpsc::Sender<DiagnosticUpdate>,
+    ) -> Result<u64> {
         {
             let state = self.state.lock().await;
             if matches!(*state, LspServerState::Starting | LspServerState::Ready) {
@@ -111,6 +151,7 @@ impl LspServer {
 
         let mut cmd = Command::new(bin.command);
         cmd.args(bin.args)
+            .current_dir(workspace_root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -123,15 +164,15 @@ impl LspServer {
         let pid = child.id().unwrap_or(0);
         self.pid.store(pid, Ordering::Relaxed);
 
-        // Drain stdout / stderr so the child does not block on a full pipe.
-        // Until the LSP protocol commit lands, we discard all output. The
-        // drainers exit when the child closes its end.
-        if let Some(stdout) = child.stdout.take() {
-            tokio::spawn(async move {
-                let mut lines = BufReader::new(stdout).lines();
-                while let Ok(Some(_)) = lines.next_line().await {}
-            });
-        }
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("child stdin missing"))?;
+        let mut stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("child stdout missing"))?;
+        // Drain stderr so the child does not block on a full pipe.
         if let Some(stderr) = child.stderr.take() {
             let lang = self.language;
             tokio::spawn(async move {
@@ -146,9 +187,6 @@ impl LspServer {
 
         *self.child.lock().await = Some(child);
         *self.started_at.lock().await = Some(started);
-        // Without the LSP `initialized` handshake we cannot truthfully claim
-        // `Ready`. Hold at `Starting` until the protocol commit advances us.
-        *self.state.lock().await = LspServerState::Starting;
         *self.last_kill_reason.lock().await = None;
         self.peak_rss_bytes.reset();
 
@@ -163,6 +201,41 @@ impl LspServer {
             cold_start_ms = cold_start_ms,
             "LSP server spawned",
         );
+
+        // Drive the handshake on a background task so spawn() returns quickly.
+        let me = Arc::clone(self);
+        let workspace_root = workspace_root.to_path_buf();
+        tokio::spawn(async move {
+            if let Err(e) = protocol::handshake(&mut stdin, &mut stdout, &workspace_root).await {
+                tracing::warn!(language = ?me.language, "LSP handshake failed: {}", e);
+                *me.state.lock().await = LspServerState::Failed;
+                return;
+            }
+            let init_ms = me
+                .started_at
+                .lock()
+                .await
+                .map(|t| t.elapsed().as_millis() as u64)
+                .unwrap_or(0);
+            *me.state.lock().await = LspServerState::Ready;
+            zedra_telemetry::send(zedra_telemetry::Event::LspReady {
+                language: language_label(me.language),
+                init_ms,
+            });
+            tracing::info!(language = ?me.language, init_ms, "LSP server ready");
+            // Reader loop owns stdout for the rest of the server's lifetime.
+            let store = Arc::clone(&me.diagnostics);
+            let lang = me.language;
+            protocol::run_reader(stdout, store, move |path, diagnostics| {
+                let _ = diag_tx.try_send(DiagnosticUpdate {
+                    language: lang,
+                    path,
+                    diagnostics,
+                });
+            })
+            .await;
+        });
+
         Ok(cold_start_ms)
     }
 

--- a/crates/zedra-lsp/src/server.rs
+++ b/crates/zedra-lsp/src/server.rs
@@ -1,0 +1,301 @@
+//! One running language server child.
+//!
+//! Scope is process supervision only: spawn, hold PID + state, drain stdout
+//! and stderr so the child does not block on a full pipe, report RSS, and
+//! shut down on demand. The actual LSP JSON-RPC protocol (initialize,
+//! publishDiagnostics, ...) lands in a follow-up commit.
+//!
+//! The reason we spawn early without speaking the protocol is the
+//! non-functional safety contract: the resource guard must enforce caps on a
+//! real child process before we wire any LSP wire surface that might pin the
+//! server in a request loop. This file is what gives the guard something to
+//! supervise.
+
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Instant;
+
+use anyhow::{Context, Result, anyhow};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+use zedra_rpc::proto::{LspKillReason, LspLanguage, LspServerState};
+
+use crate::policy::language_binary;
+
+/// Telemetry-stable language label. Kept here (mirrored in `zedra-host`) so
+/// `zedra-lsp` can emit telemetry without a back-dependency.
+pub fn language_label(language: LspLanguage) -> &'static str {
+    match language {
+        LspLanguage::Rust => "rust",
+        LspLanguage::Go => "go",
+        LspLanguage::TypeScript => "typescript",
+        LspLanguage::JavaScript => "javascript",
+        LspLanguage::Python => "python",
+    }
+}
+
+/// A single supervised language server.
+pub struct LspServer {
+    language: LspLanguage,
+    state: Mutex<LspServerState>,
+    child: Mutex<Option<Child>>,
+    pid: AtomicU32,
+    started_at: Mutex<Option<Instant>>,
+    peak_rss_bytes: AtomicRss,
+    last_kill_reason: Mutex<Option<LspKillReason>>,
+}
+
+impl LspServer {
+    pub fn new(language: LspLanguage) -> Arc<Self> {
+        Arc::new(Self {
+            language,
+            state: Mutex::new(LspServerState::Idle),
+            child: Mutex::new(None),
+            pid: AtomicU32::new(0),
+            started_at: Mutex::new(None),
+            peak_rss_bytes: AtomicRss::new(),
+            last_kill_reason: Mutex::new(None),
+        })
+    }
+
+    pub fn language(&self) -> LspLanguage {
+        self.language
+    }
+
+    pub fn pid(&self) -> Option<u32> {
+        let pid = self.pid.load(Ordering::Relaxed);
+        if pid == 0 { None } else { Some(pid) }
+    }
+
+    pub async fn state(&self) -> LspServerState {
+        *self.state.lock().await
+    }
+
+    pub async fn uptime_secs(&self) -> u64 {
+        self.started_at
+            .lock()
+            .await
+            .map(|t| t.elapsed().as_secs())
+            .unwrap_or(0)
+    }
+
+    pub fn peak_rss_bytes(&self) -> u64 {
+        self.peak_rss_bytes.get()
+    }
+
+    pub fn record_rss(&self, bytes: u64) {
+        self.peak_rss_bytes.maybe_set(bytes);
+    }
+
+    pub async fn last_kill_reason(&self) -> Option<LspKillReason> {
+        *self.last_kill_reason.lock().await
+    }
+
+    /// Spawn the child if not already running. Returns the elapsed cold-start
+    /// time so the caller can emit `lsp_spawn` telemetry.
+    pub async fn spawn(&self) -> Result<u64> {
+        {
+            let state = self.state.lock().await;
+            if matches!(*state, LspServerState::Starting | LspServerState::Ready) {
+                return Ok(0);
+            }
+        }
+
+        let bin = language_binary(self.language)
+            .ok_or_else(|| anyhow!("no language server registered for {:?}", self.language))?;
+
+        let started = Instant::now();
+        *self.state.lock().await = LspServerState::Starting;
+
+        let mut cmd = Command::new(bin.command);
+        cmd.args(bin.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = cmd
+            .spawn()
+            .with_context(|| format!("failed to spawn {}", bin.command))?;
+
+        let pid = child.id().unwrap_or(0);
+        self.pid.store(pid, Ordering::Relaxed);
+
+        // Drain stdout / stderr so the child does not block on a full pipe.
+        // Until the LSP protocol commit lands, we discard all output. The
+        // drainers exit when the child closes its end.
+        if let Some(stdout) = child.stdout.take() {
+            tokio::spawn(async move {
+                let mut lines = BufReader::new(stdout).lines();
+                while let Ok(Some(_)) = lines.next_line().await {}
+            });
+        }
+        if let Some(stderr) = child.stderr.take() {
+            let lang = self.language;
+            tokio::spawn(async move {
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if !line.is_empty() {
+                        tracing::debug!(language = ?lang, "lsp_stderr: {}", line);
+                    }
+                }
+            });
+        }
+
+        *self.child.lock().await = Some(child);
+        *self.started_at.lock().await = Some(started);
+        // Without the LSP `initialized` handshake we cannot truthfully claim
+        // `Ready`. Hold at `Starting` until the protocol commit advances us.
+        *self.state.lock().await = LspServerState::Starting;
+        *self.last_kill_reason.lock().await = None;
+        self.peak_rss_bytes.reset();
+
+        let cold_start_ms = started.elapsed().as_millis() as u64;
+        zedra_telemetry::send(zedra_telemetry::Event::LspSpawn {
+            language: language_label(self.language),
+            cold_start_ms,
+        });
+        tracing::info!(
+            language = ?self.language,
+            pid = pid,
+            cold_start_ms = cold_start_ms,
+            "LSP server spawned",
+        );
+        Ok(cold_start_ms)
+    }
+
+    /// Terminate the child. `reason` is recorded for the next status snapshot
+    /// and surfaced in `lsp_killed` telemetry.
+    pub async fn shutdown(&self, reason: LspKillReason) {
+        let mut child_guard = self.child.lock().await;
+        let Some(mut child) = child_guard.take() else {
+            *self.state.lock().await = LspServerState::Idle;
+            return;
+        };
+        let uptime = self
+            .started_at
+            .lock()
+            .await
+            .map(|t| t.elapsed().as_secs())
+            .unwrap_or(0);
+        let peak_mb = self.peak_rss_bytes.get() / (1024 * 1024);
+
+        // Best-effort SIGTERM first; fall back to SIGKILL after the grace.
+        #[cfg(unix)]
+        {
+            if let Some(pid) = child.id() {
+                // SAFETY: pid is positive and obtained from a live child handle.
+                unsafe {
+                    libc::kill(pid as libc::pid_t, libc::SIGTERM);
+                }
+            }
+        }
+        let grace = std::time::Duration::from_secs(3);
+        let waited = tokio::time::timeout(grace, child.wait()).await;
+        if waited.is_err() {
+            let _ = child.kill().await;
+        }
+        self.pid.store(0, Ordering::Relaxed);
+        *self.started_at.lock().await = None;
+        *self.state.lock().await = LspServerState::Killed;
+        *self.last_kill_reason.lock().await = Some(reason);
+
+        zedra_telemetry::send(zedra_telemetry::Event::LspKilled {
+            language: language_label(self.language),
+            reason: kill_reason_label(reason),
+            uptime_secs: uptime,
+            peak_rss_mb: peak_mb,
+        });
+        tracing::info!(
+            language = ?self.language,
+            reason = ?reason,
+            uptime_secs = uptime,
+            peak_rss_mb = peak_mb,
+            "LSP server shut down",
+        );
+    }
+
+    /// Detect crashes (child exited on its own). Returns `true` and updates
+    /// state to `Failed` when the child has exited; otherwise `false`.
+    pub async fn poll_crash(&self) -> bool {
+        let mut guard = self.child.lock().await;
+        let Some(child) = guard.as_mut() else {
+            return false;
+        };
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let uptime = self
+                    .started_at
+                    .lock()
+                    .await
+                    .map(|t| t.elapsed().as_secs())
+                    .unwrap_or(0);
+                let peak_mb = self.peak_rss_bytes.get() / (1024 * 1024);
+                let exit_code = status.code().unwrap_or(-1);
+                *guard = None;
+                self.pid.store(0, Ordering::Relaxed);
+                *self.state.lock().await = LspServerState::Failed;
+                *self.last_kill_reason.lock().await = Some(LspKillReason::Crash);
+                zedra_telemetry::send(zedra_telemetry::Event::LspKilled {
+                    language: language_label(self.language),
+                    reason: kill_reason_label(LspKillReason::Crash),
+                    uptime_secs: uptime,
+                    peak_rss_mb: peak_mb,
+                });
+                tracing::warn!(
+                    language = ?self.language,
+                    exit_code = exit_code,
+                    "LSP server crashed",
+                );
+                true
+            }
+            Ok(None) => false,
+            Err(e) => {
+                tracing::warn!(language = ?self.language, "try_wait failed: {}", e);
+                false
+            }
+        }
+    }
+}
+
+fn kill_reason_label(reason: LspKillReason) -> &'static str {
+    use LspKillReason::*;
+    match reason {
+        Oom => "oom",
+        AggregateOom => "aggregate_oom",
+        Cpu => "cpu",
+        Idle => "idle",
+        Manual => "manual",
+        Crash => "crash",
+    }
+}
+
+/// Cheap atomic peak tracker. Avoids holding a mutex on the hot RSS-poll
+/// path.
+struct AtomicRss(std::sync::atomic::AtomicU64);
+
+impl AtomicRss {
+    const fn new() -> Self {
+        Self(std::sync::atomic::AtomicU64::new(0))
+    }
+    fn get(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+    fn reset(&self) {
+        self.0.store(0, Ordering::Relaxed);
+    }
+    fn maybe_set(&self, candidate: u64) {
+        let mut cur = self.0.load(Ordering::Relaxed);
+        while candidate > cur {
+            match self
+                .0
+                .compare_exchange_weak(cur, candidate, Ordering::Relaxed, Ordering::Relaxed)
+            {
+                Ok(_) => return,
+                Err(observed) => cur = observed,
+            }
+        }
+    }
+}

--- a/crates/zedra-lsp/src/supervisor.rs
+++ b/crates/zedra-lsp/src/supervisor.rs
@@ -5,25 +5,34 @@
 //! evicting the highest-RSS server first.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc};
 use zedra_rpc::proto::{LspKillReason, LspLanguage};
 
 use crate::guard::GuardConfig;
-use crate::server::LspServer;
+use crate::server::{DiagnosticUpdate, LspServer};
 
 pub struct Supervisor {
     servers: Mutex<HashMap<LspLanguage, Arc<LspServer>>>,
     guard: GuardConfig,
+    workspace_root: PathBuf,
+    diag_tx: mpsc::Sender<DiagnosticUpdate>,
 }
 
 impl Supervisor {
-    pub fn new(guard: GuardConfig) -> Arc<Self> {
+    pub fn new(
+        guard: GuardConfig,
+        workspace_root: PathBuf,
+        diag_tx: mpsc::Sender<DiagnosticUpdate>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             servers: Mutex::new(HashMap::new()),
             guard,
+            workspace_root,
+            diag_tx,
         })
     }
 
@@ -66,7 +75,9 @@ impl Supervisor {
             );
         }
         let server = LspServer::new(language);
-        server.spawn().await?;
+        server
+            .spawn(&self.workspace_root, self.diag_tx.clone())
+            .await?;
         servers.insert(language, server);
         Ok(())
     }

--- a/crates/zedra-lsp/src/supervisor.rs
+++ b/crates/zedra-lsp/src/supervisor.rs
@@ -1,0 +1,164 @@
+//! Background watcher that enforces the resource guard contract.
+//!
+//! Polls each running `LspServer` at `guard.poll_interval`, updates RSS, kills
+//! servers that exceed caps, and tears down on aggregate-cap overflow by
+//! evicting the highest-RSS server first.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
+use tokio::sync::Mutex;
+use zedra_rpc::proto::{LspKillReason, LspLanguage};
+
+use crate::guard::GuardConfig;
+use crate::server::LspServer;
+
+pub struct Supervisor {
+    servers: Mutex<HashMap<LspLanguage, Arc<LspServer>>>,
+    guard: GuardConfig,
+}
+
+impl Supervisor {
+    pub fn new(guard: GuardConfig) -> Arc<Self> {
+        Arc::new(Self {
+            servers: Mutex::new(HashMap::new()),
+            guard,
+        })
+    }
+
+    /// Spawn the watcher task. Returns immediately. The task lives until the
+    /// returned `Arc` and all clones are dropped.
+    pub fn spawn_watcher(self: &Arc<Self>) {
+        let me = Arc::clone(self);
+        let interval = me.guard.poll_interval;
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                me.tick().await;
+            }
+        });
+    }
+
+    /// Look up a running server. `None` if no server is running for this
+    /// language (either never spawned or already terminated).
+    pub async fn get(&self, language: LspLanguage) -> Option<Arc<LspServer>> {
+        self.servers.lock().await.get(&language).cloned()
+    }
+
+    pub async fn all(&self) -> Vec<Arc<LspServer>> {
+        self.servers.lock().await.values().cloned().collect()
+    }
+
+    /// Spawn a server for `language` if not already running. Enforces the
+    /// concurrent-cap by refusing to spawn when at capacity.
+    pub async fn start(&self, language: LspLanguage) -> anyhow::Result<()> {
+        let mut servers = self.servers.lock().await;
+        if servers.contains_key(&language) {
+            return Ok(());
+        }
+        if servers.len() as u32 >= self.guard.concurrent_cap {
+            anyhow::bail!(
+                "concurrent LSP cap reached ({}); disable a language first",
+                self.guard.concurrent_cap
+            );
+        }
+        let server = LspServer::new(language);
+        server.spawn().await?;
+        servers.insert(language, server);
+        Ok(())
+    }
+
+    /// Shut down the server for `language` if running. No-op otherwise.
+    pub async fn stop(&self, language: LspLanguage, reason: LspKillReason) {
+        let server = self.servers.lock().await.remove(&language);
+        if let Some(server) = server {
+            server.shutdown(reason).await;
+        }
+    }
+
+    /// One watcher iteration: refresh RSS, detect crashes, enforce per-server
+    /// and aggregate caps.
+    async fn tick(&self) {
+        let servers: Vec<Arc<LspServer>> = self.servers.lock().await.values().cloned().collect();
+        if servers.is_empty() {
+            return;
+        }
+
+        let mut crashed: Vec<LspLanguage> = Vec::new();
+        for server in &servers {
+            if server.poll_crash().await {
+                crashed.push(server.language());
+            }
+        }
+        if !crashed.is_empty() {
+            let mut guard = self.servers.lock().await;
+            for lang in crashed {
+                guard.remove(&lang);
+            }
+        }
+
+        let live: Vec<Arc<LspServer>> = self.servers.lock().await.values().cloned().collect();
+        if live.is_empty() {
+            return;
+        }
+
+        let mut system = System::new();
+        let pids: Vec<Pid> = live
+            .iter()
+            .filter_map(|s| s.pid().map(|p| Pid::from(p as usize)))
+            .collect();
+        system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&pids),
+            ProcessRefreshKind::new().with_memory(),
+        );
+        let _ = RefreshKind::new();
+
+        let mut aggregate = 0u64;
+        let mut oversized: Vec<Arc<LspServer>> = Vec::new();
+        let mut per_server_rss: Vec<(Arc<LspServer>, u64)> = Vec::with_capacity(live.len());
+
+        for server in live {
+            let Some(pid) = server.pid() else {
+                continue;
+            };
+            let rss = system
+                .process(Pid::from(pid as usize))
+                .map(|p| p.memory())
+                .unwrap_or(0);
+            server.record_rss(rss);
+            aggregate = aggregate.saturating_add(rss);
+            if rss > self.guard.per_server_rss_cap_bytes {
+                oversized.push(Arc::clone(&server));
+            }
+            per_server_rss.push((server, rss));
+        }
+
+        for server in oversized {
+            tracing::warn!(
+                language = ?server.language(),
+                "LSP per-server RSS cap exceeded, terminating",
+            );
+            self.stop(server.language(), LspKillReason::Oom).await;
+        }
+
+        if self.guard.aggregate_rss_cap_bytes > 0 && aggregate > self.guard.aggregate_rss_cap_bytes
+        {
+            // Evict the highest-RSS live server. Repeat once if still over;
+            // tick will catch the rest next interval.
+            per_server_rss.sort_by(|a, b| b.1.cmp(&a.1));
+            if let Some((worst, _)) = per_server_rss.first() {
+                tracing::warn!(
+                    language = ?worst.language(),
+                    aggregate_bytes = aggregate,
+                    cap_bytes = self.guard.aggregate_rss_cap_bytes,
+                    "LSP aggregate RSS cap exceeded, evicting worst server",
+                );
+                self.stop(worst.language(), LspKillReason::AggregateOom)
+                    .await;
+            }
+        }
+    }
+}

--- a/crates/zedra-rpc/src/proto.rs
+++ b/crates/zedra-rpc/src/proto.rs
@@ -190,6 +190,61 @@ pub enum ZedraProto {
     /// gated on the client by `host_version`.
     #[rpc(tx = oneshot::Sender<TermCreateResult>)]
     TermCreateV2(TermCreateReqV2),
+
+    // -- LSP control plane (opt-in, decoupled) --
+    //
+    // The host LSP subsystem is opt-in and may be absent entirely. Every result
+    // carries `enabled` so clients branch on it without a host_version check.
+    // When the host has no LSP subsystem (or the workspace has not enabled any
+    // language), all of these return `enabled = false` with empty payloads and
+    // no error. Clients must treat that as "LSP not available" and hide LSP UI.
+    /// Report the current state of the LSP subsystem on the host, including
+    /// running language servers, resource usage, and last termination reason.
+    /// Backs both the `zedra status` CLI block and the in-app status pill.
+    #[rpc(tx = oneshot::Sender<LspStatusResult>)]
+    LspStatus(LspStatusReq),
+
+    /// Mark a language as enabled for the active workspace. Persists across
+    /// reconnect. Does not eagerly spawn the server — first `LspSubscribe`
+    /// triggers the spawn.
+    #[rpc(tx = oneshot::Sender<LspEnableResult>)]
+    LspEnable(LspEnableReq),
+
+    /// Mark a language as disabled for the active workspace. Shuts down a
+    /// running server for that language.
+    #[rpc(tx = oneshot::Sender<LspDisableResult>)]
+    LspDisable(LspDisableReq),
+
+    /// Subscribe to diagnostic and server-state push events. The host pushes
+    /// `LspDiagnosticsPush` and `LspServerStateChanged` through the existing
+    /// `HostEvent` stream; this request only registers paths of interest.
+    #[rpc(tx = oneshot::Sender<LspSubscribeResult>)]
+    LspSubscribe(LspSubscribeReq),
+
+    /// Drop a subscription created by `LspSubscribe`.
+    #[rpc(tx = oneshot::Sender<LspUnsubscribeResult>)]
+    LspUnsubscribe(LspUnsubscribeReq),
+
+    /// Fetch hover details (type signature, docs) at a buffer position.
+    /// Replaces the legacy `LspHover` stub. Distinct variant per append-only
+    /// rule.
+    #[rpc(tx = oneshot::Sender<LspHoverV2Result>)]
+    LspHoverV2(LspHoverV2Req),
+
+    /// List available LSP code actions in a buffer range. Quick-fixes are a
+    /// subset; the client decides which to surface.
+    #[rpc(tx = oneshot::Sender<LspCodeActionResult>)]
+    LspCodeAction(LspCodeActionReq),
+
+    /// Apply a code action previously surfaced via `LspCodeAction`. The host
+    /// performs the file edits; clients see the result through normal
+    /// filesystem watch events.
+    #[rpc(tx = oneshot::Sender<LspApplyActionResult>)]
+    LspApplyAction(LspApplyActionReq),
+
+    /// Resolve "go to definition" for a symbol at a buffer position.
+    #[rpc(tx = oneshot::Sender<LspGotoDefResult>)]
+    LspGotoDef(LspGotoDefReq),
 }
 
 // ---------------------------------------------------------------------------
@@ -676,6 +731,13 @@ pub enum HostEvent {
     FsChanged { path: String },
     /// Cached managed-agent summary updated after an async fetch (for example CLI version).
     AgentInfoChanged { info: AgentSummary },
+    /// LSP server pushed a fresh diagnostic set for a file. Replaces the
+    /// previous set for `(language, path)` wholesale — clients must not
+    /// merge with stale entries.
+    LspDiagnosticsPush(LspDiagnosticsPush),
+    /// Lifecycle change for one LSP server: started, became ready, failed,
+    /// or was killed by the resource guard.
+    LspServerStateChanged(LspServerStateChange),
 }
 
 // ---------------------------------------------------------------------------
@@ -1314,6 +1376,281 @@ pub struct LspHoverReq {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LspHoverResult {
     pub contents: String,
+}
+
+// ---------------------------------------------------------------------------
+// LSP control plane (opt-in, append-only)
+//
+// Every result carries `enabled` so clients can short-circuit when the host
+// has no LSP subsystem compiled in or no language is enabled for the active
+// workspace.
+// ---------------------------------------------------------------------------
+
+/// Language identifier for the LSP control plane. Stable enum so telemetry
+/// labels stay consistent across versions. Add new variants at the tail.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum LspLanguage {
+    Rust,
+    Go,
+    TypeScript,
+    JavaScript,
+    Python,
+}
+
+/// LSP server lifecycle phase.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum LspServerState {
+    /// Server enabled in config but not yet spawned.
+    Idle,
+    /// Process spawned; LSP `initialize` handshake in flight.
+    Starting,
+    /// `initialized` notification received; diagnostics flowing.
+    Ready,
+    /// Server crashed or `initialize` failed.
+    Failed,
+    /// Resource guard or operator killed the server.
+    Killed,
+    /// Language disabled for this workspace.
+    Disabled,
+}
+
+/// Reason an LSP server was terminated. `None` means it is still running or
+/// has never been spawned.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum LspKillReason {
+    /// Per-server RSS exceeded the configured cap.
+    Oom,
+    /// Aggregate RSS across all LSP servers exceeded the host cap.
+    AggregateOom,
+    /// Sustained CPU usage above the threshold.
+    Cpu,
+    /// No client subscriptions for the idle timeout window.
+    Idle,
+    /// Operator killed it via `zedra lsp kill` or `LspDisable`.
+    Manual,
+    /// Server exited non-zero on its own.
+    Crash,
+}
+
+/// Severity of a diagnostic. Mirrors LSP severity but kept independent to
+/// avoid leaking `lsp-types` into the wire schema.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum LspSeverity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+/// Zero-based buffer range. Lines and columns are UTF-16 code units, matching
+/// the LSP wire format; clients converting to UTF-8 byte offsets must round-
+/// trip through the buffer they were displayed against.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LspRange {
+    pub start_line: u32,
+    pub start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+}
+
+/// Position inside a buffer, encoded the same way as `LspRange` endpoints.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LspPosition {
+    pub line: u32,
+    pub col: u32,
+}
+
+/// A single diagnostic emitted by a language server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LspDiagnosticV2 {
+    pub range: LspRange,
+    pub severity: LspSeverity,
+    /// Diagnostic code, e.g. `"E0502"` or `"2304"`.
+    pub code: Option<String>,
+    /// Tool that produced the diagnostic, e.g. `"rustc"`, `"tsc"`.
+    pub source: Option<String>,
+    pub message: String,
+    pub related: Vec<LspRelated>,
+}
+
+/// Additional location referenced by a diagnostic (e.g. "first borrow here").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LspRelated {
+    /// Workspace-relative path.
+    pub path: String,
+    pub range: LspRange,
+    pub message: String,
+}
+
+/// Snapshot of one LSP server. Mirrors what `zedra status` and the in-app
+/// status pill display.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LspServerInfo {
+    pub language: LspLanguage,
+    pub state: LspServerState,
+    pub pid: Option<u32>,
+    pub rss_bytes: u64,
+    pub uptime_secs: u64,
+    pub diagnostic_errors: u32,
+    pub diagnostic_warnings: u32,
+    /// Last completed request latency in milliseconds. `None` if no requests
+    /// have completed since spawn.
+    pub last_request_ms: Option<u32>,
+    /// Populated when `state` is `Failed` or `Killed`.
+    pub last_kill_reason: Option<LspKillReason>,
+    /// Peak RSS observed during the most recent lifecycle.
+    pub peak_rss_bytes: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspStatusReq {}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspStatusResult {
+    /// `false` when the host was built without the LSP subsystem or no
+    /// language is enabled for this workspace.
+    pub enabled: bool,
+    pub servers: Vec<LspServerInfo>,
+    /// Sum of `rss_bytes` across all running servers.
+    pub aggregate_rss_bytes: u64,
+    /// Configured aggregate RSS cap. `0` means uncapped.
+    pub aggregate_rss_cap_bytes: u64,
+    /// Hard cap on concurrent running servers.
+    pub concurrent_cap: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspEnableReq {
+    pub language: LspLanguage,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspEnableResult {
+    pub enabled: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspDisableReq {
+    pub language: LspLanguage,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspDisableResult {
+    pub enabled: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspSubscribeReq {
+    /// Workspace-relative paths the client wants diagnostics for. Empty list
+    /// means "all paths in the workspace" — the host may rate-limit those.
+    pub paths: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspSubscribeResult {
+    pub enabled: bool,
+    /// Opaque subscription handle. Empty when `enabled` is false.
+    pub subscription_id: String,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspUnsubscribeReq {
+    pub subscription_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspUnsubscribeResult {
+    pub enabled: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspHoverV2Req {
+    pub path: String,
+    pub position: LspPosition,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspHoverV2Result {
+    pub enabled: bool,
+    /// Markdown body. Empty when no hover info is available.
+    pub contents: String,
+    pub range: Option<LspRange>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspCodeActionReq {
+    pub path: String,
+    pub range: LspRange,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LspCodeAction {
+    /// Opaque action handle resolved by `LspApplyAction`.
+    pub id: String,
+    pub title: String,
+    /// `true` when the server tagged this as a quick-fix.
+    pub is_quick_fix: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspCodeActionResult {
+    pub enabled: bool,
+    pub actions: Vec<LspCodeAction>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspApplyActionReq {
+    pub action_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspApplyActionResult {
+    pub enabled: bool,
+    /// Number of files modified on disk.
+    pub files_changed: u32,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspGotoDefReq {
+    pub path: String,
+    pub position: LspPosition,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LspLocation {
+    pub path: String,
+    pub range: LspRange,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LspGotoDefResult {
+    pub enabled: bool,
+    pub locations: Vec<LspLocation>,
+}
+
+/// Diagnostic push event. Sent through `HostEvent` after the server emits
+/// `textDocument/publishDiagnostics`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LspDiagnosticsPush {
+    pub language: LspLanguage,
+    pub path: String,
+    /// Buffer version the diagnostics apply to. Clients ignore the push when
+    /// they hold a newer version locally.
+    pub version: u64,
+    pub diagnostics: Vec<LspDiagnosticV2>,
+}
+
+/// Server lifecycle push event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LspServerStateChange {
+    pub language: LspLanguage,
+    pub state: LspServerState,
+    /// Populated when `state` is `Failed` or `Killed`.
+    pub reason: Option<LspKillReason>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -44,6 +44,20 @@ struct SessionHandleInner {
     /// Parsed from `SyncSessionResult.host_version`; gates post-baseline
     /// RPCs so old hosts never receive an undecodable variant.
     host_version: Mutex<Option<(u32, u32, u32)>>,
+    /// Cached diagnostics keyed by `(language, workspace-relative path)`.
+    /// Refreshed wholesale per file on every `LspDiagnosticsPush` event.
+    /// Empty `Vec` means "the host explicitly cleared this file".
+    lsp_diagnostics: Mutex<
+        std::collections::HashMap<
+            (zedra_rpc::proto::LspLanguage, String),
+            Vec<zedra_rpc::proto::LspDiagnosticV2>,
+        >,
+    >,
+    /// Cached per-language server state, set by `LspServerStateChanged`.
+    /// UI dims diagnostics for languages whose state is `Killed`/`Failed`.
+    lsp_server_states: Mutex<
+        std::collections::HashMap<zedra_rpc::proto::LspLanguage, zedra_rpc::proto::LspServerState>,
+    >,
 }
 
 impl Drop for SessionHandleInner {
@@ -79,7 +93,93 @@ impl SessionHandle {
             observer_rpc_supported: AtomicBool::new(true),
             docs_tree_rpc_supported: AtomicBool::new(true),
             host_version: Mutex::new(None),
+            lsp_diagnostics: Mutex::new(std::collections::HashMap::new()),
+            lsp_server_states: Mutex::new(std::collections::HashMap::new()),
         }))
+    }
+
+    // ─── LSP diagnostic cache ───────────────────────────────────────────────
+    //
+    // The cache mirrors what the host pushes via `HostEvent::LspDiagnosticsPush`.
+    // It is wiped on disconnect (callers do that explicitly) and survives a
+    // reconnect — the host re-pushes its current diagnostic set on subscribe,
+    // overwriting per-file entries one by one.
+
+    pub fn apply_lsp_diagnostics_push(&self, push: zedra_rpc::proto::LspDiagnosticsPush) {
+        let key = (push.language, push.path);
+        let mut guard = match self.0.lsp_diagnostics.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if push.diagnostics.is_empty() {
+            guard.remove(&key);
+        } else {
+            guard.insert(key, push.diagnostics);
+        }
+    }
+
+    pub fn apply_lsp_server_state_changed(&self, change: &zedra_rpc::proto::LspServerStateChange) {
+        let mut guard = match self.0.lsp_server_states.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        guard.insert(change.language, change.state);
+    }
+
+    pub fn lsp_diagnostics_snapshot(
+        &self,
+    ) -> std::collections::HashMap<
+        (zedra_rpc::proto::LspLanguage, String),
+        Vec<zedra_rpc::proto::LspDiagnosticV2>,
+    > {
+        match self.0.lsp_diagnostics.lock() {
+            Ok(g) => g.clone(),
+            Err(p) => p.into_inner().clone(),
+        }
+    }
+
+    pub fn lsp_diagnostics_for_path(&self, path: &str) -> Vec<zedra_rpc::proto::LspDiagnosticV2> {
+        let guard = match self.0.lsp_diagnostics.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let mut out = Vec::new();
+        for ((_, p), diags) in guard.iter() {
+            if p == path {
+                out.extend(diags.iter().cloned());
+            }
+        }
+        out
+    }
+
+    /// Aggregate `(errors, warnings)` across all cached diagnostics. Used by
+    /// the workspace header LSP pill.
+    pub fn lsp_diagnostic_counts(&self) -> (u32, u32) {
+        let guard = match self.0.lsp_diagnostics.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let mut errors = 0u32;
+        let mut warnings = 0u32;
+        for diags in guard.values() {
+            for d in diags {
+                match d.severity {
+                    zedra_rpc::proto::LspSeverity::Error => errors += 1,
+                    zedra_rpc::proto::LspSeverity::Warning => warnings += 1,
+                    _ => {}
+                }
+            }
+        }
+        (errors, warnings)
+    }
+
+    pub fn clear_lsp_state(&self) {
+        if let Ok(mut g) = self.0.lsp_diagnostics.lock() {
+            g.clear();
+        }
+        if let Ok(mut g) = self.0.lsp_server_states.lock() {
+            g.clear();
+        }
     }
 
     // ─── Credentials ─────────────────────────────────────────────────────────

--- a/crates/zedra-session/src/session.rs
+++ b/crates/zedra-session/src/session.rs
@@ -381,6 +381,21 @@ impl Session {
             HostEvent::AgentInfoChanged { info } => {
                 info!("HostEvent: agent info changed {:?}", info.kind);
             }
+            HostEvent::LspDiagnosticsPush(push) => {
+                info!(
+                    "HostEvent: lsp diagnostics path={} count={}",
+                    push.path,
+                    push.diagnostics.len()
+                );
+                handle.apply_lsp_diagnostics_push(push.clone());
+            }
+            HostEvent::LspServerStateChanged(change) => {
+                info!(
+                    "HostEvent: lsp server state {:?} -> {:?}",
+                    change.language, change.state
+                );
+                handle.apply_lsp_server_state_changed(change);
+            }
         }
 
         let _ = host_event_tx.send(event);

--- a/crates/zedra-telemetry/src/lib.rs
+++ b/crates/zedra-telemetry/src/lib.rs
@@ -326,6 +326,56 @@ pub enum Event {
         /// Current running version (e.g. "0.2.1").
         current_version: &'static str,
     },
+    // ── LSP (server-side, opt-in subsystem) ───────────────────────────────
+    //
+    // Privacy: every event carries only opaque enum-like `language` labels
+    // ("rust", "go", "typescript", ...), durations, and counts. Diagnostic
+    // message text, file paths, codes, and project names must not appear here.
+    //
+    /// Operator enabled a language for the active workspace
+    /// (`zedra lsp enable` / `LspEnable` RPC).
+    LspEnabled { language: &'static str },
+    /// Operator disabled a language.
+    LspDisabled { language: &'static str },
+    /// Language-server process spawned successfully.
+    LspSpawn {
+        language: &'static str,
+        /// Time from `spawn()` to first child PID assignment.
+        cold_start_ms: u64,
+    },
+    /// `initialize`/`initialized` handshake completed; diagnostics flowing.
+    LspReady {
+        language: &'static str,
+        /// Time from `spawn()` to `initialized` notification.
+        init_ms: u64,
+    },
+    /// Language-server terminated by the resource guard, the operator, or on
+    /// its own. `reason` matches `LspKillReason` enum labels: "oom",
+    /// "aggregate_oom", "cpu", "idle", "manual", "crash".
+    LspKilled {
+        language: &'static str,
+        reason: &'static str,
+        uptime_secs: u64,
+        peak_rss_mb: u64,
+    },
+    /// Periodic diagnostic-set sample (every 60 s while at least one server is
+    /// running). Counts only; never message text.
+    LspDiagnosticsSample {
+        language: &'static str,
+        error_count: u32,
+        warning_count: u32,
+        file_count: u32,
+    },
+    /// Hourly aggregate of LSP request latencies per method. `method` matches
+    /// the LSP wire name ("textDocument/hover", "textDocument/codeAction", ...).
+    LspRequestLatency {
+        language: &'static str,
+        method: &'static str,
+        latency_ms_p50: u32,
+        latency_ms_p95: u32,
+        sample_count: u32,
+    },
+
     /// `zedra update` ran to completion (success or failure).
     SelfUpdate {
         success: bool,
@@ -378,6 +428,13 @@ impl Event {
             Self::BandwidthSample { .. } => "bandwidth_sample",
             Self::UpdateChecked { .. } => "update_checked",
             Self::SelfUpdate { .. } => "self_update",
+            Self::LspEnabled { .. } => "lsp_enabled",
+            Self::LspDisabled { .. } => "lsp_disabled",
+            Self::LspSpawn { .. } => "lsp_spawn",
+            Self::LspReady { .. } => "lsp_ready",
+            Self::LspKilled { .. } => "lsp_killed",
+            Self::LspDiagnosticsSample { .. } => "lsp_diagnostics_sample",
+            Self::LspRequestLatency { .. } => "lsp_request_latency",
         }
     }
 
@@ -683,6 +740,55 @@ impl Event {
                 ("from_version", from_version.to_string()),
                 ("error", error.to_string()),
                 ("elapsed_ms", elapsed_ms.to_string()),
+            ],
+            Self::LspEnabled { language } | Self::LspDisabled { language } => {
+                vec![("language", language.to_string())]
+            }
+            Self::LspSpawn {
+                language,
+                cold_start_ms,
+            } => vec![
+                ("language", language.to_string()),
+                ("cold_start_ms", cold_start_ms.to_string()),
+            ],
+            Self::LspReady { language, init_ms } => vec![
+                ("language", language.to_string()),
+                ("init_ms", init_ms.to_string()),
+            ],
+            Self::LspKilled {
+                language,
+                reason,
+                uptime_secs,
+                peak_rss_mb,
+            } => vec![
+                ("language", language.to_string()),
+                ("reason", reason.to_string()),
+                ("uptime_secs", uptime_secs.to_string()),
+                ("peak_rss_mb", peak_rss_mb.to_string()),
+            ],
+            Self::LspDiagnosticsSample {
+                language,
+                error_count,
+                warning_count,
+                file_count,
+            } => vec![
+                ("language", language.to_string()),
+                ("error_count", error_count.to_string()),
+                ("warning_count", warning_count.to_string()),
+                ("file_count", file_count.to_string()),
+            ],
+            Self::LspRequestLatency {
+                language,
+                method,
+                latency_ms_p50,
+                latency_ms_p95,
+                sample_count,
+            } => vec![
+                ("language", language.to_string()),
+                ("method", method.to_string()),
+                ("latency_ms_p50", latency_ms_p50.to_string()),
+                ("latency_ms_p95", latency_ms_p95.to_string()),
+                ("sample_count", sample_count.to_string()),
             ],
         }
     }

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1102,3 +1102,69 @@ Expected:
 4. Expected: UIKit presentation chrome uses light backgrounds and dark text/icons, matching the app theme.
 5. Toggle Appearance back to **Dark** and repeat the same presentations.
 6. Expected: UIKit presentation chrome returns to dark backgrounds and light text/icons without restarting the app.
+
+## 23. LSP Control Plane (CLI + Resource Guard)
+
+End-to-end verification of the opt-in LSP subsystem. The mobile UI lands in
+a follow-up PR; this scenario covers the host-side surface that the UI will
+sit on.
+
+**Prerequisites**
+
+- `rust-analyzer` on `PATH` (or another supported binary: `gopls`,
+  `typescript-language-server`, `pyright-langserver`).
+- A small workspace with at least one source file containing a known error
+  (e.g. a `let x: u32 = "hello";` in `src/lib.rs`).
+- Daemon running for that workspace (`zedra start`).
+
+**Smoke flow**
+
+1. `zedra lsp status` while no language is enabled.
+2. Expected: section reports "no languages enabled" with the hint to enable
+   one. No table rendered.
+3. `zedra lsp enable rust`.
+4. Expected: `Enabled LSP for rust` printed. The daemon logs a
+   `LSP server spawned` line and the `lsp_spawn` telemetry event fires.
+5. `zedra status`.
+6. Expected: an `LSP servers (1 running, cap 4)` section appears with the
+   row `rust | starting | <pid> | <rss> MB | <uptime> | 0E 0W | -`. After a
+   few seconds (rust-analyzer indexing), the state advances to `ready` and
+   the diagnostic counts populate.
+7. `zedra lsp status --json`.
+8. Expected: JSON shape matches the `lsp` block in `/api/status` —
+   `enabled`, `servers[]`, `aggregate_rss_bytes`, `aggregate_rss_cap_bytes`,
+   `concurrent_cap`.
+9. `zedra lsp disable rust`.
+10. Expected: `Disabled LSP for rust` printed. Daemon emits SIGTERM,
+    waits up to 3 s, then SIGKILL if needed. `lsp_killed` event fires with
+    `reason: manual` and the recorded `uptime_secs`, `peak_rss_mb`.
+
+**Resource guard (per-server cap)**
+
+1. Stop the daemon. Restart with `ZEDRA_LSP_MEM_CAP_MB=50 zedra start`.
+2. `zedra lsp enable rust`.
+3. Expected: within ~5 s of rust-analyzer warming up, the watcher hits the
+   50 MB cap and terminates the server. `lsp_killed` event fires with
+   `reason: oom`. `zedra status` shows the row with `state: killed` and
+   `last_kill_reason: oom`. Re-running `zedra lsp enable rust` immediately
+   should refuse with the spawn rate-limit message after the second
+   attempt within 30 s; allowing 30 s between attempts respawns it.
+
+**Persistence**
+
+1. `zedra lsp enable rust`. Stop the daemon.
+2. `zedra lsp status`.
+3. Expected: "Zedra daemon not running — showing persisted config." banner
+   plus the rust row in `idle` state (server-state fields zeroed since
+   nothing is supervising).
+4. Restart the daemon.
+5. Expected: rust-analyzer is auto-spawned on startup (visible in logs and
+   `zedra status`); no manual re-enable required.
+
+**Privacy spot check**
+
+1. With LSP running, run `zedra lsp status --json` and confirm no field
+   contains workspace file paths, diagnostic message text, project names,
+   user names, or hostnames. Only language enum labels, durations, counts,
+   and kill-reason enum strings should appear. The same property should
+   hold for any `lsp_*` events captured in telemetry logs.

--- a/docs/PROTOCOL_SPECS.md
+++ b/docs/PROTOCOL_SPECS.md
@@ -292,8 +292,35 @@ All Git result types carry `error: Option<String>`. Host sends error when git re
 - `AgentSessions(AgentSessionsReq) -> AgentSessionsResult`
 - `AgentResume(AgentResumeReq) -> AgentResumeResult`
 - `AgentInstalledList(AgentInstalledListReq) -> AgentInstalledListResult`
-- `LspDiagnostics(LspDiagnosticsReq) -> LspDiagnosticsResult`
-- `LspHover(LspHoverReq) -> LspHoverResult`
+- `LspDiagnostics(LspDiagnosticsReq) -> LspDiagnosticsResult` *(legacy stub, returns empty; superseded by the LSP control plane below)*
+- `LspHover(LspHoverReq) -> LspHoverResult` *(legacy stub, returns empty; superseded by `LspHoverV2`)*
+
+### 5.7.1 LSP control plane (opt-in)
+
+The LSP subsystem on the host is **opt-in and may be entirely absent**. RPC and UI features are decoupled — clients must branch on the `enabled` flag in every result rather than checking `host_version`. When the host has no LSP subsystem (or the workspace has not enabled any language), all of the variants below return `enabled = false` with empty payloads and `error = None`.
+
+- `LspStatus(LspStatusReq) -> LspStatusResult` — running servers, RSS, kill reasons. Backs the `zedra status` LSP block and the in-app status pill.
+- `LspEnable(LspEnableReq) -> LspEnableResult` — mark a language as enabled for the active workspace. Persists across reconnect; does **not** eagerly spawn the server.
+- `LspDisable(LspDisableReq) -> LspDisableResult` — shut down a running server and clear the persisted opt-in.
+- `LspSubscribe(LspSubscribeReq) -> LspSubscribeResult` — register interest in paths so the host pushes `LspDiagnosticsPush` and `LspServerStateChanged` through `HostEvent`. Empty `paths` means "everything in the workspace"; the host may rate-limit.
+- `LspUnsubscribe(LspUnsubscribeReq) -> LspUnsubscribeResult` — drop a subscription handle.
+- `LspHoverV2(LspHoverV2Req) -> LspHoverV2Result` — hover details at a position.
+- `LspCodeAction(LspCodeActionReq) -> LspCodeActionResult` — list available actions in a range.
+- `LspApplyAction(LspApplyActionReq) -> LspApplyActionResult` — apply an action previously surfaced via `LspCodeAction`. The host performs the file edits; clients observe the result through normal filesystem watch events.
+- `LspGotoDef(LspGotoDefReq) -> LspGotoDefResult` — resolve symbol definitions.
+
+Wire conventions:
+
+- `LspLanguage` is the canonical language identifier across protocol, telemetry, and CLI surfaces. Add new variants at the tail.
+- `LspRange` and `LspPosition` use zero-based **UTF-16** code units, matching the LSP wire format. Clients converting to UTF-8 byte offsets must round-trip through the buffer they were displayed against.
+- `LspSeverity`, `LspServerState`, and `LspKillReason` are stable wire enums so telemetry labels stay consistent across versions.
+- `LspDiagnosticsPush` replaces the previous diagnostic set for `(language, path)` wholesale. Clients must not merge with stale entries. The `version` field is the buffer revision the diagnostics apply to; clients ignore the push when they hold a newer local revision.
+- `LspServerStateChange.reason` is populated only when `state` is `Failed` or `Killed`.
+
+Resource policy (host-side, observable through `LspStatusResult` and `LspServerStateChange`):
+
+- Per-server RSS cap, aggregate RSS cap, sustained-CPU watchdog, idle shutdown, spawn rate limit, and concurrent-server cap. The exact numbers are host-configurable and reported via `LspStatusResult.aggregate_rss_cap_bytes` / `concurrent_cap`.
+- A server killed by the guard surfaces `LspServerStateChange { state: Killed, reason: Some(...) }` and a corresponding telemetry event. Clients should treat killed servers as recoverable — operator (`zedra lsp enable`) or `LspEnable` reattempts a spawn subject to the rate limit.
 
 ### Managed agent conventions
 
@@ -344,6 +371,8 @@ Current host event variants:
 - `GitChanged`
 - `FsChanged { path }`
 - `AgentInfoChanged { info }`
+- `LspDiagnosticsPush(LspDiagnosticsPush)`
+- `LspServerStateChanged(LspServerStateChange)`
 
 Client rules:
 
@@ -351,6 +380,8 @@ Client rules:
 - `GitChanged`: invalidate cached git state and refresh when appropriate.
 - `FsChanged { path }`: invalidate cached file tree for the watched path and reload affected expanded nodes.
 - `AgentInfoChanged`: replace cached `AgentSummary` for `info.kind`. One event per managed agent per version refresh. Requires an active `Subscribe` stream.
+- `LspDiagnosticsPush`: replace the diagnostic set for `(language, path)` wholesale. Drop the push when the local buffer revision is newer than `version`. Requires an active `LspSubscribe`.
+- `LspServerStateChanged`: update cached server state for `language`. When `state` is `Killed` or `Failed`, surface the `reason` in the status pill and dim cached diagnostics for that language.
 
 ---
 
@@ -463,6 +494,25 @@ Any protocol-layer change must include all applicable steps:
 ---
 
 ## 11) Protocol Changelog
+
+### 2026-05-26
+
+- Added opt-in LSP control plane (decoupled from app features; clients branch on `enabled` flag in every result):
+  - `LspStatus(LspStatusReq) -> LspStatusResult`
+  - `LspEnable(LspEnableReq) -> LspEnableResult`
+  - `LspDisable(LspDisableReq) -> LspDisableResult`
+  - `LspSubscribe(LspSubscribeReq) -> LspSubscribeResult`
+  - `LspUnsubscribe(LspUnsubscribeReq) -> LspUnsubscribeResult`
+  - `LspHoverV2(LspHoverV2Req) -> LspHoverV2Result`
+  - `LspCodeAction(LspCodeActionReq) -> LspCodeActionResult`
+  - `LspApplyAction(LspApplyActionReq) -> LspApplyActionResult`
+  - `LspGotoDef(LspGotoDefReq) -> LspGotoDefResult`
+- Added LSP push events on `HostEvent`:
+  - `LspDiagnosticsPush(LspDiagnosticsPush)`
+  - `LspServerStateChanged(LspServerStateChange)`
+- Added wire types: `LspLanguage`, `LspServerState`, `LspKillReason`, `LspSeverity`, `LspRange`, `LspPosition`, `LspDiagnosticV2`, `LspRelated`, `LspServerInfo`, `LspCodeAction`, `LspLocation`.
+- Legacy `LspDiagnostics` / `LspHover` retained for binary compatibility but now return empty payloads. The previous host implementation shelled out to `cargo check` / `tsc` synchronously, which violated the resource-safety NFR; the new control plane will replace it with a guarded language-server subsystem in a follow-up commit.
+- No ALPN change.
 
 ### 2026-04-29
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -85,6 +85,15 @@ Emitted by `zedra-host` via the same `zedra_telemetry::send()` mechanism.
 | `terminal_open` | `has_launch_cmd` | `rpc_daemon.rs` — PTY spawned |
 | `bandwidth_sample` | `bytes_sent`, `bytes_recv`, `interval_secs` | `rpc_daemon.rs` — every 60s |
 | `connection_latency_sample` | `source`, `connection_type`, `network_type`, `rtt_ms`, `relay`, `relay_region`, `nearest_relay_region`, `path_count`, `interval_secs`, `sample_reason` | `rpc_daemon.rs` — every 60s while connected |
+| `lsp_enabled` | `language` | `rpc_daemon.rs` — `LspEnable` handler when state changes |
+| `lsp_disabled` | `language` | `rpc_daemon.rs` — `LspDisable` handler when state changes |
+| `lsp_spawn` | `language`, `cold_start_ms` | LSP supervisor — child PID assigned |
+| `lsp_ready` | `language`, `init_ms` | LSP supervisor — `initialized` received |
+| `lsp_killed` | `language`, `reason`, `uptime_secs`, `peak_rss_mb` | LSP supervisor — guard kill or crash |
+| `lsp_diagnostics_sample` | `language`, `error_count`, `warning_count`, `file_count` | LSP supervisor — every 60s while running |
+| `lsp_request_latency` | `language`, `method`, `latency_ms_p50`, `latency_ms_p95`, `sample_count` | LSP supervisor — hourly aggregate |
+
+LSP events carry **only** language enum labels (`"rust"`, `"go"`, `"typescript"`, `"javascript"`, `"python"`), durations, counts, and the kill `reason` enum (`"oom"`, `"aggregate_oom"`, `"cpu"`, `"idle"`, `"manual"`, `"crash"`). Diagnostic message text, file paths, codes, project names, and workspace identifiers are never included. The `lsp_spawn` / `lsp_ready` / `lsp_killed` / `lsp_diagnostics_sample` / `lsp_request_latency` events fire from the supervisor that lands in a follow-up commit; the typed variants are wired now so consumers can be built against the stable schema.
 
 Host events also carry `host_version`, `os`, and `arch` — injected automatically
 by `Ga4::build_payload()` before the GA4 HTTP POST.


### PR DESCRIPTION
## Summary

Opt-in LSP control plane for Zedra. Host-side surface complete; mobile UI deliberately deferred to a follow-up PR for design review and device testing.

End-to-end flow that works today:
- `zedra lsp enable rust` (or `go` / `typescript` / `javascript` / `python`) → host spawns rust-analyzer / etc. under a hard resource guard.
- Server's `publishDiagnostics` are parsed and pushed to every paired client as `HostEvent::LspDiagnosticsPush`.
- `SessionHandle` caches diagnostics per `(language, path)`; UI consumers (mobile) read via `lsp_diagnostics_*` accessors.
- `zedra status` and `zedra lsp status` report live RSS, uptime, diagnostic counts, kill reasons. Persistence in `lsp.json` per workspace.
- Resource guard enforces per-server RSS cap, aggregate RSS cap, concurrent count, spawn rate limit, crash detection. Every kill fires `lsp_killed` telemetry with reason + peak RSS, never message text or paths.

## Architecture

- **`zedra-rpc/proto.rs`** — opt-in `Lsp*` RPC variants with `enabled` flag in every result so app code branches without a `host_version` check. Push events `LspDiagnosticsPush` and `LspServerStateChanged` on `HostEvent`. New wire types: `LspLanguage`, `LspServerState`, `LspKillReason`, `LspSeverity`, `LspRange`, `LspPosition`, `LspDiagnosticV2`, `LspRelated`, `LspServerInfo`, `LspCodeAction`, `LspLocation`. Legacy `LspDiagnostics` / `LspHover` retained but neutered to empty payloads (previous shell-out to `cargo check` violated the resource-safety NFR).
- **`zedra-lsp/`** — new crate. `policy` (lang→binary), `guard` (caps + env overrides), `persistence` (atomic `lsp.json`), `manager` (enablement state + status snapshot), `server` (one `tokio::process` child + stdout/stderr drain + RSS tracking), `supervisor` (RSS poll loop + per-server / aggregate-cap enforcement + crash detection), `protocol` (Content-Length framing + initialize handshake + publishDiagnostics parser).
- **`zedra-host`** — `DaemonState.lsp: Arc<LspManager>`. `LspStatus`/`LspEnable`/`LspDisable`/`LspSubscribe`/`LspUnsubscribe` wired. `/api/lsp/enable` and `/api/lsp/disable` REST endpoints. `zedra lsp {status,enable,disable}` CLI. `zedra status` extended with an LSP block. Diagnostic updates fan out via `session_registry::all_sessions()` to every active session.
- **`zedra-telemetry`** — typed `Lsp{Enabled,Disabled,Spawn,Ready,Killed,DiagnosticsSample,RequestLatency}` events. `LspEnabled` / `LspDisabled` / `LspSpawn` / `LspReady` / `LspKilled` emitted today. Payloads carry language enum, kill-reason enum, durations, and counts only — no paths, message text, project names, or hostnames.
- **`zedra-session`** — `SessionHandle` caches diagnostics keyed by `(language, path)` and per-language server state. Cleared on user disconnect, repopulated by host re-push on reconnect.

## Non-Functional Requirements

**Resource safety**: child processes run under a watcher loop polling RSS via `sysinfo`. Defaults: 1.5 GB per-server, 4 GB aggregate, 4 concurrent, 5 min idle, 30 s spawn rate limit, 90% / 60 s CPU watchdog. Overrides via `ZEDRA_LSP_MEM_CAP_MB`, `ZEDRA_LSP_AGG_MEM_CAP_MB`, `ZEDRA_LSP_CONCURRENT_CAP`. SIGTERM with 3 s grace then SIGKILL. Every kill is observable via `LspKilled` telemetry and `lsp_killed` log line. Read framing in `protocol.rs` bounds headers to 8 KiB and bodies to 16 MiB so a misbehaving server can't OOM the daemon.

**Decoupling**: `zedra-lsp` has only `zedra-host` as a consumer. Removing the dep cleanly disables the subsystem. RPC layer carries `enabled: bool` in every result so app code already branches correctly when LSP is absent. App layer mounts no LSP UI when the workspace has no language enabled. Legacy `LspDiagnostics` / `LspHover` retained for binary compat but inert.

## Commits

1. `feat(rpc): add opt-in LSP control plane schema` — wire types + push events + docs; neuters the legacy stub.
2. `feat(lsp): zedra-lsp crate + wire LspStatus/Enable/Disable + zedra status block` — manager + persistence + status table.
3. `feat(host): zedra lsp CLI + HTTP API endpoints for enable/disable`.
4. `feat(telemetry): typed LSP events + emit Enabled/Disabled`.
5. `feat(lsp): supervisor + resource guard for language-server processes` — child spawn, RSS poll, kill-on-cap, crash detection.
6. `feat(lsp): JSON-RPC initialize + publishDiagnostics parsing` — wire protocol, handshake, diagnostic parser, reader loop.
7. `feat(host): fan LSP diagnostics out as HostEvent::LspDiagnosticsPush` — push fan-out to every session.
8. `feat(session): cache LSP diagnostics on SessionHandle from host pushes` — client-side cache + state mirror.
9. `docs: add manual test scenario for the LSP control plane`.

## Notes

- All new `ZedraProto` variants are appended at the tail per the postcard ordinal rule; no `ZEDRA_ALPN` bump.
- The mobile UI (Problem view drawer tab, status pill, gutter bar, file-explorer badges, long-press sheet, settings toggles) is deliberately a follow-up PR. It needs visual design review, GPUI integration, and on-device testing that would dilute the review surface of this host-side change. The `SessionHandle` cache and `WorkspaceState` convention give the UI commit a clean seam.
- `LspServerStateChanged` push event types are wired but not yet emitted; the supervisor doesn't have a state-change signal channel yet. Follow-up.
- Manual verification steps in `docs/MANUAL_TEST.md` § 23 cover enable/status/disable, RSS-cap kill via env override, daemon persistence + auto-restore, and a privacy spot check.

Refs #90.