### PR TITLE
fix(android): reload embedded fonts when text system is recreated

### DIFF
--- a/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
@@ -7,6 +7,8 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import org.json.JSONObject
+import java.io.File
 import android.view.Gravity
 import android.view.HapticFeedbackConstants
 import android.view.KeyEvent
@@ -34,6 +36,16 @@ class MainActivity : AppCompatActivity() {
     private lateinit var keyboardAccessoryBar: KeyboardAccessoryBar
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Apply the persisted theme before super.onCreate so AppCompat picks up
+        // the correct night mode as its initial state. If we set it later (e.g.
+        // from a Rust JNI callback after the activity has attached), AppCompat
+        // treats it as a mode change and recreates the Activity — which tears
+        // down the SurfaceView and the GPUI text system, dropping our embedded
+        // fonts on cold launch.
+        AppCompatDelegate.setDefaultNightMode(
+            if (readPersistedThemeIsDark(this)) AppCompatDelegate.MODE_NIGHT_YES
+            else AppCompatDelegate.MODE_NIGHT_NO,
+        )
         installSplashScreen()
         super.onCreate(savedInstanceState)
 
@@ -171,6 +183,21 @@ class MainActivity : AppCompatActivity() {
 
         private var sSurfaceView: GpuiSurfaceView? = null
         private var sActivity: Activity? = null
+
+        // Mirrors crates/zedra/src/settings.rs: `<filesDir>/zedra/settings.json`
+        // with an optional `theme_preference` field of `"Dark"` or `"Light"`.
+        // Default is dark to match `ThemePreference::default()` on the Rust side.
+        private fun readPersistedThemeIsDark(activity: Activity): Boolean {
+            val file = File(activity.filesDir, "zedra/settings.json")
+            if (!file.exists()) return true
+            return try {
+                val pref = JSONObject(file.readText()).optString("theme_preference", "Dark")
+                !pref.equals("Light", ignoreCase = true)
+            } catch (e: Throwable) {
+                Log.w(TAG, "settings.json parse failed; defaulting to dark", e)
+                true
+            }
+        }
         // Set when Rust calls setNativeTheme before the activity / accessory bar exists.
         // Applied once onCreate finishes wiring views.
         private var pendingNativeIsDark: Boolean? = null

--- a/crates/zedra/src/fonts.rs
+++ b/crates/zedra/src/fonts.rs
@@ -39,14 +39,19 @@ pub const SYMBOL_FONT_FAMILY: &str = "Noto Sans Symbols 2";
 /// across the app's lifetime (e.g. when the Android surface is destroyed and
 /// the platform is reinitialized), so a process-wide `Once` would leave the
 /// new text system without the embedded fonts and fall back to system fonts.
-/// We skip if the current text system already knows the embedded families.
+///
+/// We skip only when every embedded family is already present in the text
+/// system. Checking a single family is not enough: a device whose system
+/// font db happens to expose one of the names but not the others would
+/// short-circuit the load and leave the missing families resolving to
+/// system fallbacks.
 pub fn load_fonts(window: &mut gpui::Window) {
     let text_system = window.text_system();
-    if text_system
-        .all_font_names()
+    let names = text_system.all_font_names();
+    let already_loaded = [HEADING_FONT_FAMILY, MONO_FONT_FAMILY, SYMBOL_FONT_FAMILY]
         .iter()
-        .any(|name| name == MONO_FONT_FAMILY)
-    {
+        .all(|family| names.iter().any(|name| name == family));
+    if already_loaded {
         return;
     }
     let fonts: Vec<Cow<'static, [u8]>> = FONTS.iter().map(|&b| Cow::Borrowed(b)).collect();

--- a/crates/zedra/src/fonts.rs
+++ b/crates/zedra/src/fonts.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::sync::Once;
 
 static FONTS: &[&[u8]] = &[
     include_bytes!("../assets/fonts/Lora-VariableFont_wght.ttf"),
@@ -34,19 +33,27 @@ pub const MONO_FONT_FAMILY: &str = "JetBrainsMonoNL Nerd Font Mono";
 /// The font family name for the symbol fallback font
 pub const SYMBOL_FONT_FAMILY: &str = "Noto Sans Symbols 2";
 
-static FONT_LOADED: Once = Once::new();
-
 /// Load all embedded fonts into GPUI's text system.
-/// This should be called once during app initialization.
+///
+/// Called on every window open. The platform text system can be recreated
+/// across the app's lifetime (e.g. when the Android surface is destroyed and
+/// the platform is reinitialized), so a process-wide `Once` would leave the
+/// new text system without the embedded fonts and fall back to system fonts.
+/// We skip if the current text system already knows the embedded families.
 pub fn load_fonts(window: &mut gpui::Window) {
-    FONT_LOADED.call_once(|| {
-        let text_system = window.text_system();
-        let fonts: Vec<Cow<'static, [u8]>> = FONTS.iter().map(|&b| Cow::Borrowed(b)).collect();
-        let count = fonts.len();
-        if let Err(e) = text_system.add_fonts(fonts) {
-            tracing::error!(err = %e, "fonts: load failed");
-        } else {
-            tracing::info!(count, "fonts: loaded");
-        }
-    });
+    let text_system = window.text_system();
+    if text_system
+        .all_font_names()
+        .iter()
+        .any(|name| name == MONO_FONT_FAMILY)
+    {
+        return;
+    }
+    let fonts: Vec<Cow<'static, [u8]>> = FONTS.iter().map(|&b| Cow::Borrowed(b)).collect();
+    let count = fonts.len();
+    if let Err(e) = text_system.add_fonts(fonts) {
+        tracing::error!(err = %e, "fonts: load failed");
+    } else {
+        tracing::info!(count, "fonts: loaded");
+    }
 }


### PR DESCRIPTION
## Summary

On a realme RMX3700 (Android 13), every text in the app rendered in Roboto in 0.3, while 0.2 on the same device rendered correctly. Other devices on 0.3 were fine.

Root cause: `crates/zedra/src/fonts.rs` used a process-wide `static FONT_LOADED: Once` to add the embedded Lora / JetBrainsMono / NotoSansSymbols2 faces into GPUI's `CosmicTextSystem` at window open. On Android the text system lives on `AndroidPlatform`, and the platform is **recreated when the Activity is recreated**. After the recreation, `load_fonts` ran but the `Once` was already consumed — the fresh fontdb never received the embedded faces. `load_family("JetBrainsMonoNL Nerd Font Mono")` then returned an empty candidate list and `load_fallback_fonts` resolved to Roboto.

Confirmed with a temporary log probe inside `gpui_android::text_system::layout_line` — first shape pass picked `JetBrainsMonoNL Nerd Font Mono`; after the surface destroy / recreate, the second pass picked `Roboto`.

### Why this only appeared in 0.3

Commit `50c01027f4` (`feat(android): theme native presentations with app preference`) moved `AppCompatDelegate.setDefaultNightMode(MODE_NIGHT_YES)` out of `onCreate` (before `super.onCreate`) and into a JNI callback `setNativeTheme(isDark)` invoked from Rust after the activity has already attached. On a device whose system default night mode does not already match, that call genuinely flips the mode → `AppCompat` recreates the Activity → SurfaceView destroyed → `gpuiInit` runs again → fresh text system without embedded fonts (because of `Once`).

On devices whose default already matches dark, the call is a no-op and no recreation happens — which is why 0.3 looked fine everywhere else.

The latent bug has lived since `fonts.rs` was introduced; 0.3 just added a reliable trigger.

## Fix

Drop the `Once`. Make `load_fonts` query the current text system and only add the embedded faces if `MONO_FONT_FAMILY` is not already in `all_font_names()`. Font loading is now idempotent against any future text-system recreation (locale change, font scale, density, dark mode, …), not just this one trigger.

## Notes

- Verified on RMX3700 (Adreno 725, Android 13): debug build now renders Lora for the heading and JetBrainsMono Nerd Font Mono for the code block; previously both were Roboto.
- No changes to vendor/zed; this is purely in app code.
- Optional follow-up (not in this PR): move the `setDefaultNightMode` back to before `super.onCreate` (or rely on the manifest `night` qualifier) so we don't *cause* an unnecessary Activity recreation on cold launch.