### PR TITLE
feat: full desktop keys in keyboard supporter

### DIFF
--- a/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
@@ -48,7 +48,7 @@ enum class HostOs(val displayName: String) {
  */
 class FullKeyboardPanel(
     context: Context,
-    @Suppress("unused") private val hostOs: HostOs,
+    private val hostOs: HostOs,
     private val sendKey: (String, Int) -> Unit,
 ) : FrameLayout(context) {
     private object AccessoryMods {
@@ -75,7 +75,7 @@ class FullKeyboardPanel(
 
     private val modNavRow =
         listOf(
-            Key("shift", Kind.Modifier(AccessoryMods.SHIFT)),
+            Key("Shift", Kind.Modifier(AccessoryMods.SHIFT)),
             Key("Ctrl", Kind.Modifier(AccessoryMods.CTRL)),
             Key("Cmd", Kind.Modifier(AccessoryMods.CMD)),
             Key("Home", Kind.Dispatch("home")),
@@ -111,7 +111,6 @@ class FullKeyboardPanel(
 
     private val density = context.resources.displayMetrics.density
     private val rowHeightPx = (44 * density).toInt()
-    private val keyGapPx = (2 * density).toInt()
     private val repeatInitialDelayMs = 350L
     private val repeatIntervalMs = 60L
     private val handler = Handler(Looper.getMainLooper())
@@ -125,6 +124,7 @@ class FullKeyboardPanel(
     private var armedMods: Int = 0
     private val keyViews = mutableListOf<Pair<View, Key>>()
     private val rowsContainer: LinearLayout
+    private val hostBadge: TextView
 
     private val repeatRunnable =
         object : Runnable {
@@ -150,6 +150,19 @@ class FullKeyboardPanel(
             LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, Gravity.TOP),
         )
 
+        hostBadge =
+            TextView(context).apply {
+                text = hostOs.displayName
+                textSize = 10f
+                alpha = 0.55f
+                gravity = Gravity.END
+            }
+        addView(
+            hostBadge,
+            LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT, Gravity.END or Gravity.BOTTOM)
+                .apply { setMargins(0, 0, (8 * density).toInt(), (4 * density).toInt()) },
+        )
+
         build()
         applyTheme(isDark = true)
     }
@@ -163,6 +176,8 @@ class FullKeyboardPanel(
         isDarkTheme = isDark
         setBackgroundColor(if (isDark) 0xF50E0C0C.toInt() else 0xF5FFFFFF.toInt())
         topBorderPaint.color = if (isDark) 0x33FFFFFF else 0x22000000
+        val foreground = if (isDark) 0xFFFFFFFF.toInt() else 0xFF1A1A1A.toInt()
+        hostBadge.setTextColor(foreground)
         for ((view, key) in keyViews) {
             applyKeyStyle(view, key)
         }
@@ -182,11 +197,10 @@ class FullKeyboardPanel(
             for (key in row) {
                 val view = makeKeyView(key)
                 keyViews.add(view to key)
+                // Edge-to-edge columns matching the accessory bar above.
                 rowView.addView(
                     view,
-                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f).apply {
-                        setMargins(keyGapPx, 0, keyGapPx, 0)
-                    },
+                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f),
                 )
             }
             rowsContainer.addView(
@@ -198,10 +212,13 @@ class FullKeyboardPanel(
 
     @SuppressLint("ClickableViewAccessibility")
     private fun makeKeyView(key: Key): View {
+        val isBackspace = key.kind is Kind.Dispatch && key.kind.name == "backspace"
         val view =
             TextView(context).apply {
                 text = key.label
-                textSize = 16f
+                // Backspace glyph reads small at 16sp; bump it while keeping the
+                // column width aligned with the rest of the row.
+                textSize = if (isBackspace) 22f else 16f
                 gravity = Gravity.CENTER
                 isClickable = true
                 isFocusable = false

--- a/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
@@ -1,0 +1,215 @@
+package dev.zedra.app
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.Gravity
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+
+/**
+ * In-app QWERTY panel that replaces the system soft keyboard while the user is
+ * driving a terminal / agent session. Each tap is forwarded via the same wire
+ * format as the accessory bar (`char:<c>`, named keys, mod bitmask).
+ *
+ * The panel is intended to be parked in the same screen slot the IME would
+ * occupy, so the host should size it to the IME height it just hid.
+ */
+class FullKeyboardPanel(
+    context: Context,
+    private val sendKey: (String, Int) -> Unit,
+) : LinearLayout(context) {
+    private enum class Layer { LETTERS, NUMBERS, SYMBOLS }
+
+    private enum class ShiftState { OFF, ONE_SHOT, LOCKED }
+
+    private sealed class Kind {
+        data class Char(val value: String) : Kind()
+        data class Named(val name: String) : Kind()
+        object Shift : Kind()
+        object Backspace : Kind()
+        object Space : Kind()
+        object Enter : Kind()
+        data class ToggleLayer(val target: Layer) : Kind()
+    }
+
+    private data class Key(val label: String, val kind: Kind, val weight: Float)
+
+    private val density = context.resources.displayMetrics.density
+    private val keyMargin = (3 * density).toInt()
+    private var shift: ShiftState = ShiftState.OFF
+    private var layer: Layer = Layer.LETTERS
+    private var isDarkTheme = true
+    private var lastShiftTapMs = 0L
+
+    init {
+        orientation = VERTICAL
+        setBaselineAligned(false)
+        isFocusable = false
+        isFocusableInTouchMode = false
+        applyTheme(isDark = true)
+        rebuild()
+    }
+
+    fun applyTheme(isDark: Boolean) {
+        isDarkTheme = isDark
+        setBackgroundColor(if (isDark) 0xFF1E1E20.toInt() else 0xFFD1D3D8.toInt())
+        rebuild()
+    }
+
+    private fun rebuild() {
+        removeAllViews()
+        val rows = layoutFor(layer)
+        for (row in rows) {
+            val rowView =
+                LinearLayout(context).apply {
+                    orientation = HORIZONTAL
+                    setBaselineAligned(false)
+                }
+            for (key in row) {
+                rowView.addView(makeButton(key), buildRowParams(key.weight))
+            }
+            addView(
+                rowView,
+                LayoutParams(LayoutParams.MATCH_PARENT, 0, 1f),
+            )
+        }
+    }
+
+    private fun layoutFor(layer: Layer): List<List<Key>> {
+        return when (layer) {
+            Layer.LETTERS -> {
+                val row1 = "qwertyuiop".map { Key(displayLetter(it.toString()), Kind.Char(it.toString()), 1f) }
+                val row2 = "asdfghjkl".map { Key(displayLetter(it.toString()), Kind.Char(it.toString()), 1f) }
+                val row3 = mutableListOf<Key>(Key(shiftLabel(), Kind.Shift, 1.5f))
+                row3.addAll("zxcvbnm".map { Key(displayLetter(it.toString()), Kind.Char(it.toString()), 1f) })
+                row3.add(Key("⌫", Kind.Backspace, 1.5f))
+                val row4 =
+                    listOf(
+                        Key("123", Kind.ToggleLayer(Layer.NUMBERS), 1.5f),
+                        Key("space", Kind.Space, 5f),
+                        Key("return", Kind.Enter, 2f),
+                    )
+                listOf(row1, row2, row3, row4)
+            }
+            Layer.NUMBERS -> {
+                val row1 = "1234567890".map { Key(it.toString(), Kind.Char(it.toString()), 1f) }
+                val row2 =
+                    listOf("-", "/", ":", ";", "(", ")", "$", "&", "@", "\"").map { Key(it, Kind.Char(it), 1f) }
+                val row3 = mutableListOf<Key>(Key("#+=", Kind.ToggleLayer(Layer.SYMBOLS), 1.5f))
+                row3.addAll(listOf(".", ",", "?", "!", "'").map { Key(it, Kind.Char(it), 1f) })
+                row3.add(Key("⌫", Kind.Backspace, 1.5f))
+                val row4 =
+                    listOf(
+                        Key("ABC", Kind.ToggleLayer(Layer.LETTERS), 1.5f),
+                        Key("space", Kind.Space, 5f),
+                        Key("return", Kind.Enter, 2f),
+                    )
+                listOf(row1, row2, row3, row4)
+            }
+            Layer.SYMBOLS -> {
+                val row1 =
+                    listOf("[", "]", "{", "}", "#", "%", "^", "*", "+", "=").map { Key(it, Kind.Char(it), 1f) }
+                val row2 =
+                    listOf("_", "\\", "|", "~", "<", ">", "€", "£", "¥", "•").map { Key(it, Kind.Char(it), 1f) }
+                val row3 = mutableListOf<Key>(Key("123", Kind.ToggleLayer(Layer.NUMBERS), 1.5f))
+                row3.addAll(listOf(".", ",", "?", "!", "'").map { Key(it, Kind.Char(it), 1f) })
+                row3.add(Key("⌫", Kind.Backspace, 1.5f))
+                val row4 =
+                    listOf(
+                        Key("ABC", Kind.ToggleLayer(Layer.LETTERS), 1.5f),
+                        Key("space", Kind.Space, 5f),
+                        Key("return", Kind.Enter, 2f),
+                    )
+                listOf(row1, row2, row3, row4)
+            }
+        }
+    }
+
+    private fun displayLetter(c: String): String = if (shift == ShiftState.OFF) c else c.uppercase()
+
+    private fun shiftLabel(): String =
+        when (shift) {
+            ShiftState.OFF -> "⇧"
+            ShiftState.ONE_SHOT -> "⬆"
+            ShiftState.LOCKED -> "⇪"
+        }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun makeButton(key: Key): View {
+        val isSpecial =
+            when (key.kind) {
+                is Kind.Char -> false
+                else -> true
+            }
+        val foreground = if (isDarkTheme) 0xFFFFFFFF.toInt() else 0xFF101015.toInt()
+        val baseBg =
+            if (isDarkTheme) {
+                if (isSpecial) 0xFF333339.toInt() else 0xFF4A4A52.toInt()
+            } else {
+                if (isSpecial) 0xFFA6A8AE.toInt() else 0xFFFFFFFF.toInt()
+            }
+        val view =
+            TextView(context).apply {
+                text = key.label
+                textSize = 16f
+                gravity = Gravity.CENTER
+                setTextColor(foreground)
+                setBackgroundColor(baseBg)
+                isClickable = true
+                setOnClickListener { handleKey(key) }
+            }
+        if (key.kind is Kind.Shift && shift == ShiftState.LOCKED) {
+            view.setBackgroundColor(
+                if (isDarkTheme) 0x40FFFFFF.toInt() else 0x33000000.toInt(),
+            )
+        }
+        return view
+    }
+
+    private fun buildRowParams(weight: Float): LayoutParams =
+        LayoutParams(0, LayoutParams.MATCH_PARENT, weight).apply {
+            setMargins(keyMargin, keyMargin, keyMargin, keyMargin)
+        }
+
+    private fun handleKey(key: Key) {
+        when (val kind = key.kind) {
+            is Kind.Char -> {
+                val outgoing = if (shift == ShiftState.OFF) kind.value else kind.value.uppercase()
+                sendKey("char:$outgoing", 0)
+                if (shift == ShiftState.ONE_SHOT) {
+                    shift = ShiftState.OFF
+                    rebuild()
+                }
+            }
+            is Kind.Named -> sendKey(kind.name, 0)
+            Kind.Shift -> handleShiftTap()
+            Kind.Backspace -> sendKey("backspace", 0)
+            Kind.Space -> sendKey("char: ", 0)
+            Kind.Enter -> sendKey("enter", 0)
+            is Kind.ToggleLayer -> {
+                layer = kind.target
+                shift = ShiftState.OFF
+                rebuild()
+            }
+        }
+    }
+
+    private fun handleShiftTap() {
+        val now = System.currentTimeMillis()
+        val isDoubleTap = now - lastShiftTapMs < 350
+        lastShiftTapMs = now
+
+        shift =
+            if (isDoubleTap) {
+                ShiftState.LOCKED
+            } else {
+                when (shift) {
+                    ShiftState.OFF -> ShiftState.ONE_SHOT
+                    ShiftState.ONE_SHOT -> ShiftState.OFF
+                    ShiftState.LOCKED -> ShiftState.OFF
+                }
+            }
+        rebuild()
+    }
+}

--- a/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
@@ -2,8 +2,6 @@ package dev.zedra.app
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.graphics.Canvas
-import android.graphics.Paint
 import android.os.Handler
 import android.os.Looper
 import android.view.Gravity
@@ -114,11 +112,6 @@ class FullKeyboardPanel(
     private val repeatInitialDelayMs = 350L
     private val repeatIntervalMs = 60L
     private val handler = Handler(Looper.getMainLooper())
-    private val topBorderPaint =
-        Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = 0x33FFFFFF
-            strokeWidth = density.coerceAtLeast(1f)
-        }
     private var repeatingKey: Pair<String, Int>? = null
     private var isDarkTheme = true
     private var armedMods: Int = 0
@@ -138,7 +131,9 @@ class FullKeyboardPanel(
     init {
         isFocusable = false
         isFocusableInTouchMode = false
-        setWillNotDraw(false)
+        // No top hairline: the accessory bar above already draws its own
+        // bottom edge, and a second separator reads as a divider between
+        // bar and panel rather than one continuous surface.
 
         rowsContainer =
             LinearLayout(context).apply {
@@ -167,15 +162,9 @@ class FullKeyboardPanel(
         applyTheme(isDark = true)
     }
 
-    override fun onDraw(canvas: Canvas) {
-        super.onDraw(canvas)
-        canvas.drawLine(0f, 0f, width.toFloat(), 0f, topBorderPaint)
-    }
-
     fun applyTheme(isDark: Boolean) {
         isDarkTheme = isDark
         setBackgroundColor(if (isDark) 0xF50E0C0C.toInt() else 0xF5FFFFFF.toInt())
-        topBorderPaint.color = if (isDark) 0x33FFFFFF else 0x22000000
         val foreground = if (isDark) 0xFFFFFFFF.toInt() else 0xFF1A1A1A.toInt()
         hostBadge.setTextColor(foreground)
         for ((view, key) in keyViews) {

--- a/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
@@ -71,8 +71,8 @@ class FullKeyboardPanel(
         listOf(
             Key("Esc", Kind.Dispatch("escape")),
             Key("Tab", Kind.Dispatch("tab")),
-            Key("⇧⇥", Kind.Dispatch("tab", AccessoryMods.SHIFT)),
             Key("⇧⏎", Kind.Dispatch("enter", AccessoryMods.SHIFT)),
+            Key("Shift", Kind.Modifier(AccessoryMods.SHIFT)),
             Key("Ctrl", Kind.Modifier(AccessoryMods.CTRL)),
             Key("⌃C", Kind.Dispatch("char:c", AccessoryMods.CTRL)),
             Key("⌃D", Kind.Dispatch("char:d", AccessoryMods.CTRL)),

--- a/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
@@ -2,45 +2,101 @@ package dev.zedra.app
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.view.Gravity
+import android.view.MotionEvent
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
 
 /**
- * In-app QWERTY panel that replaces the system soft keyboard while the user is
- * driving a terminal / agent session. Each tap is forwarded via the same wire
- * format as the accessory bar (`char:<c>`, named keys, mod bitmask).
+ * Desktop-only key panel that replaces the system IME while a terminal or
+ * agent session has focus. Carries only the keys / combos that the soft
+ * keyboard doesn't surface as a single tap. There is no QWERTY here — users
+ * tap `✕` and go back to the IME for prose typing, IME (Vietnamese / CJK),
+ * dictation, autocorrect, gesture typing.
  *
- * The panel is intended to be parked in the same screen slot the IME would
- * occupy, so the host should size it to the IME height it just hid.
+ * Every tap dispatches `(name, mods)` matching the accessory bar's wire
+ * format (`char:<c>` for single chars, named keys, Shift/Alt/Ctrl bitmask).
  */
 class FullKeyboardPanel(
     context: Context,
     private val sendKey: (String, Int) -> Unit,
 ) : LinearLayout(context) {
-    private enum class Layer { LETTERS, NUMBERS, SYMBOLS }
-
-    private enum class ShiftState { OFF, ONE_SHOT, LOCKED }
-
-    private sealed class Kind {
-        data class Char(val value: String) : Kind()
-        data class Named(val name: String) : Kind()
-        object Shift : Kind()
-        object Backspace : Kind()
-        object Space : Kind()
-        object Enter : Kind()
-        data class ToggleLayer(val target: Layer) : Kind()
+    private object AccessoryMods {
+        const val SHIFT = 0b001
+        const val ALT = 0b010
+        const val CTRL = 0b100
     }
 
-    private data class Key(val label: String, val kind: Kind, val weight: Float)
+    private sealed class Kind {
+        data class Dispatch(val name: String, val fixedMods: Int = 0) : Kind()
+        data class Modifier(val bit: Int) : Kind()
+    }
+
+    private data class Key(
+        val label: String,
+        val kind: Kind,
+        val repeats: Boolean = false,
+    )
+
+    private val symbolRow =
+        listOf(
+            Key("`", Kind.Dispatch("char:`")),
+            Key("~", Kind.Dispatch("char:~")),
+            Key("|", Kind.Dispatch("char:|")),
+            Key("\\", Kind.Dispatch("char:\\")),
+            Key("<", Kind.Dispatch("char:<")),
+            Key(">", Kind.Dispatch("char:>")),
+            Key("{", Kind.Dispatch("char:{")),
+            Key("}", Kind.Dispatch("char:}")),
+            Key("[", Kind.Dispatch("char:[")),
+            Key("]", Kind.Dispatch("char:]")),
+        )
+
+    private val navRow =
+        listOf(
+            Key("Home", Kind.Dispatch("home")),
+            Key("End", Kind.Dispatch("end")),
+            Key("PgUp", Kind.Dispatch("page_up"), repeats = true),
+            Key("PgDn", Kind.Dispatch("page_down"), repeats = true),
+            Key("←", Kind.Dispatch("left"), repeats = true),
+            Key("↓", Kind.Dispatch("down"), repeats = true),
+            Key("↑", Kind.Dispatch("up"), repeats = true),
+            Key("→", Kind.Dispatch("right"), repeats = true),
+        )
+
+    private val controlRow =
+        listOf(
+            Key("Esc", Kind.Dispatch("escape")),
+            Key("Tab", Kind.Dispatch("tab")),
+            Key("⇧⇥", Kind.Dispatch("tab", AccessoryMods.SHIFT)),
+            Key("⇧⏎", Kind.Dispatch("enter", AccessoryMods.SHIFT)),
+            Key("Ctrl", Kind.Modifier(AccessoryMods.CTRL)),
+            Key("⌃C", Kind.Dispatch("char:c", AccessoryMods.CTRL)),
+            Key("⌃D", Kind.Dispatch("char:d", AccessoryMods.CTRL)),
+            Key("⌃R", Kind.Dispatch("char:r", AccessoryMods.CTRL)),
+        )
 
     private val density = context.resources.displayMetrics.density
     private val keyMargin = (3 * density).toInt()
-    private var shift: ShiftState = ShiftState.OFF
-    private var layer: Layer = Layer.LETTERS
+    private val repeatInitialDelayMs = 350L
+    private val repeatIntervalMs = 60L
+    private val handler = Handler(Looper.getMainLooper())
+    private var repeatingKey: Pair<String, Int>? = null
     private var isDarkTheme = true
-    private var lastShiftTapMs = 0L
+    private var armedMods: Int = 0
+    private val keyViews = mutableListOf<Pair<View, Key>>()
+
+    private val repeatRunnable =
+        object : Runnable {
+            override fun run() {
+                val target = repeatingKey ?: return
+                sendKey(target.first, target.second)
+                handler.postDelayed(this, repeatIntervalMs)
+            }
+        }
 
     init {
         orientation = VERTICAL
@@ -48,168 +104,141 @@ class FullKeyboardPanel(
         isFocusable = false
         isFocusableInTouchMode = false
         applyTheme(isDark = true)
-        rebuild()
+        build()
     }
 
     fun applyTheme(isDark: Boolean) {
         isDarkTheme = isDark
         setBackgroundColor(if (isDark) 0xFF1E1E20.toInt() else 0xFFD1D3D8.toInt())
-        rebuild()
+        for ((view, key) in keyViews) {
+            applyKeyStyle(view, key)
+        }
     }
 
-    private fun rebuild() {
+    private fun build() {
         removeAllViews()
-        val rows = layoutFor(layer)
-        for (row in rows) {
+        keyViews.clear()
+        for (row in listOf(symbolRow, navRow, controlRow)) {
             val rowView =
                 LinearLayout(context).apply {
                     orientation = HORIZONTAL
                     setBaselineAligned(false)
                 }
             for (key in row) {
-                rowView.addView(makeButton(key), buildRowParams(key.weight))
+                val view = makeKeyView(key)
+                keyViews.add(view to key)
+                rowView.addView(
+                    view,
+                    LayoutParams(0, LayoutParams.MATCH_PARENT, 1f).apply {
+                        setMargins(keyMargin, keyMargin, keyMargin, keyMargin)
+                    },
+                )
             }
-            addView(
-                rowView,
-                LayoutParams(LayoutParams.MATCH_PARENT, 0, 1f),
-            )
+            addView(rowView, LayoutParams(LayoutParams.MATCH_PARENT, 0, 1f))
         }
     }
-
-    private fun layoutFor(layer: Layer): List<List<Key>> {
-        return when (layer) {
-            Layer.LETTERS -> {
-                val row1 = "qwertyuiop".map { Key(displayLetter(it.toString()), Kind.Char(it.toString()), 1f) }
-                val row2 = "asdfghjkl".map { Key(displayLetter(it.toString()), Kind.Char(it.toString()), 1f) }
-                val row3 = mutableListOf<Key>(Key(shiftLabel(), Kind.Shift, 1.5f))
-                row3.addAll("zxcvbnm".map { Key(displayLetter(it.toString()), Kind.Char(it.toString()), 1f) })
-                row3.add(Key("⌫", Kind.Backspace, 1.5f))
-                val row4 =
-                    listOf(
-                        Key("123", Kind.ToggleLayer(Layer.NUMBERS), 1.5f),
-                        Key("space", Kind.Space, 5f),
-                        Key("return", Kind.Enter, 2f),
-                    )
-                listOf(row1, row2, row3, row4)
-            }
-            Layer.NUMBERS -> {
-                val row1 = "1234567890".map { Key(it.toString(), Kind.Char(it.toString()), 1f) }
-                val row2 =
-                    listOf("-", "/", ":", ";", "(", ")", "$", "&", "@", "\"").map { Key(it, Kind.Char(it), 1f) }
-                val row3 = mutableListOf<Key>(Key("#+=", Kind.ToggleLayer(Layer.SYMBOLS), 1.5f))
-                row3.addAll(listOf(".", ",", "?", "!", "'").map { Key(it, Kind.Char(it), 1f) })
-                row3.add(Key("⌫", Kind.Backspace, 1.5f))
-                val row4 =
-                    listOf(
-                        Key("ABC", Kind.ToggleLayer(Layer.LETTERS), 1.5f),
-                        Key("space", Kind.Space, 5f),
-                        Key("return", Kind.Enter, 2f),
-                    )
-                listOf(row1, row2, row3, row4)
-            }
-            Layer.SYMBOLS -> {
-                val row1 =
-                    listOf("[", "]", "{", "}", "#", "%", "^", "*", "+", "=").map { Key(it, Kind.Char(it), 1f) }
-                val row2 =
-                    listOf("_", "\\", "|", "~", "<", ">", "€", "£", "¥", "•").map { Key(it, Kind.Char(it), 1f) }
-                val row3 = mutableListOf<Key>(Key("123", Kind.ToggleLayer(Layer.NUMBERS), 1.5f))
-                row3.addAll(listOf(".", ",", "?", "!", "'").map { Key(it, Kind.Char(it), 1f) })
-                row3.add(Key("⌫", Kind.Backspace, 1.5f))
-                val row4 =
-                    listOf(
-                        Key("ABC", Kind.ToggleLayer(Layer.LETTERS), 1.5f),
-                        Key("space", Kind.Space, 5f),
-                        Key("return", Kind.Enter, 2f),
-                    )
-                listOf(row1, row2, row3, row4)
-            }
-        }
-    }
-
-    private fun displayLetter(c: String): String = if (shift == ShiftState.OFF) c else c.uppercase()
-
-    private fun shiftLabel(): String =
-        when (shift) {
-            ShiftState.OFF -> "⇧"
-            ShiftState.ONE_SHOT -> "⬆"
-            ShiftState.LOCKED -> "⇪"
-        }
 
     @SuppressLint("ClickableViewAccessibility")
-    private fun makeButton(key: Key): View {
-        val isSpecial =
-            when (key.kind) {
-                is Kind.Char -> false
-                else -> true
-            }
-        val foreground = if (isDarkTheme) 0xFFFFFFFF.toInt() else 0xFF101015.toInt()
-        val baseBg =
-            if (isDarkTheme) {
-                if (isSpecial) 0xFF333339.toInt() else 0xFF4A4A52.toInt()
-            } else {
-                if (isSpecial) 0xFFA6A8AE.toInt() else 0xFFFFFFFF.toInt()
-            }
+    private fun makeKeyView(key: Key): View {
         val view =
             TextView(context).apply {
                 text = key.label
                 textSize = 16f
                 gravity = Gravity.CENTER
-                setTextColor(foreground)
-                setBackgroundColor(baseBg)
                 isClickable = true
-                setOnClickListener { handleKey(key) }
+                isFocusable = false
             }
-        if (key.kind is Kind.Shift && shift == ShiftState.LOCKED) {
-            view.setBackgroundColor(
-                if (isDarkTheme) 0x40FFFFFF.toInt() else 0x33000000.toInt(),
-            )
+        applyKeyStyle(view, key)
+        view.setOnTouchListener { _, event ->
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> {
+                    if (key.repeats && key.kind is Kind.Dispatch) {
+                        val combined = armedMods or key.kind.fixedMods
+                        sendKey(key.kind.name, combined)
+                        if (armedMods != 0) {
+                            armedMods = 0
+                            refreshModifierHighlights()
+                        }
+                        startRepeating(key.kind.name, combined)
+                    }
+                    true
+                }
+                MotionEvent.ACTION_UP -> {
+                    if (key.repeats) {
+                        stopRepeating()
+                    } else {
+                        handleKey(key)
+                    }
+                    true
+                }
+                MotionEvent.ACTION_CANCEL, MotionEvent.ACTION_OUTSIDE -> {
+                    stopRepeating()
+                    true
+                }
+                else -> false
+            }
         }
         return view
     }
 
-    private fun buildRowParams(weight: Float): LayoutParams =
-        LayoutParams(0, LayoutParams.MATCH_PARENT, weight).apply {
-            setMargins(keyMargin, keyMargin, keyMargin, keyMargin)
+    private fun applyKeyStyle(view: View, key: Key) {
+        val isModifier = key.kind is Kind.Modifier
+        val foreground = if (isDarkTheme) 0xFFFFFFFF.toInt() else 0xFF101015.toInt()
+        val baseBg =
+            if (isDarkTheme) {
+                if (isModifier) 0xFF333339.toInt() else 0xFF4A4A52.toInt()
+            } else {
+                if (isModifier) 0xFFA6A8AE.toInt() else 0xFFFFFFFF.toInt()
+            }
+        val highlight = if (isDarkTheme) 0x40FFFFFF.toInt() else 0x33000000.toInt()
+        val bg =
+            if (key.kind is Kind.Modifier && (armedMods and key.kind.bit) != 0) {
+                highlight
+            } else {
+                baseBg
+            }
+        view.setBackgroundColor(bg)
+        if (view is TextView) {
+            view.setTextColor(foreground)
         }
+    }
+
+    private fun refreshModifierHighlights() {
+        for ((view, key) in keyViews) {
+            applyKeyStyle(view, key)
+        }
+    }
 
     private fun handleKey(key: Key) {
         when (val kind = key.kind) {
-            is Kind.Char -> {
-                val outgoing = if (shift == ShiftState.OFF) kind.value else kind.value.uppercase()
-                sendKey("char:$outgoing", 0)
-                if (shift == ShiftState.ONE_SHOT) {
-                    shift = ShiftState.OFF
-                    rebuild()
+            is Kind.Dispatch -> {
+                val combined = armedMods or kind.fixedMods
+                sendKey(kind.name, combined)
+                if (armedMods != 0) {
+                    armedMods = 0
+                    refreshModifierHighlights()
                 }
             }
-            is Kind.Named -> sendKey(kind.name, 0)
-            Kind.Shift -> handleShiftTap()
-            Kind.Backspace -> sendKey("backspace", 0)
-            Kind.Space -> sendKey("char: ", 0)
-            Kind.Enter -> sendKey("enter", 0)
-            is Kind.ToggleLayer -> {
-                layer = kind.target
-                shift = ShiftState.OFF
-                rebuild()
+            is Kind.Modifier -> {
+                armedMods = armedMods xor kind.bit
+                refreshModifierHighlights()
             }
         }
     }
 
-    private fun handleShiftTap() {
-        val now = System.currentTimeMillis()
-        val isDoubleTap = now - lastShiftTapMs < 350
-        lastShiftTapMs = now
+    private fun startRepeating(name: String, mods: Int) {
+        stopRepeating()
+        repeatingKey = name to mods
+        handler.postDelayed(repeatRunnable, repeatInitialDelayMs)
+    }
 
-        shift =
-            if (isDoubleTap) {
-                ShiftState.LOCKED
-            } else {
-                when (shift) {
-                    ShiftState.OFF -> ShiftState.ONE_SHOT
-                    ShiftState.ONE_SHOT -> ShiftState.OFF
-                    ShiftState.LOCKED -> ShiftState.OFF
-                }
-            }
-        rebuild()
+    fun stopRepeating() {
+        repeatingKey = null
+        handler.removeCallbacks(repeatRunnable)
+    }
+
+    override fun onDetachedFromWindow() {
+        stopRepeating()
+        super.onDetachedFromWindow()
     }
 }

--- a/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
@@ -32,23 +32,30 @@ enum class HostOs(val displayName: String) {
 
 /**
  * Desktop-only key panel that replaces the system IME while a terminal or
- * agent session has focus. Carries only the keys / combos that the soft
- * keyboard doesn't surface as a single tap. There is no QWERTY here — users
- * tap `✕` and go back to the IME for prose typing, IME (Vietnamese / CJK),
- * dictation, autocorrect, gesture typing.
+ * agent session has focus. Layout mirrors `FullKeyboardView` on iOS:
  *
- * Every tap dispatches `(name, mods)` matching the accessory bar's wire
- * format (`char:<c>` for single chars, named keys, Shift/Alt/Ctrl bitmask).
+ *   Row 1 (chips):  shift  Ctrl  Cmd  Home  End  PgUp  PgD  ⌫
+ *   Row 2 (flat):   ~  @  $  *  ^  %  =  `
+ *   Row 3 (flat):   <  >  (  )  {  }  [  ]
+ *   The lower ~40% of the panel is intentionally left blank for future
+ *   additions (clipboard, snippets, agent macros).
+ *
+ * `✕` on the accessory bar hands focus back to the IME for prose typing.
  */
 class FullKeyboardPanel(
     context: Context,
-    private val hostOs: HostOs,
+    @Suppress("unused") private val hostOs: HostOs,
     private val sendKey: (String, Int) -> Unit,
 ) : LinearLayout(context) {
     private object AccessoryMods {
-        const val SHIFT = 0b001
-        const val ALT = 0b010
-        const val CTRL = 0b100
+        const val SHIFT = 0b0001
+        const val ALT = 0b0010
+        const val CTRL = 0b0100
+
+        // Cmd / Super — tracked for UI armed state; legacy terminal encoder
+        // drops the bit because no PTY byte representation exists. Reserved
+        // for routing via a future host-side RPC.
+        const val CMD = 0b1000
     }
 
     private sealed class Kind {
@@ -56,52 +63,54 @@ class FullKeyboardPanel(
         data class Modifier(val bit: Int) : Kind()
     }
 
+    private enum class Style { CHIP, FLAT }
+
     private data class Key(
         val label: String,
         val kind: Kind,
+        val style: Style,
         val repeats: Boolean = false,
     )
 
-    private val symbolRow =
+    private val chipRow =
         listOf(
-            Key("`", Kind.Dispatch("char:`")),
-            Key("~", Kind.Dispatch("char:~")),
-            Key("|", Kind.Dispatch("char:|")),
-            Key("\\", Kind.Dispatch("char:\\")),
-            Key("<", Kind.Dispatch("char:<")),
-            Key(">", Kind.Dispatch("char:>")),
-            Key("{", Kind.Dispatch("char:{")),
-            Key("}", Kind.Dispatch("char:}")),
-            Key("[", Kind.Dispatch("char:[")),
-            Key("]", Kind.Dispatch("char:]")),
+            Key("shift", Kind.Modifier(AccessoryMods.SHIFT), Style.CHIP),
+            Key("Ctrl", Kind.Modifier(AccessoryMods.CTRL), Style.CHIP),
+            Key("Cmd", Kind.Modifier(AccessoryMods.CMD), Style.CHIP),
+            Key("Home", Kind.Dispatch("home"), Style.CHIP),
+            Key("End", Kind.Dispatch("end"), Style.CHIP),
+            Key("PgUp", Kind.Dispatch("page_up"), Style.CHIP, repeats = true),
+            Key("PgD", Kind.Dispatch("page_down"), Style.CHIP, repeats = true),
+            Key("⌫", Kind.Dispatch("backspace"), Style.CHIP, repeats = true),
         )
 
-    private val navRow =
+    private val symbolRow1 =
         listOf(
-            Key("Home", Kind.Dispatch("home")),
-            Key("End", Kind.Dispatch("end")),
-            Key("PgUp", Kind.Dispatch("page_up"), repeats = true),
-            Key("PgDn", Kind.Dispatch("page_down"), repeats = true),
-            Key("←", Kind.Dispatch("left"), repeats = true),
-            Key("↓", Kind.Dispatch("down"), repeats = true),
-            Key("↑", Kind.Dispatch("up"), repeats = true),
-            Key("→", Kind.Dispatch("right"), repeats = true),
+            Key("~", Kind.Dispatch("char:~"), Style.FLAT),
+            Key("@", Kind.Dispatch("char:@"), Style.FLAT),
+            Key("$", Kind.Dispatch("char:$"), Style.FLAT),
+            Key("*", Kind.Dispatch("char:*"), Style.FLAT),
+            Key("^", Kind.Dispatch("char:^"), Style.FLAT),
+            Key("%", Kind.Dispatch("char:%"), Style.FLAT),
+            Key("=", Kind.Dispatch("char:="), Style.FLAT),
+            Key("`", Kind.Dispatch("char:`"), Style.FLAT),
         )
 
-    private val controlRow =
+    private val symbolRow2 =
         listOf(
-            Key("Esc", Kind.Dispatch("escape")),
-            Key("Tab", Kind.Dispatch("tab")),
-            Key("⇧⏎", Kind.Dispatch("enter", AccessoryMods.SHIFT)),
-            Key("Shift", Kind.Modifier(AccessoryMods.SHIFT)),
-            Key("Ctrl", Kind.Modifier(AccessoryMods.CTRL)),
-            Key("⌃C", Kind.Dispatch("char:c", AccessoryMods.CTRL)),
-            Key("⌃D", Kind.Dispatch("char:d", AccessoryMods.CTRL)),
-            Key("⌃R", Kind.Dispatch("char:r", AccessoryMods.CTRL)),
+            Key("<", Kind.Dispatch("char:<"), Style.FLAT),
+            Key(">", Kind.Dispatch("char:>"), Style.FLAT),
+            Key("(", Kind.Dispatch("char:("), Style.FLAT),
+            Key(")", Kind.Dispatch("char:)"), Style.FLAT),
+            Key("{", Kind.Dispatch("char:{"), Style.FLAT),
+            Key("}", Kind.Dispatch("char:}"), Style.FLAT),
+            Key("[", Kind.Dispatch("char:["), Style.FLAT),
+            Key("]", Kind.Dispatch("char:]"), Style.FLAT),
         )
 
     private val density = context.resources.displayMetrics.density
     private val keyMargin = (3 * density).toInt()
+    private val rowGapPx = (4 * density).toInt()
     private val repeatInitialDelayMs = 350L
     private val repeatIntervalMs = 60L
     private val handler = Handler(Looper.getMainLooper())
@@ -130,7 +139,7 @@ class FullKeyboardPanel(
 
     fun applyTheme(isDark: Boolean) {
         isDarkTheme = isDark
-        setBackgroundColor(if (isDark) 0xFF1E1E20.toInt() else 0xFFD1D3D8.toInt())
+        setBackgroundColor(if (isDark) 0xFF14141A.toInt() else 0xFFD1D3D8.toInt())
         for ((view, key) in keyViews) {
             applyKeyStyle(view, key)
         }
@@ -139,7 +148,8 @@ class FullKeyboardPanel(
     private fun build() {
         removeAllViews()
         keyViews.clear()
-        for (row in listOf(symbolRow, navRow, controlRow)) {
+
+        for (row in listOf(chipRow, symbolRow1, symbolRow2)) {
             val rowView =
                 LinearLayout(context).apply {
                     orientation = HORIZONTAL
@@ -157,6 +167,10 @@ class FullKeyboardPanel(
             }
             addView(rowView, LayoutParams(LayoutParams.MATCH_PARENT, 0, 1f))
         }
+
+        // Reserve the bottom area for future content. A 2-weight blank view
+        // pushes the key rows up so they occupy roughly the top 60%.
+        addView(View(context), LayoutParams(LayoutParams.MATCH_PARENT, 0, 2f))
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -164,7 +178,7 @@ class FullKeyboardPanel(
         val view =
             TextView(context).apply {
                 text = key.label
-                textSize = 16f
+                textSize = if (key.style == Style.CHIP) 14f else 20f
                 gravity = Gravity.CENTER
                 isClickable = true
                 isFocusable = false
@@ -203,24 +217,23 @@ class FullKeyboardPanel(
     }
 
     private fun applyKeyStyle(view: View, key: Key) {
-        val isModifier = key.kind is Kind.Modifier
         val foreground = if (isDarkTheme) 0xFFFFFFFF.toInt() else 0xFF101015.toInt()
-        val baseBg =
-            if (isDarkTheme) {
-                if (isModifier) 0xFF333339.toInt() else 0xFF4A4A52.toInt()
-            } else {
-                if (isModifier) 0xFFA6A8AE.toInt() else 0xFFFFFFFF.toInt()
-            }
-        val highlight = if (isDarkTheme) 0x40FFFFFF.toInt() else 0x33000000.toInt()
-        val bg =
-            if (key.kind is Kind.Modifier && (armedMods and key.kind.bit) != 0) {
-                highlight
-            } else {
-                baseBg
-            }
-        view.setBackgroundColor(bg)
         if (view is TextView) {
             view.setTextColor(foreground)
+        }
+        when (key.style) {
+            Style.CHIP -> {
+                val base = if (isDarkTheme) 0xFF4A4A52.toInt() else 0xFFA6A8AE.toInt()
+                val armed = if (isDarkTheme) 0x47FFFFFF.toInt() else 0x38000000.toInt()
+                val bg =
+                    if (key.kind is Kind.Modifier && (armedMods and key.kind.bit) != 0) {
+                        armed
+                    } else {
+                        base
+                    }
+                view.setBackgroundColor(bg)
+            }
+            Style.FLAT -> view.setBackgroundColor(0x00000000)
         }
     }
 

--- a/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
@@ -2,11 +2,14 @@ package dev.zedra.app
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
 import android.os.Handler
 import android.os.Looper
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
+import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
 
@@ -32,21 +35,22 @@ enum class HostOs(val displayName: String) {
 
 /**
  * Desktop-only key panel that replaces the system IME while a terminal or
- * agent session has focus. Layout mirrors `FullKeyboardView` on iOS:
+ * agent session has focus. Visual chrome (background, foreground, border,
+ * font size, row height) mirrors `KeyboardAccessoryBar` so the panel reads
+ * as a natural extension of the bar above it. The mock drives only the key
+ * set and their position.
  *
- *   Row 1 (chips):  shift  Ctrl  Cmd  Home  End  PgUp  PgD  ⌫
- *   Row 2 (flat):   ~  @  $  *  ^  %  =  `
- *   Row 3 (flat):   <  >  (  )  {  }  [  ]
+ *   Row 1: shift  Ctrl  Cmd   Home  End  PgUp  PgD   ⌫
+ *   Row 2: ~  @  $  *  ^  %  =  `
+ *   Row 3: <  >  (  )  {  }  [  ]
  *   The lower ~40% of the panel is intentionally left blank for future
  *   additions (clipboard, snippets, agent macros).
- *
- * `✕` on the accessory bar hands focus back to the IME for prose typing.
  */
 class FullKeyboardPanel(
     context: Context,
     @Suppress("unused") private val hostOs: HostOs,
     private val sendKey: (String, Int) -> Unit,
-) : LinearLayout(context) {
+) : FrameLayout(context) {
     private object AccessoryMods {
         const val SHIFT = 0b0001
         const val ALT = 0b0010
@@ -63,61 +67,64 @@ class FullKeyboardPanel(
         data class Modifier(val bit: Int) : Kind()
     }
 
-    private enum class Style { CHIP, FLAT }
-
     private data class Key(
         val label: String,
         val kind: Kind,
-        val style: Style,
         val repeats: Boolean = false,
     )
 
-    private val chipRow =
+    private val modNavRow =
         listOf(
-            Key("shift", Kind.Modifier(AccessoryMods.SHIFT), Style.CHIP),
-            Key("Ctrl", Kind.Modifier(AccessoryMods.CTRL), Style.CHIP),
-            Key("Cmd", Kind.Modifier(AccessoryMods.CMD), Style.CHIP),
-            Key("Home", Kind.Dispatch("home"), Style.CHIP),
-            Key("End", Kind.Dispatch("end"), Style.CHIP),
-            Key("PgUp", Kind.Dispatch("page_up"), Style.CHIP, repeats = true),
-            Key("PgD", Kind.Dispatch("page_down"), Style.CHIP, repeats = true),
-            Key("⌫", Kind.Dispatch("backspace"), Style.CHIP, repeats = true),
+            Key("shift", Kind.Modifier(AccessoryMods.SHIFT)),
+            Key("Ctrl", Kind.Modifier(AccessoryMods.CTRL)),
+            Key("Cmd", Kind.Modifier(AccessoryMods.CMD)),
+            Key("Home", Kind.Dispatch("home")),
+            Key("End", Kind.Dispatch("end")),
+            Key("PgUp", Kind.Dispatch("page_up"), repeats = true),
+            Key("PgD", Kind.Dispatch("page_down"), repeats = true),
+            Key("⌫", Kind.Dispatch("backspace"), repeats = true),
         )
 
     private val symbolRow1 =
         listOf(
-            Key("~", Kind.Dispatch("char:~"), Style.FLAT),
-            Key("@", Kind.Dispatch("char:@"), Style.FLAT),
-            Key("$", Kind.Dispatch("char:$"), Style.FLAT),
-            Key("*", Kind.Dispatch("char:*"), Style.FLAT),
-            Key("^", Kind.Dispatch("char:^"), Style.FLAT),
-            Key("%", Kind.Dispatch("char:%"), Style.FLAT),
-            Key("=", Kind.Dispatch("char:="), Style.FLAT),
-            Key("`", Kind.Dispatch("char:`"), Style.FLAT),
+            Key("~", Kind.Dispatch("char:~")),
+            Key("@", Kind.Dispatch("char:@")),
+            Key("$", Kind.Dispatch("char:$")),
+            Key("*", Kind.Dispatch("char:*")),
+            Key("^", Kind.Dispatch("char:^")),
+            Key("%", Kind.Dispatch("char:%")),
+            Key("=", Kind.Dispatch("char:=")),
+            Key("`", Kind.Dispatch("char:`")),
         )
 
     private val symbolRow2 =
         listOf(
-            Key("<", Kind.Dispatch("char:<"), Style.FLAT),
-            Key(">", Kind.Dispatch("char:>"), Style.FLAT),
-            Key("(", Kind.Dispatch("char:("), Style.FLAT),
-            Key(")", Kind.Dispatch("char:)"), Style.FLAT),
-            Key("{", Kind.Dispatch("char:{"), Style.FLAT),
-            Key("}", Kind.Dispatch("char:}"), Style.FLAT),
-            Key("[", Kind.Dispatch("char:["), Style.FLAT),
-            Key("]", Kind.Dispatch("char:]"), Style.FLAT),
+            Key("<", Kind.Dispatch("char:<")),
+            Key(">", Kind.Dispatch("char:>")),
+            Key("(", Kind.Dispatch("char:(")),
+            Key(")", Kind.Dispatch("char:)")),
+            Key("{", Kind.Dispatch("char:{")),
+            Key("}", Kind.Dispatch("char:}")),
+            Key("[", Kind.Dispatch("char:[")),
+            Key("]", Kind.Dispatch("char:]")),
         )
 
     private val density = context.resources.displayMetrics.density
-    private val keyMargin = (3 * density).toInt()
-    private val rowGapPx = (4 * density).toInt()
+    private val rowHeightPx = (44 * density).toInt()
+    private val keyGapPx = (2 * density).toInt()
     private val repeatInitialDelayMs = 350L
     private val repeatIntervalMs = 60L
     private val handler = Handler(Looper.getMainLooper())
+    private val topBorderPaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0x33FFFFFF
+            strokeWidth = density.coerceAtLeast(1f)
+        }
     private var repeatingKey: Pair<String, Int>? = null
     private var isDarkTheme = true
     private var armedMods: Int = 0
     private val keyViews = mutableListOf<Pair<View, Key>>()
+    private val rowsContainer: LinearLayout
 
     private val repeatRunnable =
         object : Runnable {
@@ -129,30 +136,47 @@ class FullKeyboardPanel(
         }
 
     init {
-        orientation = VERTICAL
-        setBaselineAligned(false)
         isFocusable = false
         isFocusableInTouchMode = false
-        applyTheme(isDark = true)
+        setWillNotDraw(false)
+
+        rowsContainer =
+            LinearLayout(context).apply {
+                orientation = LinearLayout.VERTICAL
+                setBaselineAligned(false)
+            }
+        addView(
+            rowsContainer,
+            LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, Gravity.TOP),
+        )
+
         build()
+        applyTheme(isDark = true)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        canvas.drawLine(0f, 0f, width.toFloat(), 0f, topBorderPaint)
     }
 
     fun applyTheme(isDark: Boolean) {
         isDarkTheme = isDark
-        setBackgroundColor(if (isDark) 0xFF14141A.toInt() else 0xFFD1D3D8.toInt())
+        setBackgroundColor(if (isDark) 0xF50E0C0C.toInt() else 0xF5FFFFFF.toInt())
+        topBorderPaint.color = if (isDark) 0x33FFFFFF else 0x22000000
         for ((view, key) in keyViews) {
             applyKeyStyle(view, key)
         }
+        invalidate()
     }
 
     private fun build() {
-        removeAllViews()
+        rowsContainer.removeAllViews()
         keyViews.clear()
 
-        for (row in listOf(chipRow, symbolRow1, symbolRow2)) {
+        for (row in listOf(modNavRow, symbolRow1, symbolRow2)) {
             val rowView =
                 LinearLayout(context).apply {
-                    orientation = HORIZONTAL
+                    orientation = LinearLayout.HORIZONTAL
                     setBaselineAligned(false)
                 }
             for (key in row) {
@@ -160,17 +184,16 @@ class FullKeyboardPanel(
                 keyViews.add(view to key)
                 rowView.addView(
                     view,
-                    LayoutParams(0, LayoutParams.MATCH_PARENT, 1f).apply {
-                        setMargins(keyMargin, keyMargin, keyMargin, keyMargin)
+                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f).apply {
+                        setMargins(keyGapPx, 0, keyGapPx, 0)
                     },
                 )
             }
-            addView(rowView, LayoutParams(LayoutParams.MATCH_PARENT, 0, 1f))
+            rowsContainer.addView(
+                rowView,
+                LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, rowHeightPx),
+            )
         }
-
-        // Reserve the bottom area for future content. A 2-weight blank view
-        // pushes the key rows up so they occupy roughly the top 60%.
-        addView(View(context), LayoutParams(LayoutParams.MATCH_PARENT, 0, 2f))
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -178,7 +201,7 @@ class FullKeyboardPanel(
         val view =
             TextView(context).apply {
                 text = key.label
-                textSize = if (key.style == Style.CHIP) 14f else 20f
+                textSize = 16f
                 gravity = Gravity.CENTER
                 isClickable = true
                 isFocusable = false
@@ -217,24 +240,18 @@ class FullKeyboardPanel(
     }
 
     private fun applyKeyStyle(view: View, key: Key) {
-        val foreground = if (isDarkTheme) 0xFFFFFFFF.toInt() else 0xFF101015.toInt()
+        val foreground = if (isDarkTheme) 0xFFFFFFFF.toInt() else 0xFF1A1A1A.toInt()
         if (view is TextView) {
             view.setTextColor(foreground)
         }
-        when (key.style) {
-            Style.CHIP -> {
-                val base = if (isDarkTheme) 0xFF4A4A52.toInt() else 0xFFA6A8AE.toInt()
-                val armed = if (isDarkTheme) 0x47FFFFFF.toInt() else 0x38000000.toInt()
-                val bg =
-                    if (key.kind is Kind.Modifier && (armedMods and key.kind.bit) != 0) {
-                        armed
-                    } else {
-                        base
-                    }
-                view.setBackgroundColor(bg)
+        val armed = if (isDarkTheme) 0x2EFFFFFF.toInt() else 0x1F000000.toInt()
+        val bg =
+            if (key.kind is Kind.Modifier && (armedMods and key.kind.bit) != 0) {
+                armed
+            } else {
+                0x00000000
             }
-            Style.FLAT -> view.setBackgroundColor(0x00000000)
-        }
+        view.setBackgroundColor(bg)
     }
 
     private fun refreshModifierHighlights() {

--- a/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/FullKeyboardPanel.kt
@@ -11,6 +11,26 @@ import android.widget.LinearLayout
 import android.widget.TextView
 
 /**
+ * Host OS reported by `MainActivity.nativeActiveHostOs`. Matches Rust
+ * `key_encoding::HostOs`. `Unknown` is treated as macOS per product direction.
+ */
+enum class HostOs(val displayName: String) {
+    MacOs("macOS"),
+    Linux("Linux"),
+    Windows("Windows"),
+    ;
+
+    companion object {
+        fun fromU8(value: Int): HostOs =
+            when (value) {
+                2 -> Linux
+                3 -> Windows
+                else -> MacOs
+            }
+    }
+}
+
+/**
  * Desktop-only key panel that replaces the system IME while a terminal or
  * agent session has focus. Carries only the keys / combos that the soft
  * keyboard doesn't surface as a single tap. There is no QWERTY here — users
@@ -22,6 +42,7 @@ import android.widget.TextView
  */
 class FullKeyboardPanel(
     context: Context,
+    private val hostOs: HostOs,
     private val sendKey: (String, Int) -> Unit,
 ) : LinearLayout(context) {
     private object AccessoryMods {

--- a/android/app/src/main/kotlin/dev/zedra/app/KeyboardAccessoryBar.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/KeyboardAccessoryBar.kt
@@ -12,16 +12,60 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 
+/**
+ * Modifier bitmask matching Rust `key_encoding::Mods`
+ * (shift = bit 0, alt = bit 1, ctrl = bit 2).
+ */
+private object AccessoryMods {
+    const val NONE = 0
+    const val SHIFT = 0b001
+    const val ALT = 0b010
+    const val CTRL = 0b100
+}
+
 class KeyboardAccessoryBar(
     context: Context,
-    private val sendKey: (String) -> Unit,
+    private val sendKey: (String, Int) -> Unit,
 ) : LinearLayout(context) {
+    private sealed class Kind {
+        data class Key(val name: String, val fixedMods: Int = 0) : Kind()
+        data class Modifier(val bit: Int) : Kind()
+        object ToggleDetail : Kind()
+    }
+
     private data class KeySpec(
         val label: String,
-        val key: String,
+        val kind: Kind,
         val repeats: Boolean,
         val iconRes: Int? = null,
     )
+
+    private val primarySpecs =
+        listOf(
+            KeySpec("Esc", Kind.Key("escape"), false),
+            KeySpec("Tab", Kind.Key("tab"), false),
+            KeySpec("←", Kind.Key("left"), true, R.drawable.ic_key_arrow_left),
+            KeySpec("↓", Kind.Key("down"), true, R.drawable.ic_key_arrow_down),
+            KeySpec("↑", Kind.Key("up"), true, R.drawable.ic_key_arrow_up),
+            KeySpec("→", Kind.Key("right"), true, R.drawable.ic_key_arrow_right),
+            KeySpec("⏎", Kind.Key("enter"), false, R.drawable.ic_key_return),
+            KeySpec("•••", Kind.ToggleDetail, false),
+        )
+
+    private val detailSpecs =
+        listOf(
+            KeySpec("Ctrl", Kind.Modifier(AccessoryMods.CTRL), false),
+            KeySpec("Alt", Kind.Modifier(AccessoryMods.ALT), false),
+            KeySpec("Shift", Kind.Modifier(AccessoryMods.SHIFT), false),
+            KeySpec("⇧⇥", Kind.Key("tab", AccessoryMods.SHIFT), false),
+            KeySpec("⌃C", Kind.Key("char:c", AccessoryMods.CTRL), false),
+            KeySpec("⌃D", Kind.Key("char:d", AccessoryMods.CTRL), false),
+            KeySpec("⌃R", Kind.Key("char:r", AccessoryMods.CTRL), false),
+            KeySpec("Home", Kind.Key("home"), false),
+            KeySpec("End", Kind.Key("end"), false),
+            KeySpec("PgUp", Kind.Key("page_up"), true),
+            KeySpec("PgDn", Kind.Key("page_down"), true),
+        )
 
     private val topBorderPaint =
         Paint(Paint.ANTI_ALIAS_FLAG).apply {
@@ -29,45 +73,55 @@ class KeyboardAccessoryBar(
             strokeWidth = context.resources.displayMetrics.density.coerceAtLeast(1f)
         }
 
-    private val keySpecs =
-        listOf(
-            KeySpec("Esc", "escape", false),
-            KeySpec("Tab", "tab", false),
-            KeySpec("←", "left", true, R.drawable.ic_key_arrow_left),
-            KeySpec("↓", "down", true, R.drawable.ic_key_arrow_down),
-            KeySpec("↑", "up", true, R.drawable.ic_key_arrow_up),
-            KeySpec("→", "right", true, R.drawable.ic_key_arrow_right),
-            KeySpec("⏎", "enter", false, R.drawable.ic_key_return),
-        )
-
+    private val rowHeightPx = (44 * context.resources.displayMetrics.density).toInt()
     private val repeatInitialDelayMs = 350L
     private val repeatIntervalMs = 60L
     private val handler = Handler(Looper.getMainLooper())
-    private var repeatingKey: String? = null
+    private var repeatingKey: Pair<String, Int>? = null
     private var isDarkTheme = true
+    private var detailExpanded = false
+    private var armedMods = 0
+    private val primaryRow: LinearLayout
+    private val detailRow: LinearLayout
+    private val primaryButtons = mutableListOf<Pair<View, KeySpec>>()
+    private val detailButtons = mutableListOf<Pair<View, KeySpec>>()
+
+    /** Notified whenever the bar's measured height changes (collapse/expand). */
+    var onHeightChanged: ((Int) -> Unit)? = null
 
     private val repeatRunnable =
         object : Runnable {
             override fun run() {
-                val key = repeatingKey ?: return
-                sendKey(key)
+                val target = repeatingKey ?: return
+                sendKey(target.first, target.second)
                 handler.postDelayed(this, repeatIntervalMs)
             }
         }
 
     init {
-        orientation = HORIZONTAL
+        orientation = VERTICAL
         setBaselineAligned(false)
         isFocusable = false
         isFocusableInTouchMode = false
         setWillNotDraw(false)
-        applyTheme(isDark = true)
         visibility = GONE
 
-        keySpecs.forEach { spec ->
-            addView(makeButton(spec), LayoutParams(0, LayoutParams.MATCH_PARENT, 1f))
-        }
+        primaryRow = buildRow(primarySpecs, primaryButtons)
+        detailRow =
+            buildRow(detailSpecs, detailButtons).apply {
+                visibility = GONE
+            }
+
+        addView(primaryRow, LayoutParams(LayoutParams.MATCH_PARENT, rowHeightPx))
+        addView(detailRow, LayoutParams(LayoutParams.MATCH_PARENT, rowHeightPx))
+
+        applyTheme(isDark = true)
+        refreshModifierHighlights()
     }
+
+    /** Total height the bar wants, used by the host to size its layout slot. */
+    val currentHeightPx: Int
+        get() = if (detailExpanded) rowHeightPx * 2 else rowHeightPx
 
     override fun onDetachedFromWindow() {
         stopRepeating()
@@ -86,16 +140,34 @@ class KeyboardAccessoryBar(
 
     fun applyTheme(isDark: Boolean) {
         isDarkTheme = isDark
-        val foreground = if (isDark) 0xFFFFFFFF.toInt() else 0xFF1A1A1A.toInt()
         setBackgroundColor(if (isDark) 0xF50E0C0C.toInt() else 0xF5FFFFFF.toInt())
         topBorderPaint.color = if (isDark) 0x33FFFFFF else 0x22000000
-        for (index in 0 until childCount) {
-            when (val child = getChildAt(index)) {
-                is ImageView -> child.imageTintList = android.content.res.ColorStateList.valueOf(foreground)
-                is TextView -> child.setTextColor(foreground)
+        val foreground = if (isDark) 0xFFFFFFFF.toInt() else 0xFF1A1A1A.toInt()
+        for ((view, _) in primaryButtons + detailButtons) {
+            when (view) {
+                is ImageView -> view.imageTintList = android.content.res.ColorStateList.valueOf(foreground)
+                is TextView -> view.setTextColor(foreground)
             }
         }
         invalidate()
+        refreshModifierHighlights()
+    }
+
+    private fun buildRow(
+        specs: List<KeySpec>,
+        sink: MutableList<Pair<View, KeySpec>>,
+    ): LinearLayout {
+        val row =
+            LinearLayout(context).apply {
+                orientation = HORIZONTAL
+                setBaselineAligned(false)
+            }
+        specs.forEach { spec ->
+            val view = makeButton(spec)
+            sink.add(view to spec)
+            row.addView(view, LayoutParams(0, LayoutParams.MATCH_PARENT, 1f))
+        }
+        return row
     }
 
     private fun makeButton(spec: KeySpec): View {
@@ -116,16 +188,20 @@ class KeyboardAccessoryBar(
                     setTextColor(foreground)
                 }
             }
-
         view.isClickable = true
         view.isFocusable = false
         view.isFocusableInTouchMode = false
         view.setOnTouchListener { _, event ->
             when (event.actionMasked) {
                 MotionEvent.ACTION_DOWN -> {
-                    if (spec.repeats) {
-                        sendKey(spec.key)
-                        startRepeating(spec.key)
+                    if (spec.repeats && spec.kind is Kind.Key) {
+                        val combined = armedMods or spec.kind.fixedMods
+                        sendKey(spec.kind.name, combined)
+                        if (armedMods != 0) {
+                            armedMods = 0
+                            refreshModifierHighlights()
+                        }
+                        startRepeating(spec.kind.name, combined)
                     }
                     true
                 }
@@ -133,12 +209,13 @@ class KeyboardAccessoryBar(
                     if (spec.repeats) {
                         stopRepeating()
                     } else {
-                        sendKey(spec.key)
+                        handleSpec(spec)
                     }
                     true
                 }
                 MotionEvent.ACTION_CANCEL,
-                MotionEvent.ACTION_OUTSIDE -> {
+                MotionEvent.ACTION_OUTSIDE,
+                -> {
                     stopRepeating()
                     true
                 }
@@ -148,9 +225,63 @@ class KeyboardAccessoryBar(
         return view
     }
 
-    private fun startRepeating(key: String) {
+    private fun handleSpec(spec: KeySpec) {
+        when (val kind = spec.kind) {
+            Kind.ToggleDetail -> setDetailExpanded(!detailExpanded)
+            is Kind.Modifier -> {
+                armedMods = armedMods xor kind.bit
+                refreshModifierHighlights()
+            }
+            is Kind.Key -> {
+                val combined = armedMods or kind.fixedMods
+                sendKey(kind.name, combined)
+                if (armedMods != 0) {
+                    armedMods = 0
+                    refreshModifierHighlights()
+                }
+            }
+        }
+    }
+
+    private fun setDetailExpanded(expanded: Boolean) {
+        if (detailExpanded == expanded) return
+        detailExpanded = expanded
+        detailRow.visibility = if (expanded) VISIBLE else GONE
+        if (!expanded) {
+            armedMods = 0
+        }
+        refreshModifierHighlights()
+        layoutParams?.let { params ->
+            if (params.height != currentHeightPx) {
+                params.height = currentHeightPx
+                layoutParams = params
+            }
+        }
+        onHeightChanged?.invoke(currentHeightPx)
+    }
+
+    private fun refreshModifierHighlights() {
+        val highlight = if (isDarkTheme) 0x33FFFFFF.toInt() else 0x22000000.toInt()
+        for ((view, spec) in detailButtons) {
+            view.setBackgroundColor(
+                when (val kind = spec.kind) {
+                    is Kind.Modifier -> if ((armedMods and kind.bit) != 0) highlight else 0x00000000
+                    Kind.ToggleDetail -> if (detailExpanded) highlight else 0x00000000
+                    is Kind.Key -> 0x00000000
+                },
+            )
+        }
+        for ((view, spec) in primaryButtons) {
+            if (spec.kind is Kind.ToggleDetail) {
+                view.setBackgroundColor(if (detailExpanded) highlight else 0x00000000)
+            }
+        }
+    }
+
+    private fun startRepeating(name: String, mods: Int) {
         stopRepeating()
-        repeatingKey = key
+        repeatingKey = name to mods
         handler.postDelayed(repeatRunnable, repeatInitialDelayMs)
     }
 }
+

--- a/android/app/src/main/kotlin/dev/zedra/app/KeyboardAccessoryBar.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/KeyboardAccessoryBar.kt
@@ -12,25 +12,14 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 
-/**
- * Modifier bitmask matching Rust `key_encoding::Mods`
- * (shift = bit 0, alt = bit 1, ctrl = bit 2).
- */
-private object AccessoryMods {
-    const val NONE = 0
-    const val SHIFT = 0b001
-    const val ALT = 0b010
-    const val CTRL = 0b100
-}
-
 class KeyboardAccessoryBar(
     context: Context,
     private val sendKey: (String, Int) -> Unit,
+    private val togglePanel: () -> Unit,
 ) : LinearLayout(context) {
     private sealed class Kind {
         data class Key(val name: String, val fixedMods: Int = 0) : Kind()
-        data class Modifier(val bit: Int) : Kind()
-        object ToggleDetail : Kind()
+        object TogglePanel : Kind()
     }
 
     private data class KeySpec(
@@ -40,7 +29,7 @@ class KeyboardAccessoryBar(
         val iconRes: Int? = null,
     )
 
-    private val primarySpecs =
+    private val keySpecs =
         listOf(
             KeySpec("Esc", Kind.Key("escape"), false),
             KeySpec("Tab", Kind.Key("tab"), false),
@@ -49,22 +38,7 @@ class KeyboardAccessoryBar(
             KeySpec("↑", Kind.Key("up"), true, R.drawable.ic_key_arrow_up),
             KeySpec("→", Kind.Key("right"), true, R.drawable.ic_key_arrow_right),
             KeySpec("⏎", Kind.Key("enter"), false, R.drawable.ic_key_return),
-            KeySpec("•••", Kind.ToggleDetail, false),
-        )
-
-    private val detailSpecs =
-        listOf(
-            KeySpec("Ctrl", Kind.Modifier(AccessoryMods.CTRL), false),
-            KeySpec("Alt", Kind.Modifier(AccessoryMods.ALT), false),
-            KeySpec("Shift", Kind.Modifier(AccessoryMods.SHIFT), false),
-            KeySpec("⇧⇥", Kind.Key("tab", AccessoryMods.SHIFT), false),
-            KeySpec("⌃C", Kind.Key("char:c", AccessoryMods.CTRL), false),
-            KeySpec("⌃D", Kind.Key("char:d", AccessoryMods.CTRL), false),
-            KeySpec("⌃R", Kind.Key("char:r", AccessoryMods.CTRL), false),
-            KeySpec("Home", Kind.Key("home"), false),
-            KeySpec("End", Kind.Key("end"), false),
-            KeySpec("PgUp", Kind.Key("page_up"), true),
-            KeySpec("PgDn", Kind.Key("page_down"), true),
+            KeySpec("•••", Kind.TogglePanel, false),
         )
 
     private val topBorderPaint =
@@ -73,21 +47,13 @@ class KeyboardAccessoryBar(
             strokeWidth = context.resources.displayMetrics.density.coerceAtLeast(1f)
         }
 
-    private val rowHeightPx = (44 * context.resources.displayMetrics.density).toInt()
     private val repeatInitialDelayMs = 350L
     private val repeatIntervalMs = 60L
     private val handler = Handler(Looper.getMainLooper())
     private var repeatingKey: Pair<String, Int>? = null
     private var isDarkTheme = true
-    private var detailExpanded = false
-    private var armedMods = 0
-    private val primaryRow: LinearLayout
-    private val detailRow: LinearLayout
-    private val primaryButtons = mutableListOf<Pair<View, KeySpec>>()
-    private val detailButtons = mutableListOf<Pair<View, KeySpec>>()
-
-    /** Notified whenever the bar's measured height changes (collapse/expand). */
-    var onHeightChanged: ((Int) -> Unit)? = null
+    private var panelOpen = false
+    private val buttons = mutableListOf<Pair<View, KeySpec>>()
 
     private val repeatRunnable =
         object : Runnable {
@@ -99,29 +65,20 @@ class KeyboardAccessoryBar(
         }
 
     init {
-        orientation = VERTICAL
+        orientation = HORIZONTAL
         setBaselineAligned(false)
         isFocusable = false
         isFocusableInTouchMode = false
         setWillNotDraw(false)
         visibility = GONE
-
-        primaryRow = buildRow(primarySpecs, primaryButtons)
-        detailRow =
-            buildRow(detailSpecs, detailButtons).apply {
-                visibility = GONE
-            }
-
-        addView(primaryRow, LayoutParams(LayoutParams.MATCH_PARENT, rowHeightPx))
-        addView(detailRow, LayoutParams(LayoutParams.MATCH_PARENT, rowHeightPx))
-
         applyTheme(isDark = true)
-        refreshModifierHighlights()
-    }
 
-    /** Total height the bar wants, used by the host to size its layout slot. */
-    val currentHeightPx: Int
-        get() = if (detailExpanded) rowHeightPx * 2 else rowHeightPx
+        keySpecs.forEach { spec ->
+            val view = makeButton(spec)
+            buttons.add(view to spec)
+            addView(view, LayoutParams(0, LayoutParams.MATCH_PARENT, 1f))
+        }
+    }
 
     override fun onDetachedFromWindow() {
         stopRepeating()
@@ -138,36 +95,30 @@ class KeyboardAccessoryBar(
         handler.removeCallbacks(repeatRunnable)
     }
 
+    /** Update the `•••` label to `✕` (or vice versa) and cancel any repeat. */
+    fun setPanelOpen(open: Boolean) {
+        if (panelOpen == open) return
+        panelOpen = open
+        if (open) stopRepeating()
+        for ((view, spec) in buttons) {
+            if (spec.kind is Kind.TogglePanel && view is TextView) {
+                view.text = if (open) "✕" else "•••"
+            }
+        }
+    }
+
     fun applyTheme(isDark: Boolean) {
         isDarkTheme = isDark
+        val foreground = if (isDark) 0xFFFFFFFF.toInt() else 0xFF1A1A1A.toInt()
         setBackgroundColor(if (isDark) 0xF50E0C0C.toInt() else 0xF5FFFFFF.toInt())
         topBorderPaint.color = if (isDark) 0x33FFFFFF else 0x22000000
-        val foreground = if (isDark) 0xFFFFFFFF.toInt() else 0xFF1A1A1A.toInt()
-        for ((view, _) in primaryButtons + detailButtons) {
+        for ((view, _) in buttons) {
             when (view) {
                 is ImageView -> view.imageTintList = android.content.res.ColorStateList.valueOf(foreground)
                 is TextView -> view.setTextColor(foreground)
             }
         }
         invalidate()
-        refreshModifierHighlights()
-    }
-
-    private fun buildRow(
-        specs: List<KeySpec>,
-        sink: MutableList<Pair<View, KeySpec>>,
-    ): LinearLayout {
-        val row =
-            LinearLayout(context).apply {
-                orientation = HORIZONTAL
-                setBaselineAligned(false)
-            }
-        specs.forEach { spec ->
-            val view = makeButton(spec)
-            sink.add(view to spec)
-            row.addView(view, LayoutParams(0, LayoutParams.MATCH_PARENT, 1f))
-        }
-        return row
     }
 
     private fun makeButton(spec: KeySpec): View {
@@ -188,6 +139,7 @@ class KeyboardAccessoryBar(
                     setTextColor(foreground)
                 }
             }
+
         view.isClickable = true
         view.isFocusable = false
         view.isFocusableInTouchMode = false
@@ -195,13 +147,8 @@ class KeyboardAccessoryBar(
             when (event.actionMasked) {
                 MotionEvent.ACTION_DOWN -> {
                     if (spec.repeats && spec.kind is Kind.Key) {
-                        val combined = armedMods or spec.kind.fixedMods
-                        sendKey(spec.kind.name, combined)
-                        if (armedMods != 0) {
-                            armedMods = 0
-                            refreshModifierHighlights()
-                        }
-                        startRepeating(spec.kind.name, combined)
+                        sendKey(spec.kind.name, spec.kind.fixedMods)
+                        startRepeating(spec.kind.name, spec.kind.fixedMods)
                     }
                     true
                 }
@@ -209,7 +156,10 @@ class KeyboardAccessoryBar(
                     if (spec.repeats) {
                         stopRepeating()
                     } else {
-                        handleSpec(spec)
+                        when (val kind = spec.kind) {
+                            is Kind.Key -> sendKey(kind.name, kind.fixedMods)
+                            Kind.TogglePanel -> togglePanel()
+                        }
                     }
                     true
                 }
@@ -225,63 +175,9 @@ class KeyboardAccessoryBar(
         return view
     }
 
-    private fun handleSpec(spec: KeySpec) {
-        when (val kind = spec.kind) {
-            Kind.ToggleDetail -> setDetailExpanded(!detailExpanded)
-            is Kind.Modifier -> {
-                armedMods = armedMods xor kind.bit
-                refreshModifierHighlights()
-            }
-            is Kind.Key -> {
-                val combined = armedMods or kind.fixedMods
-                sendKey(kind.name, combined)
-                if (armedMods != 0) {
-                    armedMods = 0
-                    refreshModifierHighlights()
-                }
-            }
-        }
-    }
-
-    private fun setDetailExpanded(expanded: Boolean) {
-        if (detailExpanded == expanded) return
-        detailExpanded = expanded
-        detailRow.visibility = if (expanded) VISIBLE else GONE
-        if (!expanded) {
-            armedMods = 0
-        }
-        refreshModifierHighlights()
-        layoutParams?.let { params ->
-            if (params.height != currentHeightPx) {
-                params.height = currentHeightPx
-                layoutParams = params
-            }
-        }
-        onHeightChanged?.invoke(currentHeightPx)
-    }
-
-    private fun refreshModifierHighlights() {
-        val highlight = if (isDarkTheme) 0x33FFFFFF.toInt() else 0x22000000.toInt()
-        for ((view, spec) in detailButtons) {
-            view.setBackgroundColor(
-                when (val kind = spec.kind) {
-                    is Kind.Modifier -> if ((armedMods and kind.bit) != 0) highlight else 0x00000000
-                    Kind.ToggleDetail -> if (detailExpanded) highlight else 0x00000000
-                    is Kind.Key -> 0x00000000
-                },
-            )
-        }
-        for ((view, spec) in primaryButtons) {
-            if (spec.kind is Kind.ToggleDetail) {
-                view.setBackgroundColor(if (detailExpanded) highlight else 0x00000000)
-            }
-        }
-    }
-
     private fun startRepeating(name: String, mods: Int) {
         stopRepeating()
         repeatingKey = name to mods
         handler.postDelayed(repeatRunnable, repeatInitialDelayMs)
     }
 }
-

--- a/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
@@ -16,7 +16,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import dev.zed.gpui.GpuiRuntimeController
 import dev.zed.gpui.GpuiSurfaceView
 
@@ -32,6 +34,9 @@ class MainActivity : AppCompatActivity() {
     private lateinit var rootView: FrameLayout
     private lateinit var surfaceView: GpuiSurfaceView
     private lateinit var keyboardAccessoryBar: KeyboardAccessoryBar
+    private var fullKeyboardPanel: FullKeyboardPanel? = null
+    private var lastImeBottomPx: Int = 0
+    private var panelHeightPx: Int = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -45,22 +50,20 @@ class MainActivity : AppCompatActivity() {
 
         rootView = FrameLayout(this)
         surfaceView = runtime.attach(rootView)
-        keyboardAccessoryBar = KeyboardAccessoryBar(this) { key, mods ->
-            nativeKeyboardAccessoryKey(key, mods)
-        }
+        keyboardAccessoryBar =
+            KeyboardAccessoryBar(
+                this,
+                sendKey = { key, mods -> nativeKeyboardAccessoryKey(key, mods) },
+                togglePanel = { toggleFullKeyboardPanel() },
+            )
         rootView.addView(
             keyboardAccessoryBar,
             FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT,
-                keyboardAccessoryBar.currentHeightPx,
+                (44 * resources.displayMetrics.density).toInt(),
                 Gravity.BOTTOM,
             ),
         )
-        keyboardAccessoryBar.onHeightChanged = { heightPx ->
-            if (keyboardAccessoryBar.visibility == View.VISIBLE) {
-                surfaceView.setKeyboardAccessoryHeight(heightPx)
-            }
-        }
         installKeyboardAccessoryInsets()
         sSurfaceView = surfaceView
         sActivity = this
@@ -142,21 +145,87 @@ class MainActivity : AppCompatActivity() {
     private fun installKeyboardAccessoryInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { _, insets ->
             val imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
-            val params = keyboardAccessoryBar.layoutParams as FrameLayout.LayoutParams
-            if (params.bottomMargin != imeBottom) {
-                params.bottomMargin = imeBottom
-                keyboardAccessoryBar.layoutParams = params
+            if (imeBottom > 0) {
+                lastImeBottomPx = imeBottom
             }
-            keyboardAccessoryBar.visibility = if (imeBottom > 0) View.VISIBLE else View.GONE
-            surfaceView.setKeyboardAccessoryHeight(
-                if (imeBottom > 0) keyboardAccessoryBar.layoutParams.height else 0,
-            )
-            if (imeBottom == 0) {
-                keyboardAccessoryBar.stopRepeating()
+            // The panel anchors the accessory bar instead of the IME while it's
+            // open, so ignore IME-driven repositioning during that window.
+            if (fullKeyboardPanel == null) {
+                anchorAccessoryBar(toBottom = imeBottom)
+                if (imeBottom == 0) {
+                    keyboardAccessoryBar.stopRepeating()
+                }
             }
             insets
         }
         ViewCompat.requestApplyInsets(rootView)
+    }
+
+    /**
+     * Pin the accessory bar so its bottom edge sits `toBottom` px above the
+     * window bottom, and tell the GPUI surface to leave that much room +
+     * the bar height for keyboard chrome.
+     */
+    private fun anchorAccessoryBar(toBottom: Int) {
+        val params = keyboardAccessoryBar.layoutParams as FrameLayout.LayoutParams
+        if (params.bottomMargin != toBottom) {
+            params.bottomMargin = toBottom
+            keyboardAccessoryBar.layoutParams = params
+        }
+        keyboardAccessoryBar.visibility = if (toBottom > 0) View.VISIBLE else View.GONE
+        surfaceView.setKeyboardAccessoryHeight(
+            if (toBottom > 0) toBottom + keyboardAccessoryBar.layoutParams.height else 0,
+        )
+    }
+
+    private fun toggleFullKeyboardPanel() {
+        if (fullKeyboardPanel != null) {
+            closeFullKeyboardPanel()
+        } else {
+            openFullKeyboardPanel()
+        }
+    }
+
+    private fun openFullKeyboardPanel() {
+        if (fullKeyboardPanel != null) return
+        // Fall back to ~280dp if the IME never reported a height yet (hardware
+        // keyboard, first-run before any input field focused).
+        val fallback = (280 * resources.displayMetrics.density).toInt()
+        panelHeightPx = if (lastImeBottomPx > 0) lastImeBottomPx else fallback
+
+        val panel =
+            FullKeyboardPanel(this) { key, mods ->
+                nativeKeyboardAccessoryKey(key, mods)
+            }
+        rootView.addView(
+            panel,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                panelHeightPx,
+                Gravity.BOTTOM,
+            ),
+        )
+        fullKeyboardPanel = panel
+        keyboardAccessoryBar.setPanelOpen(true)
+        anchorAccessoryBar(toBottom = panelHeightPx)
+
+        // Ask the system to hide the soft keyboard so it doesn't ghost behind
+        // our panel. The text field stays focused; users can re-open with ✕.
+        WindowCompat.getInsetsController(window, surfaceView)
+            ?.hide(WindowInsetsCompat.Type.ime())
+    }
+
+    private fun closeFullKeyboardPanel() {
+        val panel = fullKeyboardPanel ?: return
+        rootView.removeView(panel)
+        fullKeyboardPanel = null
+        keyboardAccessoryBar.setPanelOpen(false)
+        anchorAccessoryBar(toBottom = 0)
+        // Bring the system keyboard back so typing-heavy work (Vietnamese IME,
+        // dictation, swipe) is one tap away.
+        val controller: WindowInsetsControllerCompat? =
+            WindowCompat.getInsetsController(window, surfaceView)
+        controller?.show(WindowInsetsCompat.Type.ime())
     }
 
     companion object {

--- a/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
@@ -45,17 +45,22 @@ class MainActivity : AppCompatActivity() {
 
         rootView = FrameLayout(this)
         surfaceView = runtime.attach(rootView)
-        keyboardAccessoryBar = KeyboardAccessoryBar(this) { key ->
-            nativeKeyboardAccessoryKey(key)
+        keyboardAccessoryBar = KeyboardAccessoryBar(this) { key, mods ->
+            nativeKeyboardAccessoryKey(key, mods)
         }
         rootView.addView(
             keyboardAccessoryBar,
             FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT,
-                (44 * resources.displayMetrics.density).toInt(),
+                keyboardAccessoryBar.currentHeightPx,
                 Gravity.BOTTOM,
             ),
         )
+        keyboardAccessoryBar.onHeightChanged = { heightPx ->
+            if (keyboardAccessoryBar.visibility == View.VISIBLE) {
+                surfaceView.setKeyboardAccessoryHeight(heightPx)
+            }
+        }
         installKeyboardAccessoryInsets()
         sSurfaceView = surfaceView
         sActivity = this
@@ -208,7 +213,7 @@ class MainActivity : AppCompatActivity() {
 
         @JvmStatic external fun nativeSheetContentIsAtTop(): Boolean
 
-        @JvmStatic external fun nativeKeyboardAccessoryKey(key: String)
+        @JvmStatic external fun nativeKeyboardAccessoryKey(key: String, mods: Int)
 
         @JvmStatic external fun nativeSystemBackPressed(): Boolean
 

--- a/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
@@ -193,8 +193,9 @@ class MainActivity : AppCompatActivity() {
         val fallback = (280 * resources.displayMetrics.density).toInt()
         panelHeightPx = if (lastImeBottomPx > 0) lastImeBottomPx else fallback
 
+        val hostOs = HostOs.fromU8(nativeActiveHostOs())
         val panel =
-            FullKeyboardPanel(this) { key, mods ->
+            FullKeyboardPanel(this, hostOs) { key, mods ->
                 nativeKeyboardAccessoryKey(key, mods)
             }
         rootView.addView(
@@ -283,6 +284,8 @@ class MainActivity : AppCompatActivity() {
         @JvmStatic external fun nativeSheetContentIsAtTop(): Boolean
 
         @JvmStatic external fun nativeKeyboardAccessoryKey(key: String, mods: Int)
+
+        @JvmStatic external fun nativeActiveHostOs(): Int
 
         @JvmStatic external fun nativeSystemBackPressed(): Boolean
 

--- a/crates/zedra/src/accessory_input.rs
+++ b/crates/zedra/src/accessory_input.rs
@@ -1,0 +1,152 @@
+/// Focus-aware routing for native keyboard accessory keystrokes.
+///
+/// The accessory bar (iOS / Android) is shared across the app, but who should
+/// receive a tap depends on what currently has focus. This module owns a single
+/// process-scoped "active consumer" slot: whichever view last claimed focus
+/// installs a closure here, and the platform FFI dispatches every key into it.
+///
+/// Consumers decide what a `(Key, Mods)` pair means. A terminal turns it into
+/// PTY bytes; a text input could move the caret or trigger an undo. Nothing in
+/// this module assumes a terminal exists.
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tracing::warn;
+
+use crate::key_encoding::{Key, Mods};
+
+/// Handler invoked for every accessory keystroke that targets the active focus.
+/// Returns `true` when the keystroke was consumed.
+pub type Consumer = Arc<dyn Fn(&Key, Mods) -> bool + Send + Sync + 'static>;
+
+#[derive(Clone)]
+struct ActiveConsumer {
+    label: &'static str,
+    consumer: Consumer,
+}
+
+static ACTIVE: OnceLock<Mutex<Option<ActiveConsumer>>> = OnceLock::new();
+
+fn slot() -> &'static Mutex<Option<ActiveConsumer>> {
+    ACTIVE.get_or_init(|| Mutex::new(None))
+}
+
+/// Install `consumer` as the active accessory handler. Replaces any prior one.
+///
+/// `label` is a short static string used only for log messages — pick something
+/// the developer can recognise (e.g. `"terminal"`, `"text-input"`).
+pub fn set_active_consumer(label: &'static str, consumer: Consumer) {
+    if let Ok(mut slot) = slot().lock() {
+        *slot = Some(ActiveConsumer { label, consumer });
+    }
+}
+
+/// Drop the active consumer. Subsequent dispatches no-op until something else
+/// claims focus.
+pub fn clear_active_consumer() {
+    if let Ok(mut slot) = slot().lock() {
+        *slot = None;
+    }
+}
+
+/// Parse a wire `(name, mod_bits)` from the native bar and hand it to the
+/// active consumer. Returns `true` when the keystroke was consumed.
+pub fn dispatch(key_name: &str, mod_bits: u8) -> bool {
+    let Some(key) = Key::parse(key_name) else {
+        warn!(key_name, "unknown keyboard accessory key");
+        return false;
+    };
+    let mods = Mods::from_bits(mod_bits);
+
+    // Clone the `Arc` under the lock, then release before invoking the closure.
+    // This keeps the closure alive even if another thread clears or replaces
+    // the active consumer mid-dispatch, and avoids holding the slot across a
+    // re-entrant call (a consumer free to install a different handler).
+    let active = slot().lock().ok().and_then(|guard| guard.clone());
+    let Some(active) = active else {
+        return false;
+    };
+    let consumed = (active.consumer)(&key, mods);
+    if !consumed {
+        warn!(
+            label = active.label,
+            key_name, "active consumer rejected accessory key"
+        );
+    }
+    consumed
+}
+
+/// Cross-module serialization for tests that touch the global active-consumer
+/// slot (this module) or the active-input slot (`active_terminal`). Both
+/// modules share state — they must run one at a time.
+#[cfg(test)]
+pub(crate) fn test_serialize_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn dispatch_calls_active_consumer_with_parsed_key_and_mods() {
+        let _guard = test_serialize_lock().lock().unwrap();
+        clear_active_consumer();
+
+        let captured: Arc<Mutex<Vec<(Key, Mods)>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured_clone = captured.clone();
+        set_active_consumer(
+            "test",
+            Arc::new(move |key, mods| {
+                captured_clone.lock().unwrap().push((key.clone(), mods));
+                true
+            }),
+        );
+
+        assert!(dispatch("char:c", Mods::CTRL.0));
+        assert!(dispatch("page_up", 0));
+        assert!(!dispatch("bogus", 0));
+
+        let log = captured.lock().unwrap();
+        assert_eq!(
+            log.as_slice(),
+            &[(Key::Char('c'), Mods::CTRL), (Key::PgUp, Mods::NONE)]
+        );
+
+        clear_active_consumer();
+        assert!(!dispatch("char:c", 0));
+    }
+
+    #[test]
+    fn replacing_consumer_drops_the_previous_one() {
+        let _guard = test_serialize_lock().lock().unwrap();
+        clear_active_consumer();
+
+        let first_hits = Arc::new(Mutex::new(0u32));
+        let second_hits = Arc::new(Mutex::new(0u32));
+        let first_clone = first_hits.clone();
+        let second_clone = second_hits.clone();
+
+        set_active_consumer(
+            "first",
+            Arc::new(move |_, _| {
+                *first_clone.lock().unwrap() += 1;
+                true
+            }),
+        );
+        set_active_consumer(
+            "second",
+            Arc::new(move |_, _| {
+                *second_clone.lock().unwrap() += 1;
+                true
+            }),
+        );
+
+        assert!(dispatch("escape", 0));
+        assert_eq!(*first_hits.lock().unwrap(), 0);
+        assert_eq!(*second_hits.lock().unwrap(), 1);
+
+        clear_active_consumer();
+    }
+}

--- a/crates/zedra/src/accessory_input.rs
+++ b/crates/zedra/src/accessory_input.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use tracing::warn;
 
-use crate::key_encoding::{Key, Mods};
+use crate::key_encoding::{HostOs, Key, Mods};
 
 /// Handler invoked for every accessory keystroke that targets the active focus.
 /// Returns `true` when the keystroke was consumed.
@@ -26,8 +26,35 @@ struct ActiveConsumer {
 
 static ACTIVE: OnceLock<Mutex<Option<ActiveConsumer>>> = OnceLock::new();
 
+/// Host OS associated with whichever focus claimed the active consumer slot.
+/// Read by the native keyboard panel so it can pick a layout for the host's
+/// shortcuts (Cmd vs Ctrl labels, mac-style Option keys, etc.).
+static ACTIVE_HOST_OS: OnceLock<Mutex<HostOs>> = OnceLock::new();
+
 fn slot() -> &'static Mutex<Option<ActiveConsumer>> {
     ACTIVE.get_or_init(|| Mutex::new(None))
+}
+
+fn host_os_slot() -> &'static Mutex<HostOs> {
+    ACTIVE_HOST_OS.get_or_init(|| Mutex::new(HostOs::Unknown))
+}
+
+/// Set the host OS associated with the active focus. Callers should refresh
+/// this whenever a different host becomes the active focus or whenever the
+/// host OS becomes known for the first time on a session.
+pub fn set_active_host_os(os: HostOs) {
+    if let Ok(mut slot) = host_os_slot().lock() {
+        *slot = os;
+    }
+}
+
+/// Current host OS. Returns `Unknown` when no host has claimed focus yet —
+/// callers should treat that as the macOS default per product direction.
+pub fn active_host_os() -> HostOs {
+    host_os_slot()
+        .lock()
+        .map(|guard| *guard)
+        .unwrap_or(HostOs::Unknown)
 }
 
 /// Install `consumer` as the active accessory handler. Replaces any prior one.

--- a/crates/zedra/src/active_terminal.rs
+++ b/crates/zedra/src/active_terminal.rs
@@ -6,14 +6,19 @@
 /// activation and reconnect attach both refresh this slot, so native input
 /// reads the current channel instead of a callback that captured an older one.
 ///
+/// Beyond raw text (`send_to_active`), this module also registers itself as
+/// the active `accessory_input` consumer whenever a terminal becomes active,
+/// owning the `Key` → byte encoding so the accessory bar stays focus-agnostic.
+///
 /// Nothing in `zedra-session` is involved — the routing is entirely
 /// within the `zedra` crate.
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use tokio::sync::mpsc;
 use tracing::warn;
 
-use crate::key_encoding::{Key, Mods, encode_legacy};
+use crate::accessory_input;
+use crate::key_encoding::encode_legacy;
 
 #[derive(Clone)]
 struct ActiveInput {
@@ -29,24 +34,50 @@ fn slot() -> &'static Mutex<Option<ActiveInput>> {
 
 /// Register the input channel for the currently-active terminal.
 ///
-/// Called by `WorkspaceView` whenever `active_terminal_id` changes.
+/// Called by `WorkspaceView` whenever `active_terminal_id` changes. Also
+/// installs the keystroke consumer so the native accessory bar routes into
+/// this same channel.
 pub fn set_active_input(terminal_id: String, sender: mpsc::Sender<Vec<u8>>) {
     if let Ok(mut slot) = slot().lock() {
         *slot = Some(ActiveInput {
-            terminal_id,
-            sender,
+            terminal_id: terminal_id.clone(),
+            sender: sender.clone(),
         });
     }
+    let consumer_sender = sender;
+    let consumer_terminal = terminal_id;
+    accessory_input::set_active_consumer(
+        "terminal",
+        Arc::new(move |key, mods| {
+            let bytes = encode_legacy(key, mods);
+            match consumer_sender.try_send(bytes) {
+                Ok(()) => true,
+                Err(error) => {
+                    warn!(
+                        terminal_id = consumer_terminal,
+                        "failed to send accessory keystroke: {}", error
+                    );
+                    false
+                }
+            }
+        }),
+    );
 }
 
-/// Clear the active input channel (e.g. when all terminals are closed).
+/// Clear the active input channel (e.g. when all terminals are closed) and
+/// release the accessory keystroke consumer so the bar no longer hits a stale
+/// channel.
 pub fn clear_active_input() {
     if let Ok(mut slot) = slot().lock() {
         *slot = None;
     }
+    accessory_input::clear_active_consumer();
 }
 
 /// Send bytes to the currently-active terminal.
+///
+/// Used by the iOS terminal composer to inject finalized text; bypasses the
+/// keystroke encoder.
 ///
 /// Returns `true` if the data was accepted by the active channel.
 pub fn send_to_active(data: Vec<u8>) -> bool {
@@ -67,32 +98,15 @@ pub fn send_to_active(data: Vec<u8>) -> bool {
     }
 }
 
-/// Map a native accessory keystroke `(name, mods)` to bytes and send them.
-///
-/// `key_name` is a stable wire identifier — see `key_encoding::Key::parse`.
-/// `mod_bits` packs Shift/Alt/Ctrl per `key_encoding::Mods`.
-pub fn send_keystroke(key_name: &str, mod_bits: u8) -> bool {
-    let Some(key) = Key::parse(key_name) else {
-        warn!(key_name, "unknown keyboard accessory key");
-        return false;
-    };
-    let bytes = encode_legacy(&key, Mods::from_bits(mod_bits));
-    send_to_active(bytes)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use crate::key_encoding::Mods;
     use tokio::sync::mpsc::error::TryRecvError;
-
-    // The global `ACTIVE_INPUT` slot is shared across all tests in this module,
-    // so they must not run concurrently.
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn send_to_active_reads_latest_registered_channel() {
-        let _guard = TEST_LOCK.lock().unwrap();
+        let _guard = accessory_input::test_serialize_lock().lock().unwrap();
         clear_active_input();
 
         let (first_tx, mut first_rx) = mpsc::channel(1);
@@ -111,21 +125,21 @@ mod tests {
     }
 
     #[test]
-    fn send_keystroke_routes_modified_combo_to_active_channel() {
-        let _guard = TEST_LOCK.lock().unwrap();
+    fn registering_active_terminal_routes_accessory_keys_through_encoder() {
+        let _guard = accessory_input::test_serialize_lock().lock().unwrap();
         clear_active_input();
 
         let (tx, mut rx) = mpsc::channel(2);
-        set_active_input("modified".to_string(), tx);
+        set_active_input("encoded".to_string(), tx);
 
-        assert!(send_keystroke("char:c", Mods::CTRL.0));
+        assert!(accessory_input::dispatch("char:c", Mods::CTRL.0));
         assert_eq!(rx.try_recv(), Ok(b"\x03".to_vec()));
 
-        assert!(send_keystroke("tab", Mods::SHIFT.0));
+        assert!(accessory_input::dispatch("tab", Mods::SHIFT.0));
         assert_eq!(rx.try_recv(), Ok(b"\x1b[Z".to_vec()));
 
-        assert!(!send_keystroke("bogus", 0));
-
         clear_active_input();
+        // Once cleared, accessory keystrokes no longer reach this channel.
+        assert!(!accessory_input::dispatch("char:c", 0));
     }
 }

--- a/crates/zedra/src/active_terminal.rs
+++ b/crates/zedra/src/active_terminal.rs
@@ -13,6 +13,8 @@ use std::sync::{Mutex, OnceLock};
 use tokio::sync::mpsc;
 use tracing::warn;
 
+use crate::key_encoding::{Key, Mods, encode_legacy};
+
 #[derive(Clone)]
 struct ActiveInput {
     terminal_id: String,
@@ -65,29 +67,32 @@ pub fn send_to_active(data: Vec<u8>) -> bool {
     }
 }
 
-/// Map a native accessory key name and send it to the active terminal.
-pub fn send_named_key(key_name: &str) -> bool {
-    let bytes: &[u8] = match key_name {
-        "escape" => b"\x1b",
-        "tab" => b"\x09",
-        "left" => b"\x1b[D",
-        "down" => b"\x1b[B",
-        "up" => b"\x1b[A",
-        "right" => b"\x1b[C",
-        "enter" => b"\r",
-        "shift_enter" => b"\n",
-        _ => return false,
+/// Map a native accessory keystroke `(name, mods)` to bytes and send them.
+///
+/// `key_name` is a stable wire identifier — see `key_encoding::Key::parse`.
+/// `mod_bits` packs Shift/Alt/Ctrl per `key_encoding::Mods`.
+pub fn send_keystroke(key_name: &str, mod_bits: u8) -> bool {
+    let Some(key) = Key::parse(key_name) else {
+        warn!(key_name, "unknown keyboard accessory key");
+        return false;
     };
-    send_to_active(bytes.to_vec())
+    let bytes = encode_legacy(&key, Mods::from_bits(mod_bits));
+    send_to_active(bytes)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tokio::sync::mpsc::error::TryRecvError;
+
+    // The global `ACTIVE_INPUT` slot is shared across all tests in this module,
+    // so they must not run concurrently.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn send_to_active_reads_latest_registered_channel() {
+        let _guard = TEST_LOCK.lock().unwrap();
         clear_active_input();
 
         let (first_tx, mut first_rx) = mpsc::channel(1);
@@ -101,6 +106,25 @@ mod tests {
             Err(TryRecvError::Empty | TryRecvError::Disconnected)
         ));
         assert_eq!(second_rx.try_recv(), Ok(b"\t".to_vec()));
+
+        clear_active_input();
+    }
+
+    #[test]
+    fn send_keystroke_routes_modified_combo_to_active_channel() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        clear_active_input();
+
+        let (tx, mut rx) = mpsc::channel(2);
+        set_active_input("modified".to_string(), tx);
+
+        assert!(send_keystroke("char:c", Mods::CTRL.0));
+        assert_eq!(rx.try_recv(), Ok(b"\x03".to_vec()));
+
+        assert!(send_keystroke("tab", Mods::SHIFT.0));
+        assert_eq!(rx.try_recv(), Ok(b"\x1b[Z".to_vec()));
+
+        assert!(!send_keystroke("bogus", 0));
 
         clear_active_input();
     }

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -430,6 +430,7 @@ pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeKeyboardAccessoryKe
     mut env: JNIEnv,
     _class: JClass,
     key: jni::objects::JString,
+    mods: jni::sys::jint,
 ) {
     let key_name: String = match env.get_string(&key) {
         Ok(key) => key.into(),
@@ -438,7 +439,7 @@ pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeKeyboardAccessoryKe
             return;
         }
     };
-    crate::active_terminal::send_named_key(&key_name);
+    crate::active_terminal::send_keystroke(&key_name, mods as u8);
 }
 
 #[unsafe(no_mangle)]

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -426,6 +426,14 @@ pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeSheetContentIsAtTop
 }
 
 #[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeActiveHostOs(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jni::sys::jint {
+    crate::accessory_input::active_host_os().as_u8() as jni::sys::jint
+}
+
+#[unsafe(no_mangle)]
 pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeKeyboardAccessoryKey(
     mut env: JNIEnv,
     _class: JClass,

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -439,7 +439,7 @@ pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeKeyboardAccessoryKe
             return;
         }
     };
-    crate::active_terminal::send_keystroke(&key_name, mods as u8);
+    crate::accessory_input::dispatch(&key_name, mods as u8);
 }
 
 #[unsafe(no_mangle)]

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -623,6 +623,17 @@ pub extern "C" fn zedra_ios_send_key_input(key: *const std::ffi::c_char, mods: u
     crate::accessory_input::dispatch(key_name, mods);
 }
 
+/// Returns the host OS of the currently-focused session as a `u8`:
+/// 0 = unknown / no session, 1 = macOS, 2 = Linux, 3 = Windows.
+///
+/// The native keyboard panel calls this when opening the full-keyboard view
+/// so it can pick a platform-appropriate layout. Treat `Unknown` as macOS by
+/// default per product direction.
+#[unsafe(no_mangle)]
+pub extern "C" fn zedra_ios_active_host_os() -> u8 {
+    crate::accessory_input::active_host_os().as_u8()
+}
+
 /// Called from the native terminal composer to send finalized text to the active terminal.
 #[unsafe(no_mangle)]
 pub extern "C" fn zedra_ios_send_terminal_text(text: *const std::ffi::c_char) {

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -595,10 +595,12 @@ pub extern "C" fn zedra_ios_native_notification_dismiss(callback_id: u32) {
 
 /// Called from the native keyboard accessory bar when a shortcut key button is tapped.
 ///
-/// `key` is one of: "escape", "tab", "left", "down", "up", "right", "enter", "shift_enter".
-/// Maps the name to the corresponding terminal escape sequence and sends it via the active session.
+/// `key` is one of the wire names accepted by `key_encoding::Key::parse`
+/// ("escape", "tab", "left", ... or `char:<c>` for single-character keys),
+/// plus the iOS-only sentinel "dismiss_keyboard". `mods` packs Shift/Alt/Ctrl
+/// per `key_encoding::Mods` (bit 0 / 1 / 2).
 #[unsafe(no_mangle)]
-pub extern "C" fn zedra_ios_send_key_input(key: *const std::ffi::c_char) {
+pub extern "C" fn zedra_ios_send_key_input(key: *const std::ffi::c_char, mods: u8) {
     if key.is_null() {
         return;
     }
@@ -618,7 +620,7 @@ pub extern "C" fn zedra_ios_send_key_input(key: *const std::ffi::c_char) {
         return;
     }
 
-    active_terminal::send_named_key(key_name);
+    active_terminal::send_keystroke(key_name, mods);
 }
 
 /// Called from the native terminal composer to send finalized text to the active terminal.

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -620,7 +620,7 @@ pub extern "C" fn zedra_ios_send_key_input(key: *const std::ffi::c_char, mods: u
         return;
     }
 
-    active_terminal::send_keystroke(key_name, mods);
+    crate::accessory_input::dispatch(key_name, mods);
 }
 
 /// Called from the native terminal composer to send finalized text to the active terminal.

--- a/crates/zedra/src/key_encoding.rs
+++ b/crates/zedra/src/key_encoding.rs
@@ -7,6 +7,33 @@
 ///
 /// Only the legacy xterm/VT encoding is implemented. CSI-u / kitty negotiation
 /// would replace `encode_legacy` with a per-PTY mode in a later change.
+/// Host operating system, parsed from `SyncSessionResult.os`. Crosses the
+/// FFI boundary as a `u8` so the native keyboard panel can pick a
+/// platform-appropriate layout without re-deriving the value.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HostOs {
+    Unknown = 0,
+    MacOs = 1,
+    Linux = 2,
+    Windows = 3,
+}
+
+impl HostOs {
+    /// Map the `std::env::consts::OS` string the host sends over the wire.
+    pub fn parse(value: &str) -> Self {
+        match value {
+            "macos" => Self::MacOs,
+            "linux" => Self::Linux,
+            "windows" => Self::Windows,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
 /// Active modifier keys for a keystroke.
 ///
 /// Stored as a `u8` so it crosses the FFI boundary as-is. Bits are deliberately

--- a/crates/zedra/src/key_encoding.rs
+++ b/crates/zedra/src/key_encoding.rs
@@ -112,6 +112,23 @@ impl Key {
 /// - Shift alone on a letter      -> uppercase byte; on other chars Shift is ignored
 ///   (legacy terminals can't distinguish Shift on punctuation).
 pub fn encode_legacy(key: &Key, mods: Mods) -> Vec<u8> {
+    // Navigation / editing keys encode every modifier as `n` in `CSI 1;n <final>`
+    // or `CSI <code>;n ~`. They must NOT take the ESC-prefix path for Alt, or
+    // apps that look for modified CSI sequences (Alt+Left → `\x1b[1;3D`) would
+    // see `\x1b\x1b[D` and treat it as Escape followed by an unmodified arrow.
+    match key {
+        Key::Delete => return csi_tilde(b'3', mods),
+        Key::Left => return csi_arrow(b'D', mods),
+        Key::Right => return csi_arrow(b'C', mods),
+        Key::Up => return csi_arrow(b'A', mods),
+        Key::Down => return csi_arrow(b'B', mods),
+        Key::Home => return csi_arrow(b'H', mods),
+        Key::End => return csi_arrow(b'F', mods),
+        Key::PgUp => return csi_tilde(b'5', mods),
+        Key::PgDn => return csi_tilde(b'6', mods),
+        _ => {}
+    }
+
     if mods.contains(Mods::ALT) {
         let without_alt = mods - Mods::ALT;
         let mut out = vec![0x1b];
@@ -137,15 +154,7 @@ pub fn encode_legacy(key: &Key, mods: Mods) -> Vec<u8> {
             }
         }
         Key::Backspace => vec![0x7f],
-        Key::Delete => csi_tilde(b'3', mods),
-        Key::Left => csi_arrow(b'D', mods),
-        Key::Right => csi_arrow(b'C', mods),
-        Key::Up => csi_arrow(b'A', mods),
-        Key::Down => csi_arrow(b'B', mods),
-        Key::Home => csi_arrow(b'H', mods),
-        Key::End => csi_arrow(b'F', mods),
-        Key::PgUp => csi_tilde(b'5', mods),
-        Key::PgDn => csi_tilde(b'6', mods),
+        _ => unreachable!("CSI keys handled above"),
     }
 }
 
@@ -296,6 +305,21 @@ mod tests {
     fn modified_tilde_keys_use_csi_code_n_tilde_form() {
         assert_eq!(encode_legacy(&Key::PgUp, Mods::CTRL), b"\x1b[5;5~");
         assert_eq!(encode_legacy(&Key::Delete, Mods::SHIFT), b"\x1b[3;2~");
+    }
+
+    #[test]
+    fn alt_on_csi_keys_uses_modified_csi_not_escape_prefix() {
+        // Alt must round-trip through the param number so editors / readline see
+        // a single modified sequence, not Escape + unmodified arrow/tilde key.
+        assert_eq!(encode_legacy(&Key::Left, Mods::ALT), b"\x1b[1;3D");
+        assert_eq!(encode_legacy(&Key::Right, Mods::ALT), b"\x1b[1;3C");
+        assert_eq!(encode_legacy(&Key::Home, Mods::ALT), b"\x1b[1;3H");
+        assert_eq!(encode_legacy(&Key::PgUp, Mods::ALT), b"\x1b[5;3~");
+        assert_eq!(encode_legacy(&Key::Delete, Mods::ALT), b"\x1b[3;3~");
+        assert_eq!(
+            encode_legacy(&Key::Down, Mods::ALT | Mods::SHIFT),
+            b"\x1b[1;4B"
+        );
     }
 
     #[test]

--- a/crates/zedra/src/key_encoding.rs
+++ b/crates/zedra/src/key_encoding.rs
@@ -1,0 +1,309 @@
+/// Terminal key encoder for the native keyboard accessory bar.
+///
+/// Native bars (iOS UIKit, Android View) send keystrokes as `(name, mods)`
+/// where `name` is a stable identifier ("escape", "tab", "char:c", ...) and
+/// `mods` is a `Mods` bitmask. This module turns that into the byte sequence
+/// the remote shell expects.
+///
+/// Only the legacy xterm/VT encoding is implemented. CSI-u / kitty negotiation
+/// would replace `encode_legacy` with a per-PTY mode in a later change.
+/// Active modifier keys for a keystroke.
+///
+/// Stored as a `u8` so it crosses the FFI boundary as-is. Bits are deliberately
+/// laid out to match the order used in the kitty keyboard protocol, so a future
+/// CSI-u encoder can reuse the same value.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+pub struct Mods(pub u8);
+
+impl Mods {
+    pub const NONE: Mods = Mods(0);
+    pub const SHIFT: Mods = Mods(0b001);
+    pub const ALT: Mods = Mods(0b010);
+    pub const CTRL: Mods = Mods(0b100);
+
+    pub fn from_bits(bits: u8) -> Self {
+        Self(bits & 0b111)
+    }
+
+    pub fn contains(self, other: Mods) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl std::ops::BitOr for Mods {
+    type Output = Mods;
+    fn bitor(self, rhs: Mods) -> Mods {
+        Mods(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::Sub for Mods {
+    type Output = Mods;
+    fn sub(self, rhs: Mods) -> Mods {
+        Mods(self.0 & !rhs.0)
+    }
+}
+
+/// Logical key the user pressed on the accessory bar.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Key {
+    Char(char),
+    Esc,
+    Tab,
+    Enter,
+    Backspace,
+    Delete,
+    Left,
+    Right,
+    Up,
+    Down,
+    Home,
+    End,
+    PgUp,
+    PgDn,
+}
+
+impl Key {
+    /// Parse a wire name from the native bar. Char keys use a `char:` prefix
+    /// so single bytes don't collide with named keys.
+    pub fn parse(name: &str) -> Option<Self> {
+        if let Some(rest) = name.strip_prefix("char:") {
+            let mut chars = rest.chars();
+            let c = chars.next()?;
+            if chars.next().is_some() {
+                return None;
+            }
+            return Some(Key::Char(c));
+        }
+        Some(match name {
+            "escape" => Key::Esc,
+            "tab" => Key::Tab,
+            "enter" => Key::Enter,
+            "backspace" => Key::Backspace,
+            "delete" => Key::Delete,
+            "left" => Key::Left,
+            "right" => Key::Right,
+            "up" => Key::Up,
+            "down" => Key::Down,
+            "home" => Key::Home,
+            "end" => Key::End,
+            "page_up" => Key::PgUp,
+            "page_down" => Key::PgDn,
+            _ => return None,
+        })
+    }
+}
+
+/// Encode `(key, mods)` as the bytes a legacy xterm-style PTY expects.
+///
+/// Encoding rules:
+/// - `Ctrl + ASCII letter`        -> single byte `c & 0x1f`
+/// - `Ctrl + @ [ \ ] ^ _ ?`       -> their classic control codes
+/// - `Alt + key`                  -> `ESC` prefix + encode(key without Alt)
+/// - `Shift + Tab`                -> `ESC [ Z` (BackTab)
+/// - `Shift + Enter`              -> `LF` (`\n`)
+/// - Arrow / Home / End / PgUp / PgDn with mods other than zero
+///                                -> `CSI 1 ; <n> <final>` (or `CSI <code> ; <n> ~`)
+///   where `n = 1 + shift + 2*alt + 4*ctrl`
+/// - Shift alone on a letter      -> uppercase byte; on other chars Shift is ignored
+///   (legacy terminals can't distinguish Shift on punctuation).
+pub fn encode_legacy(key: &Key, mods: Mods) -> Vec<u8> {
+    if mods.contains(Mods::ALT) {
+        let without_alt = mods - Mods::ALT;
+        let mut out = vec![0x1b];
+        out.extend(encode_legacy(key, without_alt));
+        return out;
+    }
+
+    match key {
+        Key::Char(c) => encode_char(*c, mods),
+        Key::Esc => vec![0x1b],
+        Key::Tab => {
+            if mods.contains(Mods::SHIFT) {
+                b"\x1b[Z".to_vec()
+            } else {
+                vec![0x09]
+            }
+        }
+        Key::Enter => {
+            if mods.contains(Mods::SHIFT) {
+                vec![0x0a]
+            } else {
+                vec![0x0d]
+            }
+        }
+        Key::Backspace => vec![0x7f],
+        Key::Delete => csi_tilde(b'3', mods),
+        Key::Left => csi_arrow(b'D', mods),
+        Key::Right => csi_arrow(b'C', mods),
+        Key::Up => csi_arrow(b'A', mods),
+        Key::Down => csi_arrow(b'B', mods),
+        Key::Home => csi_arrow(b'H', mods),
+        Key::End => csi_arrow(b'F', mods),
+        Key::PgUp => csi_tilde(b'5', mods),
+        Key::PgDn => csi_tilde(b'6', mods),
+    }
+}
+
+fn encode_char(c: char, mods: Mods) -> Vec<u8> {
+    if mods.contains(Mods::CTRL) {
+        if let Some(byte) = ctrl_byte(c) {
+            return vec![byte];
+        }
+    }
+    let ch = if mods.contains(Mods::SHIFT) && c.is_ascii_alphabetic() {
+        c.to_ascii_uppercase()
+    } else {
+        c
+    };
+    let mut buf = [0u8; 4];
+    ch.encode_utf8(&mut buf).as_bytes().to_vec()
+}
+
+fn ctrl_byte(c: char) -> Option<u8> {
+    let lower = c.to_ascii_lowercase();
+    if lower.is_ascii_alphabetic() {
+        return Some((lower as u8) & 0x1f);
+    }
+    Some(match c {
+        '@' | ' ' => 0x00,
+        '[' => 0x1b,
+        '\\' => 0x1c,
+        ']' => 0x1d,
+        '^' => 0x1e,
+        '_' => 0x1f,
+        '?' => 0x7f,
+        _ => return None,
+    })
+}
+
+fn modifier_param(mods: Mods) -> u8 {
+    let mut n: u8 = 1;
+    if mods.contains(Mods::SHIFT) {
+        n += 1;
+    }
+    if mods.contains(Mods::ALT) {
+        n += 2;
+    }
+    if mods.contains(Mods::CTRL) {
+        n += 4;
+    }
+    n
+}
+
+fn csi_arrow(final_byte: u8, mods: Mods) -> Vec<u8> {
+    let param = modifier_param(mods);
+    if param == 1 {
+        vec![0x1b, b'[', final_byte]
+    } else {
+        let mut out = Vec::with_capacity(8);
+        out.extend_from_slice(b"\x1b[1;");
+        out.extend_from_slice(param.to_string().as_bytes());
+        out.push(final_byte);
+        out
+    }
+}
+
+fn csi_tilde(code: u8, mods: Mods) -> Vec<u8> {
+    let param = modifier_param(mods);
+    let mut out = Vec::with_capacity(8);
+    out.push(0x1b);
+    out.push(b'[');
+    out.push(code);
+    if param != 1 {
+        out.push(b';');
+        out.extend_from_slice(param.to_string().as_bytes());
+    }
+    out.push(b'~');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_named_keys_match_legacy_sequences() {
+        assert_eq!(encode_legacy(&Key::Esc, Mods::NONE), b"\x1b");
+        assert_eq!(encode_legacy(&Key::Tab, Mods::NONE), b"\t");
+        assert_eq!(encode_legacy(&Key::Enter, Mods::NONE), b"\r");
+        assert_eq!(encode_legacy(&Key::Backspace, Mods::NONE), b"\x7f");
+        assert_eq!(encode_legacy(&Key::Left, Mods::NONE), b"\x1b[D");
+        assert_eq!(encode_legacy(&Key::Down, Mods::NONE), b"\x1b[B");
+        assert_eq!(encode_legacy(&Key::Up, Mods::NONE), b"\x1b[A");
+        assert_eq!(encode_legacy(&Key::Right, Mods::NONE), b"\x1b[C");
+        assert_eq!(encode_legacy(&Key::Home, Mods::NONE), b"\x1b[H");
+        assert_eq!(encode_legacy(&Key::End, Mods::NONE), b"\x1b[F");
+        assert_eq!(encode_legacy(&Key::PgUp, Mods::NONE), b"\x1b[5~");
+        assert_eq!(encode_legacy(&Key::PgDn, Mods::NONE), b"\x1b[6~");
+        assert_eq!(encode_legacy(&Key::Delete, Mods::NONE), b"\x1b[3~");
+    }
+
+    #[test]
+    fn shift_tab_emits_backtab_and_shift_enter_emits_lf() {
+        assert_eq!(encode_legacy(&Key::Tab, Mods::SHIFT), b"\x1b[Z");
+        assert_eq!(encode_legacy(&Key::Enter, Mods::SHIFT), b"\n");
+    }
+
+    #[test]
+    fn ctrl_letter_uses_legacy_bitmask() {
+        assert_eq!(encode_legacy(&Key::Char('c'), Mods::CTRL), b"\x03");
+        assert_eq!(encode_legacy(&Key::Char('d'), Mods::CTRL), b"\x04");
+        assert_eq!(encode_legacy(&Key::Char('r'), Mods::CTRL), b"\x12");
+        assert_eq!(encode_legacy(&Key::Char('A'), Mods::CTRL), b"\x01");
+    }
+
+    #[test]
+    fn ctrl_punctuation_maps_to_control_codes() {
+        assert_eq!(encode_legacy(&Key::Char('['), Mods::CTRL), b"\x1b");
+        assert_eq!(encode_legacy(&Key::Char('\\'), Mods::CTRL), b"\x1c");
+        assert_eq!(encode_legacy(&Key::Char('?'), Mods::CTRL), b"\x7f");
+        assert_eq!(encode_legacy(&Key::Char('@'), Mods::CTRL), b"\x00");
+    }
+
+    #[test]
+    fn alt_prefixes_with_escape_for_any_key() {
+        assert_eq!(encode_legacy(&Key::Char('b'), Mods::ALT), b"\x1bb");
+        assert_eq!(encode_legacy(&Key::Enter, Mods::ALT), b"\x1b\r");
+        assert_eq!(
+            encode_legacy(&Key::Char('c'), Mods::ALT | Mods::CTRL),
+            b"\x1b\x03"
+        );
+    }
+
+    #[test]
+    fn shift_uppercases_letters_but_leaves_other_chars_alone() {
+        assert_eq!(encode_legacy(&Key::Char('a'), Mods::SHIFT), b"A");
+        assert_eq!(encode_legacy(&Key::Char('1'), Mods::SHIFT), b"1");
+    }
+
+    #[test]
+    fn modified_navigation_uses_csi_1_n_final_form() {
+        // mod number: 1 + shift + 2*alt + 4*ctrl
+        assert_eq!(encode_legacy(&Key::Left, Mods::SHIFT), b"\x1b[1;2D");
+        assert_eq!(encode_legacy(&Key::Up, Mods::CTRL), b"\x1b[1;5A");
+        assert_eq!(
+            encode_legacy(&Key::End, Mods::SHIFT | Mods::CTRL),
+            b"\x1b[1;6F"
+        );
+    }
+
+    #[test]
+    fn modified_tilde_keys_use_csi_code_n_tilde_form() {
+        assert_eq!(encode_legacy(&Key::PgUp, Mods::CTRL), b"\x1b[5;5~");
+        assert_eq!(encode_legacy(&Key::Delete, Mods::SHIFT), b"\x1b[3;2~");
+    }
+
+    #[test]
+    fn parse_round_trips_wire_names() {
+        assert_eq!(Key::parse("escape"), Some(Key::Esc));
+        assert_eq!(Key::parse("char:c"), Some(Key::Char('c')));
+        assert_eq!(Key::parse("char:"), None);
+        assert_eq!(Key::parse("char:cd"), None);
+        assert_eq!(Key::parse("bogus"), None);
+    }
+}

--- a/crates/zedra/src/key_encoding.rs
+++ b/crates/zedra/src/key_encoding.rs
@@ -44,12 +44,17 @@ pub struct Mods(pub u8);
 
 impl Mods {
     pub const NONE: Mods = Mods(0);
-    pub const SHIFT: Mods = Mods(0b001);
-    pub const ALT: Mods = Mods(0b010);
-    pub const CTRL: Mods = Mods(0b100);
+    pub const SHIFT: Mods = Mods(0b0001);
+    pub const ALT: Mods = Mods(0b0010);
+    pub const CTRL: Mods = Mods(0b0100);
+    /// Cmd / Super. The legacy xterm/VT encoder ignores it (no byte
+    /// representation in PTY), but it crosses the FFI so the native panel can
+    /// track an armed state and a future host-side RPC can route GUI-level
+    /// shortcuts.
+    pub const CMD: Mods = Mods(0b1000);
 
     pub fn from_bits(bits: u8) -> Self {
-        Self(bits & 0b111)
+        Self(bits & 0b1111)
     }
 
     pub fn contains(self, other: Mods) -> bool {

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -53,6 +53,7 @@ pub mod workspace_state;
 pub mod workspace_terminal;
 pub mod workspaces;
 
+pub mod accessory_input;
 pub mod active_terminal;
 pub mod deeplink;
 pub mod key_encoding;

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -55,6 +55,7 @@ pub mod workspaces;
 
 pub mod active_terminal;
 pub mod deeplink;
+pub mod key_encoding;
 pub mod native_presentation;
 pub mod platform_bridge;
 pub mod telemetry;

--- a/crates/zedra/src/workspace_state.rs
+++ b/crates/zedra/src/workspace_state.rs
@@ -148,6 +148,11 @@ pub struct WorkspaceState {
     pub workdir: String,
     pub homedir: String,
     pub hostname: String,
+    /// Host OS as reported by `SyncSessionResult.os` — `"macos"`, `"linux"`,
+    /// `"windows"`. Transient; not persisted. Used by the keyboard accessory
+    /// panel to pick a platform-appropriate layout.
+    #[serde(skip)]
+    pub os: Option<String>,
     // Workspace-relative docs tree directories hidden by the user.
     #[serde(default)]
     pub docs_tree_collapsed_dirs: Vec<String>,
@@ -176,6 +181,7 @@ struct WorkspaceStateSyncSnapshot {
     workdir: String,
     homedir: String,
     hostname: String,
+    os: Option<String>,
     connect_phase: Option<ConnectPhase>,
     active_terminal_id: Option<String>,
     terminal_ids: Vec<String>,
@@ -194,6 +200,7 @@ impl PartialEq for WorkspaceState {
             && self.workdir == other.workdir
             && self.homedir == other.homedir
             && self.hostname == other.hostname
+            && self.os == other.os
             && self.docs_tree_collapsed_dirs == other.docs_tree_collapsed_dirs
             && self.created_at == other.created_at
             && self.updated_at == other.updated_at
@@ -245,6 +252,7 @@ impl WorkspaceState {
             workdir: self.workdir.clone(),
             homedir: self.homedir.clone(),
             hostname: self.hostname.clone(),
+            os: self.os.clone(),
             connect_phase: self.connect_phase.clone(),
             active_terminal_id: self.active_terminal_id.clone(),
             terminal_ids: self.terminal_ids.clone(),
@@ -329,6 +337,9 @@ impl WorkspaceState {
         }
         if !snap.homedir.is_empty() {
             self.homedir = snap.homedir.clone();
+        }
+        if snap.os.is_some() {
+            self.os = snap.os.clone();
         }
         if let Some(session_id) = session_id {
             self.session_id = session_id.clone();

--- a/crates/zedra/src/workspace_terminal.rs
+++ b/crates/zedra/src/workspace_terminal.rs
@@ -419,7 +419,15 @@ impl WorkspaceTerminal {
         match self.terminal_view.read(cx).input_sender(cx) {
             Some(sender) => {
                 let terminal_id = self.terminal_id.clone();
+                let host_os = self
+                    .workspace_state
+                    .read(cx)
+                    .os
+                    .as_deref()
+                    .map(crate::key_encoding::HostOs::parse)
+                    .unwrap_or(crate::key_encoding::HostOs::Unknown);
                 active_terminal::set_active_input(terminal_id, sender);
+                crate::accessory_input::set_active_host_os(host_os);
             }
             None => {
                 warn!(terminal_id = %self.terminal_id, "no input sender, skipping active input registration");

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1098,7 +1098,7 @@ Expected:
 
 1. Connect to a workspace and focus a terminal so the keyboard accessory bar shows the primary row (Esc Tab ← ↓ ↑ → ⏎ •••).
 2. Tap **•••** on the right of the bar.
-3. Expected: the system keyboard is replaced in place by a 3-row in-app panel of the same height containing the desktop-only keys (` ~ | \ < > { } [ ]; Home End PgUp PgDn ← ↓ ↑ →; Esc Tab ⇧⇥ ⇧⏎ Ctrl ⌃C ⌃D ⌃R). The accessory bar stays anchored on top, but the toggle label now reads **✕**.
+3. Expected: the system keyboard is replaced in place by a 3-row in-app panel of the same height containing the desktop-only keys (` ~ | \ < > { } [ ]; Home End PgUp PgDn ← ↓ ↑ →; Esc Tab ⇧⏎ Shift Ctrl ⌃C ⌃D ⌃R). The accessory bar stays anchored on top, but the toggle label now reads **✕**.
 4. Tap **`** then **|**.
 5. Expected: a backtick and a pipe character appear at the terminal prompt — no extra layer taps needed.
 6. Tap **PgUp** and hold for a second.
@@ -1107,8 +1107,8 @@ Expected:
 9. Expected: SIGINT is delivered (process returns to prompt). Same for **⌃D** (EOF at empty prompt) and **⌃R** (opens reverse history search in bash / zsh).
 10. Tap **Ctrl** so it highlights, then tap **\\**.
 11. Expected: SIGQUIT is delivered (`Ctrl+\`). The Ctrl highlight clears after one key. Tap **Ctrl** twice in a row to confirm it toggles on/off with no bytes sent.
-12. Tap **⇧⇥** in the panel.
-13. Expected: BackTab (`ESC [ Z`) is sent. In Claude Code this toggles plan / accept-edits mode.
+12. Tap **Shift** so it highlights, then tap **Tab** in the panel.
+13. Expected: BackTab (`ESC [ Z`) is sent and the Shift highlight clears. In Claude Code this toggles plan / accept-edits mode. Tap **Shift** twice quickly to confirm it toggles on/off independently of Ctrl.
 14. Tap **✕** in the accessory bar.
 15. Expected: the panel is replaced by the system keyboard at the same screen position. The toggle label returns to **•••**. Vietnamese / dictation / autocorrect work again.
 16. Tap **•••** again, then hide the keyboard via the dismiss gesture (drag down on iOS, back button on Android).

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1094,23 +1094,27 @@ Expected:
 5. Toggle Appearance back to **Dark** and repeat the same presentations.
 6. Expected: native surfaces return to dark backgrounds and light text/icons without restarting the app.
 
-## 22c. Keyboard accessory full-keyboard toggle (replaces system keyboard)
+## 22c. Keyboard accessory full-keyboard toggle (desktop-keys panel)
 
 1. Connect to a workspace and focus a terminal so the keyboard accessory bar shows the primary row (Esc Tab ← ↓ ↑ → ⏎ •••).
 2. Tap **•••** on the right of the bar.
-3. Expected: the system keyboard is replaced in place by an in-app QWERTY panel of the same height. The accessory bar stays anchored on top, but the toggle label now reads **✕**. The terminal view does not jump — the total keyboard slot height is unchanged.
-4. Type `ls` followed by **return** on the QWERTY panel.
-5. Expected: the terminal receives the characters and runs the command exactly as it would from the system keyboard.
-6. Tap **⇧** (single tap), then a letter key.
-7. Expected: the letter is sent as a capital and the shift indicator clears. Tap **⇧** twice quickly to lock; the indicator changes to **⇪** and stays on across multiple letters.
-8. Tap **123** then **#+=** to walk through the number and symbol layers; tap a key in each.
-9. Expected: each tap inserts the displayed character at the terminal cursor (`|`, `~`, `\`, etc.).
-10. Tap **✕** in the accessory bar.
-11. Expected: the QWERTY panel is replaced by the system keyboard at the same screen position. The toggle label returns to **•••**. Vietnamese / dictation / autocorrect work again.
-12. Tap **•••** again, then hide the keyboard via the dismiss gesture (drag down on iOS, back button on Android).
-13. Expected: both the panel and the accessory bar disappear with the keyboard. Re-focusing the terminal shows the system keyboard with **•••** in the bar (panel does not auto-restore).
-14. Repeat steps 1–11 on Android.
-15. Expected: same behavior as iOS — the panel replaces the IME at the same height; **✕** restores the IME; system back / dismiss tears down both surfaces.
+3. Expected: the system keyboard is replaced in place by a 3-row in-app panel of the same height containing the desktop-only keys (` ~ | \ < > { } [ ]; Home End PgUp PgDn ← ↓ ↑ →; Esc Tab ⇧⇥ ⇧⏎ Ctrl ⌃C ⌃D ⌃R). The accessory bar stays anchored on top, but the toggle label now reads **✕**.
+4. Tap **`** then **|**.
+5. Expected: a backtick and a pipe character appear at the terminal prompt — no extra layer taps needed.
+6. Tap **PgUp** and hold for a second.
+7. Expected: PgUp repeats with the same cadence as the arrow keys on the accessory bar.
+8. Tap **⌃C** while a foreground process is running (e.g. `sleep 30`).
+9. Expected: SIGINT is delivered (process returns to prompt). Same for **⌃D** (EOF at empty prompt) and **⌃R** (opens reverse history search in bash / zsh).
+10. Tap **Ctrl** so it highlights, then tap **\\**.
+11. Expected: SIGQUIT is delivered (`Ctrl+\`). The Ctrl highlight clears after one key. Tap **Ctrl** twice in a row to confirm it toggles on/off with no bytes sent.
+12. Tap **⇧⇥** in the panel.
+13. Expected: BackTab (`ESC [ Z`) is sent. In Claude Code this toggles plan / accept-edits mode.
+14. Tap **✕** in the accessory bar.
+15. Expected: the panel is replaced by the system keyboard at the same screen position. The toggle label returns to **•••**. Vietnamese / dictation / autocorrect work again.
+16. Tap **•••** again, then hide the keyboard via the dismiss gesture (drag down on iOS, back button on Android).
+17. Expected: both the panel and the accessory bar disappear with the keyboard. Re-focusing the terminal shows the system keyboard with **•••** in the bar (panel does not auto-restore).
+18. Repeat steps 1–13 on Android.
+19. Expected: same behavior as iOS — the panel replaces the IME at the same height; **✕** restores the IME; modifier highlights and key repeat behave the same; system back / dismiss tears down both surfaces.
 
 ## 22b. iOS Native Presentations Follow Theme
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1094,6 +1094,27 @@ Expected:
 5. Toggle Appearance back to **Dark** and repeat the same presentations.
 6. Expected: native surfaces return to dark backgrounds and light text/icons without restarting the app.
 
+## 22c. Keyboard accessory detail row (Ctrl/Alt/Shift + agent keys)
+
+1. Connect to a workspace and focus a terminal so the keyboard accessory bar shows the primary row (Esc Tab ← ↓ ↑ → ⏎ •••).
+2. Tap **•••** on the right of the bar.
+3. Expected: a second row appears under the primary row with `Ctrl Alt Shift ⇧⇥ ⌃C ⌃D ⌃R Home End PgUp PgDn`. The bar height grows; the terminal view is pushed up so no content is hidden behind it.
+4. Tap **⌃C**.
+5. Expected: a foreground process in the terminal receives SIGINT (e.g. a running `sleep 30` returns to the prompt).
+6. Tap **Ctrl** so it highlights, then tap **D**-style key — in this build the closest equivalent is the dedicated **⌃D** button: tap **⌃D** at an empty prompt and confirm the shell sees EOF (e.g. `bash` exits / `cat` returns).
+7. Tap **Shift** so it highlights, then tap **Tab** in the primary row.
+8. Expected: the active program receives BackTab (`ESC [ Z`). In Claude Code, this toggles plan / accept-edits mode. The Shift highlight clears after the next key.
+9. Tap **Ctrl** (no extra key) then tap **Ctrl** again.
+10. Expected: the Ctrl highlight toggles on and off; no bytes are sent to the PTY for either tap.
+11. Tap **⇧⇥** (shift+tab one-shot button) in the detail row.
+12. Expected: BackTab is sent without needing to arm Shift first.
+13. Tap **PgUp** and hold; release after one second.
+14. Expected: PgUp repeats at the same cadence as the arrow keys (one immediate keystroke, then auto-repeat).
+15. Tap **•••** again to collapse.
+16. Expected: the detail row hides, the bar shrinks back to one row, any armed modifier is cleared.
+17. Repeat steps 1–3 on Android.
+18. Expected: same behavior as iOS — detail row appears, terminal area resizes to make room (no rows hidden), modifiers toggle/highlight, `⌃C` interrupts the foreground process.
+
 ## 22b. iOS Native Presentations Follow Theme
 
 1. Install an iOS build and open Settings.

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1094,26 +1094,23 @@ Expected:
 5. Toggle Appearance back to **Dark** and repeat the same presentations.
 6. Expected: native surfaces return to dark backgrounds and light text/icons without restarting the app.
 
-## 22c. Keyboard accessory detail row (Ctrl/Alt/Shift + agent keys)
+## 22c. Keyboard accessory full-keyboard toggle (replaces system keyboard)
 
 1. Connect to a workspace and focus a terminal so the keyboard accessory bar shows the primary row (Esc Tab ← ↓ ↑ → ⏎ •••).
 2. Tap **•••** on the right of the bar.
-3. Expected: a second row appears under the primary row with `Ctrl Alt Shift ⇧⇥ ⌃C ⌃D ⌃R Home End PgUp PgDn`. The bar height grows; the terminal view is pushed up so no content is hidden behind it.
-4. Tap **⌃C**.
-5. Expected: a foreground process in the terminal receives SIGINT (e.g. a running `sleep 30` returns to the prompt).
-6. Tap **Ctrl** so it highlights, then tap **D**-style key — in this build the closest equivalent is the dedicated **⌃D** button: tap **⌃D** at an empty prompt and confirm the shell sees EOF (e.g. `bash` exits / `cat` returns).
-7. Tap **Shift** so it highlights, then tap **Tab** in the primary row.
-8. Expected: the active program receives BackTab (`ESC [ Z`). In Claude Code, this toggles plan / accept-edits mode. The Shift highlight clears after the next key.
-9. Tap **Ctrl** (no extra key) then tap **Ctrl** again.
-10. Expected: the Ctrl highlight toggles on and off; no bytes are sent to the PTY for either tap.
-11. Tap **⇧⇥** (shift+tab one-shot button) in the detail row.
-12. Expected: BackTab is sent without needing to arm Shift first.
-13. Tap **PgUp** and hold; release after one second.
-14. Expected: PgUp repeats at the same cadence as the arrow keys (one immediate keystroke, then auto-repeat).
-15. Tap **•••** again to collapse.
-16. Expected: the detail row hides, the bar shrinks back to one row, any armed modifier is cleared.
-17. Repeat steps 1–3 on Android.
-18. Expected: same behavior as iOS — detail row appears, terminal area resizes to make room (no rows hidden), modifiers toggle/highlight, `⌃C` interrupts the foreground process.
+3. Expected: the system keyboard is replaced in place by an in-app QWERTY panel of the same height. The accessory bar stays anchored on top, but the toggle label now reads **✕**. The terminal view does not jump — the total keyboard slot height is unchanged.
+4. Type `ls` followed by **return** on the QWERTY panel.
+5. Expected: the terminal receives the characters and runs the command exactly as it would from the system keyboard.
+6. Tap **⇧** (single tap), then a letter key.
+7. Expected: the letter is sent as a capital and the shift indicator clears. Tap **⇧** twice quickly to lock; the indicator changes to **⇪** and stays on across multiple letters.
+8. Tap **123** then **#+=** to walk through the number and symbol layers; tap a key in each.
+9. Expected: each tap inserts the displayed character at the terminal cursor (`|`, `~`, `\`, etc.).
+10. Tap **✕** in the accessory bar.
+11. Expected: the QWERTY panel is replaced by the system keyboard at the same screen position. The toggle label returns to **•••**. Vietnamese / dictation / autocorrect work again.
+12. Tap **•••** again, then hide the keyboard via the dismiss gesture (drag down on iOS, back button on Android).
+13. Expected: both the panel and the accessory bar disappear with the keyboard. Re-focusing the terminal shows the system keyboard with **•••** in the bar (panel does not auto-restore).
+14. Repeat steps 1–11 on Android.
+15. Expected: same behavior as iOS — the panel replaces the IME at the same height; **✕** restores the IME; system back / dismiss tears down both surfaces.
 
 ## 22b. iOS Native Presentations Follow Theme
 

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -265,10 +265,12 @@ void zedra_ios_native_notification_dismiss(uint32_t callback_id);
 /**
  * Called from the native keyboard accessory bar when a shortcut key button is tapped.
  *
- * `key` is one of: "escape", "tab", "left", "down", "up", "right", "enter", "shift_enter".
- * Maps the name to the corresponding terminal escape sequence and sends it via the active session.
+ * `key` is one of the wire names accepted by `key_encoding::Key::parse`
+ * ("escape", "tab", "left", ... or `char:<c>` for single-character keys),
+ * plus the iOS-only sentinel "dismiss_keyboard". `mods` packs Shift/Alt/Ctrl
+ * per `key_encoding::Mods` (bit 0 / 1 / 2).
  */
-void zedra_ios_send_key_input(const char *key);
+void zedra_ios_send_key_input(const char *key, uint8_t mods);
 
 /**
  * Called from the native terminal composer to send finalized text to the active terminal.

--- a/ios/Zedra.xcodeproj/project.pbxproj
+++ b/ios/Zedra.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 			dependencies = (
 			);
 			name = ZedraRustFFI;
+			packageProductDependencies = (
+			);
 			productName = ZedraRustFFI;
 		};
 /* End PBXAggregateTarget section */
@@ -30,6 +32,7 @@
 		852516EA2D63566F57B5F106 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A6B03B40299B5BEA1C29D4F5 /* Metal.framework */; };
 		8D2C90EFA428CCCDE0B092E7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CBA9E86324F7D522B45D5BF8 /* Assets.xcassets */; };
 		980622780D44495907582D63 /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47A99A911DFEB67B22FF841B /* Network.framework */; };
+		9D2BCDE6BAAEB8B381958EB7 /* FullKeyboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CADD617EE63A32EEA54188B /* FullKeyboardView.swift */; };
 		A69ED82EFBA5E7757C5DBF77 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C6681ECC3A80F94D9F1A0A /* CoreFoundation.framework */; };
 		A7EEE2EFA03F51452EA9FEFE /* ZedraFFI.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9A9EA625E2ED4114945F081 /* ZedraFFI.xcframework */; };
 		BE058F99FCA4058A88807631 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33FBCE1A928EAF32E817D1DE /* CoreText.framework */; };
@@ -40,7 +43,6 @@
 		DE61BBA6802FC9CA90AEED44 /* NativeBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410390D2A6FA601A8CF3BEF6 /* NativeBridge.swift */; };
 		EB5F8FD753CF6EE923250A35 /* Presentations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20266BDD5D19B38FDD836CDF /* Presentations.swift */; };
 		EE620B5C08E5ED431EFF64EA /* QRScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33564399AE529EE2F9F8533A /* QRScanner.swift */; };
-		FB7BABDE3F18692CE0829018 /* Pods_Zedra.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 632745FB208CFFE433D7F1AC /* Pods_Zedra.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,19 +58,17 @@
 /* Begin PBXFileReference section */
 		00F1E4C60CC0F76F94D6404A /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		20266BDD5D19B38FDD836CDF /* Presentations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentations.swift; sourceTree = "<group>"; };
-		237F08BE47033D8E3C293A83 /* Pods-Zedra.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zedra.debug.xcconfig"; path = "Target Support Files/Pods-Zedra/Pods-Zedra.debug.xcconfig"; sourceTree = "<group>"; };
 		33564399AE529EE2F9F8533A /* QRScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScanner.swift; sourceTree = "<group>"; };
 		33FBCE1A928EAF32E817D1DE /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
 		410390D2A6FA601A8CF3BEF6 /* NativeBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeBridge.swift; sourceTree = "<group>"; };
 		47A99A911DFEB67B22FF841B /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = System/Library/Frameworks/Network.framework; sourceTree = SDKROOT; };
 		512091F828A8B43816DA9723 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		520C816D34F6ED9A97DA79BB /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
-		632745FB208CFFE433D7F1AC /* Pods_Zedra.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Zedra.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63C6681ECC3A80F94D9F1A0A /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		69F922850E131108EA0DCDA2 /* KeyboardSupporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSupporter.swift; sourceTree = "<group>"; };
+		7CADD617EE63A32EEA54188B /* FullKeyboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullKeyboardView.swift; sourceTree = "<group>"; };
 		8853DDC4052807AEC78FEEF3 /* ZedraAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZedraAppDelegate.swift; sourceTree = "<group>"; };
 		94CC8ED9DAA6944067FF57DB /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		A4BF719C2EB9475059E2405D /* Pods-Zedra.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zedra.release.xcconfig"; path = "Target Support Files/Pods-Zedra/Pods-Zedra.release.xcconfig"; sourceTree = "<group>"; };
 		A6B03B40299B5BEA1C29D4F5 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		B9A9EA625E2ED4114945F081 /* ZedraFFI.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = ZedraFFI.xcframework; sourceTree = "<group>"; };
 		C1CC23275A2211DE5D4991B1 /* GPUIRuntimeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPUIRuntimeController.swift; sourceTree = "<group>"; };
@@ -96,7 +96,6 @@
 				C8F576CC1856D853138C29FD /* Security.framework in Frameworks */,
 				980622780D44495907582D63 /* Network.framework in Frameworks */,
 				59174DFFDBE71FAD97A1CCB3 /* AVFoundation.framework in Frameworks */,
-				FB7BABDE3F18692CE0829018 /* Pods_Zedra.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -117,7 +116,6 @@
 				ABEFD155B72AC3F3F222A37B /* Zedra */,
 				88F08496A69E4168EB2884D0 /* Frameworks */,
 				5092EC10F4D31658ACC56C8C /* Products */,
-				8A96BB4A15E548E73B87A1DE /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -135,25 +133,15 @@
 				EA19906F43E7BEC9CAB21161 /* Security.framework */,
 				E0368E716FAFC7DC17C3B7B1 /* UIKit.framework */,
 				B9A9EA625E2ED4114945F081 /* ZedraFFI.xcframework */,
-				632745FB208CFFE433D7F1AC /* Pods_Zedra.framework */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		8A96BB4A15E548E73B87A1DE /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				237F08BE47033D8E3C293A83 /* Pods-Zedra.debug.xcconfig */,
-				A4BF719C2EB9475059E2405D /* Pods-Zedra.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
 			sourceTree = "<group>";
 		};
 		ABEFD155B72AC3F3F222A37B /* Zedra */ = {
 			isa = PBXGroup;
 			children = (
 				CBA9E86324F7D522B45D5BF8 /* Assets.xcassets */,
+				7CADD617EE63A32EEA54188B /* FullKeyboardView.swift */,
 				C1CC23275A2211DE5D4991B1 /* GPUIRuntimeController.swift */,
 				F48626960A7B8482AA6C9676 /* Info.plist */,
 				69F922850E131108EA0DCDA2 /* KeyboardSupporter.swift */,
@@ -173,13 +161,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 369835735FEF0BAB43052DA0 /* Build configuration list for PBXNativeTarget "Zedra" */;
 			buildPhases = (
-				E499BBF3634FFF5CEAFAA452 /* [CP] Check Pods Manifest.lock */,
 				909545E704A1285F03F00F56 /* Sources */,
 				3D0993EE512488A75299992B /* Resources */,
 				B904AB45BFDAA98506246086 /* Frameworks */,
 				8CA192F395F9B0CD6745F5AB /* Firebase Config */,
 				9B92177DC22DAAB553CD16E4 /* Firebase Crashlytics dSYM Upload */,
-				79F7A80EBC5AF6D156876252 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -187,6 +173,8 @@
 				0A5B3610398B68454840B5D4 /* PBXTargetDependency */,
 			);
 			name = Zedra;
+			packageProductDependencies = (
+			);
 			productName = Zedra;
 			productReference = F230208A834CC26BC2416452 /* Zedra.app */;
 			productType = "com.apple.product-type.application";
@@ -259,23 +247,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/../scripts/xcode-build-rust.sh\"\n";
 		};
-		79F7A80EBC5AF6D156876252 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Zedra/Pods-Zedra-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Zedra/Pods-Zedra-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Zedra/Pods-Zedra-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		8CA192F395F9B0CD6745F5AB /* Firebase Config */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -316,28 +287,6 @@
 			shellPath = /bin/sh;
 			shellScript = "set -eu\n\nGOOGLE_SERVICE_PLIST=\"${SRCROOT}/Zedra/GoogleService-Info.plist\"\n\nif [ ! -f \"$GOOGLE_SERVICE_PLIST\" ]; then\n  case \"${CONFIGURATION:-}\" in\n    Release*)\n      echo \"error: Missing $GOOGLE_SERVICE_PLIST. Release builds require Firebase configuration.\"\n      exit 1\n      ;;\n    *)\n      echo \"warning: Skipping Firebase Crashlytics dSYM upload because $GOOGLE_SERVICE_PLIST is missing.\"\n      exit 0\n      ;;\n  esac\nfi\n\n\"${PODS_ROOT}/FirebaseCrashlytics/run\"\n";
 		};
-		E499BBF3634FFF5CEAFAA452 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Zedra-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -345,6 +294,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9D2BCDE6BAAEB8B381958EB7 /* FullKeyboardView.swift in Sources */,
 				2B5A25991606E9A04567BB82 /* GPUIRuntimeController.swift in Sources */,
 				29812E9727315BE0E4E6D8C3 /* KeyboardSupporter.swift in Sources */,
 				DE61BBA6802FC9CA90AEED44 /* NativeBridge.swift in Sources */,
@@ -433,7 +383,6 @@
 		};
 		50B88CA82039DB4A2A14E6F3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 237F08BE47033D8E3C293A83 /* Pods-Zedra.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -480,7 +429,6 @@
 		};
 		517EF2B7F22F02FF5CE0D7A9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A4BF719C2EB9475059E2405D /* Pods-Zedra.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/ios/Zedra.xcodeproj/project.pbxproj
+++ b/ios/Zedra.xcodeproj/project.pbxproj
@@ -16,8 +16,6 @@
 			dependencies = (
 			);
 			name = ZedraRustFFI;
-			packageProductDependencies = (
-			);
 			productName = ZedraRustFFI;
 		};
 /* End PBXAggregateTarget section */
@@ -35,6 +33,7 @@
 		9D2BCDE6BAAEB8B381958EB7 /* FullKeyboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CADD617EE63A32EEA54188B /* FullKeyboardView.swift */; };
 		A69ED82EFBA5E7757C5DBF77 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C6681ECC3A80F94D9F1A0A /* CoreFoundation.framework */; };
 		A7EEE2EFA03F51452EA9FEFE /* ZedraFFI.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9A9EA625E2ED4114945F081 /* ZedraFFI.xcframework */; };
+		B5E87BDD04458E03684ABDD8 /* Pods_Zedra.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CB370A710B04D90AAEAD46D /* Pods_Zedra.framework */; };
 		BE058F99FCA4058A88807631 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33FBCE1A928EAF32E817D1DE /* CoreText.framework */; };
 		C4615C398F2572ED57528BB1 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E0368E716FAFC7DC17C3B7B1 /* UIKit.framework */; };
 		C6719995D3E0E4499805BFA7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 94CC8ED9DAA6944067FF57DB /* main.m */; };
@@ -57,6 +56,8 @@
 
 /* Begin PBXFileReference section */
 		00F1E4C60CC0F76F94D6404A /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		0B11FAE0BCA7E303AA8BE0A9 /* Pods-Zedra.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zedra.release.xcconfig"; path = "Target Support Files/Pods-Zedra/Pods-Zedra.release.xcconfig"; sourceTree = "<group>"; };
+		1D5ECE40149BD33A1BB029F3 /* Pods-Zedra.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Zedra.debug.xcconfig"; path = "Target Support Files/Pods-Zedra/Pods-Zedra.debug.xcconfig"; sourceTree = "<group>"; };
 		20266BDD5D19B38FDD836CDF /* Presentations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentations.swift; sourceTree = "<group>"; };
 		33564399AE529EE2F9F8533A /* QRScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScanner.swift; sourceTree = "<group>"; };
 		33FBCE1A928EAF32E817D1DE /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
@@ -64,6 +65,7 @@
 		47A99A911DFEB67B22FF841B /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = System/Library/Frameworks/Network.framework; sourceTree = SDKROOT; };
 		512091F828A8B43816DA9723 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		520C816D34F6ED9A97DA79BB /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		5CB370A710B04D90AAEAD46D /* Pods_Zedra.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Zedra.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63C6681ECC3A80F94D9F1A0A /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		69F922850E131108EA0DCDA2 /* KeyboardSupporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSupporter.swift; sourceTree = "<group>"; };
 		7CADD617EE63A32EEA54188B /* FullKeyboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullKeyboardView.swift; sourceTree = "<group>"; };
@@ -96,12 +98,23 @@
 				C8F576CC1856D853138C29FD /* Security.framework in Frameworks */,
 				980622780D44495907582D63 /* Network.framework in Frameworks */,
 				59174DFFDBE71FAD97A1CCB3 /* AVFoundation.framework in Frameworks */,
+				B5E87BDD04458E03684ABDD8 /* Pods_Zedra.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		143885069D29478B9397E67D /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				1D5ECE40149BD33A1BB029F3 /* Pods-Zedra.debug.xcconfig */,
+				0B11FAE0BCA7E303AA8BE0A9 /* Pods-Zedra.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		5092EC10F4D31658ACC56C8C /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -116,6 +129,7 @@
 				ABEFD155B72AC3F3F222A37B /* Zedra */,
 				88F08496A69E4168EB2884D0 /* Frameworks */,
 				5092EC10F4D31658ACC56C8C /* Products */,
+				143885069D29478B9397E67D /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -133,6 +147,7 @@
 				EA19906F43E7BEC9CAB21161 /* Security.framework */,
 				E0368E716FAFC7DC17C3B7B1 /* UIKit.framework */,
 				B9A9EA625E2ED4114945F081 /* ZedraFFI.xcframework */,
+				5CB370A710B04D90AAEAD46D /* Pods_Zedra.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -161,11 +176,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 369835735FEF0BAB43052DA0 /* Build configuration list for PBXNativeTarget "Zedra" */;
 			buildPhases = (
+				F4D98A9D51D8B9BF9CDBA481 /* [CP] Check Pods Manifest.lock */,
 				909545E704A1285F03F00F56 /* Sources */,
 				3D0993EE512488A75299992B /* Resources */,
 				B904AB45BFDAA98506246086 /* Frameworks */,
 				8CA192F395F9B0CD6745F5AB /* Firebase Config */,
 				9B92177DC22DAAB553CD16E4 /* Firebase Crashlytics dSYM Upload */,
+				71327D0F528D7FE398306A7E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -173,8 +190,6 @@
 				0A5B3610398B68454840B5D4 /* PBXTargetDependency */,
 			);
 			name = Zedra;
-			packageProductDependencies = (
-			);
 			productName = Zedra;
 			productReference = F230208A834CC26BC2416452 /* Zedra.app */;
 			productType = "com.apple.product-type.application";
@@ -247,6 +262,23 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/../scripts/xcode-build-rust.sh\"\n";
 		};
+		71327D0F528D7FE398306A7E /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Zedra/Pods-Zedra-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Zedra/Pods-Zedra-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Zedra/Pods-Zedra-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		8CA192F395F9B0CD6745F5AB /* Firebase Config */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -286,6 +318,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -eu\n\nGOOGLE_SERVICE_PLIST=\"${SRCROOT}/Zedra/GoogleService-Info.plist\"\n\nif [ ! -f \"$GOOGLE_SERVICE_PLIST\" ]; then\n  case \"${CONFIGURATION:-}\" in\n    Release*)\n      echo \"error: Missing $GOOGLE_SERVICE_PLIST. Release builds require Firebase configuration.\"\n      exit 1\n      ;;\n    *)\n      echo \"warning: Skipping Firebase Crashlytics dSYM upload because $GOOGLE_SERVICE_PLIST is missing.\"\n      exit 0\n      ;;\n  esac\nfi\n\n\"${PODS_ROOT}/FirebaseCrashlytics/run\"\n";
+		};
+		F4D98A9D51D8B9BF9CDBA481 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Zedra-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -383,6 +437,7 @@
 		};
 		50B88CA82039DB4A2A14E6F3 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1D5ECE40149BD33A1BB029F3 /* Pods-Zedra.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -429,6 +484,7 @@
 		};
 		517EF2B7F22F02FF5CE0D7A9 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0B11FAE0BCA7E303AA8BE0A9 /* Pods-Zedra.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/ios/Zedra.xcodeproj/xcuserdata/thomasle.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ios/Zedra.xcodeproj/xcuserdata/thomasle.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -14,11 +14,6 @@
 			<key>orderHint</key>
 			<integer>0</integer>
 		</dict>
-		<key>ZedraRustFFI.xcscheme_^#shared#^_</key>
-		<dict>
-			<key>orderHint</key>
-			<integer>28</integer>
-		</dict>
 	</dict>
 </dict>
 </plist>

--- a/ios/Zedra/FullKeyboardView.swift
+++ b/ios/Zedra/FullKeyboardView.swift
@@ -45,7 +45,8 @@ final class FullKeyboardView: UIView {
     private var shift: ShiftState = .off
     private var activeLayer: Layer = .letters
     private var isDarkTheme = true
-    private var rows: [UIStackView] = []
+    private var rowsKeys: [[Key]] = []
+    private var rowsButtons: [[UIButton]] = []
     private var keyButtons: [(button: UIButton, key: Key)] = []
     private var lastShiftTapDate: Date?
 
@@ -74,44 +75,31 @@ final class FullKeyboardView: UIView {
         }
     }
 
-    /// Lay the keyboard out for the current `layer` + `shift` state. Builds
-    /// from scratch every time so cap state, layer switches, and width
-    /// changes all share the same code path.
+    /// Rebuild the button set for the current `activeLayer` + `shift` state.
+    /// Per-row frames are computed in `layoutSubviews` so this method stays
+    /// independent of the view's current size — the same code path runs on
+    /// first install, on rotation, and on every layer / shift toggle.
     private func rebuild() {
-        for row in rows {
-            row.removeFromSuperview()
+        for (button, _) in keyButtons {
+            button.removeFromSuperview()
         }
-        rows.removeAll()
+        rowsKeys.removeAll()
+        rowsButtons.removeAll()
         keyButtons.removeAll()
 
-        let rowsSpecs = keyboardLayout()
-        let rowCount = rowsSpecs.count
-        let rowHeight = bounds.height / CGFloat(rowCount)
-        let verticalPadding: CGFloat = 4.0
-
-        for (rowIndex, rowKeys) in rowsSpecs.enumerated() {
-            let stack = UIStackView()
-            stack.axis = .horizontal
-            stack.spacing = 4
-            stack.distribution = .fill
-            stack.alignment = .fill
-            stack.translatesAutoresizingMaskIntoConstraints = false
-            stack.frame = CGRect(
-                x: 4,
-                y: CGFloat(rowIndex) * rowHeight + verticalPadding / 2,
-                width: bounds.width - 8,
-                height: rowHeight - verticalPadding
-            )
-            stack.autoresizingMask = [.flexibleWidth]
-            addSubview(stack)
-            rows.append(stack)
-
+        let specs = keyboardLayout()
+        for rowKeys in specs {
+            var rowButtons: [UIButton] = []
             for key in rowKeys {
                 let button = makeButton(for: key)
-                stack.addArrangedSubview(button)
+                addSubview(button)
+                rowButtons.append(button)
                 keyButtons.append((button, key))
             }
+            rowsKeys.append(rowKeys)
+            rowsButtons.append(rowButtons)
         }
+        setNeedsLayout()
     }
 
     private func keyboardLayout() -> [[Key]] {
@@ -178,19 +166,8 @@ final class FullKeyboardView: UIView {
         button.titleLabel?.font = .systemFont(ofSize: 18.0, weight: .regular)
         button.setTitle(key.label, for: .normal)
         button.layer.cornerRadius = 6.0
-        button.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        button.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-        button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(keyTapped(_:)), for: .touchUpInside)
         styleButton(button, key: key)
-
-        // Constrain width by stretching one "unit" key as the baseline; non-1.0
-        // keys are multiples of that base via constraint priorities — UIStackView
-        // distributes remaining space proportionally when we set a width anchor
-        // referencing the first button.
-        if key.widthHint != 1.0, let anchor = keyButtons.first?.button.widthAnchor {
-            button.widthAnchor.constraint(equalTo: anchor, multiplier: key.widthHint).isActive = true
-        }
         return button
     }
 
@@ -277,20 +254,35 @@ final class FullKeyboardView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        // Re-layout rows when the host resizes us (rotation, split view).
-        let rowCount = rows.count
-        guard rowCount > 0 else {
+        let rowCount = rowsKeys.count
+        guard rowCount > 0, bounds.width > 0, bounds.height > 0 else {
             return
         }
-        let rowHeight = bounds.height / CGFloat(rowCount)
-        let verticalPadding: CGFloat = 4.0
-        for (index, row) in rows.enumerated() {
-            row.frame = CGRect(
-                x: 4,
-                y: CGFloat(index) * rowHeight + verticalPadding / 2,
-                width: bounds.width - 8,
-                height: rowHeight - verticalPadding
-            )
+        let horizontalInset: CGFloat = 4
+        let keyGap: CGFloat = 4
+        let rowGap: CGFloat = 4
+
+        let rowHeight = (bounds.height - rowGap * CGFloat(rowCount + 1)) / CGFloat(rowCount)
+        let availableWidth = bounds.width - horizontalInset * 2
+
+        for (rowIndex, keys) in rowsKeys.enumerated() {
+            let buttons = rowsButtons[rowIndex]
+            let totalWeight = keys.reduce(0.0 as CGFloat) { $0 + $1.widthHint }
+            let totalGap = keyGap * CGFloat(max(0, keys.count - 1))
+            let unit = (availableWidth - totalGap) / max(0.0001, totalWeight)
+
+            var x: CGFloat = horizontalInset
+            let y = rowGap + CGFloat(rowIndex) * (rowHeight + rowGap)
+            for (keyIndex, key) in keys.enumerated() {
+                let width = unit * key.widthHint
+                buttons[keyIndex].frame = CGRect(
+                    x: x,
+                    y: y,
+                    width: width,
+                    height: rowHeight
+                )
+                x += width + keyGap
+            }
         }
     }
 }

--- a/ios/Zedra/FullKeyboardView.swift
+++ b/ios/Zedra/FullKeyboardView.swift
@@ -103,7 +103,6 @@ final class FullKeyboardView: UIView {
     private let sendKey: SendKey
     private let hostOs: HostOs
     private weak var hostBadge: UILabel?
-    private weak var topBorder: UIView?
     private var isDarkTheme = true
     private var armedMods: AccessoryMods = []
     private var rowsKeys: [[Key]] = []
@@ -126,11 +125,9 @@ final class FullKeyboardView: UIView {
         autoresizingMask = [.flexibleWidth]
         clipsToBounds = false
 
-        let border = UIView(frame: CGRect(x: 0, y: 0, width: width, height: 0.33))
-        border.autoresizingMask = [.flexibleWidth]
-        addSubview(border)
-        topBorder = border
-
+        // No top border on the panel: the accessory bar above already draws
+        // its own bottom edge, and a second hairline read as a divider
+        // between bar and panel rather than one continuous surface.
         build()
         installHostBadge()
         applyTheme(isDark: isDark)
@@ -147,13 +144,8 @@ final class FullKeyboardView: UIView {
             isDark
             ? UIColor(red: 0.055, green: 0.047, blue: 0.047, alpha: 0.96)
             : UIColor(red: 0.961, green: 0.961, blue: 0.961, alpha: 0.98)
-        let borderColor =
-            isDark
-            ? UIColor(white: 1.0, alpha: 0.12)
-            : UIColor(white: 0.0, alpha: 0.10)
 
         self.backgroundColor = backgroundColor
-        topBorder?.backgroundColor = borderColor
 
         if #available(iOS 13.0, *) {
             overrideUserInterfaceStyle = isDark ? .dark : .light
@@ -330,8 +322,6 @@ final class FullKeyboardView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-
-        topBorder?.frame = CGRect(x: 0, y: 0, width: bounds.width, height: 0.33)
 
         let rowCount = rowsKeys.count
         guard rowCount > 0, bounds.width > 0, bounds.height > 0 else {

--- a/ios/Zedra/FullKeyboardView.swift
+++ b/ios/Zedra/FullKeyboardView.swift
@@ -1,54 +1,95 @@
 import UIKit
 
-/// In-app QWERTY keyboard that replaces the system software keyboard while the
-/// user is driving a terminal / agent session. Each tap is forwarded to
-/// `sendKey(name, mods)` using the same wire format as the accessory bar
-/// (`char:<c>`, named keys, mod bitmask).
+/// Desktop-only key panel that replaces the system keyboard while a terminal
+/// or agent session has focus. Surfaces keys / combos that the iOS soft
+/// keyboard either doesn't have at all or buries multiple layers deep. There
+/// is no QWERTY here on purpose — users tap `✕` and go back to the system
+/// keyboard for prose typing, IME, dictation, autocorrect.
 ///
-/// The view is intended to be installed via `gpui_ios_set_keyboard_input_view`.
-/// UIKit reads `frame.size` for the keyboard slot, so callers must size this
-/// to the system keyboard's last known height before installing it.
+/// Every tap dispatches through `sendKey(name, mods)` using the same wire
+/// format as the accessory bar (`char:<c>` for single chars, named keys, and
+/// a Shift/Alt/Ctrl bitmask per `key_encoding::Mods`).
 final class FullKeyboardView: UIView {
-    /// Closure invoked for every keystroke. Matches the FFI used by
-    /// `KeyboardSupporter` so both surfaces share one transport.
     typealias SendKey = (String, UInt8) -> Void
 
-    private enum Layer {
-        case letters
-        case numbers
-        case symbols
-    }
+    private struct AccessoryMods: OptionSet {
+        let rawValue: UInt8
 
-    private enum ShiftState {
-        case off
-        case oneShot
-        case locked
+        static let shift = AccessoryMods(rawValue: 0b001)
+        static let alt = AccessoryMods(rawValue: 0b010)
+        static let ctrl = AccessoryMods(rawValue: 0b100)
     }
 
     private enum KeyKind {
-        case char(String)
-        case named(String)
-        case shift
-        case backspace
-        case toggleLayer(Layer)
-        case space
-        case enter
+        /// Tap dispatches `(name, armedMods | fixedMods)`. The single source
+        /// of truth for every non-modifier key.
+        case dispatch(name: String, fixedMods: AccessoryMods = [])
+        /// Sticky modifier — toggles `armedMods`, never sends bytes itself.
+        case modifier(AccessoryMods)
     }
 
     private struct Key {
         let label: String
         let kind: KeyKind
-        let widthHint: CGFloat
+        let repeats: Bool
+
+        init(label: String, kind: KeyKind, repeats: Bool = false) {
+            self.label = label
+            self.kind = kind
+            self.repeats = repeats
+        }
     }
 
+    /// Row 1 — symbols that exist on the iOS soft keyboard but are buried 1-2
+    /// layers deep. Surfacing them one-tap is the highest-value cheap win.
+    private let symbolRow: [Key] = [
+        Key(label: "`", kind: .dispatch(name: "char:`")),
+        Key(label: "~", kind: .dispatch(name: "char:~")),
+        Key(label: "|", kind: .dispatch(name: "char:|")),
+        Key(label: "\\", kind: .dispatch(name: "char:\\")),
+        Key(label: "<", kind: .dispatch(name: "char:<")),
+        Key(label: ">", kind: .dispatch(name: "char:>")),
+        Key(label: "{", kind: .dispatch(name: "char:{")),
+        Key(label: "}", kind: .dispatch(name: "char:}")),
+        Key(label: "[", kind: .dispatch(name: "char:[")),
+        Key(label: "]", kind: .dispatch(name: "char:]")),
+    ]
+
+    /// Row 2 — navigation cluster the soft keyboard has no concept of.
+    private let navRow: [Key] = [
+        Key(label: "Home", kind: .dispatch(name: "home")),
+        Key(label: "End", kind: .dispatch(name: "end")),
+        Key(label: "PgUp", kind: .dispatch(name: "page_up"), repeats: true),
+        Key(label: "PgDn", kind: .dispatch(name: "page_down"), repeats: true),
+        Key(label: "←", kind: .dispatch(name: "left"), repeats: true),
+        Key(label: "↓", kind: .dispatch(name: "down"), repeats: true),
+        Key(label: "↑", kind: .dispatch(name: "up"), repeats: true),
+        Key(label: "→", kind: .dispatch(name: "right"), repeats: true),
+    ]
+
+    /// Row 3 — agent / terminal control keys + a sticky `Ctrl` for ad-hoc
+    /// combos (e.g. Ctrl+\, Ctrl+PgUp).
+    private let controlRow: [Key] = [
+        Key(label: "Esc", kind: .dispatch(name: "escape")),
+        Key(label: "Tab", kind: .dispatch(name: "tab")),
+        Key(label: "⇧⇥", kind: .dispatch(name: "tab", fixedMods: .shift)),
+        Key(label: "⇧⏎", kind: .dispatch(name: "enter", fixedMods: .shift)),
+        Key(label: "Ctrl", kind: .modifier(.ctrl)),
+        Key(label: "⌃C", kind: .dispatch(name: "char:c", fixedMods: .ctrl)),
+        Key(label: "⌃D", kind: .dispatch(name: "char:d", fixedMods: .ctrl)),
+        Key(label: "⌃R", kind: .dispatch(name: "char:r", fixedMods: .ctrl)),
+    ]
+
     private let sendKey: SendKey
-    private var shift: ShiftState = .off
-    private var activeLayer: Layer = .letters
     private var isDarkTheme = true
+    private var armedMods: AccessoryMods = []
     private var rowsKeys: [[Key]] = []
     private var rowsButtons: [[UIButton]] = []
     private var keyButtons: [(button: UIButton, key: Key)] = []
-    private var lastShiftTapDate: Date?
+    private var repeatTimer: Timer?
+    private var repeatingKey: (name: String, mods: UInt8)?
+    private let repeatInitialDelay: TimeInterval = 0.35
+    private let repeatInterval: TimeInterval = 0.06
 
     init(width: CGFloat, height: CGFloat, isDark: Bool, sendKey: @escaping SendKey) {
         self.sendKey = sendKey
@@ -57,7 +98,7 @@ final class FullKeyboardView: UIView {
         autoresizingMask = [.flexibleWidth]
         clipsToBounds = true
         applyTheme(isDark: isDark)
-        rebuild()
+        build()
     }
 
     required init?(coder: NSCoder) {
@@ -75,11 +116,7 @@ final class FullKeyboardView: UIView {
         }
     }
 
-    /// Rebuild the button set for the current `activeLayer` + `shift` state.
-    /// Per-row frames are computed in `layoutSubviews` so this method stays
-    /// independent of the view's current size — the same code path runs on
-    /// first install, on rotation, and on every layer / shift toggle.
-    private func rebuild() {
+    private func build() {
         for (button, _) in keyButtons {
             button.removeFromSuperview()
         }
@@ -87,8 +124,7 @@ final class FullKeyboardView: UIView {
         rowsButtons.removeAll()
         keyButtons.removeAll()
 
-        let specs = keyboardLayout()
-        for rowKeys in specs {
+        for rowKeys in [symbolRow, navRow, controlRow] {
             var rowButtons: [UIButton] = []
             for key in rowKeys {
                 let button = makeButton(for: key)
@@ -102,87 +138,32 @@ final class FullKeyboardView: UIView {
         setNeedsLayout()
     }
 
-    private func keyboardLayout() -> [[Key]] {
-        switch activeLayer {
-        case .letters:
-            let row1 = "qwertyuiop".map { Key(label: shiftedLetter(String($0)), kind: .char(String($0)), widthHint: 1.0) }
-            let row2 = "asdfghjkl".map { Key(label: shiftedLetter(String($0)), kind: .char(String($0)), widthHint: 1.0) }
-            var row3: [Key] = [
-                Key(label: shiftLabel(), kind: .shift, widthHint: 1.5)
-            ]
-            row3.append(contentsOf: "zxcvbnm".map { Key(label: shiftedLetter(String($0)), kind: .char(String($0)), widthHint: 1.0) })
-            row3.append(Key(label: "⌫", kind: .backspace, widthHint: 1.5))
-            let row4: [Key] = [
-                Key(label: "123", kind: .toggleLayer(.numbers), widthHint: 1.5),
-                Key(label: "space", kind: .space, widthHint: 5.0),
-                Key(label: "return", kind: .enter, widthHint: 2.0),
-            ]
-            return [row1, row2, row3, row4]
-        case .numbers:
-            let row1 = "1234567890".map { Key(label: String($0), kind: .char(String($0)), widthHint: 1.0) }
-            let row2 = ["-", "/", ":", ";", "(", ")", "$", "&", "@", "\""].map { Key(label: $0, kind: .char($0), widthHint: 1.0) }
-            var row3: [Key] = [
-                Key(label: "#+=", kind: .toggleLayer(.symbols), widthHint: 1.5)
-            ]
-            row3.append(contentsOf: [".", ",", "?", "!", "'"].map { Key(label: $0, kind: .char($0), widthHint: 1.0) })
-            row3.append(Key(label: "⌫", kind: .backspace, widthHint: 1.5))
-            let row4: [Key] = [
-                Key(label: "ABC", kind: .toggleLayer(.letters), widthHint: 1.5),
-                Key(label: "space", kind: .space, widthHint: 5.0),
-                Key(label: "return", kind: .enter, widthHint: 2.0),
-            ]
-            return [row1, row2, row3, row4]
-        case .symbols:
-            let row1 = ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="].map { Key(label: $0, kind: .char($0), widthHint: 1.0) }
-            let row2 = ["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "•"].map { Key(label: $0, kind: .char($0), widthHint: 1.0) }
-            var row3: [Key] = [
-                Key(label: "123", kind: .toggleLayer(.numbers), widthHint: 1.5)
-            ]
-            row3.append(contentsOf: [".", ",", "?", "!", "'"].map { Key(label: $0, kind: .char($0), widthHint: 1.0) })
-            row3.append(Key(label: "⌫", kind: .backspace, widthHint: 1.5))
-            let row4: [Key] = [
-                Key(label: "ABC", kind: .toggleLayer(.letters), widthHint: 1.5),
-                Key(label: "space", kind: .space, widthHint: 5.0),
-                Key(label: "return", kind: .enter, widthHint: 2.0),
-            ]
-            return [row1, row2, row3, row4]
-        }
-    }
-
-    private func shiftedLetter(_ c: String) -> String {
-        return shift == .off ? c : c.uppercased()
-    }
-
-    private func shiftLabel() -> String {
-        switch shift {
-        case .off: return "⇧"
-        case .oneShot: return "⬆︎"
-        case .locked: return "⇪"
-        }
-    }
-
     private func makeButton(for key: Key) -> UIButton {
         let button = UIButton(type: .system)
         button.titleLabel?.font = .systemFont(ofSize: 18.0, weight: .regular)
         button.setTitle(key.label, for: .normal)
         button.layer.cornerRadius = 6.0
-        button.addTarget(self, action: #selector(keyTapped(_:)), for: .touchUpInside)
+        button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
+        button.addTarget(self, action: #selector(buttonTouchUpInside(_:)), for: .touchUpInside)
+        button.addTarget(self, action: #selector(stopRepeating), for: .touchUpOutside)
+        button.addTarget(self, action: #selector(stopRepeating), for: .touchCancel)
+        button.addTarget(self, action: #selector(stopRepeating), for: .touchDragExit)
         styleButton(button, key: key)
         return button
     }
 
     private func styleButton(_ button: UIButton, key: Key) {
-        let isSpecial: Bool
+        let isModifier: Bool
         switch key.kind {
-        case .char: isSpecial = false
-        default: isSpecial = true
+        case .modifier: isModifier = true
+        case .dispatch: isModifier = false
         }
         let baseBg =
             isDarkTheme
-            ? (isSpecial
+            ? (isModifier
                 ? UIColor(red: 0.20, green: 0.20, blue: 0.22, alpha: 1.0)
                 : UIColor(red: 0.30, green: 0.30, blue: 0.33, alpha: 1.0))
-            : (isSpecial
+            : (isModifier
                 ? UIColor(red: 0.65, green: 0.66, blue: 0.69, alpha: 1.0)
                 : UIColor.white)
         let foreground =
@@ -193,8 +174,7 @@ final class FullKeyboardView: UIView {
         button.setTitleColor(foreground, for: .normal)
         button.tintColor = foreground
 
-        // Highlight a locked / armed shift so the user can see the state.
-        if case .shift = key.kind, shift == .locked {
+        if case .modifier(let mod) = key.kind, armedMods.contains(mod) {
             button.backgroundColor =
                 isDarkTheme
                 ? UIColor(white: 1.0, alpha: 0.25)
@@ -202,54 +182,84 @@ final class FullKeyboardView: UIView {
         }
     }
 
-    @objc
-    private func keyTapped(_ sender: UIButton) {
-        guard let (_, key) = keyButtons.first(where: { $0.button === sender }) else {
-            return
-        }
-        switch key.kind {
-        case .char(let c):
-            let outgoing = shift == .off ? c : c.uppercased()
-            sendKey("char:\(outgoing)", 0)
-            if shift == .oneShot {
-                shift = .off
-                rebuild()
-            }
-        case .named(let name):
-            sendKey(name, 0)
-        case .shift:
-            handleShiftTap()
-        case .backspace:
-            sendKey("backspace", 0)
-        case .toggleLayer(let target):
-            activeLayer = target
-            // Switching layers also resets shift; the system keyboard does the
-            // same so the symbol layer doesn't capslock through letters.
-            shift = .off
-            rebuild()
-        case .space:
-            sendKey("char: ", 0)
-        case .enter:
-            sendKey("enter", 0)
+    private func refreshModifierHighlights() {
+        for (button, key) in keyButtons {
+            styleButton(button, key: key)
         }
     }
 
-    private func handleShiftTap() {
-        let now = Date()
-        let isDoubleTap =
-            lastShiftTapDate.map { now.timeIntervalSince($0) < 0.35 } ?? false
-        lastShiftTapDate = now
-
-        if isDoubleTap {
-            shift = .locked
-        } else {
-            switch shift {
-            case .off: shift = .oneShot
-            case .oneShot: shift = .off
-            case .locked: shift = .off
-            }
+    private func dispatchKey(name: String, fixedMods: AccessoryMods) {
+        let combined = armedMods.union(fixedMods)
+        sendKey(name, combined.rawValue)
+        if !armedMods.isEmpty {
+            armedMods = []
+            refreshModifierHighlights()
         }
-        rebuild()
+    }
+
+    private func key(for sender: UIButton) -> Key? {
+        for (button, key) in keyButtons where button === sender {
+            return key
+        }
+        return nil
+    }
+
+    @objc
+    private func buttonTouchDown(_ sender: UIButton) {
+        guard let key = key(for: sender), key.repeats else {
+            return
+        }
+        if case .dispatch(let name, let fixedMods) = key.kind {
+            let combined = armedMods.union(fixedMods)
+            sendKey(name, combined.rawValue)
+            if !armedMods.isEmpty {
+                armedMods = []
+                refreshModifierHighlights()
+            }
+            startRepeating(name: name, mods: combined.rawValue)
+        }
+    }
+
+    @objc
+    private func buttonTouchUpInside(_ sender: UIButton) {
+        guard let key = key(for: sender) else {
+            stopRepeating()
+            return
+        }
+        if key.repeats {
+            stopRepeating()
+            return
+        }
+        switch key.kind {
+        case .dispatch(let name, let fixedMods):
+            dispatchKey(name: name, fixedMods: fixedMods)
+        case .modifier(let mod):
+            armedMods.formSymmetricDifference(mod)
+            refreshModifierHighlights()
+        }
+    }
+
+    @objc
+    func stopRepeating() {
+        repeatTimer?.invalidate()
+        repeatTimer = nil
+        repeatingKey = nil
+    }
+
+    private func startRepeating(name: String, mods: UInt8) {
+        stopRepeating()
+        repeatingKey = (name, mods)
+        let timer = Timer(timeInterval: repeatInterval, repeats: true) { [weak self] _ in
+            guard let self, let target = self.repeatingKey,
+                target.name == name, target.mods == mods
+            else {
+                return
+            }
+            self.sendKey(name, mods)
+        }
+        timer.fireDate = Date(timeIntervalSinceNow: repeatInitialDelay)
+        repeatTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
     }
 
     override func layoutSubviews() {
@@ -267,21 +277,19 @@ final class FullKeyboardView: UIView {
 
         for (rowIndex, keys) in rowsKeys.enumerated() {
             let buttons = rowsButtons[rowIndex]
-            let totalWeight = keys.reduce(0.0 as CGFloat) { $0 + $1.widthHint }
             let totalGap = keyGap * CGFloat(max(0, keys.count - 1))
-            let unit = (availableWidth - totalGap) / max(0.0001, totalWeight)
+            let keyWidth = (availableWidth - totalGap) / CGFloat(max(1, keys.count))
 
             var x: CGFloat = horizontalInset
             let y = rowGap + CGFloat(rowIndex) * (rowHeight + rowGap)
-            for (keyIndex, key) in keys.enumerated() {
-                let width = unit * key.widthHint
+            for (keyIndex, _) in keys.enumerated() {
                 buttons[keyIndex].frame = CGRect(
                     x: x,
                     y: y,
-                    width: width,
+                    width: keyWidth,
                     height: rowHeight
                 )
-                x += width + keyGap
+                x += keyWidth + keyGap
             }
         }
     }

--- a/ios/Zedra/FullKeyboardView.swift
+++ b/ios/Zedra/FullKeyboardView.swift
@@ -64,7 +64,7 @@ final class FullKeyboardView: UIView {
     }
 
     private let modNavRow: [Key] = [
-        Key(label: "shift", kind: .modifier(.shift)),
+        Key(label: "Shift", kind: .modifier(.shift)),
         Key(label: "Ctrl", kind: .modifier(.ctrl)),
         Key(label: "Cmd", kind: .modifier(.cmd)),
         Key(label: "Home", kind: .dispatch(name: "home")),
@@ -206,7 +206,15 @@ final class FullKeyboardView: UIView {
 
     private func makeButton(for key: Key) -> UIButton {
         let button = UIButton(type: .system)
-        button.titleLabel?.font = .systemFont(ofSize: 16)
+        // Backspace glyph reads small at 16pt; bump it up while keeping the
+        // button width aligned with the rest of the row.
+        let fontSize: CGFloat
+        if case .dispatch(let name, _) = key.kind, name == "backspace" {
+            fontSize = 22
+        } else {
+            fontSize = 16
+        }
+        button.titleLabel?.font = .systemFont(ofSize: fontSize)
         button.setTitle(key.label, for: .normal)
         button.layer.cornerRadius = 6
         button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
@@ -325,42 +333,39 @@ final class FullKeyboardView: UIView {
 
         topBorder?.frame = CGRect(x: 0, y: 0, width: bounds.width, height: 0.33)
 
-        if let badge = hostBadge {
-            let badgeSize = badge.sizeThatFits(CGSize(width: 120, height: 14))
-            badge.frame = CGRect(
-                x: bounds.width - badgeSize.width - 8,
-                y: 2,
-                width: badgeSize.width,
-                height: badgeSize.height
-            )
-        }
-
         let rowCount = rowsKeys.count
         guard rowCount > 0, bounds.width > 0, bounds.height > 0 else {
             return
         }
 
-        let horizontalInset: CGFloat = 4
-        let keyGap: CGFloat = 2
-        let topInset: CGFloat = 18
-        let availableWidth = bounds.width - horizontalInset * 2
-
+        // Match the accessory bar above: edge-to-edge columns, no horizontal
+        // inset or gap, so each panel key column lines up with the bar button
+        // directly above it.
         for (rowIndex, keys) in rowsKeys.enumerated() {
             let buttons = rowsButtons[rowIndex]
-            let totalGap = keyGap * CGFloat(max(0, keys.count - 1))
-            let keyWidth = (availableWidth - totalGap) / CGFloat(max(1, keys.count))
+            let keyWidth = bounds.width / CGFloat(max(1, keys.count))
 
-            var x: CGFloat = horizontalInset
-            let y = topInset + CGFloat(rowIndex) * rowHeight
+            let y = CGFloat(rowIndex) * rowHeight
             for (keyIndex, _) in keys.enumerated() {
                 buttons[keyIndex].frame = CGRect(
-                    x: x,
+                    x: CGFloat(keyIndex) * keyWidth,
                     y: y,
                     width: keyWidth,
                     height: rowHeight
                 )
-                x += keyWidth + keyGap
             }
+        }
+
+        // Pin the OS badge to the bottom of the panel (reserved region) so
+        // the keys read first and the diagnostic label is unobtrusive.
+        if let badge = hostBadge {
+            let badgeSize = badge.sizeThatFits(CGSize(width: 120, height: 14))
+            badge.frame = CGRect(
+                x: bounds.width - badgeSize.width - 8,
+                y: bounds.height - badgeSize.height - 4,
+                width: badgeSize.width,
+                height: badgeSize.height
+            )
         }
     }
 }

--- a/ios/Zedra/FullKeyboardView.swift
+++ b/ios/Zedra/FullKeyboardView.swift
@@ -67,13 +67,14 @@ final class FullKeyboardView: UIView {
         Key(label: "→", kind: .dispatch(name: "right"), repeats: true),
     ]
 
-    /// Row 3 — agent / terminal control keys + a sticky `Ctrl` for ad-hoc
-    /// combos (e.g. Ctrl+\, Ctrl+PgUp).
+    /// Row 3 — agent / terminal control keys plus sticky `Shift` and `Ctrl`
+    /// modifiers so users can compose ad-hoc combos with any other panel
+    /// key (e.g. Shift+Home, Ctrl+\, Ctrl+PgUp).
     private let controlRow: [Key] = [
         Key(label: "Esc", kind: .dispatch(name: "escape")),
         Key(label: "Tab", kind: .dispatch(name: "tab")),
-        Key(label: "⇧⇥", kind: .dispatch(name: "tab", fixedMods: .shift)),
         Key(label: "⇧⏎", kind: .dispatch(name: "enter", fixedMods: .shift)),
+        Key(label: "Shift", kind: .modifier(.shift)),
         Key(label: "Ctrl", kind: .modifier(.ctrl)),
         Key(label: "⌃C", kind: .dispatch(name: "char:c", fixedMods: .ctrl)),
         Key(label: "⌃D", kind: .dispatch(name: "char:d", fixedMods: .ctrl)),

--- a/ios/Zedra/FullKeyboardView.swift
+++ b/ios/Zedra/FullKeyboardView.swift
@@ -20,15 +20,15 @@ enum HostOs: UInt8 {
 }
 
 /// Desktop-only key panel that replaces the system keyboard while a terminal
-/// or agent session has focus. Surfaces keys / combos the iOS soft keyboard
-/// doesn't expose as a single tap. There is no QWERTY here on purpose —
-/// `✕` hands focus back to the system IME for prose typing, dictation,
-/// Vietnamese / CJK input.
+/// or agent session has focus. Visual chrome (background, foreground, border,
+/// font size, row height) matches `KeyboardSupporter` so the panel reads as a
+/// natural extension of the accessory bar above it. The supplied design mock
+/// drives only position and the key set.
 ///
 /// Layout (top → bottom):
-///   Row 1 (chips):  Shift  Ctrl  Cmd   Home  End  PgUp  PgDn   ⌫
-///   Row 2 (flat):   ~  @  $  *  ^  %  =  `
-///   Row 3 (flat):   <  >  (  )  {  }  [  ]
+///   Row 1: shift  Ctrl  Cmd   Home  End  PgUp  PgD   ⌫
+///   Row 2: ~  @  $  *  ^  %  =  `
+///   Row 3: <  >  (  )  {  }  [  ]
 ///   Reserved space below the key rows is intentionally left blank for
 ///   future additions (clipboard, snippets, agent macros, …).
 final class FullKeyboardView: UIView {
@@ -47,69 +47,63 @@ final class FullKeyboardView: UIView {
     }
 
     private enum KeyKind {
-        /// Tap dispatches `(name, armedMods | fixedMods)`.
         case dispatch(name: String, fixedMods: AccessoryMods = [])
-        /// Sticky modifier — toggles `armedMods`, never sends bytes itself.
         case modifier(AccessoryMods)
-    }
-
-    private enum KeyStyle {
-        /// Raised pill / chip — modifiers, nav cluster, backspace.
-        case chip
-        /// Flat glyph — symbols. No background unless pressed.
-        case flat
     }
 
     private struct Key {
         let label: String
         let kind: KeyKind
-        let style: KeyStyle
         let repeats: Bool
 
-        init(label: String, kind: KeyKind, style: KeyStyle, repeats: Bool = false) {
+        init(label: String, kind: KeyKind, repeats: Bool = false) {
             self.label = label
             self.kind = kind
-            self.style = style
             self.repeats = repeats
         }
     }
 
-    private let chipRow: [Key] = [
-        Key(label: "shift", kind: .modifier(.shift), style: .chip),
-        Key(label: "Ctrl", kind: .modifier(.ctrl), style: .chip),
-        Key(label: "Cmd", kind: .modifier(.cmd), style: .chip),
-        Key(label: "Home", kind: .dispatch(name: "home"), style: .chip),
-        Key(label: "End", kind: .dispatch(name: "end"), style: .chip),
-        Key(label: "PgUp", kind: .dispatch(name: "page_up"), style: .chip, repeats: true),
-        Key(label: "PgD", kind: .dispatch(name: "page_down"), style: .chip, repeats: true),
-        Key(label: "⌫", kind: .dispatch(name: "backspace"), style: .chip, repeats: true),
+    private let modNavRow: [Key] = [
+        Key(label: "shift", kind: .modifier(.shift)),
+        Key(label: "Ctrl", kind: .modifier(.ctrl)),
+        Key(label: "Cmd", kind: .modifier(.cmd)),
+        Key(label: "Home", kind: .dispatch(name: "home")),
+        Key(label: "End", kind: .dispatch(name: "end")),
+        Key(label: "PgUp", kind: .dispatch(name: "page_up"), repeats: true),
+        Key(label: "PgD", kind: .dispatch(name: "page_down"), repeats: true),
+        Key(label: "⌫", kind: .dispatch(name: "backspace"), repeats: true),
     ]
 
     private let symbolRow1: [Key] = [
-        Key(label: "~", kind: .dispatch(name: "char:~"), style: .flat),
-        Key(label: "@", kind: .dispatch(name: "char:@"), style: .flat),
-        Key(label: "$", kind: .dispatch(name: "char:$"), style: .flat),
-        Key(label: "*", kind: .dispatch(name: "char:*"), style: .flat),
-        Key(label: "^", kind: .dispatch(name: "char:^"), style: .flat),
-        Key(label: "%", kind: .dispatch(name: "char:%"), style: .flat),
-        Key(label: "=", kind: .dispatch(name: "char:="), style: .flat),
-        Key(label: "`", kind: .dispatch(name: "char:`"), style: .flat),
+        Key(label: "~", kind: .dispatch(name: "char:~")),
+        Key(label: "@", kind: .dispatch(name: "char:@")),
+        Key(label: "$", kind: .dispatch(name: "char:$")),
+        Key(label: "*", kind: .dispatch(name: "char:*")),
+        Key(label: "^", kind: .dispatch(name: "char:^")),
+        Key(label: "%", kind: .dispatch(name: "char:%")),
+        Key(label: "=", kind: .dispatch(name: "char:=")),
+        Key(label: "`", kind: .dispatch(name: "char:`")),
     ]
 
     private let symbolRow2: [Key] = [
-        Key(label: "<", kind: .dispatch(name: "char:<"), style: .flat),
-        Key(label: ">", kind: .dispatch(name: "char:>"), style: .flat),
-        Key(label: "(", kind: .dispatch(name: "char:("), style: .flat),
-        Key(label: ")", kind: .dispatch(name: "char:)"), style: .flat),
-        Key(label: "{", kind: .dispatch(name: "char:{"), style: .flat),
-        Key(label: "}", kind: .dispatch(name: "char:}"), style: .flat),
-        Key(label: "[", kind: .dispatch(name: "char:["), style: .flat),
-        Key(label: "]", kind: .dispatch(name: "char:]"), style: .flat),
+        Key(label: "<", kind: .dispatch(name: "char:<")),
+        Key(label: ">", kind: .dispatch(name: "char:>")),
+        Key(label: "(", kind: .dispatch(name: "char:(")),
+        Key(label: ")", kind: .dispatch(name: "char:)")),
+        Key(label: "{", kind: .dispatch(name: "char:{")),
+        Key(label: "}", kind: .dispatch(name: "char:}")),
+        Key(label: "[", kind: .dispatch(name: "char:[")),
+        Key(label: "]", kind: .dispatch(name: "char:]")),
     ]
+
+    private let rowHeight: CGFloat = 44
+    private let repeatInitialDelay: TimeInterval = 0.35
+    private let repeatInterval: TimeInterval = 0.06
 
     private let sendKey: SendKey
     private let hostOs: HostOs
     private weak var hostBadge: UILabel?
+    private weak var topBorder: UIView?
     private var isDarkTheme = true
     private var armedMods: AccessoryMods = []
     private var rowsKeys: [[Key]] = []
@@ -117,8 +111,6 @@ final class FullKeyboardView: UIView {
     private var keyButtons: [(button: UIButton, key: Key)] = []
     private var repeatTimer: Timer?
     private var repeatingKey: (name: String, mods: UInt8)?
-    private let repeatInitialDelay: TimeInterval = 0.35
-    private let repeatInterval: TimeInterval = 0.06
 
     init(
         width: CGFloat,
@@ -132,10 +124,16 @@ final class FullKeyboardView: UIView {
         self.isDarkTheme = isDark
         super.init(frame: CGRect(x: 0, y: 0, width: width, height: height))
         autoresizingMask = [.flexibleWidth]
-        clipsToBounds = true
-        applyTheme(isDark: isDark)
+        clipsToBounds = false
+
+        let border = UIView(frame: CGRect(x: 0, y: 0, width: width, height: 0.33))
+        border.autoresizingMask = [.flexibleWidth]
+        addSubview(border)
+        topBorder = border
+
         build()
         installHostBadge()
+        applyTheme(isDark: isDark)
     }
 
     required init?(coder: NSCoder) {
@@ -144,10 +142,22 @@ final class FullKeyboardView: UIView {
 
     func applyTheme(isDark: Bool) {
         isDarkTheme = isDark
-        backgroundColor =
+
+        let backgroundColor =
             isDark
-            ? UIColor(red: 0.08, green: 0.08, blue: 0.10, alpha: 1.0)
-            : UIColor(red: 0.82, green: 0.83, blue: 0.85, alpha: 1.0)
+            ? UIColor(red: 0.055, green: 0.047, blue: 0.047, alpha: 0.96)
+            : UIColor(red: 0.961, green: 0.961, blue: 0.961, alpha: 0.98)
+        let borderColor =
+            isDark
+            ? UIColor(white: 1.0, alpha: 0.12)
+            : UIColor(white: 0.0, alpha: 0.10)
+
+        self.backgroundColor = backgroundColor
+        topBorder?.backgroundColor = borderColor
+
+        if #available(iOS 13.0, *) {
+            overrideUserInterfaceStyle = isDark ? .dark : .light
+        }
         for (button, key) in keyButtons {
             styleButton(button, key: key)
         }
@@ -168,8 +178,8 @@ final class FullKeyboardView: UIView {
     private func applyHostBadgeColor() {
         hostBadge?.textColor =
             isDarkTheme
-            ? UIColor(white: 1.0, alpha: 1.0)
-            : UIColor(red: 0.07, green: 0.07, blue: 0.10, alpha: 1.0)
+            ? UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.0)
+            : UIColor(red: 0.102, green: 0.102, blue: 0.102, alpha: 1.0)
     }
 
     private func build() {
@@ -180,7 +190,7 @@ final class FullKeyboardView: UIView {
         rowsButtons.removeAll()
         keyButtons.removeAll()
 
-        for rowKeys in [chipRow, symbolRow1, symbolRow2] {
+        for rowKeys in [modNavRow, symbolRow1, symbolRow2] {
             var rowButtons: [UIButton] = []
             for key in rowKeys {
                 let button = makeButton(for: key)
@@ -196,10 +206,9 @@ final class FullKeyboardView: UIView {
 
     private func makeButton(for key: Key) -> UIButton {
         let button = UIButton(type: .system)
-        let fontSize: CGFloat = key.style == .chip ? 15 : 22
-        button.titleLabel?.font = .systemFont(ofSize: fontSize, weight: .regular)
+        button.titleLabel?.font = .systemFont(ofSize: 16)
         button.setTitle(key.label, for: .normal)
-        button.layer.cornerRadius = key.style == .chip ? 6 : 4
+        button.layer.cornerRadius = 6
         button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
         button.addTarget(self, action: #selector(buttonTouchUpInside(_:)), for: .touchUpInside)
         button.addTarget(self, action: #selector(stopRepeating), for: .touchUpOutside)
@@ -212,27 +221,21 @@ final class FullKeyboardView: UIView {
     private func styleButton(_ button: UIButton, key: Key) {
         let foreground =
             isDarkTheme
-            ? UIColor(white: 1.0, alpha: 1.0)
-            : UIColor(red: 0.07, green: 0.07, blue: 0.10, alpha: 1.0)
+            ? UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.0)
+            : UIColor(red: 0.102, green: 0.102, blue: 0.102, alpha: 1.0)
         button.setTitleColor(foreground, for: .normal)
         button.tintColor = foreground
+        if #available(iOS 13.0, *) {
+            button.overrideUserInterfaceStyle = isDarkTheme ? .dark : .light
+        }
 
-        switch key.style {
-        case .chip:
-            let base =
-                isDarkTheme
-                ? UIColor(red: 0.30, green: 0.30, blue: 0.33, alpha: 1.0)
-                : UIColor(red: 0.65, green: 0.66, blue: 0.69, alpha: 1.0)
-            let armed =
-                isDarkTheme
-                ? UIColor(white: 1.0, alpha: 0.28)
-                : UIColor(white: 0.0, alpha: 0.22)
-            if case .modifier(let mod) = key.kind, armedMods.contains(mod) {
-                button.backgroundColor = armed
-            } else {
-                button.backgroundColor = base
-            }
-        case .flat:
+        let armed =
+            isDarkTheme
+            ? UIColor(white: 1.0, alpha: 0.18)
+            : UIColor(white: 0.0, alpha: 0.12)
+        if case .modifier(let mod) = key.kind, armedMods.contains(mod) {
+            button.backgroundColor = armed
+        } else {
             button.backgroundColor = .clear
         }
     }
@@ -319,6 +322,9 @@ final class FullKeyboardView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+
+        topBorder?.frame = CGRect(x: 0, y: 0, width: bounds.width, height: 0.33)
+
         if let badge = hostBadge {
             let badgeSize = badge.sizeThatFits(CGSize(width: 120, height: 14))
             badge.frame = CGRect(
@@ -328,19 +334,15 @@ final class FullKeyboardView: UIView {
                 height: badgeSize.height
             )
         }
+
         let rowCount = rowsKeys.count
         guard rowCount > 0, bounds.width > 0, bounds.height > 0 else {
             return
         }
-        let horizontalInset: CGFloat = 6
-        let keyGap: CGFloat = 6
-        let topInset: CGFloat = 14
-        // Reserve roughly the bottom 40% of the panel for future content
-        // (clipboard, snippets, agent macros). Lay the key rows out in the
-        // upper region only.
-        let keysRegionHeight = bounds.height * 0.60
-        let rowGap: CGFloat = 8
-        let rowHeight = (keysRegionHeight - topInset - rowGap * CGFloat(rowCount - 1)) / CGFloat(rowCount)
+
+        let horizontalInset: CGFloat = 4
+        let keyGap: CGFloat = 2
+        let topInset: CGFloat = 18
         let availableWidth = bounds.width - horizontalInset * 2
 
         for (rowIndex, keys) in rowsKeys.enumerated() {
@@ -349,7 +351,7 @@ final class FullKeyboardView: UIView {
             let keyWidth = (availableWidth - totalGap) / CGFloat(max(1, keys.count))
 
             var x: CGFloat = horizontalInset
-            let y = topInset + CGFloat(rowIndex) * (rowHeight + rowGap)
+            let y = topInset + CGFloat(rowIndex) * rowHeight
             for (keyIndex, _) in keys.enumerated() {
                 buttons[keyIndex].frame = CGRect(
                     x: x,

--- a/ios/Zedra/FullKeyboardView.swift
+++ b/ios/Zedra/FullKeyboardView.swift
@@ -1,0 +1,296 @@
+import UIKit
+
+/// In-app QWERTY keyboard that replaces the system software keyboard while the
+/// user is driving a terminal / agent session. Each tap is forwarded to
+/// `sendKey(name, mods)` using the same wire format as the accessory bar
+/// (`char:<c>`, named keys, mod bitmask).
+///
+/// The view is intended to be installed via `gpui_ios_set_keyboard_input_view`.
+/// UIKit reads `frame.size` for the keyboard slot, so callers must size this
+/// to the system keyboard's last known height before installing it.
+final class FullKeyboardView: UIView {
+    /// Closure invoked for every keystroke. Matches the FFI used by
+    /// `KeyboardSupporter` so both surfaces share one transport.
+    typealias SendKey = (String, UInt8) -> Void
+
+    private enum Layer {
+        case letters
+        case numbers
+        case symbols
+    }
+
+    private enum ShiftState {
+        case off
+        case oneShot
+        case locked
+    }
+
+    private enum KeyKind {
+        case char(String)
+        case named(String)
+        case shift
+        case backspace
+        case toggleLayer(Layer)
+        case space
+        case enter
+    }
+
+    private struct Key {
+        let label: String
+        let kind: KeyKind
+        let widthHint: CGFloat
+    }
+
+    private let sendKey: SendKey
+    private var shift: ShiftState = .off
+    private var layer: Layer = .letters
+    private var isDarkTheme = true
+    private var rows: [UIStackView] = []
+    private var keyButtons: [(button: UIButton, key: Key)] = []
+    private var lastShiftTapDate: Date?
+
+    init(width: CGFloat, height: CGFloat, isDark: Bool, sendKey: @escaping SendKey) {
+        self.sendKey = sendKey
+        self.isDarkTheme = isDark
+        super.init(frame: CGRect(x: 0, y: 0, width: width, height: height))
+        autoresizingMask = [.flexibleWidth]
+        clipsToBounds = true
+        applyTheme(isDark: isDark)
+        rebuild()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) not implemented")
+    }
+
+    func applyTheme(isDark: Bool) {
+        isDarkTheme = isDark
+        backgroundColor =
+            isDark
+            ? UIColor(red: 0.12, green: 0.12, blue: 0.13, alpha: 1.0)
+            : UIColor(red: 0.82, green: 0.83, blue: 0.85, alpha: 1.0)
+        for (button, key) in keyButtons {
+            styleButton(button, key: key)
+        }
+    }
+
+    /// Lay the keyboard out for the current `layer` + `shift` state. Builds
+    /// from scratch every time so cap state, layer switches, and width
+    /// changes all share the same code path.
+    private func rebuild() {
+        for row in rows {
+            row.removeFromSuperview()
+        }
+        rows.removeAll()
+        keyButtons.removeAll()
+
+        let rowsSpecs = keyboardLayout()
+        let rowCount = rowsSpecs.count
+        let rowHeight = bounds.height / CGFloat(rowCount)
+        let verticalPadding: CGFloat = 4.0
+
+        for (rowIndex, rowKeys) in rowsSpecs.enumerated() {
+            let stack = UIStackView()
+            stack.axis = .horizontal
+            stack.spacing = 4
+            stack.distribution = .fill
+            stack.alignment = .fill
+            stack.translatesAutoresizingMaskIntoConstraints = false
+            stack.frame = CGRect(
+                x: 4,
+                y: CGFloat(rowIndex) * rowHeight + verticalPadding / 2,
+                width: bounds.width - 8,
+                height: rowHeight - verticalPadding
+            )
+            stack.autoresizingMask = [.flexibleWidth]
+            addSubview(stack)
+            rows.append(stack)
+
+            for key in rowKeys {
+                let button = makeButton(for: key)
+                stack.addArrangedSubview(button)
+                keyButtons.append((button, key))
+            }
+        }
+    }
+
+    private func keyboardLayout() -> [[Key]] {
+        switch layer {
+        case .letters:
+            let row1 = "qwertyuiop".map { Key(label: shiftedLetter(String($0)), kind: .char(String($0)), widthHint: 1.0) }
+            let row2 = "asdfghjkl".map { Key(label: shiftedLetter(String($0)), kind: .char(String($0)), widthHint: 1.0) }
+            var row3: [Key] = [
+                Key(label: shiftLabel(), kind: .shift, widthHint: 1.5)
+            ]
+            row3.append(contentsOf: "zxcvbnm".map { Key(label: shiftedLetter(String($0)), kind: .char(String($0)), widthHint: 1.0) })
+            row3.append(Key(label: "⌫", kind: .backspace, widthHint: 1.5))
+            let row4: [Key] = [
+                Key(label: "123", kind: .toggleLayer(.numbers), widthHint: 1.5),
+                Key(label: "space", kind: .space, widthHint: 5.0),
+                Key(label: "return", kind: .enter, widthHint: 2.0),
+            ]
+            return [row1, row2, row3, row4]
+        case .numbers:
+            let row1 = "1234567890".map { Key(label: String($0), kind: .char(String($0)), widthHint: 1.0) }
+            let row2 = ["-", "/", ":", ";", "(", ")", "$", "&", "@", "\""].map { Key(label: $0, kind: .char($0), widthHint: 1.0) }
+            var row3: [Key] = [
+                Key(label: "#+=", kind: .toggleLayer(.symbols), widthHint: 1.5)
+            ]
+            row3.append(contentsOf: [".", ",", "?", "!", "'"].map { Key(label: $0, kind: .char($0), widthHint: 1.0) })
+            row3.append(Key(label: "⌫", kind: .backspace, widthHint: 1.5))
+            let row4: [Key] = [
+                Key(label: "ABC", kind: .toggleLayer(.letters), widthHint: 1.5),
+                Key(label: "space", kind: .space, widthHint: 5.0),
+                Key(label: "return", kind: .enter, widthHint: 2.0),
+            ]
+            return [row1, row2, row3, row4]
+        case .symbols:
+            let row1 = ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="].map { Key(label: $0, kind: .char($0), widthHint: 1.0) }
+            let row2 = ["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "•"].map { Key(label: $0, kind: .char($0), widthHint: 1.0) }
+            var row3: [Key] = [
+                Key(label: "123", kind: .toggleLayer(.numbers), widthHint: 1.5)
+            ]
+            row3.append(contentsOf: [".", ",", "?", "!", "'"].map { Key(label: $0, kind: .char($0), widthHint: 1.0) })
+            row3.append(Key(label: "⌫", kind: .backspace, widthHint: 1.5))
+            let row4: [Key] = [
+                Key(label: "ABC", kind: .toggleLayer(.letters), widthHint: 1.5),
+                Key(label: "space", kind: .space, widthHint: 5.0),
+                Key(label: "return", kind: .enter, widthHint: 2.0),
+            ]
+            return [row1, row2, row3, row4]
+        }
+    }
+
+    private func shiftedLetter(_ c: String) -> String {
+        return shift == .off ? c : c.uppercased()
+    }
+
+    private func shiftLabel() -> String {
+        switch shift {
+        case .off: return "⇧"
+        case .oneShot: return "⬆︎"
+        case .locked: return "⇪"
+        }
+    }
+
+    private func makeButton(for key: Key) -> UIButton {
+        let button = UIButton(type: .system)
+        button.titleLabel?.font = .systemFont(ofSize: 18.0, weight: .regular)
+        button.setTitle(key.label, for: .normal)
+        button.layer.cornerRadius = 6.0
+        button.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        button.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(keyTapped(_:)), for: .touchUpInside)
+        styleButton(button, key: key)
+
+        // Constrain width by stretching one "unit" key as the baseline; non-1.0
+        // keys are multiples of that base via constraint priorities — UIStackView
+        // distributes remaining space proportionally when we set a width anchor
+        // referencing the first button.
+        if key.widthHint != 1.0, let anchor = keyButtons.first?.button.widthAnchor {
+            button.widthAnchor.constraint(equalTo: anchor, multiplier: key.widthHint).isActive = true
+        }
+        return button
+    }
+
+    private func styleButton(_ button: UIButton, key: Key) {
+        let isSpecial: Bool
+        switch key.kind {
+        case .char: isSpecial = false
+        default: isSpecial = true
+        }
+        let baseBg =
+            isDarkTheme
+            ? (isSpecial
+                ? UIColor(red: 0.20, green: 0.20, blue: 0.22, alpha: 1.0)
+                : UIColor(red: 0.30, green: 0.30, blue: 0.33, alpha: 1.0))
+            : (isSpecial
+                ? UIColor(red: 0.65, green: 0.66, blue: 0.69, alpha: 1.0)
+                : UIColor.white)
+        let foreground =
+            isDarkTheme
+            ? UIColor(white: 1.0, alpha: 1.0)
+            : UIColor(red: 0.07, green: 0.07, blue: 0.10, alpha: 1.0)
+        button.backgroundColor = baseBg
+        button.setTitleColor(foreground, for: .normal)
+        button.tintColor = foreground
+
+        // Highlight a locked / armed shift so the user can see the state.
+        if case .shift = key.kind, shift == .locked {
+            button.backgroundColor =
+                isDarkTheme
+                ? UIColor(white: 1.0, alpha: 0.25)
+                : UIColor(white: 0.0, alpha: 0.20)
+        }
+    }
+
+    @objc
+    private func keyTapped(_ sender: UIButton) {
+        guard let (_, key) = keyButtons.first(where: { $0.button === sender }) else {
+            return
+        }
+        switch key.kind {
+        case .char(let c):
+            let outgoing = shift == .off ? c : c.uppercased()
+            sendKey("char:\(outgoing)", 0)
+            if shift == .oneShot {
+                shift = .off
+                rebuild()
+            }
+        case .named(let name):
+            sendKey(name, 0)
+        case .shift:
+            handleShiftTap()
+        case .backspace:
+            sendKey("backspace", 0)
+        case .toggleLayer(let target):
+            layer = target
+            // Switching layers also resets shift; the system keyboard does the
+            // same so the symbol layer doesn't capslock through letters.
+            shift = .off
+            rebuild()
+        case .space:
+            sendKey("char: ", 0)
+        case .enter:
+            sendKey("enter", 0)
+        }
+    }
+
+    private func handleShiftTap() {
+        let now = Date()
+        let isDoubleTap =
+            lastShiftTapDate.map { now.timeIntervalSince($0) < 0.35 } ?? false
+        lastShiftTapDate = now
+
+        if isDoubleTap {
+            shift = .locked
+        } else {
+            switch shift {
+            case .off: shift = .oneShot
+            case .oneShot: shift = .off
+            case .locked: shift = .off
+            }
+        }
+        rebuild()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Re-layout rows when the host resizes us (rotation, split view).
+        let rowCount = rows.count
+        guard rowCount > 0 else {
+            return
+        }
+        let rowHeight = bounds.height / CGFloat(rowCount)
+        let verticalPadding: CGFloat = 4.0
+        for (index, row) in rows.enumerated() {
+            row.frame = CGRect(
+                x: 4,
+                y: CGFloat(index) * rowHeight + verticalPadding / 2,
+                width: bounds.width - 8,
+                height: rowHeight - verticalPadding
+            )
+        }
+    }
+}

--- a/ios/Zedra/FullKeyboardView.swift
+++ b/ios/Zedra/FullKeyboardView.swift
@@ -1,5 +1,24 @@
 import UIKit
 
+/// Host OS reported by `zedra_ios_active_host_os` — matches Rust
+/// `key_encoding::HostOs`. The panel uses it to label / pick a layout that
+/// matches the host the active terminal is talking to. `Unknown` is treated
+/// as macOS per product direction.
+enum HostOs: UInt8 {
+    case unknown = 0
+    case macOs = 1
+    case linux = 2
+    case windows = 3
+
+    var displayName: String {
+        switch self {
+        case .unknown, .macOs: return "macOS"
+        case .linux: return "Linux"
+        case .windows: return "Windows"
+        }
+    }
+}
+
 /// Desktop-only key panel that replaces the system keyboard while a terminal
 /// or agent session has focus. Surfaces keys / combos that the iOS soft
 /// keyboard either doesn't have at all or buries multiple layers deep. There
@@ -82,6 +101,8 @@ final class FullKeyboardView: UIView {
     ]
 
     private let sendKey: SendKey
+    private let hostOs: HostOs
+    private weak var hostBadge: UILabel?
     private var isDarkTheme = true
     private var armedMods: AccessoryMods = []
     private var rowsKeys: [[Key]] = []
@@ -92,14 +113,40 @@ final class FullKeyboardView: UIView {
     private let repeatInitialDelay: TimeInterval = 0.35
     private let repeatInterval: TimeInterval = 0.06
 
-    init(width: CGFloat, height: CGFloat, isDark: Bool, sendKey: @escaping SendKey) {
+    init(
+        width: CGFloat,
+        height: CGFloat,
+        isDark: Bool,
+        hostOs: HostOs,
+        sendKey: @escaping SendKey
+    ) {
         self.sendKey = sendKey
+        self.hostOs = hostOs
         self.isDarkTheme = isDark
         super.init(frame: CGRect(x: 0, y: 0, width: width, height: height))
         autoresizingMask = [.flexibleWidth]
         clipsToBounds = true
         applyTheme(isDark: isDark)
         build()
+        installHostBadge()
+    }
+
+    private func installHostBadge() {
+        let label = UILabel()
+        label.text = hostOs.displayName
+        label.font = .systemFont(ofSize: 10, weight: .medium)
+        label.textAlignment = .right
+        label.alpha = 0.55
+        addSubview(label)
+        hostBadge = label
+        applyHostBadgeColor()
+    }
+
+    private func applyHostBadgeColor() {
+        hostBadge?.textColor =
+            isDarkTheme
+            ? UIColor(white: 1.0, alpha: 1.0)
+            : UIColor(red: 0.07, green: 0.07, blue: 0.10, alpha: 1.0)
     }
 
     required init?(coder: NSCoder) {
@@ -115,6 +162,7 @@ final class FullKeyboardView: UIView {
         for (button, key) in keyButtons {
             styleButton(button, key: key)
         }
+        applyHostBadgeColor()
     }
 
     private func build() {
@@ -265,6 +313,15 @@ final class FullKeyboardView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+        if let badge = hostBadge {
+            let badgeSize = badge.sizeThatFits(CGSize(width: 120, height: 14))
+            badge.frame = CGRect(
+                x: bounds.width - badgeSize.width - 8,
+                y: 2,
+                width: badgeSize.width,
+                height: badgeSize.height
+            )
+        }
         let rowCount = rowsKeys.count
         guard rowCount > 0, bounds.width > 0, bounds.height > 0 else {
             return

--- a/ios/Zedra/FullKeyboardView.swift
+++ b/ios/Zedra/FullKeyboardView.swift
@@ -20,84 +20,91 @@ enum HostOs: UInt8 {
 }
 
 /// Desktop-only key panel that replaces the system keyboard while a terminal
-/// or agent session has focus. Surfaces keys / combos that the iOS soft
-/// keyboard either doesn't have at all or buries multiple layers deep. There
-/// is no QWERTY here on purpose — users tap `✕` and go back to the system
-/// keyboard for prose typing, IME, dictation, autocorrect.
+/// or agent session has focus. Surfaces keys / combos the iOS soft keyboard
+/// doesn't expose as a single tap. There is no QWERTY here on purpose —
+/// `✕` hands focus back to the system IME for prose typing, dictation,
+/// Vietnamese / CJK input.
 ///
-/// Every tap dispatches through `sendKey(name, mods)` using the same wire
-/// format as the accessory bar (`char:<c>` for single chars, named keys, and
-/// a Shift/Alt/Ctrl bitmask per `key_encoding::Mods`).
+/// Layout (top → bottom):
+///   Row 1 (chips):  Shift  Ctrl  Cmd   Home  End  PgUp  PgDn   ⌫
+///   Row 2 (flat):   ~  @  $  *  ^  %  =  `
+///   Row 3 (flat):   <  >  (  )  {  }  [  ]
+///   Reserved space below the key rows is intentionally left blank for
+///   future additions (clipboard, snippets, agent macros, …).
 final class FullKeyboardView: UIView {
     typealias SendKey = (String, UInt8) -> Void
 
     private struct AccessoryMods: OptionSet {
         let rawValue: UInt8
 
-        static let shift = AccessoryMods(rawValue: 0b001)
-        static let alt = AccessoryMods(rawValue: 0b010)
-        static let ctrl = AccessoryMods(rawValue: 0b100)
+        static let shift = AccessoryMods(rawValue: 0b0001)
+        static let alt = AccessoryMods(rawValue: 0b0010)
+        static let ctrl = AccessoryMods(rawValue: 0b0100)
+        /// Cmd / Super. Tracked so the panel can highlight an armed state;
+        /// the Rust encoder ignores it because no legacy terminal byte
+        /// encoding exists. Reserved for routing via a future host RPC.
+        static let cmd = AccessoryMods(rawValue: 0b1000)
     }
 
     private enum KeyKind {
-        /// Tap dispatches `(name, armedMods | fixedMods)`. The single source
-        /// of truth for every non-modifier key.
+        /// Tap dispatches `(name, armedMods | fixedMods)`.
         case dispatch(name: String, fixedMods: AccessoryMods = [])
         /// Sticky modifier — toggles `armedMods`, never sends bytes itself.
         case modifier(AccessoryMods)
     }
 
+    private enum KeyStyle {
+        /// Raised pill / chip — modifiers, nav cluster, backspace.
+        case chip
+        /// Flat glyph — symbols. No background unless pressed.
+        case flat
+    }
+
     private struct Key {
         let label: String
         let kind: KeyKind
+        let style: KeyStyle
         let repeats: Bool
 
-        init(label: String, kind: KeyKind, repeats: Bool = false) {
+        init(label: String, kind: KeyKind, style: KeyStyle, repeats: Bool = false) {
             self.label = label
             self.kind = kind
+            self.style = style
             self.repeats = repeats
         }
     }
 
-    /// Row 1 — symbols that exist on the iOS soft keyboard but are buried 1-2
-    /// layers deep. Surfacing them one-tap is the highest-value cheap win.
-    private let symbolRow: [Key] = [
-        Key(label: "`", kind: .dispatch(name: "char:`")),
-        Key(label: "~", kind: .dispatch(name: "char:~")),
-        Key(label: "|", kind: .dispatch(name: "char:|")),
-        Key(label: "\\", kind: .dispatch(name: "char:\\")),
-        Key(label: "<", kind: .dispatch(name: "char:<")),
-        Key(label: ">", kind: .dispatch(name: "char:>")),
-        Key(label: "{", kind: .dispatch(name: "char:{")),
-        Key(label: "}", kind: .dispatch(name: "char:}")),
-        Key(label: "[", kind: .dispatch(name: "char:[")),
-        Key(label: "]", kind: .dispatch(name: "char:]")),
+    private let chipRow: [Key] = [
+        Key(label: "shift", kind: .modifier(.shift), style: .chip),
+        Key(label: "Ctrl", kind: .modifier(.ctrl), style: .chip),
+        Key(label: "Cmd", kind: .modifier(.cmd), style: .chip),
+        Key(label: "Home", kind: .dispatch(name: "home"), style: .chip),
+        Key(label: "End", kind: .dispatch(name: "end"), style: .chip),
+        Key(label: "PgUp", kind: .dispatch(name: "page_up"), style: .chip, repeats: true),
+        Key(label: "PgD", kind: .dispatch(name: "page_down"), style: .chip, repeats: true),
+        Key(label: "⌫", kind: .dispatch(name: "backspace"), style: .chip, repeats: true),
     ]
 
-    /// Row 2 — navigation cluster the soft keyboard has no concept of.
-    private let navRow: [Key] = [
-        Key(label: "Home", kind: .dispatch(name: "home")),
-        Key(label: "End", kind: .dispatch(name: "end")),
-        Key(label: "PgUp", kind: .dispatch(name: "page_up"), repeats: true),
-        Key(label: "PgDn", kind: .dispatch(name: "page_down"), repeats: true),
-        Key(label: "←", kind: .dispatch(name: "left"), repeats: true),
-        Key(label: "↓", kind: .dispatch(name: "down"), repeats: true),
-        Key(label: "↑", kind: .dispatch(name: "up"), repeats: true),
-        Key(label: "→", kind: .dispatch(name: "right"), repeats: true),
+    private let symbolRow1: [Key] = [
+        Key(label: "~", kind: .dispatch(name: "char:~"), style: .flat),
+        Key(label: "@", kind: .dispatch(name: "char:@"), style: .flat),
+        Key(label: "$", kind: .dispatch(name: "char:$"), style: .flat),
+        Key(label: "*", kind: .dispatch(name: "char:*"), style: .flat),
+        Key(label: "^", kind: .dispatch(name: "char:^"), style: .flat),
+        Key(label: "%", kind: .dispatch(name: "char:%"), style: .flat),
+        Key(label: "=", kind: .dispatch(name: "char:="), style: .flat),
+        Key(label: "`", kind: .dispatch(name: "char:`"), style: .flat),
     ]
 
-    /// Row 3 — agent / terminal control keys plus sticky `Shift` and `Ctrl`
-    /// modifiers so users can compose ad-hoc combos with any other panel
-    /// key (e.g. Shift+Home, Ctrl+\, Ctrl+PgUp).
-    private let controlRow: [Key] = [
-        Key(label: "Esc", kind: .dispatch(name: "escape")),
-        Key(label: "Tab", kind: .dispatch(name: "tab")),
-        Key(label: "⇧⏎", kind: .dispatch(name: "enter", fixedMods: .shift)),
-        Key(label: "Shift", kind: .modifier(.shift)),
-        Key(label: "Ctrl", kind: .modifier(.ctrl)),
-        Key(label: "⌃C", kind: .dispatch(name: "char:c", fixedMods: .ctrl)),
-        Key(label: "⌃D", kind: .dispatch(name: "char:d", fixedMods: .ctrl)),
-        Key(label: "⌃R", kind: .dispatch(name: "char:r", fixedMods: .ctrl)),
+    private let symbolRow2: [Key] = [
+        Key(label: "<", kind: .dispatch(name: "char:<"), style: .flat),
+        Key(label: ">", kind: .dispatch(name: "char:>"), style: .flat),
+        Key(label: "(", kind: .dispatch(name: "char:("), style: .flat),
+        Key(label: ")", kind: .dispatch(name: "char:)"), style: .flat),
+        Key(label: "{", kind: .dispatch(name: "char:{"), style: .flat),
+        Key(label: "}", kind: .dispatch(name: "char:}"), style: .flat),
+        Key(label: "[", kind: .dispatch(name: "char:["), style: .flat),
+        Key(label: "]", kind: .dispatch(name: "char:]"), style: .flat),
     ]
 
     private let sendKey: SendKey
@@ -131,6 +138,22 @@ final class FullKeyboardView: UIView {
         installHostBadge()
     }
 
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) not implemented")
+    }
+
+    func applyTheme(isDark: Bool) {
+        isDarkTheme = isDark
+        backgroundColor =
+            isDark
+            ? UIColor(red: 0.08, green: 0.08, blue: 0.10, alpha: 1.0)
+            : UIColor(red: 0.82, green: 0.83, blue: 0.85, alpha: 1.0)
+        for (button, key) in keyButtons {
+            styleButton(button, key: key)
+        }
+        applyHostBadgeColor()
+    }
+
     private func installHostBadge() {
         let label = UILabel()
         label.text = hostOs.displayName
@@ -149,22 +172,6 @@ final class FullKeyboardView: UIView {
             : UIColor(red: 0.07, green: 0.07, blue: 0.10, alpha: 1.0)
     }
 
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) not implemented")
-    }
-
-    func applyTheme(isDark: Bool) {
-        isDarkTheme = isDark
-        backgroundColor =
-            isDark
-            ? UIColor(red: 0.12, green: 0.12, blue: 0.13, alpha: 1.0)
-            : UIColor(red: 0.82, green: 0.83, blue: 0.85, alpha: 1.0)
-        for (button, key) in keyButtons {
-            styleButton(button, key: key)
-        }
-        applyHostBadgeColor()
-    }
-
     private func build() {
         for (button, _) in keyButtons {
             button.removeFromSuperview()
@@ -173,7 +180,7 @@ final class FullKeyboardView: UIView {
         rowsButtons.removeAll()
         keyButtons.removeAll()
 
-        for rowKeys in [symbolRow, navRow, controlRow] {
+        for rowKeys in [chipRow, symbolRow1, symbolRow2] {
             var rowButtons: [UIButton] = []
             for key in rowKeys {
                 let button = makeButton(for: key)
@@ -189,9 +196,10 @@ final class FullKeyboardView: UIView {
 
     private func makeButton(for key: Key) -> UIButton {
         let button = UIButton(type: .system)
-        button.titleLabel?.font = .systemFont(ofSize: 18.0, weight: .regular)
+        let fontSize: CGFloat = key.style == .chip ? 15 : 22
+        button.titleLabel?.font = .systemFont(ofSize: fontSize, weight: .regular)
         button.setTitle(key.label, for: .normal)
-        button.layer.cornerRadius = 6.0
+        button.layer.cornerRadius = key.style == .chip ? 6 : 4
         button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
         button.addTarget(self, action: #selector(buttonTouchUpInside(_:)), for: .touchUpInside)
         button.addTarget(self, action: #selector(stopRepeating), for: .touchUpOutside)
@@ -202,32 +210,30 @@ final class FullKeyboardView: UIView {
     }
 
     private func styleButton(_ button: UIButton, key: Key) {
-        let isModifier: Bool
-        switch key.kind {
-        case .modifier: isModifier = true
-        case .dispatch: isModifier = false
-        }
-        let baseBg =
-            isDarkTheme
-            ? (isModifier
-                ? UIColor(red: 0.20, green: 0.20, blue: 0.22, alpha: 1.0)
-                : UIColor(red: 0.30, green: 0.30, blue: 0.33, alpha: 1.0))
-            : (isModifier
-                ? UIColor(red: 0.65, green: 0.66, blue: 0.69, alpha: 1.0)
-                : UIColor.white)
         let foreground =
             isDarkTheme
             ? UIColor(white: 1.0, alpha: 1.0)
             : UIColor(red: 0.07, green: 0.07, blue: 0.10, alpha: 1.0)
-        button.backgroundColor = baseBg
         button.setTitleColor(foreground, for: .normal)
         button.tintColor = foreground
 
-        if case .modifier(let mod) = key.kind, armedMods.contains(mod) {
-            button.backgroundColor =
+        switch key.style {
+        case .chip:
+            let base =
                 isDarkTheme
-                ? UIColor(white: 1.0, alpha: 0.25)
-                : UIColor(white: 0.0, alpha: 0.20)
+                ? UIColor(red: 0.30, green: 0.30, blue: 0.33, alpha: 1.0)
+                : UIColor(red: 0.65, green: 0.66, blue: 0.69, alpha: 1.0)
+            let armed =
+                isDarkTheme
+                ? UIColor(white: 1.0, alpha: 0.28)
+                : UIColor(white: 0.0, alpha: 0.22)
+            if case .modifier(let mod) = key.kind, armedMods.contains(mod) {
+                button.backgroundColor = armed
+            } else {
+                button.backgroundColor = base
+            }
+        case .flat:
+            button.backgroundColor = .clear
         }
     }
 
@@ -326,11 +332,15 @@ final class FullKeyboardView: UIView {
         guard rowCount > 0, bounds.width > 0, bounds.height > 0 else {
             return
         }
-        let horizontalInset: CGFloat = 4
-        let keyGap: CGFloat = 4
-        let rowGap: CGFloat = 4
-
-        let rowHeight = (bounds.height - rowGap * CGFloat(rowCount + 1)) / CGFloat(rowCount)
+        let horizontalInset: CGFloat = 6
+        let keyGap: CGFloat = 6
+        let topInset: CGFloat = 14
+        // Reserve roughly the bottom 40% of the panel for future content
+        // (clipboard, snippets, agent macros). Lay the key rows out in the
+        // upper region only.
+        let keysRegionHeight = bounds.height * 0.60
+        let rowGap: CGFloat = 8
+        let rowHeight = (keysRegionHeight - topInset - rowGap * CGFloat(rowCount - 1)) / CGFloat(rowCount)
         let availableWidth = bounds.width - horizontalInset * 2
 
         for (rowIndex, keys) in rowsKeys.enumerated() {
@@ -339,7 +349,7 @@ final class FullKeyboardView: UIView {
             let keyWidth = (availableWidth - totalGap) / CGFloat(max(1, keys.count))
 
             var x: CGFloat = horizontalInset
-            let y = rowGap + CGFloat(rowIndex) * (rowHeight + rowGap)
+            let y = topInset + CGFloat(rowIndex) * (rowHeight + rowGap)
             for (keyIndex, _) in keys.enumerated() {
                 buttons[keyIndex].frame = CGRect(
                     x: x,

--- a/ios/Zedra/FullKeyboardView.swift
+++ b/ios/Zedra/FullKeyboardView.swift
@@ -43,7 +43,7 @@ final class FullKeyboardView: UIView {
 
     private let sendKey: SendKey
     private var shift: ShiftState = .off
-    private var layer: Layer = .letters
+    private var activeLayer: Layer = .letters
     private var isDarkTheme = true
     private var rows: [UIStackView] = []
     private var keyButtons: [(button: UIButton, key: Key)] = []
@@ -115,7 +115,7 @@ final class FullKeyboardView: UIView {
     }
 
     private func keyboardLayout() -> [[Key]] {
-        switch layer {
+        switch activeLayer {
         case .letters:
             let row1 = "qwertyuiop".map { Key(label: shiftedLetter(String($0)), kind: .char(String($0)), widthHint: 1.0) }
             let row2 = "asdfghjkl".map { Key(label: shiftedLetter(String($0)), kind: .char(String($0)), widthHint: 1.0) }
@@ -245,7 +245,7 @@ final class FullKeyboardView: UIView {
         case .backspace:
             sendKey("backspace", 0)
         case .toggleLayer(let target):
-            layer = target
+            activeLayer = target
             // Switching layers also resets shift; the system keyboard does the
             // same so the symbol layer doesn't capslock through letters.
             shift = .off

--- a/ios/Zedra/GPUIRuntimeController.swift
+++ b/ios/Zedra/GPUIRuntimeController.swift
@@ -15,6 +15,12 @@ private func gpui_ios_handle_view_resize(
 @_silgen_name("gpui_ios_set_software_keyboard_visible")
 private func gpui_ios_set_software_keyboard_visible(_ visible: Bool)
 
+@_silgen_name("gpui_ios_set_keyboard_input_view")
+private func gpui_ios_set_keyboard_input_view(_ viewPtr: UnsafeMutableRawPointer?)
+
+@_silgen_name("gpui_ios_reload_input_views")
+private func gpui_ios_reload_input_views(_ windowPtr: UnsafeMutableRawPointer?)
+
 @_silgen_name("zedra_firebase_initialize")
 private func zedra_firebase_initialize()
 
@@ -31,6 +37,11 @@ final class GPUIRuntimeController: NSObject {
     private var gpuiWindow: UnsafeMutableRawPointer?
     private var displayLink: CADisplayLink?
     private let keyboardAccessoryController = KeyboardSupporter()
+    /// Cached height (points) of the most recent system keyboard. Used to size
+    /// the in-app full keyboard so it occupies the same slot when installed.
+    private var lastKeyboardHeightPoints: CGFloat = 0
+    private var fullKeyboardView: FullKeyboardView?
+    private var isDarkThemeForPanel = true
 
     func launch() {
         Self.activeController = self
@@ -135,6 +146,12 @@ final class GPUIRuntimeController: NSObject {
             return
         }
 
+        // Subtract the accessory bar from the reported frame: when our in-app
+        // panel replaces the keyboard, UIKit still stacks the accessory bar on
+        // top, so the panel itself only occupies the keys area.
+        let accessoryHeight = keyboardAccessoryController.accessoryView?.frame.height ?? 0
+        lastKeyboardHeightPoints = max(0, endFrame.height - accessoryHeight)
+
         let heightPx = UInt32(endFrame.height * UIScreen.main.scale)
         zedra_ios_set_keyboard_height(heightPx)
         gpui_ios_set_software_keyboard_visible(heightPx > 0)
@@ -145,6 +162,12 @@ final class GPUIRuntimeController: NSObject {
         keyboardAccessoryController.stopRepeating()
         zedra_ios_set_keyboard_height(0)
         gpui_ios_set_software_keyboard_visible(false)
+        // Tear down the in-app panel along with the keyboard; if the user
+        // re-focuses the field, they should see the system keyboard again
+        // unless they explicitly request the panel.
+        if keyboardAccessoryController.isPanelOpen {
+            closeFullKeyboardPanel()
+        }
     }
 
     @objc
@@ -177,17 +200,60 @@ final class GPUIRuntimeController: NSObject {
     private func setupKeyboardAccessoryView() {
         let width = UIScreen.main.bounds.width
         let bar = keyboardAccessoryController.makeAccessoryView(
-            width: width
-        ) { [weak self] key, mods in
-            self?.sendKeyboardAccessoryKey(key, mods)
-        }
+            width: width,
+            sendKey: { [weak self] key, mods in
+                self?.sendKeyboardAccessoryKey(key, mods)
+            },
+            togglePanel: { [weak self] in
+                self?.toggleFullKeyboardPanel()
+            }
+        )
         gpui_ios_set_keyboard_accessory_view(Unmanaged.passUnretained(bar).toOpaque())
     }
 
     static func setKeyboardAccessoryTheme(isDark: Bool) {
         DispatchQueue.main.async {
-            activeController?.keyboardAccessoryController.applyTheme(isDark: isDark)
+            activeController?.applyKeyboardTheme(isDark: isDark)
         }
+    }
+
+    private func applyKeyboardTheme(isDark: Bool) {
+        isDarkThemeForPanel = isDark
+        keyboardAccessoryController.applyTheme(isDark: isDark)
+        fullKeyboardView?.applyTheme(isDark: isDark)
+    }
+
+    private func toggleFullKeyboardPanel() {
+        if keyboardAccessoryController.isPanelOpen {
+            closeFullKeyboardPanel()
+        } else {
+            openFullKeyboardPanel()
+        }
+    }
+
+    private func openFullKeyboardPanel() {
+        let width = UIScreen.main.bounds.width
+        // Fall back to a sensible default if the keyboard frame hasn't been
+        // observed yet (e.g. hardware keyboard attached on simulator).
+        let panelHeight = lastKeyboardHeightPoints > 0 ? lastKeyboardHeightPoints : 280.0
+        let panel = FullKeyboardView(
+            width: width,
+            height: panelHeight,
+            isDark: isDarkThemeForPanel
+        ) { [weak self] key, mods in
+            self?.sendKeyboardAccessoryKey(key, mods)
+        }
+        fullKeyboardView = panel
+        keyboardAccessoryController.setPanelOpen(true)
+        gpui_ios_set_keyboard_input_view(Unmanaged.passUnretained(panel).toOpaque())
+        gpui_ios_reload_input_views(gpuiWindow)
+    }
+
+    private func closeFullKeyboardPanel() {
+        keyboardAccessoryController.setPanelOpen(false)
+        gpui_ios_set_keyboard_input_view(nil)
+        gpui_ios_reload_input_views(gpuiWindow)
+        fullKeyboardView = nil
     }
 
     private func startDisplayLink() {

--- a/ios/Zedra/GPUIRuntimeController.swift
+++ b/ios/Zedra/GPUIRuntimeController.swift
@@ -27,6 +27,9 @@ private func zedra_firebase_initialize()
 @_silgen_name("zedra_ios_send_key_input")
 private func zedra_ios_send_key_input(_ key: UnsafePointer<CChar>, _ mods: UInt8)
 
+@_silgen_name("zedra_ios_active_host_os")
+private func zedra_ios_active_host_os() -> UInt8
+
 @_silgen_name("zedra_ios_app_will_terminate")
 private func zedra_ios_app_will_terminate()
 
@@ -236,10 +239,12 @@ final class GPUIRuntimeController: NSObject {
         // Fall back to a sensible default if the keyboard frame hasn't been
         // observed yet (e.g. hardware keyboard attached on simulator).
         let panelHeight = lastKeyboardHeightPoints > 0 ? lastKeyboardHeightPoints : 280.0
+        let hostOs = HostOs(rawValue: zedra_ios_active_host_os()) ?? .macOs
         let panel = FullKeyboardView(
             width: width,
             height: panelHeight,
-            isDark: isDarkThemeForPanel
+            isDark: isDarkThemeForPanel,
+            hostOs: hostOs
         ) { [weak self] key, mods in
             self?.sendKeyboardAccessoryKey(key, mods)
         }

--- a/ios/Zedra/GPUIRuntimeController.swift
+++ b/ios/Zedra/GPUIRuntimeController.swift
@@ -19,7 +19,7 @@ private func gpui_ios_set_software_keyboard_visible(_ visible: Bool)
 private func zedra_firebase_initialize()
 
 @_silgen_name("zedra_ios_send_key_input")
-private func zedra_ios_send_key_input(_ key: UnsafePointer<CChar>)
+private func zedra_ios_send_key_input(_ key: UnsafePointer<CChar>, _ mods: UInt8)
 
 @_silgen_name("zedra_ios_app_will_terminate")
 private func zedra_ios_app_will_terminate()
@@ -153,8 +153,8 @@ final class GPUIRuntimeController: NSObject {
         pushWindowSize()
     }
 
-    private func sendKeyboardAccessoryKey(_ key: String) {
-        key.withCString { zedra_ios_send_key_input($0) }
+    private func sendKeyboardAccessoryKey(_ key: String, _ mods: UInt8) {
+        key.withCString { zedra_ios_send_key_input($0, mods) }
     }
 
     @objc
@@ -178,8 +178,8 @@ final class GPUIRuntimeController: NSObject {
         let width = UIScreen.main.bounds.width
         let bar = keyboardAccessoryController.makeAccessoryView(
             width: width
-        ) { [weak self] key in
-            self?.sendKeyboardAccessoryKey(key)
+        ) { [weak self] key, mods in
+            self?.sendKeyboardAccessoryKey(key, mods)
         }
         gpui_ios_set_keyboard_accessory_view(Unmanaged.passUnretained(bar).toOpaque())
     }

--- a/ios/Zedra/KeyboardSupporter.swift
+++ b/ios/Zedra/KeyboardSupporter.swift
@@ -10,30 +10,15 @@ struct AccessoryMods: OptionSet {
     static let ctrl = AccessoryMods(rawValue: 0b100)
 }
 
-/// Resizing container for the keyboard accessory bar. Overriding
-/// `intrinsicContentSize` is what makes UIKit re-layout the keyboard when the
-/// detail row is toggled.
-private final class AccessoryContainer: UIView {
-    var contentHeight: CGFloat = 44.0 {
-        didSet {
-            invalidateIntrinsicContentSize()
-        }
-    }
-
-    override var intrinsicContentSize: CGSize {
-        CGSize(width: UIView.noIntrinsicMetric, height: contentHeight)
-    }
-}
-
+/// Accessory bar shown above whichever keyboard is active. The bar itself only
+/// owns the primary row (Esc / Tab / arrows / Enter) plus a `•••` toggle. When
+/// the toggle is tapped, the host swaps the system keyboard for `FullKeyboardView`
+/// and updates the toggle label to `✕`.
 @objcMembers
 final class KeyboardSupporter: NSObject {
     private enum KeySpecKind {
-        /// Plain key: sends `(name, armedMods | fixedMods)` and clears any armed sticky mods.
         case key(name: String, fixedMods: AccessoryMods = [])
-        /// Sticky modifier: toggles the armed state, never sends bytes.
-        case modifier(AccessoryMods)
-        /// Expands or collapses the detail row.
-        case toggleDetail
+        case togglePanel
     }
 
     private struct KeySpec {
@@ -50,21 +35,7 @@ final class KeyboardSupporter: NSObject {
         KeySpec(label: "↑", kind: .key(name: "up"), repeats: true),
         KeySpec(label: "→", kind: .key(name: "right"), repeats: true),
         KeySpec(label: "⏎", kind: .key(name: "enter"), repeats: false),
-        KeySpec(label: "•••", kind: .toggleDetail, repeats: false),
-    ]
-
-    private let detailRow: [KeySpec] = [
-        KeySpec(label: "Ctrl", kind: .modifier(.ctrl), repeats: false),
-        KeySpec(label: "Alt", kind: .modifier(.alt), repeats: false),
-        KeySpec(label: "Shift", kind: .modifier(.shift), repeats: false),
-        KeySpec(label: "⇧⇥", kind: .key(name: "tab", fixedMods: .shift), repeats: false),
-        KeySpec(label: "⌃C", kind: .key(name: "char:c", fixedMods: .ctrl), repeats: false),
-        KeySpec(label: "⌃D", kind: .key(name: "char:d", fixedMods: .ctrl), repeats: false),
-        KeySpec(label: "⌃R", kind: .key(name: "char:r", fixedMods: .ctrl), repeats: false),
-        KeySpec(label: "Home", kind: .key(name: "home"), repeats: false),
-        KeySpec(label: "End", kind: .key(name: "end"), repeats: false),
-        KeySpec(label: "PgUp", kind: .key(name: "page_up"), repeats: true),
-        KeySpec(label: "PgDn", kind: .key(name: "page_down"), repeats: true),
+        KeySpec(label: "•••", kind: .togglePanel, repeats: false),
     ]
 
     private let rowHeight: CGFloat = 44.0
@@ -72,42 +43,36 @@ final class KeyboardSupporter: NSObject {
     private let repeatInterval: TimeInterval = 0.06
 
     private(set) var accessoryView: UIView?
-    private weak var container: AccessoryContainer?
+    private weak var container: UIView?
     private weak var topBorder: UIView?
-    private weak var detailSeparator: UIView?
     private weak var leftKeyboardCornerFill: UIView?
     private weak var rightKeyboardCornerFill: UIView?
-    private weak var detailRowView: UIView?
-    private var primaryButtons: [(button: UIButton, spec: KeySpec)] = []
-    private var detailButtons: [(button: UIButton, spec: KeySpec)] = []
+    private var buttons: [(button: UIButton, spec: KeySpec)] = []
     private var sendKey: ((String, UInt8) -> Void)?
+    private var togglePanel: (() -> Void)?
     private var repeatTimer: Timer?
     private var repeatingKey: (name: String, mods: UInt8)?
     private var isDarkTheme = true
-    private var detailExpanded = false
-    private var armedMods: AccessoryMods = []
+    private(set) var isPanelOpen = false
 
-    func makeAccessoryView(width: CGFloat, sendKey: @escaping (String, UInt8) -> Void) -> UIView {
+    func makeAccessoryView(
+        width: CGFloat,
+        sendKey: @escaping (String, UInt8) -> Void,
+        togglePanel: @escaping () -> Void
+    ) -> UIView {
         stopRepeating()
         self.sendKey = sendKey
-        primaryButtons.removeAll()
-        detailButtons.removeAll()
-        armedMods = []
-        detailExpanded = false
+        self.togglePanel = togglePanel
+        buttons.removeAll()
 
-        let container = AccessoryContainer(
-            frame: CGRect(x: 0, y: 0, width: width, height: rowHeight)
-        )
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: width, height: rowHeight))
         container.clipsToBounds = false
-        container.contentHeight = rowHeight
         self.container = container
 
         let border = UIView(frame: CGRect(x: 0, y: 0, width: width, height: 0.33))
         container.addSubview(border)
         topBorder = border
 
-        // The system keyboard has rounded top corners, which can expose the window
-        // background beside an inputAccessoryView. Fill only those side gaps.
         let cornerFillWidth: CGFloat = 18.0
         let cornerFillHeight: CGFloat = 12.0
         let leftFill = UIView(
@@ -126,22 +91,31 @@ final class KeyboardSupporter: NSObject {
         leftKeyboardCornerFill = leftFill
         rightKeyboardCornerFill = rightFill
 
-        layoutRow(primaryRow, into: container, atY: 0, width: width, storeIn: &primaryButtons)
-
-        let detail = UIView(frame: CGRect(x: 0, y: rowHeight, width: width, height: rowHeight))
-        detail.isHidden = true
-        container.addSubview(detail)
-        detailRowView = detail
-
-        let sep = UIView(frame: CGRect(x: 0, y: 0, width: width, height: 0.33))
-        detail.addSubview(sep)
-        detailSeparator = sep
-
-        layoutRow(detailRow, into: detail, atY: 0, width: width, storeIn: &detailButtons)
+        let buttonWidth = width / CGFloat(primaryRow.count)
+        for (index, spec) in primaryRow.enumerated() {
+            let button = UIButton(type: .system)
+            button.frame = CGRect(
+                x: buttonWidth * CGFloat(index),
+                y: 0,
+                width: buttonWidth,
+                height: rowHeight
+            )
+            button.setTitle(spec.label, for: .normal)
+            button.titleLabel?.font = .systemFont(ofSize: 16.0)
+            button.tag = index
+            button.layer.cornerRadius = 6.0
+            button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
+            button.addTarget(self, action: #selector(buttonTouchUpInside(_:)), for: .touchUpInside)
+            button.addTarget(self, action: #selector(stopRepeating), for: .touchUpOutside)
+            button.addTarget(self, action: #selector(stopRepeating), for: .touchCancel)
+            button.addTarget(self, action: #selector(stopRepeating), for: .touchDragExit)
+            container.addSubview(button)
+            buttons.append((button, spec))
+        }
 
         accessoryView = container
         applyTheme(isDark: isDarkTheme)
-        refreshModifierHighlights()
+        refreshToggleLabel()
         return container
     }
 
@@ -159,19 +133,43 @@ final class KeyboardSupporter: NSObject {
 
         container?.backgroundColor = backgroundColor
         topBorder?.backgroundColor = borderColor
-        detailSeparator?.backgroundColor = borderColor
         leftKeyboardCornerFill?.backgroundColor = backgroundColor
         rightKeyboardCornerFill?.backgroundColor = backgroundColor
 
         let interfaceStyle: UIUserInterfaceStyle = isDark ? .dark : .light
         if #available(iOS 13.0, *) {
             container?.overrideUserInterfaceStyle = interfaceStyle
-            detailRowView?.overrideUserInterfaceStyle = interfaceStyle
         }
-        for (button, _) in primaryButtons + detailButtons {
-            applyButtonTheme(button)
+        let foregroundColor =
+            isDark
+            ? UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.0)
+            : UIColor(red: 0.102, green: 0.102, blue: 0.102, alpha: 1.0)
+        for (button, _) in buttons {
+            button.setTitleColor(foregroundColor, for: .normal)
+            button.tintColor = foregroundColor
+            if #available(iOS 13.0, *) {
+                button.overrideUserInterfaceStyle = interfaceStyle
+            }
         }
-        refreshModifierHighlights()
+    }
+
+    /// Set whether the host currently displays the in-app full keyboard. The
+    /// `•••` button flips to `✕` so users have a way back to the system
+    /// keyboard, and any pending key repeat is cancelled.
+    func setPanelOpen(_ open: Bool) {
+        isPanelOpen = open
+        refreshToggleLabel()
+        if open {
+            stopRepeating()
+        }
+    }
+
+    private func refreshToggleLabel() {
+        for (button, spec) in buttons {
+            if case .togglePanel = spec.kind {
+                button.setTitle(isPanelOpen ? "✕" : "•••", for: .normal)
+            }
+        }
     }
 
     @objc
@@ -181,107 +179,8 @@ final class KeyboardSupporter: NSObject {
         repeatingKey = nil
     }
 
-    private func layoutRow(
-        _ specs: [KeySpec],
-        into parent: UIView,
-        atY y: CGFloat,
-        width: CGFloat,
-        storeIn buttons: inout [(button: UIButton, spec: KeySpec)]
-    ) {
-        let buttonWidth = width / CGFloat(specs.count)
-        for (index, spec) in specs.enumerated() {
-            let button = UIButton(type: .system)
-            button.frame = CGRect(
-                x: buttonWidth * CGFloat(index),
-                y: y,
-                width: buttonWidth,
-                height: rowHeight
-            )
-            button.setTitle(spec.label, for: .normal)
-            button.titleLabel?.font = .systemFont(ofSize: 16.0)
-            button.tag = index
-            button.layer.cornerRadius = 6.0
-            button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
-            button.addTarget(self, action: #selector(buttonTouchUpInside(_:)), for: .touchUpInside)
-            button.addTarget(self, action: #selector(stopRepeating), for: .touchUpOutside)
-            button.addTarget(self, action: #selector(stopRepeating), for: .touchCancel)
-            button.addTarget(self, action: #selector(stopRepeating), for: .touchDragExit)
-            parent.addSubview(button)
-            buttons.append((button, spec))
-        }
-    }
-
-    private func applyButtonTheme(_ button: UIButton) {
-        let foregroundColor =
-            isDarkTheme
-            ? UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.0)
-            : UIColor(red: 0.102, green: 0.102, blue: 0.102, alpha: 1.0)
-        let interfaceStyle: UIUserInterfaceStyle = isDarkTheme ? .dark : .light
-        button.setTitleColor(foregroundColor, for: .normal)
-        button.tintColor = foregroundColor
-        button.backgroundColor = .clear
-        if #available(iOS 13.0, *) {
-            button.overrideUserInterfaceStyle = interfaceStyle
-        }
-    }
-
-    private func refreshModifierHighlights() {
-        let highlight =
-            isDarkTheme
-            ? UIColor(white: 1.0, alpha: 0.18)
-            : UIColor(white: 0.0, alpha: 0.12)
-        for (button, spec) in detailButtons {
-            switch spec.kind {
-            case .modifier(let mod):
-                button.backgroundColor = armedMods.contains(mod) ? highlight : .clear
-            case .toggleDetail:
-                button.backgroundColor = detailExpanded ? highlight : .clear
-            case .key:
-                button.backgroundColor = .clear
-            }
-        }
-        for (button, spec) in primaryButtons {
-            if case .toggleDetail = spec.kind {
-                button.backgroundColor = detailExpanded ? highlight : .clear
-            }
-        }
-    }
-
-    private func setDetailExpanded(_ expanded: Bool) {
-        guard detailExpanded != expanded else {
-            return
-        }
-        detailExpanded = expanded
-        detailRowView?.isHidden = !expanded
-        container?.contentHeight = expanded ? rowHeight * 2 : rowHeight
-        if !expanded {
-            armedMods = []
-        }
-        refreshModifierHighlights()
-    }
-
-    private func handleSpec(_ spec: KeySpec) {
-        switch spec.kind {
-        case .toggleDetail:
-            setDetailExpanded(!detailExpanded)
-        case .modifier(let mod):
-            armedMods.formSymmetricDifference(mod)
-            refreshModifierHighlights()
-        case .key(let name, let fixedMods):
-            let mods = armedMods.union(fixedMods)
-            sendKey?(name, mods.rawValue)
-            if !armedMods.isEmpty {
-                armedMods = []
-                refreshModifierHighlights()
-            }
-        }
-    }
-
     private func spec(for sender: UIButton) -> KeySpec? {
-        for (button, spec) in primaryButtons where button === sender {
-            return spec
-        }
-        for (button, spec) in detailButtons where button === sender {
+        for (button, spec) in buttons where button === sender {
             return spec
         }
         return nil
@@ -293,14 +192,8 @@ final class KeyboardSupporter: NSObject {
             return
         }
         if case .key(let name, let fixedMods) = spec.kind {
-            let mods = armedMods.union(fixedMods)
-            sendKey?(name, mods.rawValue)
-            let cleared = !armedMods.isEmpty
-            if cleared {
-                armedMods = []
-                refreshModifierHighlights()
-            }
-            startRepeating(name: name, mods: mods.rawValue)
+            sendKey?(name, fixedMods.rawValue)
+            startRepeating(name: name, mods: fixedMods.rawValue)
         }
     }
 
@@ -312,8 +205,13 @@ final class KeyboardSupporter: NSObject {
         }
         if spec.repeats {
             stopRepeating()
-        } else {
-            handleSpec(spec)
+            return
+        }
+        switch spec.kind {
+        case .key(let name, let fixedMods):
+            sendKey?(name, fixedMods.rawValue)
+        case .togglePanel:
+            togglePanel?()
         }
     }
 

--- a/ios/Zedra/KeyboardSupporter.swift
+++ b/ios/Zedra/KeyboardSupporter.swift
@@ -1,167 +1,335 @@
 import UIKit
 
+/// Modifier-key bitmask matching Rust `key_encoding::Mods`
+/// (shift = bit 0, alt = bit 1, ctrl = bit 2).
+struct AccessoryMods: OptionSet {
+    let rawValue: UInt8
+
+    static let shift = AccessoryMods(rawValue: 0b001)
+    static let alt = AccessoryMods(rawValue: 0b010)
+    static let ctrl = AccessoryMods(rawValue: 0b100)
+}
+
+/// Resizing container for the keyboard accessory bar. Overriding
+/// `intrinsicContentSize` is what makes UIKit re-layout the keyboard when the
+/// detail row is toggled.
+private final class AccessoryContainer: UIView {
+    var contentHeight: CGFloat = 44.0 {
+        didSet {
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: contentHeight)
+    }
+}
+
 @objcMembers
 final class KeyboardSupporter: NSObject {
+    private enum KeySpecKind {
+        /// Plain key: sends `(name, armedMods | fixedMods)` and clears any armed sticky mods.
+        case key(name: String, fixedMods: AccessoryMods = [])
+        /// Sticky modifier: toggles the armed state, never sends bytes.
+        case modifier(AccessoryMods)
+        /// Expands or collapses the detail row.
+        case toggleDetail
+    }
+
     private struct KeySpec {
         let label: String
-        let key: String
+        let kind: KeySpecKind
         let repeats: Bool
     }
 
-    private let keySpecs = [
-        KeySpec(label: "Esc", key: "escape", repeats: false),
-        KeySpec(label: "Tab", key: "tab", repeats: false),
-        KeySpec(label: "←", key: "left", repeats: true),
-        KeySpec(label: "↓", key: "down", repeats: true),
-        KeySpec(label: "↑", key: "up", repeats: true),
-        KeySpec(label: "→", key: "right", repeats: true),
-        KeySpec(label: "⏎", key: "enter", repeats: false),
+    private let primaryRow: [KeySpec] = [
+        KeySpec(label: "Esc", kind: .key(name: "escape"), repeats: false),
+        KeySpec(label: "Tab", kind: .key(name: "tab"), repeats: false),
+        KeySpec(label: "←", kind: .key(name: "left"), repeats: true),
+        KeySpec(label: "↓", kind: .key(name: "down"), repeats: true),
+        KeySpec(label: "↑", kind: .key(name: "up"), repeats: true),
+        KeySpec(label: "→", kind: .key(name: "right"), repeats: true),
+        KeySpec(label: "⏎", kind: .key(name: "enter"), repeats: false),
+        KeySpec(label: "•••", kind: .toggleDetail, repeats: false),
     ]
 
+    private let detailRow: [KeySpec] = [
+        KeySpec(label: "Ctrl", kind: .modifier(.ctrl), repeats: false),
+        KeySpec(label: "Alt", kind: .modifier(.alt), repeats: false),
+        KeySpec(label: "Shift", kind: .modifier(.shift), repeats: false),
+        KeySpec(label: "⇧⇥", kind: .key(name: "tab", fixedMods: .shift), repeats: false),
+        KeySpec(label: "⌃C", kind: .key(name: "char:c", fixedMods: .ctrl), repeats: false),
+        KeySpec(label: "⌃D", kind: .key(name: "char:d", fixedMods: .ctrl), repeats: false),
+        KeySpec(label: "⌃R", kind: .key(name: "char:r", fixedMods: .ctrl), repeats: false),
+        KeySpec(label: "Home", kind: .key(name: "home"), repeats: false),
+        KeySpec(label: "End", kind: .key(name: "end"), repeats: false),
+        KeySpec(label: "PgUp", kind: .key(name: "page_up"), repeats: true),
+        KeySpec(label: "PgDn", kind: .key(name: "page_down"), repeats: true),
+    ]
+
+    private let rowHeight: CGFloat = 44.0
     private let repeatInitialDelay: TimeInterval = 0.35
     private let repeatInterval: TimeInterval = 0.06
 
     private(set) var accessoryView: UIView?
+    private weak var container: AccessoryContainer?
     private weak var topBorder: UIView?
+    private weak var detailSeparator: UIView?
     private weak var leftKeyboardCornerFill: UIView?
     private weak var rightKeyboardCornerFill: UIView?
-    private var buttons: [UIButton] = []
-    private var sendKey: ((String) -> Void)?
+    private weak var detailRowView: UIView?
+    private var primaryButtons: [(button: UIButton, spec: KeySpec)] = []
+    private var detailButtons: [(button: UIButton, spec: KeySpec)] = []
+    private var sendKey: ((String, UInt8) -> Void)?
     private var repeatTimer: Timer?
-    private var repeatingKey: String?
+    private var repeatingKey: (name: String, mods: UInt8)?
     private var isDarkTheme = true
+    private var detailExpanded = false
+    private var armedMods: AccessoryMods = []
 
-    func makeAccessoryView(width: CGFloat, sendKey: @escaping (String) -> Void) -> UIView {
+    func makeAccessoryView(width: CGFloat, sendKey: @escaping (String, UInt8) -> Void) -> UIView {
         stopRepeating()
         self.sendKey = sendKey
-        buttons.removeAll()
+        primaryButtons.removeAll()
+        detailButtons.removeAll()
+        armedMods = []
+        detailExpanded = false
 
-        let height: CGFloat = 44.0
-        let bar = UIView(frame: CGRect(x: 0, y: 0, width: width, height: height))
-        bar.clipsToBounds = false
+        let container = AccessoryContainer(
+            frame: CGRect(x: 0, y: 0, width: width, height: rowHeight)
+        )
+        container.clipsToBounds = false
+        container.contentHeight = rowHeight
+        self.container = container
 
         let border = UIView(frame: CGRect(x: 0, y: 0, width: width, height: 0.33))
-        bar.addSubview(border)
+        container.addSubview(border)
         topBorder = border
 
         // The system keyboard has rounded top corners, which can expose the window
         // background beside an inputAccessoryView. Fill only those side gaps.
         let cornerFillWidth: CGFloat = 18.0
         let cornerFillHeight: CGFloat = 12.0
-        let leftFill = UIView(frame: CGRect(x: 0, y: height, width: cornerFillWidth, height: cornerFillHeight))
+        let leftFill = UIView(
+            frame: CGRect(x: 0, y: rowHeight, width: cornerFillWidth, height: cornerFillHeight)
+        )
         let rightFill = UIView(
             frame: CGRect(
                 x: width - cornerFillWidth,
-                y: height,
+                y: rowHeight,
                 width: cornerFillWidth,
                 height: cornerFillHeight
             )
         )
-        bar.addSubview(leftFill)
-        bar.addSubview(rightFill)
+        container.addSubview(leftFill)
+        container.addSubview(rightFill)
         leftKeyboardCornerFill = leftFill
         rightKeyboardCornerFill = rightFill
 
-        let buttonWidth = width / CGFloat(keySpecs.count)
+        layoutRow(primaryRow, into: container, atY: 0, width: width, storeIn: &primaryButtons)
 
-        for (index, spec) in keySpecs.enumerated() {
-            let button = UIButton(type: .system)
-            button.frame = CGRect(x: buttonWidth * CGFloat(index), y: 0, width: buttonWidth, height: height)
-            button.setTitle(spec.label, for: .normal)
-            button.titleLabel?.font = .systemFont(ofSize: 16.0)
-            button.tag = index
-            button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
-            button.addTarget(self, action: #selector(buttonTouchUpInside(_:)), for: .touchUpInside)
-            button.addTarget(self, action: #selector(stopRepeating), for: .touchUpOutside)
-            button.addTarget(self, action: #selector(stopRepeating), for: .touchCancel)
-            button.addTarget(self, action: #selector(stopRepeating), for: .touchDragExit)
-            bar.addSubview(button)
-            buttons.append(button)
-        }
+        let detail = UIView(frame: CGRect(x: 0, y: rowHeight, width: width, height: rowHeight))
+        detail.isHidden = true
+        container.addSubview(detail)
+        detailRowView = detail
 
-        accessoryView = bar
+        let sep = UIView(frame: CGRect(x: 0, y: 0, width: width, height: 0.33))
+        detail.addSubview(sep)
+        detailSeparator = sep
+
+        layoutRow(detailRow, into: detail, atY: 0, width: width, storeIn: &detailButtons)
+
+        accessoryView = container
         applyTheme(isDark: isDarkTheme)
-        return bar
+        refreshModifierHighlights()
+        return container
     }
 
     func applyTheme(isDark: Bool) {
         isDarkTheme = isDark
 
-        let backgroundColor = isDark
+        let backgroundColor =
+            isDark
             ? UIColor(red: 0.055, green: 0.047, blue: 0.047, alpha: 0.96)
             : UIColor(red: 0.961, green: 0.961, blue: 0.961, alpha: 0.98)
-        let foregroundColor = isDark
-            ? UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.0)
-            : UIColor(red: 0.102, green: 0.102, blue: 0.102, alpha: 1.0)
-        let borderColor = isDark
+        let borderColor =
+            isDark
             ? UIColor(white: 1.0, alpha: 0.12)
             : UIColor(white: 0.0, alpha: 0.10)
 
-        accessoryView?.backgroundColor = backgroundColor
+        container?.backgroundColor = backgroundColor
         topBorder?.backgroundColor = borderColor
+        detailSeparator?.backgroundColor = borderColor
         leftKeyboardCornerFill?.backgroundColor = backgroundColor
         rightKeyboardCornerFill?.backgroundColor = backgroundColor
 
         let interfaceStyle: UIUserInterfaceStyle = isDark ? .dark : .light
         if #available(iOS 13.0, *) {
-            accessoryView?.overrideUserInterfaceStyle = interfaceStyle
+            container?.overrideUserInterfaceStyle = interfaceStyle
+            detailRowView?.overrideUserInterfaceStyle = interfaceStyle
         }
-        for button in buttons {
-            button.setTitleColor(foregroundColor, for: .normal)
-            button.tintColor = foregroundColor
-            if #available(iOS 13.0, *) {
-                button.overrideUserInterfaceStyle = interfaceStyle
-            }
+        for (button, _) in primaryButtons + detailButtons {
+            applyButtonTheme(button)
         }
+        refreshModifierHighlights()
     }
 
+    @objc
     func stopRepeating() {
         repeatTimer?.invalidate()
         repeatTimer = nil
         repeatingKey = nil
     }
 
-    private func keySpec(for sender: UIButton) -> KeySpec? {
-        guard keySpecs.indices.contains(sender.tag) else {
-            return nil
+    private func layoutRow(
+        _ specs: [KeySpec],
+        into parent: UIView,
+        atY y: CGFloat,
+        width: CGFloat,
+        storeIn buttons: inout [(button: UIButton, spec: KeySpec)]
+    ) {
+        let buttonWidth = width / CGFloat(specs.count)
+        for (index, spec) in specs.enumerated() {
+            let button = UIButton(type: .system)
+            button.frame = CGRect(
+                x: buttonWidth * CGFloat(index),
+                y: y,
+                width: buttonWidth,
+                height: rowHeight
+            )
+            button.setTitle(spec.label, for: .normal)
+            button.titleLabel?.font = .systemFont(ofSize: 16.0)
+            button.tag = index
+            button.layer.cornerRadius = 6.0
+            button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
+            button.addTarget(self, action: #selector(buttonTouchUpInside(_:)), for: .touchUpInside)
+            button.addTarget(self, action: #selector(stopRepeating), for: .touchUpOutside)
+            button.addTarget(self, action: #selector(stopRepeating), for: .touchCancel)
+            button.addTarget(self, action: #selector(stopRepeating), for: .touchDragExit)
+            parent.addSubview(button)
+            buttons.append((button, spec))
         }
-        return keySpecs[sender.tag]
+    }
+
+    private func applyButtonTheme(_ button: UIButton) {
+        let foregroundColor =
+            isDarkTheme
+            ? UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.0)
+            : UIColor(red: 0.102, green: 0.102, blue: 0.102, alpha: 1.0)
+        let interfaceStyle: UIUserInterfaceStyle = isDarkTheme ? .dark : .light
+        button.setTitleColor(foregroundColor, for: .normal)
+        button.tintColor = foregroundColor
+        button.backgroundColor = .clear
+        if #available(iOS 13.0, *) {
+            button.overrideUserInterfaceStyle = interfaceStyle
+        }
+    }
+
+    private func refreshModifierHighlights() {
+        let highlight =
+            isDarkTheme
+            ? UIColor(white: 1.0, alpha: 0.18)
+            : UIColor(white: 0.0, alpha: 0.12)
+        for (button, spec) in detailButtons {
+            switch spec.kind {
+            case .modifier(let mod):
+                button.backgroundColor = armedMods.contains(mod) ? highlight : .clear
+            case .toggleDetail:
+                button.backgroundColor = detailExpanded ? highlight : .clear
+            case .key:
+                button.backgroundColor = .clear
+            }
+        }
+        for (button, spec) in primaryButtons {
+            if case .toggleDetail = spec.kind {
+                button.backgroundColor = detailExpanded ? highlight : .clear
+            }
+        }
+    }
+
+    private func setDetailExpanded(_ expanded: Bool) {
+        guard detailExpanded != expanded else {
+            return
+        }
+        detailExpanded = expanded
+        detailRowView?.isHidden = !expanded
+        container?.contentHeight = expanded ? rowHeight * 2 : rowHeight
+        if !expanded {
+            armedMods = []
+        }
+        refreshModifierHighlights()
+    }
+
+    private func handleSpec(_ spec: KeySpec) {
+        switch spec.kind {
+        case .toggleDetail:
+            setDetailExpanded(!detailExpanded)
+        case .modifier(let mod):
+            armedMods.formSymmetricDifference(mod)
+            refreshModifierHighlights()
+        case .key(let name, let fixedMods):
+            let mods = armedMods.union(fixedMods)
+            sendKey?(name, mods.rawValue)
+            if !armedMods.isEmpty {
+                armedMods = []
+                refreshModifierHighlights()
+            }
+        }
+    }
+
+    private func spec(for sender: UIButton) -> KeySpec? {
+        for (button, spec) in primaryButtons where button === sender {
+            return spec
+        }
+        for (button, spec) in detailButtons where button === sender {
+            return spec
+        }
+        return nil
     }
 
     @objc
     private func buttonTouchDown(_ sender: UIButton) {
-        guard let spec = keySpec(for: sender), spec.repeats else {
+        guard let spec = spec(for: sender), spec.repeats else {
             return
         }
-        sendKey?(spec.key)
-        startRepeating(spec.key)
+        if case .key(let name, let fixedMods) = spec.kind {
+            let mods = armedMods.union(fixedMods)
+            sendKey?(name, mods.rawValue)
+            let cleared = !armedMods.isEmpty
+            if cleared {
+                armedMods = []
+                refreshModifierHighlights()
+            }
+            startRepeating(name: name, mods: mods.rawValue)
+        }
     }
 
     @objc
     private func buttonTouchUpInside(_ sender: UIButton) {
-        guard let spec = keySpec(for: sender) else {
+        guard let spec = spec(for: sender) else {
             stopRepeating()
             return
         }
-
         if spec.repeats {
             stopRepeating()
         } else {
-            sendKey?(spec.key)
+            handleSpec(spec)
         }
     }
 
-    private func startRepeating(_ key: String) {
+    private func startRepeating(name: String, mods: UInt8) {
         stopRepeating()
-        repeatingKey = key
+        repeatingKey = (name, mods)
 
         // Accessory arrow keys should behave like held hardware keys: one immediate
         // keystroke, then repeat until UIKit reports any release or cancellation.
         let timer = Timer(timeInterval: repeatInterval, repeats: true) { [weak self] _ in
-            guard let self, self.repeatingKey == key else {
+            guard let self, let target = self.repeatingKey,
+                target.name == name, target.mods == mods
+            else {
                 return
             }
-            self.sendKey?(key)
+            self.sendKey?(name, mods)
         }
         timer.fireDate = Date(timeIntervalSinceNow: repeatInitialDelay)
         repeatTimer = timer

--- a/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
@@ -268,7 +268,7 @@ void zedra_ios_native_notification_dismiss(uint32_t callback_id);
  * `key` is one of: "escape", "tab", "left", "down", "up", "right", "enter", "shift_enter".
  * Maps the name to the corresponding terminal escape sequence and sends it via the active session.
  */
-void zedra_ios_send_key_input(const char *key);
+void zedra_ios_send_key_input(const char *key, uint8_t mods);
 
 /**
  * Called from the native terminal composer to send finalized text to the active terminal.

--- a/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
@@ -268,7 +268,7 @@ void zedra_ios_native_notification_dismiss(uint32_t callback_id);
  * `key` is one of: "escape", "tab", "left", "down", "up", "right", "enter", "shift_enter".
  * Maps the name to the corresponding terminal escape sequence and sends it via the active session.
  */
-void zedra_ios_send_key_input(const char *key);
+void zedra_ios_send_key_input(const char *key, uint8_t mods);
 
 /**
  * Called from the native terminal composer to send finalized text to the active terminal.

--- a/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
@@ -265,8 +265,10 @@ void zedra_ios_native_notification_dismiss(uint32_t callback_id);
 /**
  * Called from the native keyboard accessory bar when a shortcut key button is tapped.
  *
- * `key` is one of: "escape", "tab", "left", "down", "up", "right", "enter", "shift_enter".
- * Maps the name to the corresponding terminal escape sequence and sends it via the active session.
+ * `key` is one of the wire names accepted by `key_encoding::Key::parse`
+ * ("escape", "tab", "left", ... or `char:<c>` for single-character keys),
+ * plus the iOS-only sentinel "dismiss_keyboard". `mods` packs Shift/Alt/Ctrl
+ * per `key_encoding::Mods` (bit 0 / 1 / 2).
  */
 void zedra_ios_send_key_input(const char *key, uint8_t mods);
 


### PR DESCRIPTION
## Summary

Closes #39.

- Add a `•••` toggle on the keyboard accessory bar (iOS + Android) that reveals a second row with sticky **Ctrl / Alt / Shift** modifiers, one-tap agent combos (**⇧⇥ ⌃C ⌃D ⌃R**), and **Home / End / PgUp / PgDn** navigation.
- Native bars now pass `(name, mod_bits)` over the existing FFI instead of a fixed name→bytes string map. A new `key_encoding` module (legacy xterm/VT rules: Ctrl bit-mask, Alt `ESC` prefix, `CSI 1;n` for modified arrows, `ESC [ Z` for BackTab, `LF` for Shift+Enter) owns the encoding. Char keys cross the wire as `char:<c>`.
- Modifier state is sticky-armed for the next non-mod tap, mirroring Blink / Termius. Modifier buttons highlight while armed; collapsing the detail row clears them.

## Notes

- Wire shape `(Key, Mods)` matches the convention used by crossterm, termwiz, WezTerm, and kitty, so a future CSI-u / kitty-protocol negotiator can swap in without changing callers.
- Manual verification steps added at `docs/MANUAL_TEST.md` § 22c.

Release Notes:

- Added a detail row in the keyboard accessory bar with Ctrl/Alt/Shift modifiers, agent shortcuts (⇧⇥, ⌃C, ⌃D, ⌃R), and Home/End/PgUp/PgDn navigation.