### PR TITLE
feat(agent): add Pi as a managed agent

### DIFF
--- a/crates/zedra-host/src/agent.rs
+++ b/crates/zedra-host/src/agent.rs
@@ -144,7 +144,7 @@ fn degraded_agent_summary(kind: ManagedAgentKind, workdir: &Path) -> AgentSummar
             code: "session_scan_panicked".to_string(),
             message: "agent session scan crashed; counts unavailable".to_string(),
         }],
-        account: account_summary(kind),
+        account: account_summary(kind, workdir),
         usage: None,
     }
 }
@@ -321,7 +321,7 @@ fn agent_summary_scan(kind: ManagedAgentKind, workdir: &Path) -> AgentSummary {
         updated_at: now,
         data_sources,
         warnings,
-        account: account_summary(kind),
+        account: account_summary(kind, workdir),
         usage: None,
     }
 }
@@ -621,12 +621,13 @@ fn lifecycle_from_shell(state: HostShellState) -> AgentLifecycleStatus {
 // Account snapshot dispatch
 // ---------------------------------------------------------------------------
 
-fn account_summary(kind: ManagedAgentKind) -> AgentAccountSummary {
+fn account_summary(kind: ManagedAgentKind, workdir: &Path) -> AgentAccountSummary {
     let fields = match kind {
         ManagedAgentKind::Claude => agent_claude::account_fields(),
         ManagedAgentKind::Codex => agent_codex::account_fields(),
         ManagedAgentKind::OpenCode => agent_opencode::account_fields(),
-        ManagedAgentKind::Pi => agent_pi::account_fields(),
+        // Pi merges global + project (`<workdir>/.pi`) config, so it needs the workdir.
+        ManagedAgentKind::Pi => agent_pi::account_fields(workdir),
     };
     AgentAccountSummary { fields }
 }

--- a/crates/zedra-host/src/agent.rs
+++ b/crates/zedra-host/src/agent.rs
@@ -3,6 +3,7 @@ use crate::agent_claude;
 use crate::agent_codex;
 use crate::agent_installed;
 use crate::agent_opencode;
+use crate::agent_pi;
 use crate::agent_setup::setup_summary;
 use crate::agent_utils::{
     capabilities, display_name, first_non_empty_line, program_name, shell_quote,
@@ -20,10 +21,11 @@ pub use crate::agent_utils::home_path;
 const AGENT_SESSION_DEFAULT_LIMIT: u32 = 50;
 const AGENT_SESSION_MAX_LIMIT: u32 = 200;
 
-pub const MANAGED_AGENT_KINDS: [ManagedAgentKind; 3] = [
+pub const MANAGED_AGENT_KINDS: [ManagedAgentKind; 4] = [
     ManagedAgentKind::Claude,
     ManagedAgentKind::Codex,
     ManagedAgentKind::OpenCode,
+    ManagedAgentKind::Pi,
 ];
 
 pub fn default_agent_session_limit() -> usize {
@@ -234,6 +236,7 @@ pub fn resume_launch_command(kind: ManagedAgentKind, session_id: &str) -> Option
         ManagedAgentKind::Claude => format!("claude --resume {quoted}"),
         ManagedAgentKind::Codex => format!("codex resume {quoted}"),
         ManagedAgentKind::OpenCode => format!("opencode --session {quoted}"),
+        ManagedAgentKind::Pi => format!("pi --session {quoted}"),
     })
 }
 
@@ -249,6 +252,7 @@ pub fn normalize_event(
         ManagedAgentKind::Claude => agent_claude::normalize_event(event_name),
         ManagedAgentKind::Codex => agent_codex::normalize_event(event_name),
         ManagedAgentKind::OpenCode => agent_opencode::normalize_event(event_name),
+        ManagedAgentKind::Pi => agent_pi::normalize_event(event_name),
     }
 }
 
@@ -257,6 +261,7 @@ pub fn managed_kind_from_slug(raw: &str) -> Option<ManagedAgentKind> {
         "claude" => Some(ManagedAgentKind::Claude),
         "codex" => Some(ManagedAgentKind::Codex),
         "opencode" | "open-code" | "open_code" => Some(ManagedAgentKind::OpenCode),
+        "pi" => Some(ManagedAgentKind::Pi),
         _ => None,
     }
 }
@@ -370,6 +375,17 @@ fn session_counts_for_kind(
                 provider_project_id: c.provider_project_id,
             })
         }
+        ManagedAgentKind::Pi => {
+            let c = agent_pi::session_counts(workdir)?;
+            Ok(SessionCounts {
+                total: c.total,
+                resumable: c.resumable,
+                latest_session_id: c.latest_session_id,
+                latest_session_title: c.latest_session_title,
+                last_activity_at: c.last_activity_at,
+                provider_project_id: None,
+            })
+        }
     }
 }
 
@@ -386,6 +402,7 @@ fn sessions_for_kind_blocking(
         ManagedAgentKind::Claude => agent_claude::sessions(workdir, &cli, limit),
         ManagedAgentKind::Codex => agent_codex::sessions(workdir, &cli, limit),
         ManagedAgentKind::OpenCode => agent_opencode::sessions(workdir, &cli, limit),
+        ManagedAgentKind::Pi => agent_pi::sessions(workdir, &cli, limit),
     }?;
     let total = u32::try_from(sessions.1).unwrap_or(u32::MAX);
     sessions
@@ -430,6 +447,7 @@ fn agent_list_cli_summary(kind: ManagedAgentKind, workdir: &Path) -> AgentCliSum
         ManagedAgentKind::Claude => agent_claude::cli_available(workdir),
         ManagedAgentKind::Codex => agent_codex::cli_available(),
         ManagedAgentKind::OpenCode => agent_opencode::cli_available(),
+        ManagedAgentKind::Pi => agent_pi::cli_available(),
     };
     if available {
         AgentCliSummary {
@@ -532,6 +550,7 @@ fn terminal_matches(kind: ManagedAgentKind, meta: &HostTermMetaSnapshot) -> bool
         ManagedAgentKind::Claude => "claude",
         ManagedAgentKind::Codex => "codex",
         ManagedAgentKind::OpenCode => "opencode",
+        ManagedAgentKind::Pi => "pi",
     };
     meta.icon_name
         .as_deref()
@@ -548,6 +567,11 @@ fn command_mentions(kind: ManagedAgentKind, command: &str) -> bool {
         ManagedAgentKind::Claude => low.contains("claude"),
         ManagedAgentKind::Codex => low.contains("codex"),
         ManagedAgentKind::OpenCode => low.contains("opencode") || low.contains("open-code"),
+        ManagedAgentKind::Pi => low
+            .split_whitespace()
+            .next()
+            .map(|first| first == "pi" || first.ends_with("/pi"))
+            .unwrap_or(false),
     }
 }
 
@@ -566,6 +590,7 @@ fn infer_session_id(kind: ManagedAgentKind, meta: &HostTermMetaSnapshot) -> Opti
         ManagedAgentKind::OpenCode => {
             value_after_flag(&tokens, "--session").or_else(|| value_after_flag(&tokens, "-s"))
         }
+        ManagedAgentKind::Pi => value_after_flag(&tokens, "--session"),
     }
 }
 
@@ -601,6 +626,7 @@ fn account_summary(kind: ManagedAgentKind) -> AgentAccountSummary {
         ManagedAgentKind::Claude => agent_claude::account_fields(),
         ManagedAgentKind::Codex => agent_codex::account_fields(),
         ManagedAgentKind::OpenCode => agent_opencode::account_fields(),
+        ManagedAgentKind::Pi => agent_pi::account_fields(),
     };
     AgentAccountSummary { fields }
 }
@@ -609,6 +635,7 @@ pub async fn scan_account_plans() -> HashMap<ManagedAgentKind, Vec<AgentInfoFiel
     let claude = tokio::spawn(agent_claude::fetch_subscription_plan());
     let codex = tokio::task::spawn_blocking(agent_codex::subscription_plan_fields);
     let opencode = tokio::task::spawn_blocking(agent_opencode::subscription_plan_fields);
+    let pi = tokio::task::spawn_blocking(agent_pi::subscription_plan_fields);
 
     let mut out = HashMap::new();
     if let Ok(Some(fields)) = claude.await {
@@ -619,6 +646,9 @@ pub async fn scan_account_plans() -> HashMap<ManagedAgentKind, Vec<AgentInfoFiel
     }
     if let Ok(Some(fields)) = opencode.await {
         out.insert(ManagedAgentKind::OpenCode, fields);
+    }
+    if let Ok(Some(fields)) = pi.await {
+        out.insert(ManagedAgentKind::Pi, fields);
     }
     out
 }
