### PR TITLE
feat: editable markdown preview with conflict-safe live save

### DIFF
--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -2201,19 +2201,26 @@ async fn dispatch(
                             content: String::new(),
                             too_large: false,
                             error: Some(e.to_string()),
+                            mtime: None,
+                            size: 0,
                         })
                         .await;
                     return Ok(());
                 }
             };
             const MAX_FILE_SIZE: u64 = 500 * 1024;
-            if std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0) > MAX_FILE_SIZE {
+            // One stat drives the size guard and the (mtime, size) version token
+            // the client echoes on write for optimistic concurrency.
+            let stat = state.fs.stat(&path).ok();
+            if stat.as_ref().map(|s| s.size).unwrap_or(0) > MAX_FILE_SIZE {
                 let _ = msg
                     .tx
                     .send(FsReadResult {
                         content: String::new(),
                         too_large: true,
                         error: None,
+                        mtime: None,
+                        size: 0,
                     })
                     .await;
                 return Ok(());
@@ -2226,6 +2233,8 @@ async fn dispatch(
                             content,
                             too_large: false,
                             error: None,
+                            mtime: stat.as_ref().and_then(|s| s.modified),
+                            size: stat.as_ref().map(|s| s.size).unwrap_or(0),
                         })
                         .await;
                 }
@@ -2237,6 +2246,8 @@ async fn dispatch(
                             content: String::new(),
                             too_large: false,
                             error: Some(e.to_string()),
+                            mtime: None,
+                            size: 0,
                         })
                         .await;
                 }
@@ -2249,12 +2260,84 @@ async fn dispatch(
                 Ok(p) => p,
                 Err(e) => {
                     tracing::warn!("FsWrite: rejected path {:?}: {}", msg.path, e);
-                    let _ = msg.tx.send(FsWriteResult { ok: false }).await;
+                    let _ = msg
+                        .tx
+                        .send(FsWriteResult {
+                            ok: false,
+                            conflict: false,
+                            mtime: None,
+                            size: 0,
+                            current_content: None,
+                        })
+                        .await;
                     return Ok(());
                 }
             };
