### PR TITLE
feat(mobile): foundation for editor pinch zoom — PinchEvent dispatch

### DIFF
--- a/crates/zedra/src/editor/code_editor.rs
+++ b/crates/zedra/src/editor/code_editor.rs
@@ -61,8 +61,28 @@ pub struct EditorView {
     /// True once a gesture has been committed to horizontal scroll.
     /// Stays true until a clearly vertical event overrides it.
     h_scroll_active: bool,
+    /// Pinch-to-zoom factor for the rendered editor surface. The layout still
+    /// runs at scale 1.0 — this scales the emitted geometry only via
+    /// [`paint_transform`] so text re-rasterizes sharp at any factor and no
+    /// reflow is triggered. Clamped to [`MIN_ZOOM`, `MAX_ZOOM`].
+    zoom_factor: f32,
+    /// Pinch focus in window-screen logical pixels, used as the scale pivot
+    /// while a gesture is active so the pinched point stays stationary as
+    /// `zoom_factor` changes.
+    pinch_focus: Option<Point<Pixels>>,
     on_scroll_boundary_changed: Option<Box<dyn FnMut(bool)>>,
 }
+
+/// Lower bound for [`EditorView::zoom_factor`]. Below this the gutter and
+/// caret targets become hard to hit on mobile.
+const MIN_ZOOM: f32 = 0.5;
+/// Upper bound. Past this the per-glyph atlas tile grows enough to be
+/// counter-productive for typical editor sessions.
+const MAX_ZOOM: f32 = 4.0;
+/// Maximum absolute `delta` accepted from any single pinch sample. Bounds the
+/// jitter from very fast pinches so the factor changes smoothly rather than
+/// jumping by multiple integer steps per frame.
+const ZOOM_DELTA_CLAMP: f32 = 0.25;
 
 impl EditorView {
     /// Create with automatic language detection from filename.
@@ -91,6 +111,8 @@ impl EditorView {
             h_scroll_offset: 0.0,
             max_line_chars: 0,
             h_scroll_active: false,
+            zoom_factor: 1.0,
+            pinch_focus: None,
             on_scroll_boundary_changed: None,
         }
     }
@@ -343,12 +365,40 @@ impl Render for EditorView {
             style
         };
 
+        let paint_xf = if (self.zoom_factor - 1.0).abs() < f32::EPSILON {
+            ScreenTransform::identity()
+        } else {
+            // The pivot is set to the most recent pinch focus so the user's
+            // finger stays anchored to the same pixel as the gesture zooms.
+            // Falling back to the editor origin keeps a sensible default if a
+            // pinch begins and ends before any Moved sample arrives.
+            let pivot = self.pinch_focus.unwrap_or(point(px(0.0), px(0.0)));
+            ScreenTransform::scale_around_pivot(self.zoom_factor, pivot)
+        };
+
         div()
             .flex()
             .flex_col()
             .size_full()
+            .overflow_hidden()
             .bg(rgb(editor_theme.background))
             .font_family(fonts::MONO_FONT_FAMILY)