@@ -649,6 +679,7 @@ pub async fn scan_account_usage() -> HashMap<ManagedAgentKind, AgentUsageSnapsho
     let claude = tokio::spawn(agent_claude::fetch_account_usage());
     let codex = tokio::spawn(agent_codex::fetch_account_usage());
     let opencode = tokio::task::spawn_blocking(agent_opencode::fetch_account_usage);
+    let pi = tokio::task::spawn_blocking(agent_pi::fetch_account_usage);
 
     let mut out = HashMap::new();
     if let Ok(Some(snap)) = claude.await {
@@ -659,6 +690,9 @@ pub async fn scan_account_usage() -> HashMap<ManagedAgentKind, AgentUsageSnapsho
     }
     if let Ok(Some(snap)) = opencode.await {
         out.insert(ManagedAgentKind::OpenCode, snap);
+    }
+    if let Ok(Some(snap)) = pi.await {
+        out.insert(ManagedAgentKind::Pi, snap);
     }
     out
 }
@@ -691,6 +725,10 @@ mod tests {
         assert_eq!(
             resume_launch_command(ManagedAgentKind::OpenCode, "ses_123").as_deref(),
             Some("opencode --session ses_123")
+        );
+        assert_eq!(
+            resume_launch_command(ManagedAgentKind::Pi, "abc-def").as_deref(),
+            Some("pi --session abc-def")
         );
     }
 

--- a/crates/zedra-host/src/agent_cli.rs
+++ b/crates/zedra-host/src/agent_cli.rs
@@ -246,6 +246,7 @@ pub enum CliManagedAgentKind {
     Codex,
     #[value(name = "opencode", alias = "open-code", alias = "open_code")]
     OpenCode,
+    Pi,
 }
 
 impl CliManagedAgentKind {
@@ -254,6 +255,7 @@ impl CliManagedAgentKind {
             Self::Claude => "claude",
             Self::Codex => "codex",
             Self::OpenCode => "opencode",
+            Self::Pi => "pi",
         }
     }
 }
@@ -264,6 +266,7 @@ impl From<CliManagedAgentKind> for ManagedAgentKind {
             CliManagedAgentKind::Claude => ManagedAgentKind::Claude,
             CliManagedAgentKind::Codex => ManagedAgentKind::Codex,
             CliManagedAgentKind::OpenCode => ManagedAgentKind::OpenCode,
+            CliManagedAgentKind::Pi => ManagedAgentKind::Pi,
         }
     }
 }
@@ -409,6 +412,7 @@ fn scan_bench(args: AgentScanBenchArgs) -> Result<()> {
         ManagedAgentKind::Claude,
         ManagedAgentKind::Codex,
         ManagedAgentKind::OpenCode,
+        ManagedAgentKind::Pi,
     ] {
         let started = Instant::now();
         let result = agent::scan_agent_sessions(kind, &workdir, args.limit);
@@ -479,6 +483,7 @@ fn scan_bench(args: AgentScanBenchArgs) -> Result<()> {
         ManagedAgentKind::Claude,
         ManagedAgentKind::Codex,
         ManagedAgentKind::OpenCode,
+        ManagedAgentKind::Pi,
     ] {
         println!();
         if let Some(result) = sessions.get(&format!("{kind:?}")) {
@@ -515,11 +520,12 @@ async fn scan_usage(args: AgentScanCommonArgs) -> Result<()> {
         );
     } else {
         use zedra_rpc::proto::ManagedAgentKind::*;
-        for kind in [Claude, Codex, OpenCode] {
+        for kind in [Claude, Codex, OpenCode, Pi] {
             let label = match kind {
                 Claude => "Claude",
                 Codex => "Codex",
                 OpenCode => "OpenCode",
+                Pi => "Pi",
             };
             match snapshots.get(&kind) {
                 None => println!("{label}: no credentials / fetch failed"),
@@ -778,6 +784,9 @@ fn install_hooks(args: AgentHookInstallArgs) -> Result<()> {
                 &script_path,
                 args.force,
             )?),
+            CliManagedAgentKind::Pi => {
+                eprintln!("warning: Pi has no documented hook system; skipping");
+            }
         }
     }
 
@@ -1037,6 +1046,14 @@ fn synthetic_hook_payload(
                 "sessionID": "zedra-test-session",
                 "cwd": cwd,
                 "tool": "bash"
+            })
+        }
+        CliManagedAgentKind::Pi => {
+            let cwd = workdir.to_string_lossy();
+            serde_json::json!({
+                "event": event_name,
+                "sessionId": "zedra-test-session",
+                "cwd": cwd,
             })
         }
     }

--- a/crates/zedra-host/src/agent_pi.rs
+++ b/crates/zedra-host/src/agent_pi.rs
@@ -9,7 +9,8 @@ use serde_json::Value;
 use zedra_rpc::proto::*;
 
 use crate::agent_utils::{
-    command_on_path, empty_session_live, file_size_bytes, home_path, resume_summary, session_title,
+    command_on_path, empty_session_live, file_size_bytes, home_path, read_json_file,
+    resume_summary, session_title,
 };
 
 const LIST_HEAD_SCAN_MAX_LINES: usize = 32;
