### PR TITLE
chore: bump Android to 0.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,8 +38,8 @@ android {
         applicationId = "dev.zedra.app"
         minSdk = 23
         targetSdk = 35
-        versionCode = 3
-        versionName = "0.3"
+        versionCode = 4
+        versionName = "0.4"
         manifestPlaceholders = [
             appLabel: "@string/app_name",
             firebaseAnalyticsCollectionEnabled: "false",


### PR DESCRIPTION
## Summary

- Android `versionCode` 3 → 4, `versionName` "0.3" → "0.4".

## Notes

- iOS not bumped here.