+            .on_pinch(cx.listener(|this, event: &PinchEvent, _window, cx| {
+                if event.phase == TouchPhase::Started {
+                    this.pinch_focus = Some(event.position);
+                }
+                if event.phase != TouchPhase::Moved || event.delta == 0.0 {
+                    return;
+                }
+                this.pinch_focus = Some(event.position);
+                let delta = event.delta.clamp(-ZOOM_DELTA_CLAMP, ZOOM_DELTA_CLAMP);
+                let new_factor =
+                    (this.zoom_factor * (1.0 + delta)).clamp(MIN_ZOOM, MAX_ZOOM);
+                if (new_factor - this.zoom_factor).abs() > f32::EPSILON {
+                    this.zoom_factor = new_factor;
+                    cx.notify();
+                }
+            }))
             .on_scroll_wheel(
                 cx.listener(move |this, event: &ScrollWheelEvent, _window, cx| {
                     let (delta_x, delta_y) = match event.delta {
@@ -383,7 +433,8 @@ impl Render for EditorView {
                     this.notify_scroll_boundary_changed();
                 }),
             )
-            .child(
+            .child(paint_transform(
+                paint_xf,
                 selection_area(
                     uniform_list("editor-lines", line_count + extra_items, {
                         let text_style = text_style.clone();
@@ -465,7 +516,7 @@ impl Render for EditorView {
                 )
                 .id(CODE_EDITOR_SELECTION_AREA_ID)
                 .action_with_image("Add to Chat", "Zedra", AddSelectionToChat),
-            )
+            ))
     }
 }
 

--- a/crates/zedra/src/editor/markdown.rs
+++ b/crates/zedra/src/editor/markdown.rs
@@ -51,8 +51,19 @@ pub struct MarkdownView {
     mermaid_states: HashMap<usize, MermaidBlockState>,
     mermaid_show_source: HashSet<usize>,
     mermaid_generation: u64,
+    /// Pinch-to-zoom factor for the rendered markdown surface. Scales the
+    /// emitted geometry only via [`paint_transform`]; layout stays at scale
+    /// 1.0 so paragraph wrap and table widths do not reflow.
+    zoom_factor: f32,
+    /// Pinch focus in window-screen logical pixels, used as the scale pivot
+    /// while a gesture is active.
+    pinch_focus: Option<Point<Pixels>>,
     _theme_subscription: Vec<Subscription>,
 }
+
+const MIN_ZOOM: f32 = 0.5;
+const MAX_ZOOM: f32 = 4.0;
+const ZOOM_DELTA_CLAMP: f32 = 0.25;
 
 impl MarkdownView {
     pub fn new(source: impl Into<SharedString>, cx: &mut Context<Self>) -> Self {
@@ -78,6 +89,8 @@ impl MarkdownView {
             mermaid_states: HashMap::new(),
             mermaid_show_source: HashSet::new(),
             mermaid_generation: 0,
+            zoom_factor: 1.0,
+            pinch_focus: None,
             _theme_subscription: subscriptions,
         };
         view.schedule_mermaid_renders(cx);
@@ -375,10 +388,18 @@ impl Render for MarkdownView {
         .with_sizing_behavior(ListSizingBehavior::Auto)
         .size_full();
 
+        let paint_xf = if (self.zoom_factor - 1.0).abs() < f32::EPSILON {
+            ScreenTransform::identity()
+        } else {
+            let pivot = self.pinch_focus.unwrap_or(point(px(0.0), px(0.0)));
+            ScreenTransform::scale_around_pivot(self.zoom_factor, pivot)
+        };
+
         div()
             .id("markdown-preview-scroll")
             .size_full()
             .min_h_0()
+            .overflow_hidden()
             // Empty markdown taps should move focus and dismiss read-only selection.
             .track_focus(&focus_handle)
             .on_press(move |event, window, cx| {
@@ -387,12 +408,28 @@ impl Render for MarkdownView {
                     press_focus_handle.focus(window, cx);
                 }
             })
-            .child(
+            .on_pinch(cx.listener(|this, event: &PinchEvent, _window, cx| {
+                if event.phase == TouchPhase::Started {
+                    this.pinch_focus = Some(event.position);
+                }
+                if event.phase != TouchPhase::Moved || event.delta == 0.0 {
+                    return;
+                }
+                this.pinch_focus = Some(event.position);
+                let delta = event.delta.clamp(-ZOOM_DELTA_CLAMP, ZOOM_DELTA_CLAMP);
+                let new_factor =
+                    (this.zoom_factor * (1.0 + delta)).clamp(MIN_ZOOM, MAX_ZOOM);
+                if (new_factor - this.zoom_factor).abs() > f32::EPSILON {
+                    this.zoom_factor = new_factor;
+                    cx.notify();
+                }
+            }))
+            .child(paint_transform(
+                paint_xf,
                 selection_area(markdown_list)
                     .id(MARKDOWN_SELECTION_AREA_ID)
-                    .action_with_image("Add to Chat", "Zedra", AddSelectionToChat)
-                    .into_any_element(),
-            )
+                    .action_with_image("Add to Chat", "Zedra", AddSelectionToChat),
+            ))
     }
 }
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1102,3 +1102,14 @@ Expected:
 4. Expected: UIKit presentation chrome uses light backgrounds and dark text/icons, matching the app theme.
 5. Toggle Appearance back to **Dark** and repeat the same presentations.
 6. Expected: UIKit presentation chrome returns to dark backgrounds and light text/icons without restarting the app.
+
+## 23. Pinch Gesture Dispatch (Foundation for #106)
+
+Verifies `PlatformInput::Pinch` reaches GPUI on mobile. No editor zoom UI yet — this is the platform-layer wiring only.
+
+1. Install an iOS build and open any file in the editor.
+2. Pinch in and out with two fingers on the editor area.
+3. Expected: no crash, no visual change yet, single-finger scrolling still works between pinches.
+4. Expected (developer check): a temporary `.on_pinch(...)` on any view receives `PinchEvent` with `phase` = Started/Moved/Ended and non-zero `delta` during Moved.
+5. Repeat on an Android build.
+6. Expected: pinch-in-progress suppresses pan/scroll (the document does not also scroll mid-pinch); release lets normal scrolling resume.

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1113,3 +1113,15 @@ Verifies `PlatformInput::Pinch` reaches GPUI on mobile. No editor zoom UI yet �
 4. Expected (developer check): a temporary `.on_pinch(...)` on any view receives `PinchEvent` with `phase` = Started/Moved/Ended and non-zero `delta` during Moved.
 5. Repeat on an Android build.
 6. Expected: pinch-in-progress suppresses pan/scroll (the document does not also scroll mid-pinch); release lets normal scrolling resume.
+
+## 24. Pinch Canvas Zoom in Editor and Markdown (#106)
+
+Verifies the canvas-zoom slice: editor + markdown views scale their entire visual tree under pinch.
+
+1. iOS — open a source file in the code editor. Pinch out; the editor surface scales up around the pinch focus point.
+2. Expected: text stays sharp at every zoom level (no blurry resampling); gutter line numbers scale with the text; bg fills the original viewport rect, not the zoomed extent.
+3. Pinch in below 1.0×; clamped at 0.5×. Pinch out past 4.0×; clamped at 4.0×.
+4. Open a Markdown preview (`README.md`). Repeat. Headings, paragraphs, code blocks, tables all scale together; no reflow (line breaks stay where they were at 1.0×).
+5. Repeat on Android.
+6. Expected: zoom factor is per-view (closing and reopening a file does not preserve the previous zoom; this is intentional for the first slice).
+7. Known gap: when zoomed in, single-finger pan does not yet scroll the zoomed canvas — the underlying list scrolls instead. Tracked as follow-up under issue #106.

--- a/docs/PINCH_ZOOM_DESIGN.md
+++ b/docs/PINCH_ZOOM_DESIGN.md
@@ -1,0 +1,124 @@
+# Pinch-to-Zoom Design (#106)
+
+## Goal
+
+User pinches the editor or markdown view; content scales like a canvas. Text stays sharp at any zoom factor. Pan around the larger zoomed content. Layout does not reflow.
+
+## Foundation (already landed in tanlethanh/zed#4 + tanlethanh/zedra#128)
+
+- `UIPinchGestureRecognizer` on iOS and `ScaleGestureDetector` on Android dispatch `PlatformInput::Pinch` to GPUI views.
+- Single-finger pan/scroll is suppressed while a pinch is in progress.
+
+This is platform-layer only. No view yet consumes `PinchEvent`.
+
+## Architecture choice
+
+Three honest options.
+
+### Option A — Scale-multiplier stack on `Window` (recommended)
+
+Add a parallel stack alongside `element_offset_stack` and `content_mask_stack`:
+
+```rust
+struct PaintTransform {
+    scale: f32,
+    offset: Point<Pixels>, // applied AFTER scale
+    pivot: Point<Pixels>,  // scale anchor, in pre-transform logical space
+}
+
+// Window
+pub(crate) paint_transform_stack: Vec<PaintTransform>,
+
+pub fn with_paint_transform<R>(
+    &mut self,
+    transform: PaintTransform,
+    f: impl FnOnce(&mut Self) -> R,
+) -> R;
+```
+
+`current_paint_transform()` composes the stack into a single affine `T`.
+
+Paint methods (`paint_quad`, `paint_path`, `paint_underline`, `paint_strikethrough`, `paint_glyph`, `paint_emoji`, `paint_shadows`, `paint_layer`) apply `T` to incoming positions and sizes, and use `paint_scale_factor()` (= `self.scale_factor() * T.scale`) in place of `self.scale_factor()` for glyph atlas keying, corner radii, and stroke snapping.
+
+**Sharp text comes for free**: `RenderGlyphParams.scale_factor` keys the glyph atlas. Bumping it re-rasterizes at the on-screen pixel size, no extra atlas plumbing.
+
+Hit-test integrates by storing `T` on each `Hitbox` at insert time; the dispatch tree applies `T^-1` to the pointer before testing.
+
+**Pros:** smallest realistic diff (~400 LOC); reuses existing scale_factor → atlas plumbing; sharp text; works on iOS Metal + Android wgpu unchanged.
+**Cons:** every existing paint method needs a few-line patch; hit-test path needs careful inverse-transform threading.
+
+### Option B — Render-to-texture
+
+`with_offscreen_render(bounds, scale, f)` renders the subtree into a separate GPU texture, then composites that texture scaled into the main scene. Conceptually pure; isolates the transform to the composite step.
+
+**Pros:** zero changes to existing paint methods.
+**Cons:** requires render-target infrastructure that mobile GPUI lacks. Roughly equal LOC to add the offscreen pass on both Metal and wgpu. Memory cost per zoomed view. Text sharpness still requires re-rasterizing at the texture scale, so we still touch the atlas key.
+
+### Option C — Per-primitive transformation matrix
+
+Sprite primitives already carry a `transformation: TransformationMatrix` field honored by the vertex shaders. Extend that to Quad/Path/Underline.
+
+**Pros:** smallest renderer-side diff.
+**Cons:** geometry scales but text rasterizes at base resolution → blurry text. To fix, must also re-rasterize at effective scale, which means we end up with Option A's atlas work plus shader changes on both renderers.
+
+## Recommendation
+
+**Option A.** Cleanest cost/value ratio; integrates with the existing `with_element_offset`/`with_content_mask` style; sharp text is automatic.
+
+## Hit-test plan (Option A detail)
+
+Each `Hitbox` insertion captures `current_paint_transform()`. At dispatch:
+
+```
+fn pointer_in_hitbox(mouse: Point<Pixels>, hitbox: &Hitbox) -> bool {
+    let local = hitbox.transform.inverse().apply(mouse);
+    hitbox.bounds.contains(local)
+}
+```
+
+Pointer events that bubble into a transformed view also expose the local coords so `.on_pinch` callbacks can anchor scaling at the pinch focus correctly.
+
+## Scroll geometry under zoom
+
+When `zoom_factor != 1.0`, the zoomed content extends beyond its layout bounds. Single-finger pan inside the transformed subtree must translate `pan_offset` (state on the view), not scroll the underlying `UniformListScrollHandle`.
+
+The view's `.on_scroll_wheel`/pan handler chooses between the two based on `zoom_factor`:
+
+- `zoom_factor == 1.0`: forward to existing scroll handle (current behavior).
+- `zoom_factor != 1.0`: translate `pan_offset` clamped to `[0, content_size * (zoom - 1)]` per axis.
+
+## Editor + markdown wiring
+
+```rust
+struct EditorView {
+    // ...
+    zoom_factor: f32,
+    pan_offset: Point<f32>,
+    pinch_focus: Option<Point<Pixels>>,
+}
+
+fn render(&mut self, ...) {
+    let t = PaintTransform {
+        scale: self.zoom_factor,
+        offset: self.pan_offset,
+        pivot: self.pinch_focus.unwrap_or(viewport_center),
+    };
+    div().with_paint_transform(t, |...| { existing tree })
+        .on_pinch(...)
+}
+```
+
+Pinch handler updates `zoom_factor` (clamped to `[0.5, 4.0]`), updates `pan_offset` to keep the pinch focus stationary on screen (canvas-zoom invariant), and `cx.notify()`.
+
+## Phasing
+
+1. **Vendor PR 1**: `Window::with_paint_transform` + paint method patches + hit-test transform threading. Ships with a small `examples/zoom_demo` view in `vendor/zed/crates/gpui/examples/` that pinches a static panel. ~400 LOC.
+2. **Zedra PR 1**: `EditorView` + `MarkdownView` consume the new API; pinch handler, pan, focus anchoring, scroll-geometry switch. ~150 LOC. Manual test entry updated.
+3. **Polish**: clamp behavior, reset action, telemetry, edge cases (drawer interaction, native selection under zoom).
+
+## Out of scope (initial PRs)
+
+- Zooming `git_diff_view`, `terminal_view`, or any non-editor surface.
+- Persisting `zoom_factor` across sessions or per-file.
+- Two-finger double-tap reset gesture.
+- Programmatic zoom-to-fit actions.


### PR DESCRIPTION
## Summary

- Bumps `vendor/zed` to bring in mobile `PinchEvent` dispatch (tanlethanh/zed#4) and the new `Window::with_paint_transform` + `paint_transform` element wrapper (tanlethanh/zed#5).
- `EditorView` and `MarkdownView` wrap their rendered tree in `paint_transform` with a `ScreenTransform` driven by `zoom_factor` and the most recent pinch focus. Layout still runs at scale 1.0; the transform composites at paint time, and the glyph atlas re-rasterizes at the on-screen pixel size so text stays sharp at every zoom level.
- `.on_pinch` updates `zoom_factor` clamped to `[0.5, 4.0]` with a per-event delta cap to bound jitter.
- Pinch focus is captured at Started and on every Moved sample, so the user's finger stays anchored to the same pixel as the gesture zooms.

## Notes

- Closes the canvas-zoom slice of #106. Pan-around-larger-canvas and zoom reset are intentionally left for a follow-up — when zoomed in, single-finger pan still scrolls the underlying list. Noted in `docs/MANUAL_TEST.md` §24.
- Vendor PRs must merge first (or the branch SHA stays on `tanlethanh/zed:feat/window-paint-transform`):
  - tanlethanh/zed#4 — mobile `PinchEvent` dispatch
  - tanlethanh/zed#5 — `Window::with_paint_transform`
- `paint_transform` is a separate vendor change because it touches GPUI core paint, hitbox, and content-mask paths. Design is documented in `docs/PINCH_ZOOM_DESIGN.md`.