@@ -61,7 +62,9 @@ pub fn sessions(
     limit: usize,
 ) -> Result<(Vec<AgentSessionSummary>, usize), String> {
     let total = count_session_files(workdir).map_err(|e| e.to_string())?;
-    let files = collect_session_files(workdir, Some(limit), true).map_err(|e| e.to_string())?;
+    // Full-scan: session summaries surface message/malformed counters and the
+    // latest activity timestamp, which a head-only scan would underreport.
+    let files = collect_session_files(workdir, Some(limit), false).map_err(|e| e.to_string())?;
     let summaries = files
         .iter()
         .map(|file| session_summary(file, cli))
@@ -69,21 +72,42 @@ pub fn sessions(
     Ok((summaries, total))
 }
 
-pub fn account_fields() -> Vec<AgentInfoField> {
+pub fn account_fields(workdir: &Path) -> Vec<AgentInfoField> {
     let mut fields = Vec::new();
-    fields.push(AgentInfoField {
-        label: "Logged in".to_string(),
-        value: if pi_sessions_root().is_dir() {
-            "yes"
-        } else {
-            "no"
-        }
-        .to_string(),
-    });
+    let (settings, has_project) = effective_settings(workdir);
+    let providers = provider_fields();
+
+    // Per-provider auth replaces a single "Logged in" boolean: Pi is multi-provider.
+    if providers.is_empty() {
+        fields.push(info_field("Logged in", "no"));
+    } else {
+        fields.extend(providers);
+    }
+
+    if let Some(model) = &settings.default_model {
+        fields.push(info_field("Default model", model));
+    }
+    if let Some(provider) = &settings.default_provider {
+        fields.push(info_field("Default provider", provider));
+    }
+    if let Some(level) = &settings.default_thinking_level {
+        fields.push(info_field("Thinking", level));
+    }
+    if let Some(value) = extensions_value(&settings) {
+        fields.push(info_field("Extensions", &value));
+    }
+    fields.push(info_field(
+        "Project config",
+        if has_project { "yes" } else { "no" },
+    ));
     fields
 }
 
 pub fn subscription_plan_fields() -> Option<Vec<AgentInfoField>> {
+    // Pi has no remote plan to fetch: provider/auth state is local and already
+    // populated synchronously by `account_fields`. The async plan-refresh path
+    // would only re-read the same files and merge identical rows back, so opt
+    // out instead of duplicating that work.
     None
 }
 
@@ -265,9 +289,16 @@ fn read_session_file(
             .to_string();
     }
 
-    let last_activity_at = last_timestamp.or_else(|| {
-        mtime_unix_secs.and_then(|secs| DateTime::<Utc>::from_timestamp(secs as i64, 0))
-    });
+    // A head-only scan stops after the first few records, so its newest scanned
+    // timestamp reflects the opening prompt rather than the latest turn. Trust
+    // file mtime for activity there; full scans use the real last timestamp.
+    let mtime_activity =
+        mtime_unix_secs.and_then(|secs| DateTime::<Utc>::from_timestamp(secs as i64, 0));
+    let last_activity_at = if head_only {
+        mtime_activity.or(last_timestamp)
+    } else {
+        last_timestamp.or(mtime_activity)
+    };
 
     Ok(PiSessionFile {
         path: path.to_path_buf(),
@@ -323,6 +354,166 @@ fn session_summary(file: &PiSessionFile, cli: &AgentCliSummary) -> AgentSessionS
         data_sources: vec![AgentDataSource::HistoricalScan],
         warnings: crate::agent_utils::malformed_warning(file.malformed_line_count as usize),
         transcript_size_bytes: file_size_bytes(&file.path),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config / auth (account info)
+// ---------------------------------------------------------------------------
+
+fn pi_agent_dir() -> PathBuf {
+    home_path(&[".pi", "agent"])
+}
+
+/// Subset of Pi's `settings.json` we surface. Pi stores far more, but the agent
+/// info panel only needs the model defaults and the extensibility counts.
+#[derive(Default, serde::Deserialize)]
+struct PiSettings {
+    #[serde(rename = "defaultModel")]
+    default_model: Option<String>,
+    #[serde(rename = "defaultProvider")]
+    default_provider: Option<String>,
+    #[serde(rename = "defaultThinkingLevel")]
+    default_thinking_level: Option<String>,
+    /// npm/git package sources (string or `{ source, .. }`).
+    packages: Option<Vec<Value>>,
+    /// Local extension file/dir paths.
+    extensions: Option<Vec<String>>,
+}
+
+fn read_pi_settings(path: &Path) -> PiSettings {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+/// Effective config = global (`~/.pi/agent`) overlaid with project
+/// (`<workdir>/.pi`); per field the project value replaces the global one
+/// (scalars and lists alike), matching Pi's own settings merge. Returns the
+/// merged view plus whether the workspace has its own `settings.json`.
+fn effective_settings(workdir: &Path) -> (PiSettings, bool) {
+    let global = read_pi_settings(&pi_agent_dir().join("settings.json"));
+    let project_path = workdir.join(".pi").join("settings.json");
+    let has_project = project_path.is_file();
+    let project = read_pi_settings(&project_path);
+    let merged = PiSettings {
+        default_model: project.default_model.or(global.default_model),
+        default_provider: project.default_provider.or(global.default_provider),
+        default_thinking_level: project
+            .default_thinking_level
+            .or(global.default_thinking_level),
+        packages: project.packages.or(global.packages),
+        extensions: project.extensions.or(global.extensions),
+    };
+    (merged, has_project)
+}
+
+fn extensions_value(settings: &PiSettings) -> Option<String> {
+    let packages = settings.packages.as_deref().unwrap_or(&[]);
+    let locals = settings.extensions.as_deref().map(<[_]>::len).unwrap_or(0);
+    let total = packages.len() + locals;
+    if total == 0 {
+        return None;
+    }
+    // Show the first package source as a hint; "configured" is honest because we
+    // read settings statically and never resolve the package into its resources.
+    match packages.iter().find_map(package_source) {
+        Some(src) if total == 1 => Some(src),
+        Some(src) => Some(format!("{total} configured ({src}, …)")),
+        None => Some(format!("{total} configured")),
+    }
+}
+
+fn package_source(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::to_string)
+        .or_else(|| string_field(value, &["source"]).map(str::to_string))
+}
+
+#[derive(serde::Deserialize)]
+struct PiAuthEntry {
+    #[serde(rename = "type")]
+    kind: String,
+    /// OAuth access-token expiry, Unix milliseconds.
+    expires: Option<i64>,
+}
+
+/// Authenticated providers from `auth.json` plus custom providers declared in
+/// `models.json`, formatted as `{provider → auth state}` info rows. Never
+/// exposes tokens or account ids.
+fn provider_fields() -> Vec<AgentInfoField> {
+    let mut fields = Vec::new();
+    if let Ok(Value::Object(map)) = read_json_file(&pi_agent_dir().join("auth.json")) {
+        let mut entries: Vec<_> = map.into_iter().collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        for (provider, value) in entries {
+            if let Ok(entry) = serde_json::from_value::<PiAuthEntry>(value) {
+                fields.push(info_field(&provider, &auth_value(&entry)));
+            }
+        }
+    }
+    for (id, models) in custom_providers() {
+        fields.push(info_field(&id, &format!("custom · {models} models")));
+    }
+    fields
+}
+
+fn auth_value(entry: &PiAuthEntry) -> String {
+    match entry.kind.as_str() {
+        "oauth" => match entry.expires {
+            Some(expires_ms) => {
+                let remaining_ms = expires_ms - Utc::now().timestamp_millis();
+                if remaining_ms <= 0 {
+                    "OAuth · expired".to_string()
+                } else {
+                    format!("OAuth · expires in {}", humanize_secs(remaining_ms / 1000))
+                }
+            }
+            None => "OAuth".to_string(),
+        },
+        "api_key" => "API key".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn humanize_secs(secs: i64) -> String {
+    if secs >= 86_400 {
+        format!("{}d", secs / 86_400)
+    } else if secs >= 3_600 {
+        format!("{}h", secs / 3_600)
+    } else {
+        format!("{}m", (secs / 60).max(1))
+    }
+}
+
+/// Custom provider ids (e.g. `ollama`) from `models.json` and their model count.
+fn custom_providers() -> Vec<(String, usize)> {
+    let Ok(file) = read_json_file(&pi_agent_dir().join("models.json")) else {
+        return Vec::new();
+    };
+    let Some(providers) = file.get("providers").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    let mut out: Vec<(String, usize)> = providers
+        .iter()
+        .map(|(id, cfg)| {
+            let count = cfg
+                .get("models")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len);
+            (id.clone(), count)
+        })
+        .collect();
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+fn info_field(label: &str, value: &str) -> AgentInfoField {
+    AgentInfoField {
+        label: label.to_string(),
+        value: value.to_string(),
     }
 }
 
@@ -405,6 +596,80 @@ mod tests {
     }
 
     #[test]
+    fn humanize_secs_picks_coarsest_unit() {
+        assert_eq!(humanize_secs(9 * 86_400 + 5), "9d");
+        assert_eq!(humanize_secs(5 * 3_600), "5h");
+        assert_eq!(humanize_secs(120), "2m");
+        assert_eq!(humanize_secs(10), "1m"); // never "0m"
+    }
+
+    #[test]
+    fn auth_value_covers_oauth_and_api_key() {
+        let future = Utc::now().timestamp_millis() + 3 * 86_400 * 1000;
+        assert!(auth_value(&PiAuthEntry {
+            kind: "oauth".into(),
+            expires: Some(future),
+        })
+        .starts_with("OAuth · expires in"));
+        assert_eq!(
+            auth_value(&PiAuthEntry {
+                kind: "oauth".into(),
+                expires: Some(0),
+            }),
+            "OAuth · expired"
+        );
+        assert_eq!(
+            auth_value(&PiAuthEntry {
+                kind: "oauth".into(),
+                expires: None,
+            }),
+            "OAuth"
+        );
+        assert_eq!(
+            auth_value(&PiAuthEntry {
+                kind: "api_key".into(),
+                expires: None,
+            }),
+            "API key"
+        );
+    }
+
+    #[test]
+    fn package_source_reads_string_and_object_forms() {
+        assert_eq!(
+            package_source(&serde_json::json!("npm:foo")).as_deref(),
+            Some("npm:foo")
+        );
+        assert_eq!(
+            package_source(&serde_json::json!({ "source": "git:bar", "skills": [] })).as_deref(),
+            Some("git:bar")
+        );
+        assert_eq!(package_source(&serde_json::json!({ "skills": [] })), None);
+    }
+
+    #[test]
+    fn extensions_value_counts_packages_and_locals() {
+        let none = PiSettings::default();
+        assert_eq!(extensions_value(&none), None);
+
+        let single = PiSettings {
+            packages: Some(vec![serde_json::json!("npm:web-search")]),
+            ..Default::default()
+        };
+        assert_eq!(extensions_value(&single).as_deref(), Some("npm:web-search"));
+
+        let many = PiSettings {
+            packages: Some(vec![serde_json::json!("npm:a"), serde_json::json!("npm:b")]),
+            extensions: Some(vec!["/local/ext".to_string()]),
+            ..Default::default()
+        };
+        assert_eq!(
+            extensions_value(&many).as_deref(),
+            Some("3 configured (npm:a, …)")
+        );
+    }
+
+    #[test]
     fn reads_session_header_and_first_user_message() {
         let dir = tempfile::tempdir().unwrap();
         let workdir = Path::new("/Users/me/project");
@@ -440,5 +705,38 @@ mod tests {
         .unwrap();
         let file = read_session_file(&path, None, false).unwrap();
         assert_eq!(file.session_id, "2026-05-28_xyz");
+    }
+
+    #[test]
+    fn full_scan_reaches_latest_activity_and_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("2026-05-28_long.jsonl");
+        let mut lines = String::from(
+            r#"{"type":"session","id":"long","timestamp":"2026-05-28T10:00:00Z","cwd":"/p"}
+{"type":"message","id":"u","message":{"role":"user","content":[{"type":"text","text":"start"}]}}
+"#,
+        );
+        // Push well past LIST_HEAD_SCAN_MAX_LINES so head-only would stop early.
+        for i in 0..(LIST_HEAD_SCAN_MAX_LINES + 10) {
+            lines.push_str(&format!(
+                "{{\"type\":\"message\",\"id\":\"m{i}\",\"timestamp\":\"2026-05-28T12:00:{:02}Z\",\"message\":{{\"role\":\"assistant\",\"content\":[]}}}}\n",
+                i % 60
+            ));
+        }
+        std::fs::write(&path, lines).unwrap();
+
+        // Head-only: timestamps are unreliable, so fall back to mtime; counters
+        // are partial.
+        let head = read_session_file(&path, Some(1_700_000_000), true).unwrap();
+        assert_eq!(
+            head.last_activity_at,
+            DateTime::<Utc>::from_timestamp(1_700_000_000, 0)
+        );
+        assert!(head.message_count < (LIST_HEAD_SCAN_MAX_LINES as u64));
+
+        // Full scan: sees the latest turn timestamp and every message.
+        let full = read_session_file(&path, Some(1_700_000_000), false).unwrap();
+        assert_eq!(full.message_count, (LIST_HEAD_SCAN_MAX_LINES + 11) as u64);
+        assert!(full.last_activity_at.unwrap() > head.last_activity_at.unwrap());
     }
 }

--- a/crates/zedra-host/src/agent_pi.rs
+++ b/crates/zedra-host/src/agent_pi.rs
@@ -1,0 +1,444 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use zedra_rpc::proto::*;
+
+use crate::agent_utils::{
+    command_on_path, empty_session_live, file_size_bytes, home_path, resume_summary, session_title,
+};
+
+const LIST_HEAD_SCAN_MAX_LINES: usize = 32;
+
+pub struct SessionCounts {
+    pub total: usize,
+    pub resumable: usize,
+    pub latest_session_id: Option<String>,
+    pub latest_session_title: Option<String>,
+    pub last_activity_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+struct PiSessionFile {
+    path: PathBuf,
+    session_id: String,
+    cwd: Option<String>,
+    created_at: Option<DateTime<Utc>>,
+    last_activity_at: Option<DateTime<Utc>>,
+    title: Option<String>,
+    message_count: u64,
+    malformed_line_count: u64,
+}
+
+pub fn cli_available() -> bool {
+    command_on_path("pi") || pi_sessions_root().is_dir()
+}
+
+pub fn normalize_event(_event_name: &str) -> Option<(AgentEventKind, AgentLifecycleStatus)> {
+    None
+}
+
+pub fn session_counts(workdir: &Path) -> Result<SessionCounts, String> {
+    let files = collect_session_files(workdir, Some(1), true).map_err(|e| e.to_string())?;
+    let total = count_session_files(workdir).map_err(|e| e.to_string())?;
+    let latest = files.first();
+    Ok(SessionCounts {
+        total,
+        resumable: total,
+        latest_session_id: latest.map(|f| f.session_id.clone()),
+        latest_session_title: latest.and_then(|f| f.title.clone()),
+        last_activity_at: latest.and_then(|f| f.last_activity_at),
+    })
+}
+
+pub fn sessions(
+    workdir: &Path,
+    cli: &AgentCliSummary,
+    limit: usize,
+) -> Result<(Vec<AgentSessionSummary>, usize), String> {
+    let total = count_session_files(workdir).map_err(|e| e.to_string())?;
+    let files = collect_session_files(workdir, Some(limit), true).map_err(|e| e.to_string())?;
+    let summaries = files
+        .iter()
+        .map(|file| session_summary(file, cli))
+        .collect();
+    Ok((summaries, total))
+}
+
+pub fn account_fields() -> Vec<AgentInfoField> {
+    let mut fields = Vec::new();
+    fields.push(AgentInfoField {
+        label: "Logged in".to_string(),
+        value: if pi_sessions_root().is_dir() {
+            "yes"
+        } else {
+            "no"
+        }
+        .to_string(),
+    });
+    fields
+}
+
+pub fn subscription_plan_fields() -> Option<Vec<AgentInfoField>> {
+    None
+}
+
+pub fn fetch_account_usage() -> Option<AgentUsageSnapshot> {
+    None
+}
+
+// ---------------------------------------------------------------------------
+// File-system scan
+// ---------------------------------------------------------------------------
+
+fn pi_sessions_root() -> PathBuf {
+    home_path(&[".pi", "agent", "sessions"])
+}
+
+fn encoded_project_dir(workdir: &Path) -> String {
+    let encoded: String = workdir
+        .to_string_lossy()
+        .chars()
+        .map(|ch| match ch {
+            '/' | '\\' => '-',
+            _ => ch,
+        })
+        .collect();
+    format!("-{encoded}--")
+}
+
+fn project_dir(workdir: &Path) -> PathBuf {
+    pi_sessions_root().join(encoded_project_dir(workdir))
+}
+
+fn count_session_files(workdir: &Path) -> Result<usize> {
+    let dir = project_dir(workdir);
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to read Pi project dir {}", dir.display()));
+        }
+    };
+    let mut count = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+fn collect_session_files(
+    workdir: &Path,
+    limit: Option<usize>,
+    head_only: bool,
+) -> Result<Vec<PiSessionFile>> {
+    let dir = project_dir(workdir);
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to read Pi project dir {}", dir.display()));
+        }
+    };
+
+    let mut candidates: Vec<(PathBuf, Option<u64>)> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+            continue;
+        }
+        candidates.push((path.clone(), mtime_unix_secs(&path)));
+    }
+    candidates.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| b.0.cmp(&a.0)));
+
+    let take = limit.unwrap_or(candidates.len());
+    let mut files = Vec::with_capacity(take.min(candidates.len()));
+    for (path, mtime) in candidates.into_iter().take(take) {
+        let file = read_session_file(&path, mtime, head_only)?;
+        files.push(file);
+    }
+    Ok(files)
+}
+
+fn read_session_file(
+    path: &Path,
+    mtime_unix_secs: Option<u64>,
+    head_only: bool,
+) -> Result<PiSessionFile> {
+    let file = File::open(path)
+        .with_context(|| format!("failed to read Pi transcript {}", path.display()))?;
+    let mut session_id = String::new();
+    let mut cwd = None;
+    let mut created_at = None;
+    let mut last_timestamp: Option<DateTime<Utc>> = None;
+    let mut title: Option<String> = None;
+    let mut message_count: u64 = 0;
+    let mut malformed_line_count: u64 = 0;
+    let mut scanned_lines = 0usize;
+
+    for line in BufReader::new(file).lines() {
+        let line = line.with_context(|| format!("failed to read line in {}", path.display()))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let record = match serde_json::from_str::<Value>(trimmed) {
+            Ok(Value::Object(record)) => Value::Object(record),
+            _ => {
+                malformed_line_count += 1;
+                continue;
+            }
+        };
+        scanned_lines += 1;
+
+        let record_type = string_field(&record, &["type"]).unwrap_or("");
+        match record_type {
+            "session" => {
+                if session_id.is_empty() {
+                    if let Some(id) = string_field(&record, &["id"]) {
+                        session_id = id.to_string();
+                    }
+                }
+                if cwd.is_none() {
+                    cwd = string_field(&record, &["cwd"]).map(str::to_string);
+                }
+                if created_at.is_none() {
+                    if let Some(ts) = string_field(&record, &["timestamp"]) {
+                        created_at = parse_timestamp(ts);
+                    }
+                }
+            }
+            "session_info" => {
+                if let Some(name) = string_field(&record, &["displayName", "display_name", "name"])
+                {
+                    title = Some(name.to_string());
+                }
+            }
+            "label" => {
+                if title.is_none() {
+                    if let Some(label) = string_field(&record, &["label", "text", "value"]) {
+                        title = Some(label.to_string());
+                    }
+                }
+            }
+            "message" => {
+                message_count += 1;
+                if title.is_none() {
+                    if let Some(text) = first_user_text(&record) {
+                        title = Some(truncate_title(&text));
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        if let Some(ts) = string_field(&record, &["timestamp"]).and_then(parse_timestamp) {
+            last_timestamp = match last_timestamp {
+                Some(current) if current >= ts => Some(current),
+                _ => Some(ts),
+            };
+        }
+
+        if head_only
+            && !session_id.is_empty()
+            && title.is_some()
+            && scanned_lines >= LIST_HEAD_SCAN_MAX_LINES
+        {
+            break;
+        }
+    }
+
+    if session_id.is_empty() {
+        session_id = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+    }
+
+    let last_activity_at = last_timestamp.or_else(|| {
+        mtime_unix_secs.and_then(|secs| DateTime::<Utc>::from_timestamp(secs as i64, 0))
+    });
+
+    Ok(PiSessionFile {
+        path: path.to_path_buf(),
+        session_id,
+        cwd,
+        created_at,
+        last_activity_at,
+        title,
+        message_count,
+        malformed_line_count,
+    })
+}
+
+fn session_summary(file: &PiSessionFile, cli: &AgentCliSummary) -> AgentSessionSummary {
+    AgentSessionSummary {
+        kind: ManagedAgentKind::Pi,
+        session_id: file.session_id.clone(),
+        title: session_title(file.title.clone()),
+        cwd: file.cwd.clone(),
+        created_at: file.created_at,
+        last_activity_at: file.last_activity_at,
+        resume: resume_summary(ManagedAgentKind::Pi, &file.session_id),
+        live: empty_session_live(),
+        provider: AgentProviderSessionInfo {
+            model: None,
+            permission_mode: None,
+            cli_version: cli.version.clone(),
+            origin: None,
+            source: None,
+            entrypoint: None,
+            native_project_id: None,
+            model_provider: None,
+        },
+        git: None,
+        usage: None,
+        counters: AgentSessionCounters {
+            record_count: file.message_count,
+            message_count: file.message_count,
+            turn_count: 0,
+            tool_count: 0,
+            tool_failure_count: 0,
+            hook_success_count: 0,
+            hook_failure_count: 0,
+            malformed_record_count: file.malformed_line_count,
+        },
+        flags: AgentSessionFlags {
+            is_sidechain: false,
+            is_subagent: false,
+            is_archived: false,
+            historical_only: true,
+            live_bound: false,
+        },
+        data_sources: vec![AgentDataSource::HistoricalScan],
+        warnings: crate::agent_utils::malformed_warning(file.malformed_line_count as usize),
+        transcript_size_bytes: file_size_bytes(&file.path),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn string_field<'a>(record: &'a Value, names: &[&str]) -> Option<&'a str> {
+    names
+        .iter()
+        .find_map(|name| record.get(*name)?.as_str())
+        .filter(|value| !value.is_empty())
+}
+
+fn first_user_text(record: &Value) -> Option<String> {
+    let message = record.get("message").unwrap_or(record);
+    let role = string_field(message, &["role"]).unwrap_or("");
+    if role != "user" {
+        return None;
+    }
+    let content = message.get("content")?;
+    let text = if let Some(text) = content.as_str() {
+        text.to_string()
+    } else if let Some(array) = content.as_array() {
+        array.iter().find_map(|part| {
+            if string_field(part, &["type"]) == Some("text") {
+                string_field(part, &["text"]).map(str::to_string)
+            } else {
+                None
+            }
+        })?
+    } else {
+        return None;
+    };
+    let text = text.trim();
+    if text.is_empty() || text.starts_with('<') {
+        return None;
+    }
+    Some(text.to_string())
+}
+
+fn truncate_title(text: &str) -> String {
+    const MAX_LEN: usize = 80;
+    if text.chars().count() <= MAX_LEN {
+        return text.to_string();
+    }
+    let mut end = 0;
+    for (index, _) in text.char_indices().take(MAX_LEN) {
+        end = index;
+    }
+    format!("{}…", &text[..end])
+}
+
+fn parse_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn mtime_unix_secs(path: &Path) -> Option<u64> {
+    std::fs::metadata(path)
+        .ok()?
+        .modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_project_dir_with_pi_wrapping() {
+        assert_eq!(
+            encoded_project_dir(Path::new("/Users/me/project")),
+            "--Users-me-project--"
+        );
+    }
+
+    #[test]
+    fn reads_session_header_and_first_user_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let workdir = Path::new("/Users/me/project");
+        let sessions = dir.path().join(encoded_project_dir(workdir));
+        std::fs::create_dir_all(&sessions).unwrap();
+        let path = sessions.join("2026-05-28_abc.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"session","version":3,"id":"abc","timestamp":"2026-05-28T10:00:00Z","cwd":"/Users/me/project"}
+{"type":"message","id":"a","message":{"role":"user","content":[{"type":"text","text":"Refactor terminal scrollback"}]}}
+{"type":"message","id":"b","message":{"role":"assistant","content":[]}}
+"#,
+        )
+        .unwrap();
+
+        let file = read_session_file(&path, None, false).unwrap();
+        assert_eq!(file.session_id, "abc");
+        assert_eq!(file.cwd.as_deref(), Some("/Users/me/project"));
+        assert_eq!(file.title.as_deref(), Some("Refactor terminal scrollback"));
+        assert_eq!(file.message_count, 2);
+        assert_eq!(file.malformed_line_count, 0);
+    }
+
+    #[test]
+    fn falls_back_to_filename_when_session_id_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("2026-05-28_xyz.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"message","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}
+"#,
+        )
+        .unwrap();
+        let file = read_session_file(&path, None, false).unwrap();
+        assert_eq!(file.session_id, "2026-05-28_xyz");
+    }
+}

--- a/crates/zedra-host/src/agent_setup.rs
+++ b/crates/zedra-host/src/agent_setup.rs
@@ -57,6 +57,7 @@ pub fn setup_summary(
             hooks_enabled()
                 && (opencode_hooks_installed() || opencode_local_hooks_installed(workdir)),
         ),
+        ManagedAgentKind::Pi => (false, false, false),
     };
     let state = if error.is_some() {
         AgentSetupState::Error

--- a/crates/zedra-host/src/agent_utils.rs
+++ b/crates/zedra-host/src/agent_utils.rs
@@ -69,6 +69,7 @@ pub fn kind_slug(kind: ManagedAgentKind) -> &'static str {
         ManagedAgentKind::Claude => "claude",
         ManagedAgentKind::Codex => "codex",
         ManagedAgentKind::OpenCode => "opencode",
+        ManagedAgentKind::Pi => "pi",
     }
 }
 