-            let ok = state.fs.write(&path, &msg.content).is_ok();
-            let _ = msg.tx.send(FsWriteResult { ok }).await;
+
+            // Optimistic concurrency: when the client supplied an expected
+            // (mtime, size), reject if the file on disk no longer matches it,
+            // unless `force`. A missing expected token (new file) skips the
+            // check. The client adopts the returned version after a successful
+            // write so its own next write does not self-conflict.
+            if !msg.force && (msg.expected_mtime.is_some() || msg.expected_size.is_some()) {
+                let current = state.fs.stat(&path).ok();
+                let cur_mtime = current.as_ref().and_then(|s| s.modified);
+                let cur_size = current.as_ref().map(|s| s.size);
+                let conflict = current.is_some()
+                    && (cur_mtime != msg.expected_mtime
+                        || Some(cur_size.unwrap_or(0)) != msg.expected_size);
+                if conflict {
+                    tracing::info!(
+                        "[debug:fs-conflict] FsWrite rejected for {:?}: expected ({:?},{:?}) disk ({:?},{:?})",
+                        path,
+                        msg.expected_mtime,
+                        msg.expected_size,
+                        cur_mtime,
+                        cur_size,
+                    );
+                    let current_content = state.fs.read(&path).ok();
+                    let _ = msg
+                        .tx
+                        .send(FsWriteResult {
+                            ok: false,
+                            conflict: true,
+                            mtime: cur_mtime,
+                            size: cur_size.unwrap_or(0),
+                            current_content,
+                        })
+                        .await;
+                    return Ok(());
+                }
+            }
+
+            match state.fs.write(&path, &msg.content) {
+                Ok(()) => {
+                    let stat = state.fs.stat(&path).ok();
+                    let _ = msg
+                        .tx
+                        .send(FsWriteResult {
+                            ok: true,
+                            conflict: false,
+                            mtime: stat.as_ref().and_then(|s| s.modified),
+                            size: stat.as_ref().map(|s| s.size).unwrap_or(0),
+                            current_content: None,
+                        })
+                        .await;
+                }
+                Err(e) => {
+                    tracing::warn!("FsWrite: write failed for {:?}: {}", path, e);
+                    let _ = msg
+                        .tx
+                        .send(FsWriteResult {
+                            ok: false,
+                            conflict: false,
+                            mtime: None,
+                            size: 0,
+                            current_content: None,
+                        })
+                        .await;
+                }
+            }
         }
 
         ZedraMessage::FsStat(msg) => {

--- a/crates/zedra-rpc/src/proto.rs
+++ b/crates/zedra-rpc/src/proto.rs
@@ -225,7 +225,7 @@ pub enum ZedraProto {
 // ALPN protocol identifier
 // ---------------------------------------------------------------------------
 
-pub const ZEDRA_ALPN: &[u8] = b"zedra/rpc/3";
+pub const ZEDRA_ALPN: &[u8] = b"zedra/rpc/4";
 
 /// Default page size for `FsList` requests (host uses this when `limit == 0`).
 pub const FS_LIST_DEFAULT_LIMIT: u32 = 50;
@@ -658,17 +658,38 @@ pub struct FsReadResult {
     pub content: String,
     pub too_large: bool,
     pub error: Option<String>,
+    /// Disk version at read time. Pairs with `size` to form the optimistic
+    /// concurrency token a later `FsWrite` echoes as `expected_*`. Mirrors how
+    /// editors (Vim, VS Code, Zed) detect external edits via stat, not hashing.
+    pub mtime: Option<u64>,
+    pub size: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FsWriteReq {
     pub path: String,
     pub content: String,
+    /// Expected on-disk version (mtime, size) from the last read/write the
+    /// client observed. `None` skips the check (blind write, e.g. new file).
+    pub expected_mtime: Option<u64>,
+    pub expected_size: Option<u64>,
+    /// Overwrite even when the disk version no longer matches `expected_*`.
+    pub force: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FsWriteResult {
     pub ok: bool,
+    /// Set when the write was rejected because the disk version changed since
+    /// the client's `expected_*`. The client should reload or force-overwrite.
+    pub conflict: bool,
+    /// Disk version after a successful write, or the current (conflicting) disk
+    /// version when `conflict` is set. The client adopts this as its new token.
+    pub mtime: Option<u64>,
+    pub size: u64,
+    /// Current on-disk content, populated only on `conflict`, so the client can
+    /// reload or merge without a second round trip.
+    pub current_content: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -338,14 +338,32 @@ impl SessionHandle {
             .await?)
     }
 
-    pub async fn fs_write(&self, path: &str, content: &str) -> Result<()> {
-        let _: FsWriteResult = self
+    /// Write `content` to `path` with optimistic concurrency. `expected` is the
+    /// `(mtime, size)` version the client last observed for this file (`None`
+    /// for a new file or a deliberate blind write). When the disk version no
+    /// longer matches, the returned [`FsWriteResult`] has `conflict: true` and
+    /// `current_content`; pass `force` to overwrite regardless. On success the
+    /// caller must adopt the returned `(mtime, size)` as its new token.
+    pub async fn fs_write(
+        &self,
+        path: &str,
+        content: &str,
+        expected: Option<(Option<u64>, u64)>,
+        force: bool,
+    ) -> Result<FsWriteResult> {
+        let (expected_mtime, expected_size) = match expected {
+            Some((mtime, size)) => (mtime, Some(size)),
+            None => (None, None),
+        };
+        Ok(self
             .call(FsWriteReq {
                 path: path.to_string(),
                 content: content.to_string(),
+                expected_mtime,
+                expected_size,
+                force,
             })
-            .await?;
-        Ok(())
+            .await?)
     }
 
     pub async fn fs_stat(&self, path: &str) -> Result<FsStatResult> {

--- a/crates/zedra/src/file_preview_view.rs
+++ b/crates/zedra/src/file_preview_view.rs
@@ -1,5 +1,8 @@
+use std::time::Duration;
+
+use gpui::prelude::FluentBuilder;
 use gpui::*;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 use zedra_session::SessionHandle;
 use zedra_terminal::terminal::{TerminalHyperlink, TerminalHyperlinkTarget};
 
@@ -9,10 +12,15 @@ use crate::fonts;
 use crate::native_presentation;
 use crate::placeholder::render_placeholder;
 use crate::theme;
+use crate::ui::input::{Input, InputChanged};
 use crate::workspace::ActiveWorkspace;
 use crate::workspace_action::AddSelectionToChat;
 use crate::workspace_editor::{EditorSelection, resolve_read_only_selection};
 use crate::workspace_state::WorkspaceState;
+
+/// Debounce before a live edit is flushed to the host. Coalesces bursts of
+/// keystrokes into a single `fs/write` while keeping saves feeling immediate.
+const MARKDOWN_AUTOSAVE_DEBOUNCE: Duration = Duration::from_millis(500);
 
 #[derive(Clone, Debug)]
 enum PreviewState {
@@ -21,6 +29,18 @@ enum PreviewState {
     Loaded,
     TooLarge,
     Error(String),
+}
+
+/// Live-save status for the markdown editor, surfaced in the sheet header.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum SaveState {
+    Idle,
+    Saving,
+    Saved,
+    /// The file changed on the host since we last read it; autosave is paused
+    /// until the user reloads or overwrites.
+    Conflict,
+    Error,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -49,6 +69,32 @@ pub struct FilePreviewView {
     active_path: Option<String>,
     read_task: Option<Task<()>>,
     open_epoch: u64,
+    /// Multiline source editor used in markdown edit mode.
+    editor_input: Entity<Input>,
+    /// True while the markdown file is being edited (rendered preview replaced
+    /// by `editor_input`).
+    editing: bool,
+    /// Whether the active markdown file may be edited. Only workspace files
+    /// loaded via [`open_hyperlink`] are writable; read-only agent content from
+    /// [`open_content`] is not.
+    ///
+    /// [`open_hyperlink`]: FilePreviewView::open_hyperlink
+    /// [`open_content`]: FilePreviewView::open_content
+    allow_edit: bool,
+    /// Current raw markdown source, kept in sync with `editor_input` while
+    /// editing so the preview can re-parse it on exit.
+    markdown_source: String,
+    /// Optimistic-concurrency token `(mtime, size)` for the active file, from
+    /// the last read or successful write. Drives conflict detection on save.
+    version: Option<(Option<u64>, u64)>,
+    save_state: SaveState,
+    /// True while the save loop is running; keeps writes single-flighted so the
+    /// concurrency token can never drift from overlapping writes.
+    saving: bool,
+    save_task: Option<Task<()>>,
+    /// Current host content captured on a conflict, offered for reload.
+    conflict_content: Option<String>,
+    _input_subscription: Subscription,
 }
 
 impl FilePreviewView {
@@ -57,6 +103,18 @@ impl FilePreviewView {
         workspace_state: Entity<WorkspaceState>,
         cx: &mut Context<Self>,
     ) -> Self {
+        let editor_input = cx.new(|cx| {
+            Input::new(cx)
+                .multiline(true)
+                .native_suggestions(true)
+                .placeholder("Markdown source")
+        });
+        let input_subscription = cx.subscribe(
+            &editor_input,
+            |this: &mut Self, _input, event: &InputChanged, cx| {
+                this.on_source_input(event.value.clone(), cx);
+            },
+        );
         Self {
             session_handle,
             workspace_state,
@@ -69,6 +127,16 @@ impl FilePreviewView {
             active_path: None,
             read_task: None,
             open_epoch: 0,
+            editor_input,
+            editing: false,
+            allow_edit: false,
+            markdown_source: String::new(),
+            version: None,
+            save_state: SaveState::Idle,
+            saving: false,
+            save_task: None,
+            conflict_content: None,
+            _input_subscription: input_subscription,
         }
     }
 
@@ -106,6 +174,7 @@ impl FilePreviewView {
     pub fn open_hyperlink(&mut self, hyperlink: TerminalHyperlink, cx: &mut Context<Self>) {
         self.open_epoch = self.open_epoch.wrapping_add(1);
         let epoch = self.open_epoch;
+        self.reset_edit_state();
         native_presentation::set_sheet_content_at_top(true);
         match hyperlink.target {
             TerminalHyperlinkTarget::Url { url } => {
@@ -226,6 +295,8 @@ impl FilePreviewView {
                             });
                         }
                         PreviewContent::Markdown => {
+                            let source = result.content.clone();
+                            let version = (result.mtime, result.size);
                             let parsed = cx
                                 .background_spawn(
                                     async move { parse_markdown_source(result.content) },
@@ -240,6 +311,11 @@ impl FilePreviewView {
                                     return;
                                 }
                                 this.state = PreviewState::Loaded;
+                                // Workspace markdown loaded over fs/read is editable;
+                                // seed the live-save source and concurrency token.
+                                this.allow_edit = true;
+                                this.markdown_source = source;
+                                this.version = Some(version);
                                 this.markdown_view.update(cx, |markdown_view, cx| {
                                     markdown_view.set_parsed_source(parsed, cx);
                                 });
@@ -280,6 +356,7 @@ impl FilePreviewView {
     ) {
         self.open_epoch = self.open_epoch.wrapping_add(1);
         let epoch = self.open_epoch;
+        self.reset_edit_state();
         native_presentation::set_sheet_content_at_top(true);
 
         let prev_task = self.read_task.take();
@@ -359,6 +436,195 @@ impl FilePreviewView {
         }
     }
 
+    /// Clear all per-file edit/save state. Called when a new file is opened so
+    /// edit mode, the live-save loop, and the concurrency token never leak from
+    /// the previously previewed file.
+    fn reset_edit_state(&mut self) {
+        self.editing = false;
+        self.allow_edit = false;
+        self.markdown_source.clear();
+        self.version = None;
+        self.save_state = SaveState::Idle;
+        self.saving = false;
+        self.save_task = None;
+        self.conflict_content = None;
+    }
+
+    /// True when the active file is editable markdown currently loaded.
+    fn can_edit(&self) -> bool {
+        self.allow_edit
+            && self.content == PreviewContent::Markdown
+            && matches!(self.state, PreviewState::Loaded)
+    }
+
+    /// Toggle between rendered preview and the source editor.
+    fn toggle_edit(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.editing {
+            self.exit_edit(cx);
+        } else {
+            if !self.can_edit() {
+                return;
+            }
+            self.editing = true;
+            let source = self.markdown_source.clone();
+            self.editor_input
+                .update(cx, |input, _cx| input.set_value(source));
+            self.editor_input
+                .read(cx)
+                .focus_handle(cx)
+                .focus(window, cx);
+            cx.notify();
+        }
+    }
+
+    /// Leave edit mode: re-render the (possibly edited) source as preview.
+    fn exit_edit(&mut self, cx: &mut Context<Self>) {
+        self.editing = false;
+        let source = self.markdown_source.clone();
+        let parsed = parse_markdown_source(source);
+        self.markdown_view.update(cx, |markdown_view, cx| {
+            markdown_view.set_parsed_source(parsed, cx)
+        });
+        cx.notify();
+    }
+
+    /// Handle a live edit from the source editor: track the new source and
+    /// schedule an autosave.
+    fn on_source_input(&mut self, value: String, cx: &mut Context<Self>) {
+        if !self.editing {
+            return;
+        }
+        self.markdown_source = value;
+        // A fresh edit clears a prior terminal save status but not an unresolved
+        // conflict — that must be reloaded or overwritten explicitly.
+        if matches!(self.save_state, SaveState::Saved | SaveState::Error) {
+            self.save_state = SaveState::Idle;
+        }
+        self.schedule_save(cx);
+    }
+
+    /// Start (or let the running loop pick up) a debounced live save.
+    fn schedule_save(&mut self, cx: &mut Context<Self>) {
+        if !self.allow_edit || self.active_path.is_none() || self.save_state == SaveState::Conflict
+        {
+            return;
+        }
+        self.save_state = SaveState::Saving;
+        cx.notify();
+        if self.saving {
+            // The running loop re-reads `markdown_source` after its debounce.
+            return;
+        }
+        self.saving = true;
+        let handle = self.session_handle.clone();
+        self.save_task = Some(cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(MARKDOWN_AUTOSAVE_DEBOUNCE)
+                    .await;
+                let Ok(Some((path, source, expected))) = this.update(cx, |this, _cx| {
+                    if !this.allow_edit || this.save_state == SaveState::Conflict {
+                        return None;
+                    }
+                    let path = this.active_path.clone()?;
+                    Some((path, this.markdown_source.clone(), this.version))
+                }) else {
+                    break;
+                };
+
+                let result = handle.fs_write(&path, &source, expected, false).await;
+
+                let keep_going = this
+                    .update(cx, |this, cx| this.apply_write_result(result, &source, cx))
+                    .unwrap_or(false);
+                if !keep_going {
+                    break;
+                }
+            }
+            let _ = this.update(cx, |this, _cx| this.saving = false);
+        }));
+    }
+
+    /// Apply a write result. Returns `true` if the source changed again during
+    /// the write and the loop should write once more.
+    fn apply_write_result(
+        &mut self,
+        result: anyhow::Result<zedra_rpc::proto::FsWriteResult>,
+        written: &str,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        match result {
+            Ok(res) if res.conflict => {
+                info!(
+                    "[debug:fs-conflict] markdown autosave paused for {:?}",
+                    self.active_path
+                );
+                self.version = Some((res.mtime, res.size));
+                self.conflict_content = res.current_content;
+                self.save_state = SaveState::Conflict;
+                cx.notify();
+                false
+            }
+            Ok(res) if res.ok => {
+                self.version = Some((res.mtime, res.size));
+                if self.markdown_source != written {
+                    // More edits arrived during the write; write again.
+                    true
+                } else {
+                    self.save_state = SaveState::Saved;
+                    cx.notify();
+                    false
+                }
+            }
+            other => {
+                if let Err(e) = other {
+                    error!("markdown autosave failed for {:?}: {}", self.active_path, e);
+                }
+                self.save_state = SaveState::Error;
+                cx.notify();
+                false
+            }
+        }
+    }
+
+    /// Reload the host's current content, discarding local edits, to resolve a
+    /// conflict.
+    fn reload_conflict(&mut self, cx: &mut Context<Self>) {
+        let Some(content) = self.conflict_content.take() else {
+            return;
+        };
+        self.markdown_source = content.clone();
+        self.save_state = SaveState::Idle;
+        if self.editing {
+            self.editor_input
+                .update(cx, |input, _cx| input.set_value(content.clone()));
+        }
+        let parsed = parse_markdown_source(content);
+        self.markdown_view.update(cx, |markdown_view, cx| {
+            markdown_view.set_parsed_source(parsed, cx)
+        });
+        cx.notify();
+    }
+
+    /// Force-overwrite the host with local edits, resolving a conflict in favor
+    /// of this editor.
+    fn overwrite_conflict(&mut self, cx: &mut Context<Self>) {
+        let Some(path) = self.active_path.clone() else {
+            return;
+        };
+        self.conflict_content = None;
+        self.save_state = SaveState::Saving;
+        cx.notify();
+        let handle = self.session_handle.clone();
+        let source = self.markdown_source.clone();
+        self.save_task = Some(cx.spawn(async move |this, cx| {
+            let result = handle.fs_write(&path, &source, None, true).await;
+            let _ = this.update(cx, |this, cx| {
+                this.apply_write_result(result, &source, cx);
+            });
+        }));
+    }
+
     fn should_ignore_load_result(&self, epoch: u64, path: &str, content: PreviewContent) -> bool {
         self.open_epoch != epoch
             || self.active_path.as_deref() != Some(path)
@@ -388,8 +654,96 @@ fn preview_content_for_path(path: &str) -> PreviewContent {
     }
 }
 
+impl FilePreviewView {
+    /// "Edit" / "Done" pill shown for editable markdown.
+    fn render_edit_action(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let label = if self.editing { "Done" } else { "Edit" };
+        div()
+            .id("file-preview-edit-toggle")
+            .flex_none()
+            .px(px(12.0))
+            .py(px(6.0))
+            .rounded(px(6.0))
+            .bg(rgb(theme::bg_surface(cx)))
+            .border_1()
+            .border_color(rgb(theme::border_subtle(cx)))
+            .text_size(px(theme::FONT_DETAIL))
+            .text_color(rgb(theme::text_primary(cx)))
+            .child(label)
+            .on_press(cx.listener(|this, event: &PressEvent, window, cx| {
+                if event.completed() {
+                    this.toggle_edit(window, cx);
+                }
+            }))
+    }
+
+    fn save_status_label(&self) -> Option<&'static str> {
+        match self.save_state {
+            SaveState::Saving => Some("Saving…"),
+            SaveState::Saved => Some("Saved"),
+            SaveState::Error => Some("Save failed"),
+            SaveState::Idle | SaveState::Conflict => None,
+        }
+    }
+
+    /// Banner shown while autosave is paused on a conflict, offering reload or
+    /// overwrite.
+    fn render_conflict_banner(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let button = |id: &'static str, label: &'static str, cx: &mut Context<Self>| {
+            div()
+                .id(id)
+                .px(px(12.0))
+                .py(px(6.0))
+                .rounded(px(6.0))
+                .bg(rgb(theme::bg_surface(cx)))
+                .border_1()
+                .border_color(rgb(theme::border_subtle(cx)))
+                .text_size(px(theme::FONT_DETAIL))
+                .text_color(rgb(theme::text_primary(cx)))
+                .child(label)
+        };
+        div()
+            .w_full()
+            .px(px(theme::SPACING_LG))
+            .py(px(8.0))
+            .border_b_1()
+            .border_color(rgb(theme::border_subtle(cx)))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(8.0))
+            .child(
+                div()
+                    .flex_1()
+                    .text_size(px(theme::FONT_DETAIL))
+                    .text_color(rgb(theme::text_muted(cx)))
+                    .child("File changed on the host. Reload or overwrite?"),
+            )
+            .child(
+                button("file-preview-conflict-reload", "Reload", cx).on_press(cx.listener(
+                    |this, event: &PressEvent, _window, cx| {
+                        if event.completed() {
+                            this.reload_conflict(cx);
+                        }
+                    },
+                )),
+            )
+            .child(
+                button("file-preview-conflict-overwrite", "Overwrite", cx).on_press(cx.listener(
+                    |this, event: &PressEvent, _window, cx| {
+                        if event.completed() {
+                            this.overwrite_conflict(cx);
+                        }
+                    },
+                )),
+            )
+    }
+}
+
 impl Render for FilePreviewView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let editing_markdown =
+            self.editing && self.content == PreviewContent::Markdown && self.can_edit();
         let body: AnyElement = match &self.state {
             PreviewState::Idle => {
                 render_placeholder(cx, "Tap a file path in the terminal").into_any_element()
@@ -401,6 +755,14 @@ impl Render for FilePreviewView {
             PreviewState::Error(error) => {
                 render_placeholder(cx, format!("Error: {error}")).into_any_element()
             }
+            PreviewState::Loaded if editing_markdown => div()
+                .id("file-preview-markdown-editor")
+                .size_full()
+                .min_h_0()
+                .overflow_y_scroll()
+                .p(px(theme::SPACING_LG))
+                .child(self.editor_input.clone())
+                .into_any_element(),
             PreviewState::Loaded => match self.content {
                 PreviewContent::Editor => self.editor_view.clone().into_any_element(),
                 PreviewContent::Markdown => div()
@@ -413,6 +775,9 @@ impl Render for FilePreviewView {
                     .into_any_element(),
             },
         };
+
+        let show_edit_action = self.can_edit() || self.editing;
+        let save_status = self.save_status_label();
 
         div()
             .id("file-preview-sheet")
@@ -430,24 +795,48 @@ impl Render for FilePreviewView {
                     .border_b_1()
                     .border_color(rgb(theme::border_subtle(cx)))
                     .flex()
-                    .flex_col()
-                    .gap(px(2.0))
+                    .flex_row()
+                    .items_center()
+                    .gap(px(8.0))
                     .child(
                         div()
-                            .text_color(rgb(theme::text_primary(cx)))
-                            .text_size(px(theme::FONT_HEADING))
-                            .font_family(fonts::HEADING_FONT_FAMILY)
-                            .font_weight(FontWeight::MEDIUM)
-                            .child(self.title.clone()),
+                            .flex_1()
+                            .min_w_0()
+                            .flex()
+                            .flex_col()
+                            .gap(px(2.0))
+                            .child(
+                                div()
+                                    .text_color(rgb(theme::text_primary(cx)))
+                                    .text_size(px(theme::FONT_HEADING))
+                                    .font_family(fonts::HEADING_FONT_FAMILY)
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .child(self.title.clone()),
+                            )
+                            .child(
+                                div()
+                                    .text_color(rgb(theme::text_muted(cx)))
+                                    .text_size(px(theme::FONT_DETAIL))
+                                    .font_family(fonts::MONO_FONT_FAMILY)
+                                    .child(self.subtitle.clone()),
+                            ),
                     )
-                    .child(
-                        div()
-                            .text_color(rgb(theme::text_muted(cx)))
-                            .text_size(px(theme::FONT_DETAIL))
-                            .font_family(fonts::MONO_FONT_FAMILY)
-                            .child(self.subtitle.clone()),
-                    ),
+                    .when_some(save_status, |this, label| {
+                        this.child(
+                            div()
+                                .flex_none()
+                                .text_size(px(theme::FONT_DETAIL))
+                                .text_color(rgb(theme::text_muted(cx)))
+                                .child(label),
+                        )
+                    })
+                    .when(show_edit_action, |this| {
+                        this.child(self.render_edit_action(cx))
+                    }),
             )
+            .when(self.save_state == SaveState::Conflict, |this| {
+                this.child(self.render_conflict_banner(cx))
+            })
             .child(
                 div()
                     .id("file-preview-body")

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -174,6 +174,19 @@
 6. Expected: manual `screen_view` events include `screen_name` and `screen_class` for `Home`, `Settings`, `Quick Actions`, `Workspace Connecting`, `Workspace Editor`, `Workspace Markdown`, `Workspace Git Diff`, `Workspace Terminal`, each drawer tab, `Custom Sheet Editor`, and `Custom Sheet Markdown`
 7. Expected: native automatic rows such as `UIViewController`, `CustomSheetViewController`, `UIAlertController`, and `ZedraQRScannerVC` on iOS or Android activity rows on Android are still present because native Firebase screen reporting remains enabled
 
+## 0d-Markdown. Editable Markdown Preview
+
+1. Connect to a workspace and tap a terminal file link for a markdown file (`.md`) so the native custom sheet opens with the rendered preview
+2. Expected: an `Edit` pill appears in the sheet header (it does not appear for non-markdown files, nor for read-only agent config/memory files opened from the managed-agent view)
+3. Tap `Edit`: the rendered preview is replaced by an editable source view seeded with the file's markdown; the keyboard opens
+4. Type an edit and pause (~0.5s)
+5. Expected: the header shows `Saving…` then `Saved`; re-reading the file on the host (e.g. `cat` in the terminal) shows the edit persisted
+6. Tap `Done`: edit mode exits and the preview re-renders with your changes
+7. Conflict path: with the sheet still open on a file, modify that same file on the host from the terminal (append a line), then type another edit in the editor
+8. Expected: the header save status clears and a banner appears — "File changed on the host. Reload or overwrite?" — with `Reload` and `Overwrite` buttons; autosave is paused
+9. Tap `Reload`: the editor and preview adopt the host's current content, discarding the local edit; autosave resumes on the next edit
+10. Repeat the conflict, then tap `Overwrite`: the local edit is written over the host change and the banner clears
+
 ## 0e. Developer Native Selection
 
 1. Run a Debug iOS build and open Settings

--- a/docs/PROTOCOL_SPECS.md
+++ b/docs/PROTOCOL_SPECS.md
@@ -35,7 +35,7 @@ The protocol layer includes:
 
 - Network transport: iroh QUIC.
 - RPC framing: `irpc` over iroh streams.
-- ALPN: `zedra/rpc/3` (see `ZEDRA_ALPN` in `crates/zedra-rpc/src/proto.rs`). Bump the trailing integer on any change that alters how existing bytes decode (see §2.4).
+- ALPN: `zedra/rpc/4` (see `ZEDRA_ALPN` in `crates/zedra-rpc/src/proto.rs`). Bump the trailing integer on any change that alters how existing bytes decode (see §2.4).
 
 ### 2.2 Serialization
 
@@ -236,13 +236,24 @@ Result types that carry `error: Option<String>`:
 `AgentResumeResult`, `LspDiagnosticsResult`.
 
 Types that use non-string status fields or enum variants instead:
-`FsWriteResult` (`ok: bool`), `GitCheckoutResult` (`ok: bool`), `FsWatchResult`/`FsUnwatchResult` (enum),
+`FsWriteResult` (`ok: bool` plus `conflict: bool`; see FsWrite optimistic concurrency), `GitCheckoutResult` (`ok: bool`), `FsWatchResult`/`FsUnwatchResult` (enum),
 `FsDocsTreeResult` (`error: Option<FsDocsTreeError>`).
 
 ### FsRead additional fields
 
 - `content`: file contents (empty on error or when `too_large`)
 - `too_large`: true when file exceeds the 500 KB limit
+- `mtime` / `size`: on-disk version at read time (mtime in seconds since epoch, byte size). Together they form the optimistic-concurrency token the client echoes on `FsWrite`. Both zero/`None` on error or when `too_large`.
+
+### FsWrite optimistic concurrency
+
+Editing reuses the stat-based external-change detection used by Vim, VS Code, and Zed (mtime + size, not content hashing).
+
+- `expected_mtime` / `expected_size`: the `(mtime, size)` the client last observed for the path (from `FsRead` or a prior successful `FsWrite`). Send both `None` to skip the check — a blind write for new files or deliberate overwrites.
+- `force`: write even when the disk version no longer matches `expected_*`.
+- The host stats the path before writing. When an `expected_*` token is present, the file exists, and its current `(mtime, size)` differs, the host rejects the write with `conflict: true` and returns the current `mtime`, `size`, and `current_content` so the client can reload or merge without another round trip.
+- On success the host returns the new `(mtime, size)`. The client must adopt it as its token before the next write, or its own subsequent write will self-conflict.
+- mtime is second-granular, so a same-size edit within the same second as the recorded version is not detected. This matches the accepted precision of stat-based editors and is sufficient for human-paced editing.
 
 ### FsList paging conventions
 


### PR DESCRIPTION
## Summary

Adds an `Edit` / `Done` toggle to the markdown file preview sheet that swaps the rendered view for a multiline source editor. Edits autosave to the host live (500 ms debounce, single-flighted so the concurrency token never drifts), and the preview re-renders on `Done`.

External-change conflicts are detected with **stat-based optimistic concurrency (mtime + size)** rather than content hashing — the same approach Vim, VS Code, and Zed use. On conflict, autosave pauses and a banner offers `Reload` (adopt the host's content) or `Overwrite` (force-write local edits).

Only writable workspace files (opened via terminal file links) are editable; read-only agent config/memory files stay read-only.

Protocol (ALPN `3` → `4`):
- `FsReadResult` returns the `(mtime, size)` version token.
- `FsWriteReq` carries `expected_mtime`/`expected_size` + `force`; `FsWriteResult` reports `conflict` and `current_content`.
- Host does the compare-and-swap before writing and returns the new version on success.

## Notes

- Edit mode reuses the existing form `Input` widget (rounded/bordered); full-bleed editor styling is a follow-up best done against the running app.
- Read-only agent config/memory files are intentionally not editable — they arrive out-of-workspace with no guaranteed write path; enabling them needs a dedicated write route.
- Host-side CAS logic lives inline in the RPC dispatch loop and is covered by the `MANUAL_TEST.md` conflict steps rather than a unit test.
- mtime is second-granular (a same-size edit within the same second is not detected), which matches the accepted precision of stat-based editors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added editable markdown preview with automatic saving
  * Integrated conflict detection when files are edited externally, with options to reload or force overwrite
  * Real-time save status indicators showing progress and any errors

* **Documentation**
  * Updated protocol specifications
  * Added manual test plan for markdown editing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->