### PR TITLE
fix: probe foreground connection liveness, simplify tokio reactor with gpui_tokio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,6 @@ Mobile remote editor for iOS and Android. Primary platform is iOS (`gpui_ios` + 
 - GPUI scroll containers need an explicit `.id(...)`. In nested flex layouts, also constrain the full parent chain with `size_full()` and `min_h_0()` or scrolling can silently fail.
 - In GPUI `flex_col()` children, avoid `w_full()` for width fill; let stretch work with `min_w_0()`. For right-aligned row actions, make the left text column `flex_1()` and the action `flex_none()`.
 - GPUI text wrapping requires definite width constraints. Use `.w(px(width))` not `.max_w(px(width))` for text containers or text wraps at viewport width.
-- Prefer `cx.spawn(...)` for UI-thread async work and `session_runtime().spawn(...)` for Tokio session or network work when `cx` is unavailable.
+- In `cx.spawn`, host RPC calls (`SessionHandle` methods, incl. `tokio::join!`) `.await` directly — irpc oneshots, no reactor on the GPUI thread. Only reactor-driving futures crash there (`tokio::time`, iroh I/O, Delta HTTP); wrap those in `Tokio::spawn_result(cx, fut).await` (`use gpui_tokio::Tokio;`), or `Tokio::handle(cx).spawn(...)` for fire-and-forget / background-surviving tasks. See `docs/CONVENTIONS.md` § Async Runtime Selection.
 - Session-to-UI flow is `Session / SessionHandle -> ConnectEvent -> SessionState -> WorkspaceState -> Views`. Preserve that layering.
 - New `extern "C"` Rust→Swift call: add a weak stub in `crates/zedra/src/ios_stub.c` matching the function signature or the iOS staticlib link will fail with undefined symbol.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3071,6 +3071,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpui_tokio"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gpui",
+ "tokio",
+ "util",
+]
+
+[[package]]
 name = "gpui_util"
 version = "0.1.0"
 dependencies = [
@@ -10095,6 +10105,7 @@ dependencies = [
  "gpui",
  "gpui_android",
  "gpui_ios",
+ "gpui_tokio",
  "gpui_wgpu",
  "http_client",
  "iroh",

--- a/crates/zedra-session/AGENTS.md
+++ b/crates/zedra-session/AGENTS.md
@@ -20,13 +20,15 @@ Client-side connection and reconnect layer for mobile. Owns endpoint binding, au
 
 ## Runtime Rules
 
-- Reusable session-layer code should use `session_runtime()` instead of bare `tokio::spawn()`, unless it is already guaranteed to run inside the session runtime.
+- This crate owns no Tokio runtime — it is a pure tokio-backed library; every `async fn` assumes a runtime, and bare `tokio::spawn` needs an ambient one. The caller supplies it via `Session::new(runtime: tokio::runtime::Handle)` (app: `gpui_tokio::Tokio::handle(cx)`; host/tests: `Handle::current()`).
+- Bare `tokio::spawn()` only when already on a runtime-polled future (e.g. the `connect()` loop). Use the stored `Session::runtime` handle only at sync foreign-thread entry points that start a detached task (the connect loop).
 - `Session::connect()` intentionally stores signer, endpoint, ticket, session id, and token on `SessionHandle` before the async loop starts. Keep those credentials synchronized if connection flow changes.
 - Host event subscription is a sidecar task after successful connection. Changes there must respect abort signals and `closed_notify`.
 
 ## Terminal Rules
 
 - `RemoteTerminal` owns `last_seq`, attach state, and the bridging tasks for terminal I/O.
+- `attach_remote` takes an explicit `tokio::runtime::Handle` for its pump tasks — never bare `tokio::spawn`. It is awaited from the GPUI thread (terminal create / agent resume) where no ambient runtime exists; `SessionHandle` carries the handle (set in `Session::new`).
 - Preserve replay semantics: `TermAttachReq.last_seq` is how reconnect resume works.
 - On reattach, abort and replace prior input/output tasks rather than stacking them.
 - If terminal lifecycle changes, keep `SessionHandle`, `RemoteTerminal`, and the host-side `TermAttach` flow consistent.

--- a/crates/zedra-session/src/connect.rs
+++ b/crates/zedra-session/src/connect.rs
@@ -671,8 +671,9 @@ impl Connector {
     ) -> Result<Vec<RemoteTerminal>, ConnectError> {
         let terminals = reconcile_synced_terminals(&sync.terminals, existing_terminals.as_deref());
 
+        let runtime = tokio::runtime::Handle::current();
         join_all(terminals.iter().map(async |t| {
-            if let Err(e) = t.attach_remote(client).await {
+            if let Err(e) = t.attach_remote(client, &runtime).await {
                 warn!("failed to attach terminal {}: {}", t.id(), e);
             }
         }))

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -37,6 +37,9 @@ struct SessionHandleInner {
     docs_tree_rpc_supported: AtomicBool,
     fs_search_rpc_supported: AtomicBool,
     set_app_state_rpc_supported: AtomicBool,
+    /// Runtime the terminal pump tasks spawn onto. Set by `Session::new` so
+    /// `attach_remote` works even when a method is awaited from the GPUI thread.
+    runtime: Mutex<Option<tokio::runtime::Handle>>,
 }
 
 impl Drop for SessionHandleInner {
@@ -74,7 +77,23 @@ impl SessionHandle {
             docs_tree_rpc_supported: AtomicBool::new(true),
             fs_search_rpc_supported: AtomicBool::new(true),
             set_app_state_rpc_supported: AtomicBool::new(true),
+            runtime: Mutex::new(None),
         }))
+    }
+
+    pub fn set_runtime(&self, runtime: tokio::runtime::Handle) {
+        *self.0.runtime.lock().unwrap() = Some(runtime);
+    }
+
+    /// Runtime for terminal pump tasks. Errors if the handle was built outside
+    /// `Session::new` (e.g. a bare test handle) and never given a runtime.
+    fn runtime(&self) -> Result<tokio::runtime::Handle> {
+        self.0
+            .runtime
+            .lock()
+            .ok()
+            .and_then(|g| g.clone())
+            .ok_or_else(|| anyhow::anyhow!("session handle has no runtime"))
     }
 
     // ─── Credentials ─────────────────────────────────────────────────────────
@@ -652,7 +671,11 @@ impl SessionHandle {
         }
 
         let terminal = RemoteTerminal::new(result.id.clone());
-        if terminal.attach_remote(&client).await.is_ok() {
+        if terminal
+            .attach_remote(&client, &self.runtime()?)
+            .await
+            .is_ok()
+        {
             self.add_terminal(terminal);
             tracing::info!("Terminal created: {}", result.id);
             Ok(result.id)
@@ -776,7 +799,11 @@ impl SessionHandle {
         }
 
         let terminal = RemoteTerminal::new(result.terminal_id.clone());
-        if terminal.attach_remote(&client).await.is_ok() {
+        if terminal
+            .attach_remote(&client, &self.runtime()?)
+            .await
+            .is_ok()
+        {
             self.add_terminal(terminal);
             tracing::info!("Agent session resumed in terminal: {}", result.terminal_id);
             Ok(result.terminal_id)

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -1,6 +1,9 @@
-use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicBool, Ordering},
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::Result;
@@ -11,7 +14,7 @@ use irpc::{
 use zedra_rpc::proto::*;
 
 use crate::{
-    register_active_connection, signer::ClientSigner, terminal::RemoteTerminal,
+    ReconnectReason, register_active_connection, signer::ClientSigner, terminal::RemoteTerminal,
     unregister_active_connection,
 };
 
@@ -25,6 +28,7 @@ struct SessionHandleInner {
     signer: Mutex<Option<Arc<dyn ClientSigner>>>,
     session_token: Mutex<Option<[u8; 32]>>,
     pending_ticket: Mutex<Option<zedra_rpc::ZedraPairingTicket>>,
+    pending_reconnect_reason: Mutex<Option<ReconnectReason>>,
     rpc_client: Mutex<Option<irpc::Client<ZedraProto>>>,
     active_connection: Mutex<Option<iroh::endpoint::Connection>>,
     terminals: Mutex<Vec<RemoteTerminal>>,
@@ -61,6 +65,7 @@ impl SessionHandle {
             signer: Mutex::new(None),
             session_token: Mutex::new(None),
             pending_ticket: Mutex::new(None),
+            pending_reconnect_reason: Mutex::new(None),
             rpc_client: Mutex::new(None),
             active_connection: Mutex::new(None),
             terminals: Mutex::new(Vec::new()),
@@ -106,6 +111,14 @@ impl SessionHandle {
         self.0.pending_ticket.lock().ok()?.take()
     }
 
+    pub fn set_pending_reconnect_reason(&self, reason: ReconnectReason) {
+        *self.0.pending_reconnect_reason.lock().unwrap() = Some(reason);
+    }
+
+    pub fn take_pending_reconnect_reason(&self) -> Option<ReconnectReason> {
+        self.0.pending_reconnect_reason.lock().ok()?.take()
+    }
+
     pub fn set_session_token(&self, token: Option<[u8; 32]>) {
         *self.0.session_token.lock().unwrap() = token;
     }
@@ -145,13 +158,23 @@ impl SessionHandle {
         }
     }
 
-    pub fn close_active_connection(&self, reason: &'static [u8]) {
+    pub fn active_connection_id(&self) -> Option<usize> {
+        self.0
+            .active_connection
+            .lock()
+            .ok()
+            .and_then(|active| active.as_ref().map(|conn| conn.stable_id()))
+    }
+
+    pub fn close_active_connection(&self, reason: &'static [u8]) -> bool {
         if let Ok(mut active) = self.0.active_connection.lock() {
             if let Some(conn) = active.take() {
                 unregister_active_connection(&conn);
                 conn.close(0u32.into(), reason);
+                return true;
             }
         }
+        false
     }
 
     pub fn clear_rpc_client(&self) {
@@ -184,6 +207,27 @@ impl SessionHandle {
         self.client()?.rpc(msg).await.map_err(map_rpc_error)
     }
 
+    pub async fn probe_liveness(&self, timeout: Duration) -> Result<Duration> {
+        let timestamp_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let sent_at = Instant::now();
+        let pong: PongResult = tokio::time::timeout(timeout, self.call(PingReq { timestamp_ms }))
+            .await
+            .map_err(|_| anyhow::anyhow!("liveness ping timed out after {:?}", timeout))??;
+
+        if pong.timestamp_ms != timestamp_ms {
+            return Err(anyhow::anyhow!(
+                "liveness ping timestamp mismatch: sent {}, got {}",
+                timestamp_ms,
+                pong.timestamp_ms
+            ));
+        }
+
+        Ok(sent_at.elapsed())
+    }
+
     pub fn user_disconnect(&self) -> bool {
         self.0.user_disconnect.load(Ordering::Acquire)
     }
@@ -194,6 +238,7 @@ impl SessionHandle {
 
     pub fn clear_session(&self) {
         self.set_user_disconnect(true);
+        self.take_pending_reconnect_reason();
         // Send CONNECTION_CLOSE before dropping RPC handles so the host can
         // release this client's active slot without waiting for QUIC idle expiry.
         self.close_active_connection(b"client disconnect");
@@ -970,6 +1015,19 @@ mod tests {
         assert!(!handle.reorder_terminals(&["term-a".to_string()]));
         assert!(!handle.reorder_terminals(&["term-a".to_string(), "missing".to_string()]));
         assert_eq!(handle.terminal_ids(), vec!["term-a", "term-b"]);
+    }
+
+    #[test]
+    fn reconnect_reason_can_be_stored_on_handle() {
+        let handle = SessionHandle::new();
+
+        assert_eq!(handle.take_pending_reconnect_reason(), None);
+        handle.set_pending_reconnect_reason(ReconnectReason::AppForegrounded);
+        assert_eq!(
+            handle.take_pending_reconnect_reason(),
+            Some(ReconnectReason::AppForegrounded)
+        );
+        assert_eq!(handle.take_pending_reconnect_reason(), None);
     }
 
     #[test]

--- a/crates/zedra-session/src/lib.rs
+++ b/crates/zedra-session/src/lib.rs
@@ -14,7 +14,6 @@ pub use terminal::*;
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
-static SESSION_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 static ACTIVE_CONNECTIONS: OnceLock<Mutex<HashMap<usize, iroh::endpoint::Connection>>> =
     OnceLock::new();
 
@@ -44,20 +43,4 @@ pub fn close_all_active_connections_for_lifecycle(reason: &'static [u8]) {
     for conn in connections {
         conn.close(0u32.into(), reason);
     }
-}
-
-/// Returns the shared Tokio runtime for session/network work.
-///
-/// Use this from reusable session-layer code that may be called from GPUI or
-/// other non-Tokio threads. Prefer this over bare `tokio::spawn()` unless the
-/// caller is already guaranteed to be running inside the session runtime.
-pub fn session_runtime() -> &'static tokio::runtime::Runtime {
-    SESSION_RUNTIME.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .enable_all()
-            .thread_name("zedra-session")
-            .build()
-            .expect("failed to create session runtime")
-    })
 }

--- a/crates/zedra-session/src/session.rs
+++ b/crates/zedra-session/src/session.rs
@@ -117,6 +117,7 @@ impl Session {
         handle.set_signer(signer.clone());
         handle.set_endpoint_addr(addr.clone());
         handle.set_user_disconnect(false);
+        handle.take_pending_reconnect_reason();
         if let Some(ref t) = ticket {
             handle.set_pending_ticket(t.clone());
         }
@@ -301,7 +302,11 @@ impl Session {
                             break;
                         }
 
-                        reconnect_reason = Some(crate::ReconnectReason::ConnectionLost);
+                        reconnect_reason = Some(
+                            handle
+                                .take_pending_reconnect_reason()
+                                .unwrap_or(crate::ReconnectReason::ConnectionLost),
+                        );
                     }
                     Err(e) => {
                         connector.abort();
@@ -339,7 +344,11 @@ impl Session {
     /// reconnect reason for telemetry/UI.
     pub fn request_reconnect(&self, reason: ReconnectReason) {
         info!(?reason, "requesting reconnect");
-        self.handle.close_active_connection(b"client reconnect");
+        self.handle.set_pending_reconnect_reason(reason.clone());
+        if !self.handle.close_active_connection(b"client reconnect") {
+            self.handle.take_pending_reconnect_reason();
+            warn!(?reason, "reconnect requested without an active connection");
+        }
     }
 
     fn reset_abort_signal(&self) -> CancellationToken {
@@ -420,6 +429,15 @@ impl Default for Session {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn request_reconnect_without_active_connection_does_not_leave_pending_reason() {
+        let session = Session::new();
+
+        session.request_reconnect(ReconnectReason::AppForegrounded);
+
+        assert_eq!(session.handle().take_pending_reconnect_reason(), None);
+    }
 
     #[tokio::test]
     async fn subscribe_host_events_fans_out_to_multiple_receivers() {

--- a/crates/zedra-session/src/session.rs
+++ b/crates/zedra-session/src/session.rs
@@ -12,8 +12,7 @@ use zedra_rpc::proto::{
 
 use crate::RemoteTerminal;
 use crate::{
-    ConnectEvent, Connector, ReconnectReason, SessionHandle, SessionState, session_runtime,
-    signer::ClientSigner,
+    ConnectEvent, Connector, ReconnectReason, SessionHandle, SessionState, signer::ClientSigner,
 };
 
 const AUTO_RECONNECT_MAX_ATTEMPTS: u32 = 3;
@@ -37,11 +36,15 @@ pub struct Session {
     /// `connect()` awaits the previous loop's exit before running so old/new
     /// loops never race on the same `event_tx` or `SessionHandle`.
     connect_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+    /// Runtime handle for the detached connect loop. `Session` owns no runtime;
+    /// the caller supplies one (keeps this crate a pure tokio-backed library).
+    runtime: tokio::runtime::Handle,
 }
 
 impl Session {
-    pub fn new() -> Self {
+    pub fn new(runtime: tokio::runtime::Handle) -> Self {
         let handle = SessionHandle::new();
+        handle.set_runtime(runtime.clone());
         let state = SessionState::new();
         let (event_tx, event_rx) = mpsc::channel(64);
         let abort_signal = Arc::new(Mutex::new(CancellationToken::new()));
@@ -59,6 +62,7 @@ impl Session {
             host_event_tx,
             host_info_tx,
             connect_task: Arc::new(Mutex::new(None)),
+            runtime,
         }
     }
 
@@ -128,7 +132,7 @@ impl Session {
         // writing to the same `event_tx`/`SessionHandle` simultaneously.
         let previous_task = self.connect_task.lock().unwrap().take();
         let task_slot = self.connect_task.clone();
-        let new_task = session_runtime().spawn(async move {
+        let new_task = self.runtime.spawn(async move {
             if let Some(prev) = previous_task {
                 let _ = prev.await;
             }
@@ -199,8 +203,9 @@ impl Session {
                             let subscribe_closed = closed_notify.clone();
                             let subscribe_events = host_event_tx.clone();
 
-                            // Subscribe to host events and and broadcast them via host_event_tx.
-                            session_runtime().spawn(async move {
+                            // Broadcast host events via host_event_tx. Bare spawn:
+                            // already inside the connect-loop task's runtime.
+                            tokio::spawn(async move {
                                 let mut host_events = match subscribe_client
                                     .server_streaming(SubscribeReq {}, 32)
                                     .await
@@ -246,7 +251,7 @@ impl Session {
                             let subscribe_closed = closed_notify.clone();
                             let subscribe_info = host_info_tx.clone();
 
-                            session_runtime().spawn(async move {
+                            tokio::spawn(async move {
                                 let mut snapshots = match subscribe_client
                                     .server_streaming(SubscribeHostInfoReq {}, 4)
                                     .await
@@ -381,7 +386,10 @@ impl Session {
                     handle.add_terminal(terminal.clone());
                     terminal
                 };
-                if let Err(e) = terminal.attach_remote(client).await {
+                if let Err(e) = terminal
+                    .attach_remote(client, &tokio::runtime::Handle::current())
+                    .await
+                {
                     warn!(
                         "Failed to attach host-created terminal {}: {e}",
                         terminal.id()
@@ -420,19 +428,13 @@ impl Session {
     }
 }
 
-impl Default for Session {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn request_reconnect_without_active_connection_does_not_leave_pending_reason() {
-        let session = Session::new();
+    #[tokio::test]
+    async fn request_reconnect_without_active_connection_does_not_leave_pending_reason() {
+        let session = Session::new(tokio::runtime::Handle::current());
 
         session.request_reconnect(ReconnectReason::AppForegrounded);
 
@@ -441,7 +443,7 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_host_events_fans_out_to_multiple_receivers() {
-        let session = Session::new();
+        let session = Session::new(tokio::runtime::Handle::current());
         let mut rx1 = session.subscribe_host_events();
         let mut rx2 = session.subscribe_host_events();
 
@@ -453,7 +455,7 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_host_info_fans_out_to_multiple_receivers() {
-        let session = Session::new();
+        let session = Session::new(tokio::runtime::Handle::current());
         let mut rx1 = session.subscribe_host_info();
         let mut rx2 = session.subscribe_host_info();
 

--- a/crates/zedra-session/src/terminal.rs
+++ b/crates/zedra-session/src/terminal.rs
@@ -4,8 +4,6 @@ use tokio::sync::mpsc;
 use tracing::*;
 use zedra_rpc::proto::{TermAttachReq, TermInput, TermOutput, ZedraProto};
 
-use crate::session_runtime;
-
 /// Keep track of created terminals.
 #[derive(Clone)]
 pub struct RemoteTerminal(Arc<RemoteTerminalInner>);
@@ -242,9 +240,13 @@ impl RemoteTerminal {
         self.0.last_seq.store(seq, Ordering::Release);
     }
 
+    /// `runtime` is the Tokio handle the input/output pump tasks spawn onto.
+    /// Passed explicitly because `attach_remote` may be awaited from the GPUI
+    /// thread (terminal create / agent resume), which has no ambient runtime.
     pub async fn attach_remote(
         &self,
         client: &irpc::Client<ZedraProto>,
+        runtime: &tokio::runtime::Handle,
     ) -> Result<(), anyhow::Error> {
         let term_id = self.id();
         let Some(generation) = self.0.begin_attach()? else {
@@ -288,7 +290,7 @@ impl RemoteTerminal {
         }
 
         let terminal_inner = self.0.clone();
-        let input_task = session_runtime().spawn(async move {
+        let input_task = runtime.spawn(async move {
             while let Some(data) = input_rx.recv().await {
                 if let Err(e) = irpc_input_tx.send(TermInput { data }).await {
                     info!("failed to send input: {:?}", e);
@@ -299,7 +301,7 @@ impl RemoteTerminal {
         });
 
         let terminal_inner = self.0.clone();
-        let output_task = session_runtime().spawn(async move {
+        let output_task = runtime.spawn(async move {
             loop {
                 match irpc_output_rx.recv().await {
                     Ok(Some(output)) => {

--- a/crates/zedra/AGENTS.md
+++ b/crates/zedra/AGENTS.md
@@ -32,6 +32,8 @@ Main mobile app crate. Owns GPUI application flow, workspace orchestration, plat
 - Use actions for decoupled commands that bubble through the view tree.
 - Preserve the drawer and sheet interaction patterns already established in `ui/drawer_host.rs`, `sheet_host_view.rs`, and `native_presentation.rs`.
 - Scroll containers still need explicit `.id(...)` plus constrained parent height. Follow the existing `size_full()` and `min_h_0()` patterns when editing nested layouts.
+- Async in `cx.spawn`: host RPC calls (`SessionHandle` methods, incl. `tokio::join!`) and pure GPUI awaits (`timer`, `background_spawn`, channel `recv()`) `.await` directly — RPC is an irpc oneshot, no reactor touched. Only reactor-driving futures (`tokio::time`, iroh I/O, Delta HTTP) need `Tokio::spawn_result(cx, fut).await` (`use gpui_tokio::Tokio;`; folds `JoinError` into `anyhow`); use `Tokio::spawn` for non-`Result` outputs. Runtime is created in `app::init_platform_app`; `zedra-session` owns none (takes `Tokio::handle(cx)` at `Session::new`). Full rules: `docs/CONVENTIONS.md` § Async Runtime Selection.
+- Fire-and-forget from a `'static` callback (no `cx`) or work that must outlive backgrounding (GPUI executor pauses): capture `Tokio::handle(cx)` and spawn on it directly, not `Tokio::spawn` (its join half rides the paused executor).
 
 ## Platform Rules
 

--- a/crates/zedra/Cargo.toml
+++ b/crates/zedra/Cargo.toml
@@ -18,6 +18,7 @@ devtool = ["gpui_android/devtool"]
 
 [dependencies]
 gpui = { path = "../../vendor/zed/crates/gpui", default-features = false }
+gpui_tokio = { path = "../../vendor/zed/crates/gpui_tokio" }
 http_client = { path = "../../vendor/zed/crates/http_client" }
 anyhow.workspace = true
 tracing.workspace = true

--- a/crates/zedra/src/android/entry.rs
+++ b/crates/zedra/src/android/entry.rs
@@ -16,14 +16,13 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use gpui::*;
 use jni::JNIEnv;
 use jni::objects::JClass;
 
 use crate::android::bridge::AndroidBridge;
-use crate::{ZedraAssets, app, install_panic_hook, platform_bridge};
+use crate::{app, install_panic_hook, platform_bridge};
 
 thread_local! {
     /// Kept alive so the GPUI runtime survives across Choreographer ticks.
@@ -41,17 +40,10 @@ pub extern "system" fn Java_dev_zedra_app_MainActivity_zedraLaunchGpui(
     crate::telemetry::init();
     install_panic_hook();
 
-    platform_bridge::set_bridge(AndroidBridge);
-
     tracing::info!("Zedra Android: creating GPUI application with AndroidPlatform");
 
     let platform: Rc<dyn Platform> = gpui_android::create_platform();
-
-    let app_cell = App::new_app(
-        platform.clone(),
-        Arc::new(ZedraAssets),
-        Arc::new(http_client::BlockedHttpClient),
-    );
+    let app_cell = app::init_platform_app(platform.clone(), AndroidBridge);
 
     let app_cell_for_callback = app_cell.clone();
     platform.run(Box::new(move || {

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -462,6 +462,23 @@ fn screen_after_workspace_disconnect() -> AppScreen {
     AppScreen::Home
 }
 
+/// Shared platform bootstrap (both `ios/app.rs` and `android/entry.rs`): register
+/// the bridge, build the `App`, and init the gpui_tokio runtime that owns all
+/// session/network work.
+pub fn init_platform_app(
+    platform: std::rc::Rc<dyn Platform>,
+    bridge: impl platform_bridge::PlatformBridge,
+) -> std::rc::Rc<AppCell> {
+    platform_bridge::set_bridge(bridge);
+    let app_cell = App::new_app(
+        platform,
+        std::sync::Arc::new(crate::ZedraAssets),
+        std::sync::Arc::new(http_client::BlockedHttpClient),
+    );
+    gpui_tokio::init(&mut app_cell.borrow_mut());
+    app_cell
+}
+
 pub fn open_zedra_window(app: &mut App, window_options: WindowOptions) -> Result<AnyWindowHandle> {
     app.open_window(window_options, |window, cx| {
         let view = cx.new(|cx| ZedraApp::new(window, cx));

--- a/crates/zedra/src/delta.rs
+++ b/crates/zedra/src/delta.rs
@@ -1,11 +1,9 @@
 use std::collections::HashMap;
-use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context as _, Result, bail};
 use base64::{Engine as _, engine::general_purpose::STANDARD_NO_PAD};
-use futures::channel::oneshot;
 use gpui::{Context, EventEmitter};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -382,21 +380,6 @@ impl EventEmitter<DeltaStateEvent> for DeltaState {}
 
 fn default_base_url() -> String {
     DEFAULT_BASE_URL.to_string()
-}
-
-/// Run a Delta network operation on the session (Tokio) runtime and await the
-/// result on the caller's executor. Delta's HTTP client requires a Tokio
-/// reactor, so async ops cannot run directly on the GPUI executor.
-pub async fn offload<T>(fut: impl Future<Output = Result<T>> + Send + 'static) -> Result<T>
-where
-    T: Send + 'static,
-{
-    let (tx, rx) = oneshot::channel();
-    zedra_session::session_runtime().spawn(async move {
-        let _ = tx.send(fut.await);
-    });
-    rx.await
-        .map_err(|_| anyhow::anyhow!("Delta runtime task was dropped"))?
 }
 
 /// Clear all signed-in state, preserving the configured base URL. Persists to

--- a/crates/zedra/src/docs_tree.rs
+++ b/crates/zedra/src/docs_tree.rs
@@ -1,4 +1,5 @@
 use gpui::*;
+use gpui_tokio::Tokio;
 use std::{collections::HashSet, f32::consts::TAU, time::Duration};
 use tracing::*;
 
@@ -144,7 +145,8 @@ impl DocsTree {
         cx.notify();
 
         cx.spawn(async move |this, cx| {
-            let result = request_docs_tree_page(handle, 0, true, None).await;
+            let result =
+                Tokio::spawn_result(cx, request_docs_tree_page(handle, 0, true, None)).await;
             let _ = this.update(cx, |this, cx| {
                 if this.build_epoch != epoch {
                     return;
@@ -199,7 +201,11 @@ impl DocsTree {
         cx.notify();
 
         cx.spawn(async move |this, cx| {
-            let result = request_docs_tree_page(handle, offset, false, Some(snapshot_id)).await;
+            let result = Tokio::spawn_result(
+                cx,
+                request_docs_tree_page(handle, offset, false, Some(snapshot_id)),
+            )
+            .await;
             let _ = this.update(cx, |this, cx| {
                 if this.build_epoch != epoch {
                     return;
@@ -660,32 +666,27 @@ impl Render for DocsTree {
     }
 }
 
+/// Uses `tokio::time`, so must be polled on Tokio (via `Tokio::spawn_result`).
 async fn request_docs_tree_page(
     handle: SessionHandle,
     offset: u32,
     rebuild: bool,
     snapshot_id: Option<String>,
 ) -> anyhow::Result<FsDocsTreeResult> {
-    let (tx, rx) = futures::channel::oneshot::channel();
-    zedra_session::session_runtime().spawn(async move {
-        let result = tokio::time::timeout(
-            DOCS_TREE_BUILD_TIMEOUT,
-            handle.fs_docs_tree(
-                DOCS_TREE_ROOT_PATH,
-                offset,
-                FS_DOCS_TREE_DEFAULT_LIMIT,
-                rebuild,
-                snapshot_id,
-            ),
-        )
-        .await;
-        let _ = tx.send(result);
-    });
-
-    match rx.await {
-        Ok(Ok(result)) => result,
-        Ok(Err(_)) => Err(anyhow::anyhow!("docs tree request timed out")),
-        Err(_) => Err(anyhow::anyhow!("docs tree request task dropped")),
+    match tokio::time::timeout(
+        DOCS_TREE_BUILD_TIMEOUT,
+        handle.fs_docs_tree(
+            DOCS_TREE_ROOT_PATH,
+            offset,
+            FS_DOCS_TREE_DEFAULT_LIMIT,
+            rebuild,
+            snapshot_id,
+        ),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(anyhow::anyhow!("docs tree request timed out")),
     }
 }
 
@@ -1028,14 +1029,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn docs_tree_request_helper_does_not_require_caller_tokio_runtime() {
-        let result = futures::executor::block_on(request_docs_tree_page(
-            SessionHandle::new(),
-            0,
-            true,
-            None,
-        ));
+    #[tokio::test]
+    async fn docs_tree_request_helper_errors_when_not_connected() {
+        let result = request_docs_tree_page(SessionHandle::new(), 0, true, None).await;
 
         assert!(result.unwrap_err().to_string().contains("not connected"));
     }

--- a/crates/zedra/src/ios/app.rs
+++ b/crates/zedra/src/ios/app.rs
@@ -8,14 +8,12 @@
 ///   5. gpui_ios_request_frame()      — called each frame by CADisplayLink
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use gpui::*;
 use gpui_ios::IosPlatform;
 
 use crate::{
-    ZedraAssets, app, install_panic_hook, native_presentation, platform_bridge,
-    sheet_host_view::SheetHostView,
+    app, install_panic_hook, native_presentation, platform_bridge, sheet_host_view::SheetHostView,
 };
 
 thread_local! {
@@ -179,17 +177,10 @@ pub extern "C" fn zedra_launch_gpui() {
     crate::telemetry::init();
     install_panic_hook();
 
-    platform_bridge::set_bridge(super::bridge::IosBridge);
-
     tracing::info!("Zedra iOS: Creating GPUI application with IosPlatform");
 
     let platform: Rc<dyn Platform> = Rc::new(IosPlatform::new());
-
-    let app_cell = App::new_app(
-        platform.clone(),
-        Arc::new(ZedraAssets),
-        Arc::new(http_client::BlockedHttpClient),
-    );
+    let app_cell = app::init_platform_app(platform.clone(), super::bridge::IosBridge);
 
     // Register the finish-launching callback via platform.run().
     // On iOS this does NOT block — it stores the callback in the FFI layer.

--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -1,4 +1,5 @@
 use gpui::{prelude::FluentBuilder as _, *};
+use gpui_tokio::Tokio;
 
 use futures::channel::oneshot;
 
@@ -24,7 +25,9 @@ impl EventEmitter<SettingsEvent> for SettingsView {}
 pub fn reconcile_delta_on_launch<T: 'static>(delta_state: Entity<DeltaState>, cx: &mut Context<T>) {
     let snapshot = delta_state.read(cx).snapshot();
     cx.spawn(async move |_owner, cx| {
-        match delta::offload(delta::reconcile_mobile_node(snapshot.clone())).await {
+        match Tokio::spawn_result(cx, delta::reconcile_mobile_node(snapshot.clone()))
+            .await
+        {
             Ok((outcome, next)) => {
                 let applied = delta_state.update(cx, |state, cx| {
                     // Skip launch-time reconciliation if Delta state changed while it was in flight.
@@ -154,16 +157,18 @@ impl SettingsView {
             let snapshot = delta_state.read_with(cx, |state, _| state.snapshot());
             let result = match provider {
                 OAuthProvider::Google => {
-                    delta::offload(delta::sign_in_with_google(
-                        snapshot.clone(),
-                        id_token,
-                        email,
-                    ))
+                    Tokio::spawn_result(
+                        cx,
+                        delta::sign_in_with_google(snapshot.clone(), id_token, email),
+                    )
                     .await
                 }
                 OAuthProvider::Apple => {
-                    delta::offload(delta::sign_in_with_apple(snapshot.clone(), id_token, email))
-                        .await
+                    Tokio::spawn_result(
+                        cx,
+                        delta::sign_in_with_apple(snapshot.clone(), id_token, email),
+                    )
+                    .await
                 }
             };
             Self::apply_delta_result(
@@ -240,12 +245,15 @@ impl SettingsView {
                 cx.notify();
             });
             let snapshot = delta_state.read_with(cx, |state, _| state.snapshot());
-            let result = delta::offload(delta::register_push_token(
-                snapshot.clone(),
-                token.provider,
-                token.token,
-                token.environment,
-            ))
+            let result = Tokio::spawn_result(
+                cx,
+                delta::register_push_token(
+                    snapshot.clone(),
+                    token.provider,
+                    token.token,
+                    token.environment,
+                ),
+            )
             .await;
             Self::apply_delta_result(
                 &this,

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Result as AnyhowResult, anyhow};
 use gpui::{prelude::FluentBuilder as _, *};
+use gpui_tokio::Tokio;
 use tokio::sync::{broadcast, mpsc};
 use tracing::*;
 use uuid::Uuid;
@@ -709,7 +710,7 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let session = Session::new();
+        let session = Session::new(Tokio::handle(cx));
         let session_state = cx.new(|_cx| session.state().clone());
         let terminal_state = cx.new(|_| TerminalState::new());
 
@@ -901,16 +902,15 @@ impl Workspace {
 
                         match foreground_resume_action(&phase) {
                             ForegroundResumeAction::ProbeLiveness => {
-                                // probe_liveness uses tokio timers, so it must run on the
-                                // Tokio runtime, not the GPUI executor this task lives on.
-                                let probe = zedra_session::session_runtime().spawn(async move {
+                                // probe_liveness uses tokio timers — must run on Tokio.
+                                let probe = Tokio::spawn(cx, async move {
                                     handle.probe_liveness(FOREGROUND_LIVENESS_TIMEOUT).await
                                 });
                                 let result = match probe.await {
                                     Ok(result) => result,
-                                    Err(join_error) => {
-                                        Err(anyhow::anyhow!("liveness probe task failed: {join_error}"))
-                                    }
+                                    Err(join_error) => Err(anyhow::anyhow!(
+                                        "liveness probe task failed: {join_error}"
+                                    )),
                                 };
                                 match result {
                                     Ok(rtt) => {
@@ -963,13 +963,12 @@ impl Workspace {
             }
         });
 
-        // Notify host when app foreground state changes so it can switch
-        // between RPC-only delivery and Delta push notifications.
-        // Run on Tokio, not GPUI: the GPUI executor pauses when the app backgrounds,
-        // which is exactly when we need this listener to fire and call notify_app_state.
+        // Notify host on foreground changes (toggles RPC-only vs Delta push).
+        // Must run on the bare Tokio handle, not `Tokio::spawn`: the GPUI executor
+        // pauses on background — exactly when this listener needs to fire.
         let foreground_handle = session.handle().clone();
         let mut foreground_rx = platform_bridge::subscribe_foreground_state();
-        let foreground_state_listener = zedra_session::session_runtime().spawn(async move {
+        let foreground_state_listener = Tokio::handle(cx).spawn(async move {
             // Seed the host with the current app state so a workspace that
             // starts while already backgrounded does not stay pinned to the
             // default foreground=true state.
@@ -1299,11 +1298,10 @@ impl Workspace {
         let host_pubkey = host_pubkey;
 
         cx.spawn(async move |workspace, cx| {
-            let result = crate::delta::offload(crate::delta::register_paired_host_node(
-                snapshot.clone(),
-                host_pubkey,
-                metadata,
-            ))
+            let result = Tokio::spawn_result(
+                cx,
+                crate::delta::register_paired_host_node(snapshot.clone(), host_pubkey, metadata),
+            )
             .await;
             match result {
                 Ok((Some(result), next)) => {
@@ -2125,7 +2123,7 @@ impl Workspace {
         &mut self,
         action: &GitShowItemActions,
         _window: &mut Window,
-        _cx: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
         info!("handle GitItemLongPress from workspace");
         let path = action.path.clone();
@@ -2136,6 +2134,8 @@ impl Workspace {
         };
 
         let handle = self.session.handle().clone();
+        // 'static platform callback has no executor; capture the runtime handle.
+        let runtime = Tokio::handle(cx);
         let display_path = path.clone();
 
         platform_bridge::show_selection(
@@ -2145,32 +2145,28 @@ impl Workspace {
                 AlertButton::default(main_action_label),
                 AlertButton::cancel("Cancel"),
             ],
-            move |selection| {
-                match selection {
-                    Some(0) => {
-                        let h = handle.clone();
-                        let p = path.clone();
-                        match section {
-                            GitFileSection::Staged => {
-                                // TODO: use cx.spawn
-                                zedra_session::session_runtime().spawn(async move {
-                                    if let Err(e) = h.git_unstage(&[p]).await {
-                                        tracing::error!("git unstage failed: {}", e);
-                                    }
-                                });
-                            }
-                            _ => {
-                                // TODO: use cx.spawn
-                                zedra_session::session_runtime().spawn(async move {
-                                    if let Err(e) = h.git_stage(&[p]).await {
-                                        tracing::error!("git stage failed: {}", e);
-                                    }
-                                });
-                            }
+            move |selection| match selection {
+                Some(0) => {
+                    let h = handle.clone();
+                    let p = path.clone();
+                    match section {
+                        GitFileSection::Staged => {
+                            runtime.spawn(async move {
+                                if let Err(e) = h.git_unstage(&[p]).await {
+                                    tracing::error!("git unstage failed: {}", e);
+                                }
+                            });
+                        }
+                        _ => {
+                            runtime.spawn(async move {
+                                if let Err(e) = h.git_stage(&[p]).await {
+                                    tracing::error!("git stage failed: {}", e);
+                                }
+                            });
                         }
                     }
-                    _ => {}
                 }
+                _ => {}
             },
         );
     }
@@ -2179,7 +2175,7 @@ impl Workspace {
         &mut self,
         action: &GitCommit,
         window: &mut Window,
-        _cx: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
         info!("handle GitCommit from workspace");
         let message = action.message.trim().to_string();
@@ -2196,6 +2192,8 @@ impl Workspace {
         let confirm_message = format!("Commit {file_label}?\n\n{message}");
 
         let handle = self.session.handle().clone();
+        // 'static platform callback has no executor; capture the runtime handle.
+        let runtime = Tokio::handle(cx);
         window.hide_soft_keyboard();
         platform_bridge::show_alert(
             "",
@@ -2209,8 +2207,7 @@ impl Workspace {
                     let h = handle.clone();
                     let m = message.clone();
                     let p = paths.clone();
-                    // TODO: use cx.spawn
-                    zedra_session::session_runtime().spawn(async move {
+                    runtime.spawn(async move {
                         match h.git_commit(&m, &p).await {
                             Ok(_) => {
                                 tracing::info!("git commit succeeded");

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -339,6 +339,24 @@ fn foreground_resume_action(phase: &ConnectPhase) -> ForegroundResumeAction {
     }
 }
 
+/// Foreground-resume step from the UI-thread snapshot. A user disconnect is never
+/// resurrected; a phase that still reads connected but lost its transport restarts
+/// rather than probe a stale RPC client.
+fn classify_foreground_resume(
+    phase: &ConnectPhase,
+    connection_id: Option<usize>,
+    user_disconnect: bool,
+) -> ForegroundResumeAction {
+    if user_disconnect {
+        return ForegroundResumeAction::Ignore;
+    }
+    let action = foreground_resume_action(phase);
+    if matches!(action, ForegroundResumeAction::ProbeLiveness) && connection_id.is_none() {
+        return ForegroundResumeAction::RestartConnection;
+    }
+    action
+}
+
 fn path_label(snap: &ConnectSnapshot) -> &'static str {
     if snap
         .transport
@@ -876,9 +894,8 @@ impl Workspace {
             }
         });
 
-        // Foreground resume needs an application-level proof of liveness. QUIC
-        // close/idle signals can lag after app suspension while the UI still
-        // shows the last connected phase.
+        // QUIC close/idle can lag after suspension, so foreground resume probes
+        // liveness at the application level rather than trusting the phase.
         let mut foreground_resume_rx = platform_bridge::subscribe_foreground_state();
         let foreground_resume_listener = cx.spawn_in(window, async move |ws, cx| {
             loop {
@@ -888,30 +905,30 @@ impl Workspace {
                             continue;
                         }
 
-                        let (phase, handle, connection_id) = match ws.update(cx, |ws, cx| {
-                            let handle = ws.session_handle().clone();
-                            (
-                                ws.session_state.read(cx).phase(),
-                                handle.clone(),
-                                handle.active_connection_id(),
-                            )
-                        }) {
-                            Ok(value) => value,
-                            Err(_) => break,
-                        };
+                        let (phase, handle, connection_id, user_disconnect) =
+                            match ws.update(cx, |ws, cx| {
+                                let handle = ws.session_handle().clone();
+                                (
+                                    ws.session_state.read(cx).phase(),
+                                    handle.clone(),
+                                    handle.active_connection_id(),
+                                    handle.user_disconnect(),
+                                )
+                            }) {
+                                Ok(value) => value,
+                                Err(_) => break,
+                            };
 
-                        match foreground_resume_action(&phase) {
+                        let action =
+                            classify_foreground_resume(&phase, connection_id, user_disconnect);
+
+                        match action {
                             ForegroundResumeAction::ProbeLiveness => {
                                 // probe_liveness uses tokio timers — must run on Tokio.
-                                let probe = Tokio::spawn(cx, async move {
+                                let result = Tokio::spawn_result(cx, async move {
                                     handle.probe_liveness(FOREGROUND_LIVENESS_TIMEOUT).await
-                                });
-                                let result = match probe.await {
-                                    Ok(result) => result,
-                                    Err(join_error) => Err(anyhow::anyhow!(
-                                        "liveness probe task failed: {join_error}"
-                                    )),
-                                };
+                                })
+                                .await;
                                 match result {
                                     Ok(rtt) => {
                                         info!(
@@ -939,20 +956,30 @@ impl Workspace {
                                                 return;
                                             }
 
-                                            if connection_id.is_some() {
-                                                ws.session.request_reconnect(
-                                                    ReconnectReason::AppForegrounded,
-                                                );
-                                            } else {
-                                                ws.restart_connection(cx);
+                                            // User may have disconnected mid-probe.
+                                            if ws.session_handle().user_disconnect() {
+                                                return;
                                             }
+
+                                            // ProbeLiveness implies a live transport (classify
+                                            // routes the no-transport case to RestartConnection).
+                                            ws.session.request_reconnect(
+                                                ReconnectReason::AppForegrounded,
+                                            );
                                         })
                                         .ok();
                                     }
                                 }
                             }
                             ForegroundResumeAction::RestartConnection => {
-                                ws.update(cx, |ws, cx| ws.restart_connection(cx)).ok();
+                                ws.update(cx, |ws, cx| {
+                                    // User may have disconnected before this update ran.
+                                    if ws.session_handle().user_disconnect() {
+                                        return;
+                                    }
+                                    ws.restart_connection(cx);
+                                })
+                                .ok();
                             }
                             ForegroundResumeAction::Ignore => {}
                         }
@@ -963,15 +990,14 @@ impl Workspace {
             }
         });
 
-        // Notify host on foreground changes (toggles RPC-only vs Delta push).
-        // Must run on the bare Tokio handle, not `Tokio::spawn`: the GPUI executor
-        // pauses on background — exactly when this listener needs to fire.
+        // Notify host on foreground changes (toggles RPC-only vs Delta push). Bare
+        // Tokio handle, not `Tokio::spawn`: the GPUI executor pauses on background,
+        // exactly when this must fire.
         let foreground_handle = session.handle().clone();
         let mut foreground_rx = platform_bridge::subscribe_foreground_state();
         let foreground_state_listener = Tokio::handle(cx).spawn(async move {
-            // Seed the host with the current app state so a workspace that
-            // starts while already backgrounded does not stay pinned to the
-            // default foreground=true state.
+            // Seed current state so a workspace started while backgrounded
+            // isn't pinned to the default foreground=true.
             foreground_handle
                 .notify_app_state(platform_bridge::is_app_in_foreground())
                 .await;
@@ -3101,6 +3127,67 @@ mod tests {
         );
         assert_eq!(
             foreground_resume_action(&ConnectPhase::Sync),
+            ForegroundResumeAction::Ignore
+        );
+    }
+
+    #[::core::prelude::v1::test]
+    fn classify_foreground_resume_ignores_user_disconnect() {
+        // A user-disconnected workspace must never be resurrected by a
+        // foreground event, even if the phase still reads Connected.
+        assert_eq!(
+            classify_foreground_resume(&ConnectPhase::Connected, Some(7), true),
+            ForegroundResumeAction::Ignore
+        );
+        assert_eq!(
+            classify_foreground_resume(
+                &ConnectPhase::Idle {
+                    idle_since: Instant::now()
+                },
+                None,
+                true
+            ),
+            ForegroundResumeAction::Ignore
+        );
+        assert_eq!(
+            classify_foreground_resume(&ConnectPhase::Disconnected, None, true),
+            ForegroundResumeAction::Ignore
+        );
+    }
+
+    #[::core::prelude::v1::test]
+    fn classify_foreground_resume_skips_probe_when_no_transport() {
+        // Lifecycle close took the active connection but the phase has not
+        // advanced yet; probing the stale RPC client only delays the restart.
+        assert_eq!(
+            classify_foreground_resume(&ConnectPhase::Connected, None, false),
+            ForegroundResumeAction::RestartConnection
+        );
+        assert_eq!(
+            classify_foreground_resume(
+                &ConnectPhase::Idle {
+                    idle_since: Instant::now()
+                },
+                None,
+                false,
+            ),
+            ForegroundResumeAction::RestartConnection
+        );
+        // With a live transport, the probe path is still chosen.
+        assert_eq!(
+            classify_foreground_resume(&ConnectPhase::Connected, Some(7), false),
+            ForegroundResumeAction::ProbeLiveness
+        );
+    }
+
+    #[::core::prelude::v1::test]
+    fn classify_foreground_resume_passes_through_restart_and_ignore() {
+        assert_eq!(
+            classify_foreground_resume(&ConnectPhase::Disconnected, None, false),
+            ForegroundResumeAction::RestartConnection
+        );
+        assert_eq!(
+            classify_foreground_resume(&ConnectPhase::Sync, Some(7), false),
             ForegroundResumeAction::Ignore
         );
     }

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -901,7 +901,18 @@ impl Workspace {
 
                         match foreground_resume_action(&phase) {
                             ForegroundResumeAction::ProbeLiveness => {
-                                match handle.probe_liveness(FOREGROUND_LIVENESS_TIMEOUT).await {
+                                // probe_liveness uses tokio timers, so it must run on the
+                                // Tokio runtime, not the GPUI executor this task lives on.
+                                let probe = zedra_session::session_runtime().spawn(async move {
+                                    handle.probe_liveness(FOREGROUND_LIVENESS_TIMEOUT).await
+                                });
+                                let result = match probe.await {
+                                    Ok(result) => result,
+                                    Err(join_error) => {
+                                        Err(anyhow::anyhow!("liveness probe task failed: {join_error}"))
+                                    }
+                                };
+                                match result {
                                     Ok(rtt) => {
                                         info!(
                                             rtt_ms = rtt.as_millis() as u64,

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -154,6 +154,7 @@ pub(crate) enum PendingWorkspaceAction {
 }
 
 const ADD_TO_CHAT_SEND_DELAY: Duration = Duration::from_millis(250);
+const FOREGROUND_LIVENESS_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Clone)]
 struct ConnectionRequest {
@@ -308,6 +309,32 @@ fn reconnect_reason_label(reason: &ReconnectReason) -> &'static str {
     match reason {
         ReconnectReason::ConnectionLost => "connection_lost",
         ReconnectReason::AppForegrounded => "app_foregrounded",
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ForegroundResumeAction {
+    ProbeLiveness,
+    RestartConnection,
+    Ignore,
+}
+
+fn foreground_resume_action(phase: &ConnectPhase) -> ForegroundResumeAction {
+    match phase {
+        ConnectPhase::Connected | ConnectPhase::Idle { .. } => {
+            ForegroundResumeAction::ProbeLiveness
+        }
+        ConnectPhase::Disconnected | ConnectPhase::Failed(_) => {
+            ForegroundResumeAction::RestartConnection
+        }
+        ConnectPhase::Init
+        | ConnectPhase::BindingEndpoint
+        | ConnectPhase::HolePunching
+        | ConnectPhase::Registering
+        | ConnectPhase::Authenticating
+        | ConnectPhase::Proving
+        | ConnectPhase::Sync
+        | ConnectPhase::Reconnecting { .. } => ForegroundResumeAction::Ignore,
     }
 }
 
@@ -848,10 +875,9 @@ impl Workspace {
             }
         });
 
-        // Notify host when app foreground state changes so it can switch
-        // between RPC-only delivery and Delta push notifications.
-        // Run on Tokio, not GPUI: the GPUI executor pauses when the app backgrounds,
-        // which is exactly when we need this listener to fire and call notify_app_state.
+        // Foreground resume needs an application-level proof of liveness. QUIC
+        // close/idle signals can lag after app suspension while the UI still
+        // shows the last connected phase.
         let mut foreground_resume_rx = platform_bridge::subscribe_foreground_state();
         let foreground_resume_listener = cx.spawn_in(window, async move |ws, cx| {
             loop {
@@ -861,19 +887,63 @@ impl Workspace {
                             continue;
                         }
 
-                        let phase = match ws.update(cx, |ws, cx| ws.session_state.read(cx).phase())
-                        {
+                        let (phase, handle, connection_id) = match ws.update(cx, |ws, cx| {
+                            let handle = ws.session_handle().clone();
+                            (
+                                ws.session_state.read(cx).phase(),
+                                handle.clone(),
+                                handle.active_connection_id(),
+                            )
+                        }) {
                             Ok(value) => value,
                             Err(_) => break,
                         };
 
-                        // Trigger reconnect from foregrounding but not connected
-                        if !phase.is_connected() {
-                            ws.update(cx, |ws, _cx| {
-                                ws.session
-                                    .request_reconnect(ReconnectReason::AppForegrounded);
-                            })
-                            .ok();
+                        match foreground_resume_action(&phase) {
+                            ForegroundResumeAction::ProbeLiveness => {
+                                match handle.probe_liveness(FOREGROUND_LIVENESS_TIMEOUT).await {
+                                    Ok(rtt) => {
+                                        info!(
+                                            rtt_ms = rtt.as_millis() as u64,
+                                            "foreground liveness probe succeeded"
+                                        );
+                                    }
+                                    Err(error) => {
+                                        warn!(
+                                            error = %error,
+                                            "foreground liveness probe failed; forcing reconnect"
+                                        );
+                                        ws.update(cx, |ws, cx| {
+                                            let current_phase = ws.session_state.read(cx).phase();
+                                            if !matches!(
+                                                foreground_resume_action(&current_phase),
+                                                ForegroundResumeAction::ProbeLiveness
+                                            ) {
+                                                return;
+                                            }
+
+                                            if ws.session_handle().active_connection_id()
+                                                != connection_id
+                                            {
+                                                return;
+                                            }
+
+                                            if connection_id.is_some() {
+                                                ws.session.request_reconnect(
+                                                    ReconnectReason::AppForegrounded,
+                                                );
+                                            } else {
+                                                ws.restart_connection(cx);
+                                            }
+                                        })
+                                        .ok();
+                                    }
+                                }
+                            }
+                            ForegroundResumeAction::RestartConnection => {
+                                ws.update(cx, |ws, cx| ws.restart_connection(cx)).ok();
+                            }
+                            ForegroundResumeAction::Ignore => {}
                         }
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
@@ -2989,6 +3059,42 @@ mod tests {
         let mode = sync_refresh_mode_for_event(&sync_complete_event(), &mut seen_reconnect);
 
         assert_eq!(mode, Some(SyncRefreshMode::Reconnect));
+    }
+
+    #[::core::prelude::v1::test]
+    fn foreground_resume_probes_only_established_connections() {
+        assert_eq!(
+            foreground_resume_action(&ConnectPhase::Connected),
+            ForegroundResumeAction::ProbeLiveness
+        );
+        assert_eq!(
+            foreground_resume_action(&ConnectPhase::Idle {
+                idle_since: Instant::now()
+            }),
+            ForegroundResumeAction::ProbeLiveness
+        );
+        assert_eq!(
+            foreground_resume_action(&ConnectPhase::Disconnected),
+            ForegroundResumeAction::RestartConnection
+        );
+        assert_eq!(
+            foreground_resume_action(&ConnectPhase::Failed(
+                zedra_session::ConnectError::ConnectionClosed
+            )),
+            ForegroundResumeAction::RestartConnection
+        );
+        assert_eq!(
+            foreground_resume_action(&ConnectPhase::Reconnecting {
+                attempt: 1,
+                reason: ReconnectReason::ConnectionLost,
+                next_retry_secs: 0,
+            }),
+            ForegroundResumeAction::Ignore
+        );
+        assert_eq!(
+            foreground_resume_action(&ConnectPhase::Sync),
+            ForegroundResumeAction::Ignore
+        );
     }
 
     #[::core::prelude::v1::test]

--- a/crates/zedra/src/workspace_state.rs
+++ b/crates/zedra/src/workspace_state.rs
@@ -791,9 +791,9 @@ mod tests {
         assert_eq!(state.host_info, None);
     }
 
-    #[test]
-    fn sync_fields_ignores_network_only_session_snapshot_changes() {
-        let session = Session::new();
+    #[tokio::test]
+    async fn sync_fields_ignores_network_only_session_snapshot_changes() {
+        let session = Session::new(tokio::runtime::Handle::current());
         let mut session_state = SessionState::new();
         session_state.phase = ConnectPhase::Connected;
         session_state.snapshot.session_id = Some("session".into());
@@ -815,9 +815,9 @@ mod tests {
         assert!(!state.sync_fields_from_session(session.handle(), &session_state));
     }
 
-    #[test]
-    fn sync_fields_reports_workspace_phase_changes() {
-        let session = Session::new();
+    #[tokio::test]
+    async fn sync_fields_reports_workspace_phase_changes() {
+        let session = Session::new(tokio::runtime::Handle::current());
         let mut session_state = SessionState::new();
         session_state.phase = ConnectPhase::Connected;
         session_state.snapshot.session_id = Some("session".into());

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -174,13 +174,13 @@ Keep Swift access control consistent across native bridge helper types and APIs.
 
 ## Async Runtime Selection
 
-Choose the executor based on which thread/context owns the work:
+The GPUI executor has no Tokio reactor. A future that drives the reactor on the calling thread panics (`there is no reactor running`) when polled inside `cx.spawn`. The runtime is owned by `gpui_tokio` (created in `app::init_platform_app` via `gpui_tokio::init`); `zedra-session` owns none and takes `Tokio::handle(cx)` at `Session::new`. With `use gpui_tokio::Tokio;`:
 
-- `cx.spawn(...)` or `cx.spawn_in(window, ...)` for UI-thread async work in GPUI.
-- `zedra_session::session_runtime().spawn(...)` for session/network tasks that must run on Tokio even when called from GPUI or other non-Tokio threads.
-- `tokio::spawn(...)` only when the current function is already guaranteed to run inside the session Tokio runtime and the task is not part of a reusable API that may also be called from GPUI.
-
-**Rule of thumb**: library/session-layer code should not assume the caller has entered a Tokio runtime. If it needs to spawn Tokio tasks internally, prefer `session_runtime()` over bare `tokio::spawn()`.
+- **Host RPC calls** (`SessionHandle` methods, incl. `tokio::join!` over them) — `.await` directly in `cx.spawn`. They're irpc oneshots; no reactor touched on the calling thread.
+- **Reactor-driving futures** (`tokio::time`, iroh I/O, Delta HTTP/`reqwest`) — wrap in `Tokio::spawn_result(cx, fut).await`. It folds `JoinError` into `anyhow`, so `match`/`?` is unchanged. Use `Tokio::spawn` for non-`Result` outputs (e.g. a `tokio::join!` tuple).
+- **Fire-and-forget** from a `'static` callback (no `cx`) or work that must outlive backgrounding (GPUI executor pauses) — `Tokio::handle(cx).spawn(...)`, captured before the closure. Not `Tokio::spawn`, whose join half rides the paused GPUI executor.
+- Pure GPUI awaits (`cx.background_executor().timer`, `cx.background_spawn`, channel `recv()`) — directly in `cx.spawn`.
+- Inside `zedra-session`, bare `tokio::spawn` only when already on a runtime-polled future (e.g. the `connect()` loop).
 
 ## GPUI Entities And Tasks
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -571,8 +571,10 @@ or beyond.
 4. Keep waiting
 5. Background the app, then bring it back to the foreground while the badge is still `Idle`
 6. Expected: reconnect starts immediately on resume (`Idle` -> `Reconnecting` -> `Connected` or `Disconnected`), without waiting for the idle loop to time out
-7. Restore network before reconnect exhausts
-8. Expected: badge returns from `Idle` to `Connected` before or during reconnect recovery
+7. Repeat with a shorter background interval where the badge still shows `Connected`
+8. Expected: foreground resume probes liveness; if the host is unreachable, reconnect starts instead of leaving the active indicator stuck
+9. Restore network before reconnect exhausts
+10. Expected: badge returns from `Idle` or `Connected` to `Connected` during reconnect recovery
 
 ## 5b. Path Changes Do Not False Idle
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -576,6 +576,22 @@ or beyond.
 9. Restore network before reconnect exhausts
 10. Expected: badge returns from `Idle` or `Connected` to `Connected` during reconnect recovery
 
+## 5a.1. Foreground Resume Respects User Disconnect
+
+1. Connect via QR and wait for the session badge to show "Connected"
+2. Tap the Session Disconnect button (the intentional disconnect path, not backgrounding)
+3. Expected: badge goes to `Disconnected`/home and `SessionHandle::user_disconnect()` is set
+4. Background the app for a few seconds, then bring it back to the foreground
+5. Expected: the workspace is **not** resurrected — no liveness probe fires, no reconnect/restart starts, and the home/disconnected state remains
+6. Tap the workspace again to reconnect explicitly and confirm recovery still works
+
+## 5a.2. Foreground Resume Skips Probe When Transport Already Gone
+
+1. Connect via QR and wait for "Connected"
+2. Background the app long enough that the iOS lifecycle takes the active QUIC connection (`close_transport_for_lifecycle`) without the phase advancing past `Connected`/`Idle`
+3. Bring the app back to the foreground
+4. Expected: resume does **not** spend ~`FOREGROUND_LIVENESS_TIMEOUT` (2s) probing the stale RPC client; reconnect/restart begins promptly because `active_connection_id()` is `None` while the phase still reads `Connected`/`Idle`
+
 ## 5b. Path Changes Do Not False Idle
 
 1. Connect and wait for the transport badge to settle on `Relay` or `P2P`


### PR DESCRIPTION
## Summary
- Add a foreground-resume liveness probe using the existing Ping RPC before trusting a stale Connected or Idle badge.
- Preserve AppForegrounded as the reconnect reason across the transport close/reconnect loop.
- Extend manual reconnect verification to cover the case where the badge still shows Connected on resume.

## Notes
- Created as a draft PR.
- Local validation was run before unrelated working-tree changes appeared in the checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added foreground liveness probing to verify connection health before triggering reconnects.
  * Centralized platform/app initialization via a shared bootstrap helper.
* **Bug Fixes**
  * Prevented stale “connected” UI states by improving reconnect logic and liveness validation.
  * Ensured remote terminal attachment and session lifecycle work with the correct Tokio runtime handle.
* **Documentation**
  * Updated async/runtime spawning guidance and expanded the idle-before-reconnect manual test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->