@@ -77,6 +78,7 @@ pub fn program_name(kind: ManagedAgentKind) -> &'static str {
         ManagedAgentKind::Claude => "claude",
         ManagedAgentKind::Codex => "codex",
         ManagedAgentKind::OpenCode => "opencode",
+        ManagedAgentKind::Pi => "pi",
     }
 }
 
@@ -85,6 +87,7 @@ pub fn display_name(kind: ManagedAgentKind) -> &'static str {
         ManagedAgentKind::Claude => "Claude",
         ManagedAgentKind::Codex => "Codex",
         ManagedAgentKind::OpenCode => "OpenCode",
+        ManagedAgentKind::Pi => "Pi",
     }
 }
 

--- a/crates/zedra-host/src/lib.rs
+++ b/crates/zedra-host/src/lib.rs
@@ -8,6 +8,7 @@ mod agent_claude_probe;
 pub mod agent_codex;
 pub mod agent_installed;
 pub mod agent_opencode;
+pub mod agent_pi;
 pub mod agent_setup;
 pub mod agent_utils;
 pub mod api;

--- a/crates/zedra-rpc/src/proto.rs
+++ b/crates/zedra-rpc/src/proto.rs
@@ -967,6 +967,7 @@ pub enum ManagedAgentKind {
     Claude,
     Codex,
     OpenCode,
+    Pi,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -11,20 +11,6 @@ use crate::{
     unregister_active_connection,
 };
 
-/// Minimum host CLI version for agent-management RPCs and `TermCreateV2`.
-///
-/// TEMPORARY: workspace-version gate, to be replaced by capability
-/// negotiation in `SyncSessionResult`. Until then, every new post-baseline
-/// variant must either bump this constant or add its own gate.
-const HOST_VERSION_AGENT_MGMT: (u32, u32, u32) = (0, 2, 5);
-
-/// Public so views can show the same message when they short-circuit at the
-/// app layer instead of letting each per-kind RPC produce its own copy.
-pub const AGENT_MGMT_UNSUPPORTED_MSG: &str =
-    "Requires host CLI 0.2.5+. Please update your host to match the version.";
-
-const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-
 #[derive(Clone)]
 pub struct SessionHandle(Arc<SessionHandleInner>);
 
@@ -41,9 +27,6 @@ struct SessionHandleInner {
     user_disconnect: AtomicBool,
     observer_rpc_supported: AtomicBool,
     docs_tree_rpc_supported: AtomicBool,
-    /// Parsed from `SyncSessionResult.host_version`; gates post-baseline
-    /// RPCs so old hosts never receive an undecodable variant.
-    host_version: Mutex<Option<(u32, u32, u32)>>,
 }
 
 impl Drop for SessionHandleInner {
@@ -78,7 +61,6 @@ impl SessionHandle {
             user_disconnect: AtomicBool::new(false),
             observer_rpc_supported: AtomicBool::new(true),
             docs_tree_rpc_supported: AtomicBool::new(true),
-            host_version: Mutex::new(None),
         }))
     }
 
@@ -134,71 +116,6 @@ impl SessionHandle {
 
     pub fn set_rpc_client(&self, client: irpc::Client<ZedraProto>) {
         *self.0.rpc_client.lock().unwrap() = Some(client);
-    }
-
-    /// Accepts strings like `"0.2.5"` or `"0.2.5-pre-1"`; unparseable → `None`.
-    pub fn set_host_version(&self, raw: Option<String>) {
-        *self.0.host_version.lock().unwrap() = raw.as_deref().and_then(parse_semver_triplet);
-    }
-
-    pub fn host_version(&self) -> Option<(u32, u32, u32)> {
-        self.0.host_version.lock().ok().and_then(|g| *g)
-    }
-
-    /// False when the version is unknown (treat as "old, don't risk it").
-    pub fn host_at_least(&self, want: (u32, u32, u32)) -> bool {
-        match self.host_version() {
-            Some(v) => v >= want,
-            None => false,
-        }
-    }
-
-    /// Single source of truth for agent-management capability. Views call
-    /// this and short-circuit so the user sees one message, not one per
-    /// kind (`agent_sessions` fans out across Claude / Codex / OpenCode).
-    pub fn supports_agent_mgmt(&self) -> bool {
-        self.host_at_least(HOST_VERSION_AGENT_MGMT)
-    }
-
-    /// Names both sides for the user when an RPC fails because the host
-    /// can't decode it. ALPN match means the baseline surface still works;
-    /// only this specific call is unsupported.
-    fn version_mismatch_notice(&self) -> String {
-        let host = self
-            .0
-            .host_version
-            .lock()
-            .ok()
-            .and_then(|g| *g)
-            .map(|(a, b, c)| format!("{a}.{b}.{c}"))
-            .unwrap_or_else(|| "unknown".to_string());
-        format!(
-            "This action is not supported by host CLI {host} (client {CLIENT_VERSION}). \
-             Update the host or client so the versions match."
-        )
-    }
-
-    /// Rewrite "host can't decode this variant" errors to a version-skew
-    /// notice. Requires either an unambiguous decode keyword or an
-    /// older-than-client host, so benign transport closes (idle timeout,
-    /// reconnect race, host crash) on a same-version peer pass through raw.
-    fn map_rpc_error(&self, err: irpc::Error) -> anyhow::Error {
-        let raw = err.to_string();
-        let lower = raw.to_lowercase();
-        let definite_decode = lower.contains("unknown variant")
-            || lower.contains("invalid type")
-            || lower.contains("decode")
-            || lower.contains("deserialize");
-        let ambiguous_close = lower.contains("oneshot recv") || lower.contains("sender closed");
-        let host_older = match (self.host_version(), parse_semver_triplet(CLIENT_VERSION)) {
-            (Some(host), Some(client)) => host < client,
-            _ => false,
-        };
-        if definite_decode || (ambiguous_close && host_older) {
-            anyhow::anyhow!(self.version_mismatch_notice())
-        } else {
-            anyhow::anyhow!(raw)
-        }
     }
 
     pub fn set_active_connection(&self, conn: iroh::endpoint::Connection) {
@@ -608,30 +525,15 @@ impl SessionHandle {
         color_scheme: Option<TerminalColorScheme>,
     ) -> Result<String> {
         let client = self.client()?;
-        // Host < 0.2.5: send legacy V1 to keep its dispatch loop alive.
-        let result: TermCreateResult = if self.host_at_least(HOST_VERSION_AGENT_MGMT) {
-            client
-                .rpc(TermCreateReqV2 {
-                    cols,
-                    rows,
-                    launch_cmd,
-                    color_scheme,
-                })
-                .await
-                .map_err(|e| self.map_rpc_error(e))?
-        } else {
-            if color_scheme.is_some() {
-                tracing::warn!("host < 0.2.5: color scheme dropped, using host defaults");
-            }
-            client
-                .rpc(TermCreateReq {
-                    cols,
-                    rows,
-                    launch_cmd,
-                })
-                .await
-                .map_err(|e| self.map_rpc_error(e))?
-        };
+        let result: TermCreateResult = client
+            .rpc(TermCreateReqV2 {
+                cols,
+                rows,
+                launch_cmd,
+                color_scheme,
+            })
+            .await
+            .map_err(map_rpc_error)?;
         if let Some(e) = result.error {
             return Err(anyhow::anyhow!(e));
         }
@@ -647,14 +549,11 @@ impl SessionHandle {
     }
 
     pub async fn agent_installed_list(&self, refresh: bool) -> Result<Vec<InstalledAgentEntry>> {
-        if !self.host_at_least(HOST_VERSION_AGENT_MGMT) {
-            return Err(anyhow::anyhow!(AGENT_MGMT_UNSUPPORTED_MSG));
-        }
         let result: AgentInstalledListResult = self
             .client()?
             .rpc(AgentInstalledListReq { refresh })
             .await
-            .map_err(|e| self.map_rpc_error(e))?;
+            .map_err(map_rpc_error)?;
         if let Some(e) = result.error {
             return Err(anyhow::anyhow!(e));
         }
@@ -662,14 +561,11 @@ impl SessionHandle {
     }
 
     pub async fn agent_list(&self, refresh: bool) -> Result<Vec<AgentSummary>> {
-        if !self.host_at_least(HOST_VERSION_AGENT_MGMT) {
-            return Err(anyhow::anyhow!(AGENT_MGMT_UNSUPPORTED_MSG));
-        }
         let result: AgentListResult = self
             .client()?
             .rpc(AgentListReq { refresh })
             .await
-            .map_err(|e| self.map_rpc_error(e))?;
+            .map_err(map_rpc_error)?;
         if let Some(e) = result.error {
             return Err(anyhow::anyhow!(e));
         }
@@ -682,9 +578,6 @@ impl SessionHandle {
         refresh: bool,
         limit: u32,
     ) -> Result<Vec<AgentSessionSummary>> {
-        if !self.host_at_least(HOST_VERSION_AGENT_MGMT) {
-            return Err(anyhow::anyhow!(AGENT_MGMT_UNSUPPORTED_MSG));
-        }
         let result: AgentSessionsResult = self
             .client()?
             .rpc(AgentSessionsReq {
@@ -693,7 +586,7 @@ impl SessionHandle {
                 limit,
             })
             .await
-            .map_err(|e| self.map_rpc_error(e))?;
+            .map_err(map_rpc_error)?;
         if let Some(e) = result.error {
             return Err(anyhow::anyhow!(e));
         }
@@ -707,9 +600,6 @@ impl SessionHandle {
         cols: u16,
         rows: u16,
     ) -> Result<String> {
-        if !self.host_at_least(HOST_VERSION_AGENT_MGMT) {
-            return Err(anyhow::anyhow!(AGENT_MGMT_UNSUPPORTED_MSG));
-        }
         let client = self.client()?;
         let result: AgentResumeResult = client
             .rpc(AgentResumeReq {
@@ -719,7 +609,7 @@ impl SessionHandle {
                 rows,
             })
             .await
-            .map_err(|e| self.map_rpc_error(e))?;
+            .map_err(map_rpc_error)?;
         if let Some(e) = result.error {
             return Err(anyhow::anyhow!(e));
         }
@@ -788,43 +678,38 @@ fn git_checkout_result(result: GitCheckoutResult, branch: &str) -> Result<()> {
     }
 }
 
-/// Parse leading `major.minor.patch`, ignoring `-pre-N` / `+build` suffix.
-fn parse_semver_triplet(raw: &str) -> Option<(u32, u32, u32)> {
-    let core = raw
-        .split(|c: char| c == '-' || c == '+')
-        .next()
-        .unwrap_or(raw);
-    let mut parts = core.split('.');
-    let major = parts.next()?.parse::<u32>().ok()?;
-    let minor = parts.next()?.parse::<u32>().ok()?;
-    let patch = parts.next()?.parse::<u32>().ok()?;
-    Some((major, minor, patch))
+/// True when an RPC error carries no useful cause on its own: the host dropped
+/// the response (an older host that can't decode the request, or the link
+/// dropped) or a reply came back undecodable. Used to append context to the
+/// forwarded error, not to replace or swallow it.
+fn is_incompatible_close(err: &irpc::Error) -> bool {
+    let lower = err.to_string().to_lowercase();
+    lower.contains("oneshot recv")
+        || lower.contains("sender closed")
+        || lower.contains("unknown variant")
+        || lower.contains("invalid type")
+        || lower.contains("decode")
+        || lower.contains("deserialize")
+}
+
+/// Forward the actual RPC error so the failure is legible. irpc's opaque
+/// transport closes (e.g. "oneshot recv error") carry no real cause, so replace
+/// them with the likely explanation; every other error is forwarded verbatim.
+/// Applies uniformly to every RPC; no per-agent special casing.
+fn map_rpc_error(err: irpc::Error) -> anyhow::Error {
+    if is_incompatible_close(&err) {
+        anyhow::anyhow!(
+            "host may be an older build that can't decode this request, or the \
+             connection dropped — update the host or reconnect"
+        )
+    } else {
+        anyhow::anyhow!(err.to_string())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parse_semver_triplet_handles_release_and_prerelease() {
-        assert_eq!(parse_semver_triplet("0.2.5"), Some((0, 2, 5)));
-        assert_eq!(parse_semver_triplet("0.2.5-pre-1"), Some((0, 2, 5)));
-        assert_eq!(parse_semver_triplet("1.0.0+build.7"), Some((1, 0, 0)));
-        assert_eq!(parse_semver_triplet("0.2"), None);
-        assert_eq!(parse_semver_triplet("garbage"), None);
-    }
-
-    #[test]
-    fn host_at_least_returns_false_when_version_unknown() {
-        let handle = SessionHandle::new();
-        assert!(!handle.host_at_least((0, 2, 5)));
-        handle.set_host_version(Some("0.2.4".into()));
-        assert!(!handle.host_at_least((0, 2, 5)));
-        handle.set_host_version(Some("0.2.5".into()));
-        assert!(handle.host_at_least((0, 2, 5)));
-        handle.set_host_version(Some("0.3.0".into()));
-        assert!(handle.host_at_least((0, 2, 5)));
-    }
 
     #[test]
     fn add_terminal_replaces_existing_id() {

--- a/crates/zedra-session/src/session.rs
+++ b/crates/zedra-session/src/session.rs
@@ -187,7 +187,6 @@ impl Session {
                         handle.set_rpc_client(client.clone());
                         handle.set_session_id(Some(sync.session_id.clone()));
                         handle.set_session_token(Some(sync.session_token));
-                        handle.set_host_version(sync.host_version.clone());
                         handle.set_terminals(terminals);
                         on_connected(&handle);
 

--- a/crates/zedra/src/agent_detail.rs
+++ b/crates/zedra/src/agent_detail.rs
@@ -2,7 +2,7 @@ use gpui::prelude::FluentBuilder;
 use gpui::*;
 use tracing::error;
 use zedra_rpc::proto::{AgentSummary, HostEvent, ManagedAgentKind};
-use zedra_session::{AGENT_MGMT_UNSUPPORTED_MSG, Session, SessionHandle};
+use zedra_session::{Session, SessionHandle};
 
 use crate::agent_ui::{
     AgentSessionListProps, cli_version_display, group_sessions_by_day, managed_agent_name,
@@ -93,12 +93,6 @@ impl AgentDetail {
     fn reload(&mut self, refresh: bool, cx: &mut Context<Self>) {
         self.loading_epoch = self.loading_epoch.wrapping_add(1);
         let epoch = self.loading_epoch;
-        if !self.session_handle.supports_agent_mgmt() {
-            self.agent_state = LoadState::Error(AGENT_MGMT_UNSUPPORTED_MSG.into());
-            self.session_state = LoadState::Error(AGENT_MGMT_UNSUPPORTED_MSG.into());
-            cx.notify();
-            return;
-        }
         self.agent_state = LoadState::Loading;
         self.session_state = LoadState::Loading;
         cx.notify();

--- a/crates/zedra/src/agent_manage.rs
+++ b/crates/zedra/src/agent_manage.rs
@@ -1,7 +1,7 @@
 use gpui::*;
 use tracing::error;
 use zedra_rpc::proto::{AgentSummary, HostEvent};
-use zedra_session::{AGENT_MGMT_UNSUPPORTED_MSG, Session, SessionHandle};
+use zedra_session::{Session, SessionHandle};
 
 use crate::agent_ui::{AgentCardProps, render_agent_card};
 use crate::fonts;
@@ -84,11 +84,6 @@ impl AgentManage {
     fn load_agents(&mut self, refresh: bool, cx: &mut Context<Self>) {
         self.loading_epoch = self.loading_epoch.wrapping_add(1);
         let epoch = self.loading_epoch;
-        if !self.session_handle.supports_agent_mgmt() {
-            self.agent_state = LoadState::Error(AGENT_MGMT_UNSUPPORTED_MSG.into());
-            cx.notify();
-            return;
-        }
         self.agent_state = LoadState::Loading;
         cx.notify();
 

--- a/crates/zedra/src/agent_picker.rs
+++ b/crates/zedra/src/agent_picker.rs
@@ -1,7 +1,7 @@
 use gpui::*;
 use tracing::error;
 use zedra_rpc::proto::InstalledAgentEntry;
-use zedra_session::{AGENT_MGMT_UNSUPPORTED_MSG, SessionHandle};
+use zedra_session::SessionHandle;
 
 use crate::pending::SharedPendingSlot;
 use crate::platform_bridge::{self, ListPickerItem};
@@ -36,10 +36,6 @@ impl AgentPicker {
     /// Called when the user taps "Create Agent". Shows the native picker
     /// immediately with cached items if available, otherwise fetches first.
     pub fn trigger(&mut self, cx: &mut Context<Self>) {
-        if !self.session_handle.supports_agent_mgmt() {
-            self.present_placeholder(AGENT_MGMT_UNSUPPORTED_MSG);
-            return;
-        }
         match &self.state {
             State::Ready(agents) => {
                 self.present(agents.clone());

--- a/crates/zedra/src/agent_sessions.rs
+++ b/crates/zedra/src/agent_sessions.rs
@@ -54,10 +54,11 @@ impl AgentSessions {
 
         let handle = self.session_handle.clone();
         let task = cx.spawn(async move |this, cx| {
-            let (claude, codex, opencode) = tokio::join!(
+            let (claude, codex, opencode, pi) = tokio::join!(
                 handle.agent_sessions(ManagedAgentKind::Claude, refresh, 0),
                 handle.agent_sessions(ManagedAgentKind::Codex, refresh, 0),
                 handle.agent_sessions(ManagedAgentKind::OpenCode, refresh, 0),
+                handle.agent_sessions(ManagedAgentKind::Pi, refresh, 0),
             );
             let mut sessions = Vec::new();
             let mut errors = Vec::new();
@@ -65,6 +66,7 @@ impl AgentSessions {
                 (ManagedAgentKind::Claude, claude),
                 (ManagedAgentKind::Codex, codex),
                 (ManagedAgentKind::OpenCode, opencode),
+                (ManagedAgentKind::Pi, pi),
             ] {
                 match result {
                     Ok(mut rows) => sessions.append(&mut rows),

--- a/crates/zedra/src/agent_sessions.rs
+++ b/crates/zedra/src/agent_sessions.rs
@@ -1,7 +1,7 @@
 use gpui::*;
 use tracing::error;
 use zedra_rpc::proto::ManagedAgentKind;
-use zedra_session::{AGENT_MGMT_UNSUPPORTED_MSG, SessionHandle};
+use zedra_session::SessionHandle;
 
 use crate::agent_ui::{
     AgentSessionListProps, AgentSessionSection, group_sessions_by_day, render_agent_session_list,
@@ -44,11 +44,6 @@ impl AgentSessions {
         self.loading_epoch = self.loading_epoch.wrapping_add(1);
         let epoch = self.loading_epoch;
         self.sections.clear();
-        if !self.session_handle.supports_agent_mgmt() {
-            self.load_state = LoadState::Error(AGENT_MGMT_UNSUPPORTED_MSG.into());
-            cx.notify();
-            return;
-        }
         self.load_state = LoadState::Loading;
         cx.notify();
 

--- a/crates/zedra/src/agent_ui.rs
+++ b/crates/zedra/src/agent_ui.rs
@@ -45,6 +45,7 @@ pub fn managed_agent_icon(kind: ManagedAgentKind) -> &'static str {
         ManagedAgentKind::Claude => "icons/claude.svg",
         ManagedAgentKind::Codex => "icons/openai.svg",
         ManagedAgentKind::OpenCode => "icons/opencode.svg",
+        ManagedAgentKind::Pi => "icons/pi.svg",
     }
 }
 
@@ -53,6 +54,7 @@ pub fn kind_slug(kind: ManagedAgentKind) -> &'static str {
         ManagedAgentKind::Claude => "claude",
         ManagedAgentKind::Codex => "codex",
         ManagedAgentKind::OpenCode => "opencode",
+        ManagedAgentKind::Pi => "pi",
     }
 }
 
@@ -61,6 +63,7 @@ pub fn managed_agent_name(kind: ManagedAgentKind) -> &'static str {
         ManagedAgentKind::Claude => "Claude",
         ManagedAgentKind::Codex => "Codex",
         ManagedAgentKind::OpenCode => "OpenCode",
+        ManagedAgentKind::Pi => "Pi",
     }
 }
 

--- a/crates/zedra/src/agent_ui.rs
+++ b/crates/zedra/src/agent_ui.rs
@@ -86,12 +86,22 @@ pub fn render_agent_card(cx: &App, props: AgentCardProps<'_>) -> Stateful<Div> {
     let version = cli_version_display(agent);
     let session_count = agent.sessions.resumable.max(agent.sessions.total);
     let sessions_label = format!("{session_count} sessions");
-    let plan = agent
-        .account
-        .fields
-        .iter()
-        .find(|f| f.label == "Plan")
-        .map(|f| f.value.clone());
+    let field_value = |label: &str| {
+        agent
+            .account
+            .fields
+            .iter()
+            .find(|f| f.label == label)
+            .map(|f| f.value.clone())
+    };
+    let plan = field_value("Plan");
+    let model_provider = match (
+        field_value("Default model"),
+        field_value("Default provider"),
+    ) {
+        (Some(model), Some(provider)) => Some(format!("{model} · {provider}")),
+        (model, provider) => model.or(provider),
+    };
     let usage = agent.usage.clone();
 
     div()
@@ -189,6 +199,18 @@ pub fn render_agent_card(cx: &App, props: AgentCardProps<'_>) -> Stateful<Div> {
                                 .child(sessions_label),
                         ),
                 )
+                .when_some(model_provider, |el, text| {
+                    el.child(
+                        div()
+                            .w_full()
+                            .min_w_0()
+                            .overflow_hidden()
+                            .whitespace_nowrap()
+                            .text_size(px(theme::FONT_DETAIL))
+                            .text_color(rgb(theme::text_muted(cx)))
+                            .child(text),
+                    )
+                })
                 .when_some(usage, |el, snap| {
                     el.child(render_usage_row(kind, &snap, cx))
                 }),

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -598,6 +598,7 @@ fn managed_agent_command_hint(kind: ManagedAgentKind) -> &'static str {
         ManagedAgentKind::Claude => "claude",
         ManagedAgentKind::Codex => "codex",
         ManagedAgentKind::OpenCode => "opencode",
+        ManagedAgentKind::Pi => "pi",
     }
 }
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -997,7 +997,7 @@ Expected:
    agent icon once OSC metadata arrives.
 9. Tap `View sessions`.
 10. Expected: the drawer closes and the main view shows a unified session list
-    grouped by day across Claude, Codex, and OpenCode for the current
+    grouped by day across Claude, Codex, OpenCode, and Pi for the current
     workspace. Each row shows agent icon, title, datetime, branch/worktree,
     transcript size, and model when available.
 11. Tap a resumable session row.
@@ -1020,6 +1020,10 @@ Expected:
     - Codex: logged in, plan, plan until, account name from `auth.json`, model/
       personality from `config.toml`
     - OpenCode: config dir presence
+    - Pi: logged in (sessions dir presence). Install with `npm install -g
+      @earendil-works/pi-coding-agent`; sessions live at
+      `~/.pi/agent/sessions/--<workdir>--/<timestamp>_<uuid>.jsonl`. Resume
+      should run `pi --session <id>` in a new terminal.
 16. Tap `Resume` on a session from manage detail.
 17. Expected: same immediate resume behavior as the unified sessions view.
 18. Re-open `View sessions` or `Manage agents` without tapping Refresh.

--- a/docs/PROTOCOL_SPECS.md
+++ b/docs/PROTOCOL_SPECS.md
@@ -297,7 +297,7 @@ All Git result types carry `error: Option<String>`. Host sends error when git re
 
 ### Managed agent conventions
 
-**Terminology:** A *managed agent* is one of `ManagedAgentKind`: Claude Code (`Claude`), Codex (`Codex`), and OpenCode (`OpenCode`). This is narrower than `AgentInstalledList`, which lists every terminal agent CLI the host can launch (Amp, Cline, Cursor, etc.).
+**Terminology:** A *managed agent* is one of `ManagedAgentKind`: Claude Code (`Claude`), Codex (`Codex`), OpenCode (`OpenCode`), and Pi (`Pi`). This is narrower than `AgentInstalledList`, which lists every terminal agent CLI the host can launch (Amp, Cline, Cursor, etc.).
 
 - `AgentListResult.agents` returns one `AgentSummary` for every managed agent, even when the CLI is missing or no sessions exist.
 - `AgentListReq.refresh` and `AgentInstalledListReq.refresh` default to `false`. When `false`, the host serves its startup cache; when `true`, the host rescans synchronous fields before responding.
@@ -316,6 +316,7 @@ All Git result types carry `error: Option<String>`. Host sends error when git re
   - **Claude**: Logged in, Plan (from `~/.claude/.credentials.json` `subscriptionType` / `rateLimitTier`, refreshed from `api.anthropic.com/api/oauth/profile` when OAuth is available, or CLI PTY when the token lives in Keychain); Organization (OAuth profile only); Model, Effort, Permission mode (from `~/.claude/settings.json`); Total cost (USD), Today msgs (from `~/.claude/stats-cache.json` `dailyActivity`). Live rate limits and extra spend come from `AgentUsageSnapshot` on the summary (OAuth API or CLI PTY), not account fields.
   - **Codex**: Logged in, Account (name from JWT), Plan, Plan until (from `~/.codex/auth.json` `id_token` payload, re-read on async refresh); Model, Personality, Reasoning effort (from `~/.codex/config.toml`); Week threads, Total threads (from `~/.codex/state_5.sqlite`).
   - **OpenCode**: Config dir presence (from `~/.config/opencode`).
+  - **Pi**: Logged in (presence of `~/.pi/agent/sessions/`). Sessions are scanned from `~/.pi/agent/sessions/--<workdir>--/<timestamp>_<uuid>.jsonl`; resume uses `pi --session <id>`. No lifecycle hooks; live binding falls back to terminal command detection (`pi` as first token).
 - `AgentSessionSummary.title` uses provider-stored titles when available, otherwise `"Unknown"`.
 - `AgentSessionSummary.transcript_size_bytes` reports transcript file size when the host scan has a local file path.
 - `AgentGitSummary.worktree` is populated for Claude when the encoded project path includes `--claude-worktrees-<name>`.


### PR DESCRIPTION
## Summary

- Closes #132 by adding `ManagedAgentKind::Pi` end-to-end (proto, host scan, dispatcher arms, UI icon/slug/name, docs).
- New `crates/zedra-host/src/agent_pi.rs` scans `~/.pi/agent/sessions/--<workdir>--/*.jsonl`, reads session header + first user message for title, counts messages, sorts by mtime.
- Resume command: `pi --session <id>`. Live binding falls back to terminal command detection (`pi` as first token); Pi has no documented hook system so setup state is `NotConfigured` and `agent hook install pi` warns and skips.
- Verified locally against real Pi sessions: `zedra agent scan list` and `zedra agent scan sessions pi` correctly surface 4 zedra-workdir sessions with titles, IDs, timestamps, and resume action IDs.

## Notes

- Pi message records nest `role`/`content` under `message`; title extraction targets that shape.
- `CliManagedAgentKind` extended so `zedra agent scan sessions pi` works; hook install path explicitly opts out.
- No usage/plan API integration (Pi is a local harness; no provider rate-limit endpoint).