### PR TITLE
feat: serve legacy zedra/rpc/2 clients alongside rpc/3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10083,7 +10083,7 @@ dependencies = [
 
 [[package]]
 name = "zedra"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "android_logger",
  "anyhow",
@@ -10139,7 +10139,7 @@ dependencies = [
 
 [[package]]
 name = "zedra-host"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10185,11 +10185,11 @@ dependencies = [
 
 [[package]]
 name = "zedra-osc"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "zedra-rpc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "base64-url",
@@ -10212,7 +10212,7 @@ dependencies = [
 
 [[package]]
 name = "zedra-session"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "ed25519-dalek 2.2.0",
@@ -10234,14 +10234,14 @@ dependencies = [
 
 [[package]]
 name = "zedra-telemetry"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "zedra-terminal"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alacritty_terminal",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["vendor"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 [workspace.dependencies]

--- a/crates/zedra-host/src/iroh_listener.rs
+++ b/crates/zedra-host/src/iroh_listener.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use crate::rpc_daemon::{self, DaemonState};
 use crate::session_registry::SessionRegistry;
 use zedra_rpc::proto::ZEDRA_ALPN;
+use zedra_rpc::proto_v2::ZEDRA_ALPN_V2;
 use zedra_telemetry::Event;
 
 use crate::identity::SharedIdentity;
@@ -63,7 +64,8 @@ pub async fn create_endpoint(
     let relay_mode = iroh::RelayMode::Custom(relay_map_from_urls(&urls)?);
     let mut builder = iroh::Endpoint::builder()
         .secret_key(identity.iroh_secret_key().clone())
-        .alpns(vec![ZEDRA_ALPN.to_vec()])
+        // Current ALPN first; the previous one keeps older clients connecting.
+        .alpns(vec![ZEDRA_ALPN.to_vec(), ZEDRA_ALPN_V2.to_vec()])
         .relay_mode(relay_mode);
     if relay_only {
         // Skip pkarr address publishing — no direct addresses to advertise.

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -26,6 +26,9 @@ use crate::session_registry::{
 };
 use crate::utils;
 use anyhow::Result;
+use iroh::endpoint::ConnectionError;
+use irpc::rpc::{RemoteService, MAX_MESSAGE_SIZE};
+use irpc::util::AsyncReadVarintExt;
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher, Utf32Str};
 use std::collections::HashMap;
@@ -36,7 +39,77 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zedra_rpc::proto::*;
+use zedra_rpc::proto_v2::{ZedraProtoV2, ZEDRA_ALPN_V2};
 use zedra_telemetry::Event;
+
+/// Log a decode failure with the leading discriminant varint (the RPC's index in
+/// `ZedraProto`/`ZedraProtoV2`) and a payload preview.
+fn log_decode_failure(alpn: &[u8], buf: &[u8], err: &postcard::Error) {
+    let variant_index = postcard::take_from_bytes::<u32>(buf).map(|(v, _)| v).ok();
+    let preview_len = buf.len().min(32);
+    tracing::warn!(
+        "ignoring undecodable request: variant_index={variant_index:?} alpn={} \
+         payload_len={} payload_prefix={:02x?} error={err}",
+        String::from_utf8_lossy(alpn),
+        buf.len(),
+        &buf[..preview_len],
+    );
+}
+
+/// Read one request, decoding with the negotiated version (`zedra/rpc/2` lifts to
+/// the live message). Mirrors `irpc_iroh::read_request` but decodes locally so a
+/// failure can name the RPC (see `log_decode_failure`).
+async fn read_zedra_message(
+    conn: &iroh::endpoint::Connection,
+) -> std::io::Result<Option<ZedraMessage>> {
+    use std::io;
+
+    // The negotiated ALPN is the only version seam; keep it local to decoding.
+    let is_v2 = conn.alpn() == ZEDRA_ALPN_V2;
+
+    let (send, mut recv) = match conn.accept_bi().await {
+        Ok(pair) => pair,
+        // Remote closed the connection cleanly (error code 0).
+        Err(ConnectionError::ApplicationClosed(cause)) if cause.error_code.into_inner() == 0 => {
+            return Ok(None);
+        }
+        Err(cause) => return Err(cause.into()),
+    };
+
+    let size = recv
+        .read_varint_u64()
+        .await?
+        .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "failed to read size"))?;
+    if size > MAX_MESSAGE_SIZE {
+        conn.close(1u32.into(), b"request exceeded max message size");
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "request exceeded max message size",
+        ));
+    }
+    let mut buf = vec![0u8; size as usize];
+    recv.read_exact(&mut buf)
+        .await
+        .map_err(|e| io::Error::new(io::ErrorKind::UnexpectedEof, e))?;
+
+    if is_v2 {
+        match postcard::from_bytes::<ZedraProtoV2>(&buf) {
+            Ok(proto) => Ok(Some(proto.with_remote_channels(recv, send).into_live())),
+            Err(e) => {
+                log_decode_failure(conn.alpn(), &buf, &e);
+                Err(io::Error::new(io::ErrorKind::InvalidData, e))
+            }
+        }
+    } else {
+        match postcard::from_bytes::<ZedraProto>(&buf) {
+            Ok(proto) => Ok(Some(proto.with_remote_channels(recv, send))),
+            Err(e) => {
+                log_decode_failure(conn.alpn(), &buf, &e);
+                Err(io::Error::new(io::ErrorKind::InvalidData, e))
+            }
+        }
+    }
+}
 
 struct HostEnvInfo {
     hostname: String,
@@ -968,7 +1041,11 @@ pub async fn handle_connection(
     state: Arc<DaemonState>,
 ) -> Result<()> {
     let remote = conn.remote_id();
-    tracing::info!("connection from {}", remote.fmt_short());
+    tracing::info!(
+        "connection from {} (alpn={})",
+        remote.fmt_short(),
+        String::from_utf8_lossy(conn.alpn()),
+    );
 
     // Auth phase: returns (session, client_pubkey, is_new_client) or closes connection
     let auth_start = std::time::Instant::now();
@@ -1090,7 +1167,7 @@ pub async fn handle_connection(
     // extended struct) as per-stream, not connection-level: breaking here
     // would brick every other in-flight RPC on the same QUIC connection.
     loop {
-        match irpc_iroh::read_request::<ZedraProto>(&conn).await {
+        match read_zedra_message(&conn).await {
             Ok(Some(msg)) => {
                 let s = session.clone();
                 let st = state.clone();
@@ -1105,7 +1182,7 @@ pub async fn handle_connection(
             }
             Ok(None) => break,
             Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
-                tracing::warn!("ignoring undecodable request: {}", e);
+                // Detailed per-variant log already emitted in read_zedra_message.
                 continue;
             }
             Err(e) => {
@@ -1189,7 +1266,7 @@ async fn auth_phase(
     bool,
     AuthTiming,
 )> {
-    let first = irpc_iroh::read_request::<ZedraProto>(conn).await?;
+    let first = read_zedra_message(conn).await?;
 
     match first {
         Some(ZedraMessage::Register(msg)) => {
@@ -1212,7 +1289,7 @@ async fn auth_phase(
             if !ok {
                 anyhow::bail!("register rejected");
             }
-            let connect_msg = irpc_iroh::read_request::<ZedraProto>(conn).await?;
+            let connect_msg = read_zedra_message(conn).await?;
             match connect_msg {
                 Some(ZedraMessage::Connect(msg)) => {
                     // is_new_client = true: came through the Register path
@@ -1477,7 +1554,7 @@ async fn finish_auth(
     u64,
 )> {
     let prove_start = std::time::Instant::now();
-    let prove_msg = irpc_iroh::read_request::<ZedraProto>(conn).await?;
+    let prove_msg = read_zedra_message(conn).await?;
 
     let msg = match prove_msg {
         Some(ZedraMessage::AuthProve(m)) => m,

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -45,14 +45,14 @@ use zedra_telemetry::Event;
 /// Log a decode failure with the leading discriminant varint (the RPC's index in
 /// `ZedraProto`/`ZedraProtoV2`) and a payload preview.
 fn log_decode_failure(alpn: &[u8], buf: &[u8], err: &postcard::Error) {
+    // Metadata only — never log payload bytes; client frames can carry paths,
+    // file contents, or tokens.
     let variant_index = postcard::take_from_bytes::<u32>(buf).map(|(v, _)| v).ok();
-    let preview_len = buf.len().min(32);
     tracing::warn!(
         "ignoring undecodable request: variant_index={variant_index:?} alpn={} \
-         payload_len={} payload_prefix={:02x?} error={err}",
+         payload_len={} error={err}",
         String::from_utf8_lossy(alpn),
         buf.len(),
-        &buf[..preview_len],
     );
 }
 

--- a/crates/zedra-rpc/src/lib.rs
+++ b/crates/zedra-rpc/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod pairing;
 pub mod proto;
+pub mod proto_v2;
 
 pub use pairing::{
     ZedraPairingTicket, compute_registration_hmac, decode_endpoint_addr, encode_endpoint_addr,

--- a/crates/zedra-rpc/src/proto.rs
+++ b/crates/zedra-rpc/src/proto.rs
@@ -248,7 +248,7 @@ pub const FS_DOCS_TREE_MAX_VISITED_ENTRIES: u32 = 10_000;
 // Serde helper for [u8; 64] (serde supports arrays only up to size 32 by default)
 // ---------------------------------------------------------------------------
 
-mod bytes64 {
+pub(crate) mod bytes64 {
     use serde::{Deserializer, Serializer};
 
     pub fn serialize<S: Serializer>(val: &[u8; 64], s: S) -> Result<S::Ok, S::Error> {

--- a/crates/zedra-rpc/src/proto_v2.rs
+++ b/crates/zedra-rpc/src/proto_v2.rs
@@ -1,0 +1,691 @@
+// Frozen `zedra/rpc/2` wire schema, for clients built before the `zedra/rpc/3`
+// ALPN bump. The host advertises both ALPNs and serves a `zedra/rpc/2` client by
+// decoding requests with `ZedraProtoV2`, lifting them into `proto::ZedraMessage`
+// via `into_live`, and reusing the live dispatch; the only seam is the per-RPC
+// channel wrap that re-encodes responses to the `zedra/rpc/2` shape.
+//
+// Wire contract for shipped binaries — do not edit types or variant order. Only
+// types that diverged at `zedra/rpc/3` are defined here; the rest reuse `proto`
+// (pinned by the roundtrip tests below). A future wire change must bump the ALPN
+// (§2.4) and re-freeze the reused types.
+
+use chrono::{DateTime, Utc};
+use irpc::channel::{mpsc, oneshot};
+use irpc::rpc_requests;
+use serde::{Deserialize, Serialize};
+
+use crate::proto;
+
+/// Previous ALPN, advertised alongside `ZEDRA_ALPN`.
+pub const ZEDRA_ALPN_V2: &[u8] = b"zedra/rpc/2";
+
+// ---------------------------------------------------------------------------
+// Protocol enum (frozen at the final `zedra/rpc/2` variant set and order)
+// ---------------------------------------------------------------------------
+
+#[rpc_requests(message = ZedraMessageV2)]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum ZedraProtoV2 {
+    #[rpc(tx = oneshot::Sender<proto::RegisterResult>)]
+    Register(proto::RegisterReq),
+    #[rpc(tx = oneshot::Sender<proto::AuthChallengeResult>)]
+    Authenticate(proto::AuthReq),
+    #[rpc(tx = oneshot::Sender<AuthProveResult>)]
+    AuthProve(proto::AuthProveReq),
+    #[rpc(tx = oneshot::Sender<ConnectResult>)]
+    Connect(proto::ConnectReq),
+    #[rpc(tx = oneshot::Sender<proto::PongResult>)]
+    Ping(proto::PingReq),
+    #[rpc(tx = oneshot::Sender<proto::SessionInfoResult>)]
+    GetSessionInfo(proto::SessionInfoReq),
+    #[rpc(tx = oneshot::Sender<proto::SessionListResult>)]
+    ListSessions(proto::SessionListReq),
+    #[rpc(tx = oneshot::Sender<proto::SessionSwitchResult>)]
+    SwitchSession(proto::SessionSwitchReq),
+    #[rpc(tx = oneshot::Sender<proto::FsListResult>)]
+    FsList(proto::FsListReq),
+    #[rpc(tx = oneshot::Sender<proto::FsReadResult>)]
+    FsRead(proto::FsReadReq),
+    #[rpc(tx = oneshot::Sender<proto::FsWriteResult>)]
+    FsWrite(proto::FsWriteReq),
+    #[rpc(tx = oneshot::Sender<proto::FsStatResult>)]
+    FsStat(proto::FsStatReq),
+    #[rpc(tx = oneshot::Sender<proto::TermCreateResult>)]
+    TermCreate(proto::TermCreateReq),
+    #[rpc(tx = mpsc::Sender<HostEvent>)]
+    Subscribe(proto::SubscribeReq),
+    #[rpc(rx = mpsc::Receiver<proto::TermInput>, tx = mpsc::Sender<proto::TermOutput>)]
+    TermAttach(proto::TermAttachReq),
+    #[rpc(tx = oneshot::Sender<proto::TermResizeResult>)]
+    TermResize(proto::TermResizeReq),
+    #[rpc(tx = oneshot::Sender<proto::TermCloseResult>)]
+    TermClose(proto::TermCloseReq),
+    #[rpc(tx = oneshot::Sender<proto::TermListResult>)]
+    TermList(proto::TermListReq),
+    #[rpc(tx = oneshot::Sender<proto::GitStatusResult>)]
+    GitStatus(proto::GitStatusReq),
+    #[rpc(tx = oneshot::Sender<proto::GitDiffResult>)]
+    GitDiff(proto::GitDiffReq),
+    #[rpc(tx = oneshot::Sender<proto::GitLogResult>)]
+    GitLog(proto::GitLogReq),
+    #[rpc(tx = oneshot::Sender<proto::GitCommitResult>)]
+    GitCommit(proto::GitCommitReq),
+    #[rpc(tx = oneshot::Sender<proto::GitStageResult>)]
+    GitStage(proto::GitStageReq),
+    #[rpc(tx = oneshot::Sender<proto::GitUnstageResult>)]
+    GitUnstage(proto::GitUnstageReq),
+    #[rpc(tx = oneshot::Sender<proto::GitBranchesResult>)]
+    GitBranches(proto::GitBranchesReq),
+    #[rpc(tx = oneshot::Sender<proto::GitCheckoutResult>)]
+    GitCheckout(proto::GitCheckoutReq),
+    #[rpc(tx = oneshot::Sender<proto::AiPromptResult>)]
+    AiPrompt(proto::AiPromptReq),
+    #[rpc(tx = oneshot::Sender<proto::LspDiagnosticsResult>)]
+    LspDiagnostics(proto::LspDiagnosticsReq),
+    #[rpc(tx = oneshot::Sender<proto::LspHoverResult>)]
+    LspHover(proto::LspHoverReq),
+    #[rpc(tx = oneshot::Sender<proto::FsWatchResult>)]
+    FsWatch(proto::FsWatchReq),
+    #[rpc(tx = oneshot::Sender<proto::FsUnwatchResult>)]
+    FsUnwatch(proto::FsUnwatchReq),
+    #[rpc(tx = oneshot::Sender<SyncSessionResult>)]
+    SyncSession(proto::SyncSessionReq),
+    #[rpc(tx = mpsc::Sender<proto::HostInfoSnapshot>)]
+    SubscribeHostInfo(proto::SubscribeHostInfoReq),
+    #[rpc(tx = oneshot::Sender<proto::TermReorderResult>)]
+    TermReorder(proto::TermReorderReq),
+    #[rpc(tx = oneshot::Sender<proto::FsDocsTreeResult>)]
+    FsDocsTree(proto::FsDocsTreeReq),
+    #[rpc(tx = oneshot::Sender<AgentListResult>)]
+    AgentList(proto::AgentListReq),
+    #[rpc(tx = oneshot::Sender<AgentSessionsResult>)]
+    AgentSessions(AgentSessionsReq),
+    #[rpc(tx = oneshot::Sender<proto::AgentResumeResult>)]
+    AgentResume(AgentResumeReq),
+    #[rpc(tx = oneshot::Sender<proto::AgentInstalledListResult>)]
+    AgentInstalledList(proto::AgentInstalledListReq),
+    #[rpc(tx = oneshot::Sender<proto::TermCreateResult>)]
+    TermCreateV2(proto::TermCreateReqV2),
+}
+
+// ---------------------------------------------------------------------------
+// Divergent types — frozen at their final `zedra/rpc/2` wire shape
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TerminalSyncEntry {
+    pub id: String,
+    pub position: u64,
+    pub last_seq: u64,
+    pub title: Option<String>,
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub icon_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncSessionResult {
+    pub session_id: String,
+    pub session_token: [u8; 32],
+    pub hostname: String,
+    pub workdir: String,
+    pub username: String,
+    pub home_dir: Option<String>,
+    pub os: Option<String>,
+    pub arch: Option<String>,
+    pub os_version: Option<String>,
+    pub host_version: Option<String>,
+    pub terminals: Vec<TerminalSyncEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ConnectResult {
+    Ok(SyncSessionResult),
+    Challenge {
+        nonce: [u8; 32],
+        #[serde(with = "crate::proto::bytes64")]
+        host_signature: [u8; 64],
+    },
+    Unauthorized,
+    NotInSessionAcl,
+    SessionOccupied,
+    SessionNotFound,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum AuthProveResult {
+    Ok(SyncSessionResult),
+    Unauthorized,
+    NotInSessionAcl,
+    SessionOccupied,
+    SessionNotFound,
+    InvalidSignature,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum HostEvent {
+    TerminalCreated {
+        id: String,
+        launch_cmd: Option<String>,
+    },
+    GitChanged,
+    FsChanged {
+        path: String,
+    },
+    AgentInfoChanged {
+        info: AgentSummary,
+    },
+}
+
+/// Lowest common denominator across shipped `zedra/rpc/2` builds (some predate
+/// `Pi`). Only these three are emitted/accepted; `Pi`/`Hermes` are filtered out.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum ManagedAgentKind {
+    Claude,
+    Codex,
+    OpenCode,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AgentLiveSummary {
+    pub active_terminal_ids: Vec<String>,
+    pub pending_action_count: usize,
+    pub latest_event: Option<AgentEventSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentEventSummary {
+    pub kind: AgentEventKind,
+    pub status: AgentLifecycleStatus,
+    pub at: Option<DateTime<Utc>>,
+    pub terminal_id: Option<String>,
+    pub session_id: Option<String>,
+    pub turn_id: Option<String>,
+    pub tool_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum AgentEventKind {
+    SessionStarted,
+    SessionUpdated,
+    TurnStarted,
+    TurnCompleted,
+    TurnFailed,
+    TaskCreated,
+    TaskCompleted,
+    TaskFailed,
+    ToolStarted,
+    ToolCompleted,
+    ToolFailed,
+    PermissionRequested,
+    PermissionResolved,
+    Notification,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub enum AgentLifecycleStatus {
+    #[default]
+    Unknown,
+    Starting,
+    Running,
+    WaitingForUser,
+    WaitingForPermission,
+    Idle,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSummary {
+    pub kind: ManagedAgentKind,
+    pub display_name: String,
+    pub cli: proto::AgentCliSummary,
+    pub setup: proto::AgentSetupSummary,
+    pub capabilities: proto::AgentCapabilities,
+    pub workspace: proto::AgentWorkspaceSummary,
+    pub sessions: AgentSessionCounts,
+    pub live: AgentLiveSummary,
+    pub last_activity_at: Option<DateTime<Utc>>,
+    pub updated_at: DateTime<Utc>,
+    pub data_sources: Vec<proto::AgentDataSource>,
+    pub warnings: Vec<proto::AgentWarning>,
+    pub account: proto::AgentAccountSummary,
+    pub usage: Option<proto::AgentUsageSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentListResult {
+    pub agents: Vec<AgentSummary>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSessionCounts {
+    pub total: usize,
+    pub resumable: usize,
+    pub active_live: usize,
+    pub latest_session_id: Option<String>,
+    pub latest_session_title: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AgentSessionLiveSummary {
+    pub terminal_id: Option<String>,
+    pub status: AgentLifecycleStatus,
+    pub pending_action_count: usize,
+    pub current_turn_id: Option<String>,
+    pub latest_event: Option<AgentEventSummary>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AgentProviderSessionInfo {
+    pub model: Option<String>,
+    pub permission_mode: Option<String>,
+    pub cli_version: Option<String>,
+    pub origin: Option<String>,
+    pub source: Option<String>,
+    pub entrypoint: Option<String>,
+    pub native_project_id: Option<String>,
+    pub model_provider: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AgentSessionCounters {
+    pub record_count: u64,
+    pub message_count: u64,
+    pub turn_count: u64,
+    pub tool_count: u64,
+    pub tool_failure_count: u64,
+    pub hook_success_count: u64,
+    pub hook_failure_count: u64,
+    pub malformed_record_count: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AgentSessionFlags {
+    pub is_sidechain: bool,
+    pub is_subagent: bool,
+    pub is_archived: bool,
+    pub historical_only: bool,
+    pub live_bound: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSessionSummary {
+    pub kind: ManagedAgentKind,
+    pub session_id: String,
+    pub title: Option<String>,
+    pub cwd: Option<String>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub last_activity_at: Option<DateTime<Utc>>,
+    pub resume: proto::AgentResumeSummary,
+    pub live: AgentSessionLiveSummary,
+    pub provider: AgentProviderSessionInfo,
+    pub git: Option<proto::AgentGitSummary>,
+    pub usage: Option<proto::AgentUsageSnapshot>,
+    pub counters: AgentSessionCounters,
+    pub flags: AgentSessionFlags,
+    pub data_sources: Vec<proto::AgentDataSource>,
+    pub warnings: Vec<proto::AgentWarning>,
+    pub transcript_size_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSessionsResult {
+    pub sessions: Vec<AgentSessionSummary>,
+    pub total: u32,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSessionsReq {
+    pub kind: ManagedAgentKind,
+    #[serde(default)]
+    pub refresh: bool,
+    #[serde(default)]
+    pub limit: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentResumeReq {
+    pub kind: ManagedAgentKind,
+    pub session_id: String,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+// ---------------------------------------------------------------------------
+// Live (v3) -> `zedra/rpc/2` response conversions
+// ---------------------------------------------------------------------------
+
+impl From<proto::TerminalSyncEntry> for TerminalSyncEntry {
+    fn from(t: proto::TerminalSyncEntry) -> Self {
+        // Drops the fields appended at `zedra/rpc/3`: agent_command, shell_state,
+        // last_exit_code, agent_state.
+        Self {
+            id: t.id,
+            position: t.position,
+            last_seq: t.last_seq,
+            title: t.title,
+            cwd: t.cwd,
+            icon_name: t.icon_name,
+        }
+    }
+}
+
+impl From<proto::SyncSessionResult> for SyncSessionResult {
+    fn from(s: proto::SyncSessionResult) -> Self {
+        // Drops delta_pubkey (added at `zedra/rpc/3`).
+        Self {
+            session_id: s.session_id,
+            session_token: s.session_token,
+            hostname: s.hostname,
+            workdir: s.workdir,
+            username: s.username,
+            home_dir: s.home_dir,
+            os: s.os,
+            arch: s.arch,
+            os_version: s.os_version,
+            host_version: s.host_version,
+            terminals: s.terminals.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<proto::ConnectResult> for ConnectResult {
+    fn from(r: proto::ConnectResult) -> Self {
+        match r {
+            proto::ConnectResult::Ok(s) => ConnectResult::Ok(s.into()),
+            proto::ConnectResult::Challenge {
+                nonce,
+                host_signature,
+            } => ConnectResult::Challenge {
+                nonce,
+                host_signature,
+            },
+            proto::ConnectResult::Unauthorized => ConnectResult::Unauthorized,
+            proto::ConnectResult::NotInSessionAcl => ConnectResult::NotInSessionAcl,
+            proto::ConnectResult::SessionOccupied => ConnectResult::SessionOccupied,
+            proto::ConnectResult::SessionNotFound => ConnectResult::SessionNotFound,
+        }
+    }
+}
+
+impl From<proto::AuthProveResult> for AuthProveResult {
+    fn from(r: proto::AuthProveResult) -> Self {
+        match r {
+            proto::AuthProveResult::Ok(s) => AuthProveResult::Ok(s.into()),
+            proto::AuthProveResult::Unauthorized => AuthProveResult::Unauthorized,
+            proto::AuthProveResult::NotInSessionAcl => AuthProveResult::NotInSessionAcl,
+            proto::AuthProveResult::SessionOccupied => AuthProveResult::SessionOccupied,
+            proto::AuthProveResult::SessionNotFound => AuthProveResult::SessionNotFound,
+            proto::AuthProveResult::InvalidSignature => AuthProveResult::InvalidSignature,
+        }
+    }
+}
+
+/// `Pi`/`Hermes` have no safe `v2` representation; they yield `None` and callers
+/// drop those agents/sessions.
+fn managed_agent_kind(kind: proto::AgentKind) -> Option<ManagedAgentKind> {
+    match kind {
+        proto::AgentKind::Claude => Some(ManagedAgentKind::Claude),
+        proto::AgentKind::Codex => Some(ManagedAgentKind::Codex),
+        proto::AgentKind::OpenCode => Some(ManagedAgentKind::OpenCode),
+        proto::AgentKind::Pi | proto::AgentKind::Hermes => None,
+    }
+}
+
+/// Maps a `v2` agent kind up to the live kind (always representable).
+fn agent_kind_to_v3(kind: ManagedAgentKind) -> proto::AgentKind {
+    match kind {
+        ManagedAgentKind::Claude => proto::AgentKind::Claude,
+        ManagedAgentKind::Codex => proto::AgentKind::Codex,
+        ManagedAgentKind::OpenCode => proto::AgentKind::OpenCode,
+    }
+}
+
+impl From<proto::AgentSessionCounts> for AgentSessionCounts {
+    fn from(c: proto::AgentSessionCounts) -> Self {
+        // `active_live` was removed at `zedra/rpc/3`; synthesize 0.
+        Self {
+            total: c.total,
+            resumable: c.resumable,
+            active_live: 0,
+            latest_session_id: c.latest_session_id,
+            latest_session_title: c.latest_session_title,
+        }
+    }
+}
+
+// Request lift: `v2` client -> live handler. Only `kind` widened.
+impl From<AgentSessionsReq> for proto::AgentSessionsReq {
+    fn from(r: AgentSessionsReq) -> Self {
+        Self {
+            kind: agent_kind_to_v3(r.kind),
+            refresh: r.refresh,
+            limit: r.limit,
+        }
+    }
+}
+
+impl From<AgentResumeReq> for proto::AgentResumeReq {
+    fn from(r: AgentResumeReq) -> Self {
+        Self {
+            kind: agent_kind_to_v3(r.kind),
+            session_id: r.session_id,
+            cols: r.cols,
+            rows: r.rows,
+        }
+    }
+}
+
+/// `None` for kinds absent in `v2`. Fields removed at `zedra/rpc/3` (live,
+/// provider, counters, flags, data_sources, warnings) get empty defaults.
+fn agent_session_summary_v2(s: proto::AgentSessionSummary) -> Option<AgentSessionSummary> {
+    Some(AgentSessionSummary {
+        kind: managed_agent_kind(s.kind)?,
+        session_id: s.session_id,
+        title: s.title,
+        cwd: s.cwd,
+        created_at: s.created_at,
+        last_activity_at: s.last_activity_at,
+        resume: s.resume,
+        live: AgentSessionLiveSummary::default(),
+        provider: AgentProviderSessionInfo::default(),
+        git: s.git,
+        usage: s.usage,
+        counters: AgentSessionCounters::default(),
+        flags: AgentSessionFlags::default(),
+        data_sources: Vec::new(),
+        warnings: Vec::new(),
+        transcript_size_bytes: s.transcript_size_bytes,
+    })
+}
+
+impl From<proto::AgentSessionsResult> for AgentSessionsResult {
+    fn from(r: proto::AgentSessionsResult) -> Self {
+        Self {
+            sessions: r
+                .sessions
+                .into_iter()
+                .filter_map(agent_session_summary_v2)
+                .collect(),
+            total: r.total,
+            error: r.error,
+        }
+    }
+}
+
+/// `None` for kinds absent in `v2`. The `live` subtree, removed at `zedra/rpc/3`,
+/// is sent empty.
+fn agent_summary_v2(a: proto::AgentSummary) -> Option<AgentSummary> {
+    Some(AgentSummary {
+        kind: managed_agent_kind(a.kind)?,
+        display_name: a.display_name,
+        cli: a.cli,
+        setup: a.setup,
+        capabilities: a.capabilities,
+        workspace: a.workspace,
+        sessions: a.sessions.into(),
+        live: AgentLiveSummary::default(),
+        last_activity_at: a.last_activity_at,
+        updated_at: a.updated_at,
+        data_sources: a.data_sources,
+        warnings: a.warnings,
+        account: a.account,
+        usage: a.usage,
+    })
+}
+
+impl From<proto::AgentListResult> for AgentListResult {
+    fn from(r: proto::AgentListResult) -> Self {
+        Self {
+            agents: r.agents.into_iter().filter_map(agent_summary_v2).collect(),
+            error: r.error,
+        }
+    }
+}
+
+/// `None` drops events the old client can't decode: the `v3` variants, and
+/// `AgentInfoChanged` for a filtered agent kind.
+fn host_event_v2(e: proto::HostEvent) -> Option<HostEvent> {
+    match e {
+        proto::HostEvent::TerminalCreated { id, launch_cmd } => {
+            Some(HostEvent::TerminalCreated { id, launch_cmd })
+        }
+        proto::HostEvent::GitChanged => Some(HostEvent::GitChanged),
+        proto::HostEvent::FsChanged { path } => Some(HostEvent::FsChanged { path }),
+        proto::HostEvent::AgentInfoChanged { info } => {
+            agent_summary_v2(info).map(|info| HostEvent::AgentInfoChanged { info })
+        }
+        proto::HostEvent::AgentHookReceived { .. } | proto::HostEvent::AgentStateChanged { .. } => {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lift a decoded `zedra/rpc/2` request into the live message, wrapping each
+// response channel to re-encode to `zedra/rpc/2` bytes on send.
+// ---------------------------------------------------------------------------
+
+impl ZedraMessageV2 {
+    pub fn into_live(self) -> proto::ZedraMessage {
+        use proto::ZedraMessage as M;
+        match self {
+            // Byte-identical: same concrete channel types, rebuilt under M.
+            ZedraMessageV2::Register(m) => M::Register((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::Authenticate(m) => M::Authenticate((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::Ping(m) => M::Ping((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::GetSessionInfo(m) => M::GetSessionInfo((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::ListSessions(m) => M::ListSessions((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::SwitchSession(m) => M::SwitchSession((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::FsList(m) => M::FsList((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::FsRead(m) => M::FsRead((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::FsWrite(m) => M::FsWrite((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::FsStat(m) => M::FsStat((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::TermCreate(m) => M::TermCreate((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::TermAttach(m) => M::TermAttach((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::TermResize(m) => M::TermResize((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::TermClose(m) => M::TermClose((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::TermList(m) => M::TermList((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::GitStatus(m) => M::GitStatus((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::GitDiff(m) => M::GitDiff((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::GitLog(m) => M::GitLog((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::GitCommit(m) => M::GitCommit((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::GitStage(m) => M::GitStage((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::GitUnstage(m) => M::GitUnstage((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::GitBranches(m) => M::GitBranches((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::GitCheckout(m) => M::GitCheckout((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::AiPrompt(m) => M::AiPrompt((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::LspDiagnostics(m) => M::LspDiagnostics((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::LspHover(m) => M::LspHover((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::FsWatch(m) => M::FsWatch((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::FsUnwatch(m) => M::FsUnwatch((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::SubscribeHostInfo(m) => {
+                M::SubscribeHostInfo((m.inner, m.tx, m.rx).into())
+            }
+            ZedraMessageV2::TermReorder(m) => M::TermReorder((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::FsDocsTree(m) => M::FsDocsTree((m.inner, m.tx, m.rx).into()),
+            ZedraMessageV2::AgentInstalledList(m) => {
+                M::AgentInstalledList((m.inner, m.tx, m.rx).into())
+            }
+            ZedraMessageV2::TermCreateV2(m) => M::TermCreateV2((m.inner, m.tx, m.rx).into()),
+
+            // Agent RPCs: lift the request kind and map the result back. The
+            // `AgentResume` result is wire-identical, so only its request lifts.
+            ZedraMessageV2::AgentResume(m) => M::AgentResume((m.inner.into(), m.tx, m.rx).into()),
+            ZedraMessageV2::AgentSessions(m) => M::AgentSessions(
+                (
+                    m.inner.into(),
+                    m.tx.with_map(AgentSessionsResult::from),
+                    m.rx,
+                )
+                    .into(),
+            ),
+
+            // Divergent responses: map the live result back to `zedra/rpc/2` bytes.
+            ZedraMessageV2::Connect(m) => {
+                M::Connect((m.inner, m.tx.with_map(ConnectResult::from), m.rx).into())
+            }
+            ZedraMessageV2::AuthProve(m) => {
+                M::AuthProve((m.inner, m.tx.with_map(AuthProveResult::from), m.rx).into())
+            }
+            ZedraMessageV2::SyncSession(m) => {
+                M::SyncSession((m.inner, m.tx.with_map(SyncSessionResult::from), m.rx).into())
+            }
+            ZedraMessageV2::AgentList(m) => {
+                M::AgentList((m.inner, m.tx.with_map(AgentListResult::from), m.rx).into())
+            }
+            // Stream: drop events the old client cannot decode.
+            ZedraMessageV2::Subscribe(m) => {
+                M::Subscribe((m.inner, m.tx.with_filter_map(host_event_v2), m.rx).into())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Asserts `v3` bytes decode as the reused `v2` type — guards against a
+    /// reused `proto` type drifting without an ALPN bump.
+    fn assert_v3_decodes_as<V3, V2>(value: &V3)
+    where
+        V3: Serialize,
+        V2: for<'de> Deserialize<'de>,
+    {
+        let bytes = postcard::to_stdvec(value).unwrap();
+        postcard::from_bytes::<V2>(&bytes).expect("v3 bytes must decode as v2 type");
+    }
+
+    #[test]
+    fn reused_results_are_wire_identical() {
+        assert_v3_decodes_as::<_, proto::PongResult>(&proto::PongResult { timestamp_ms: 7 });
+        assert_v3_decodes_as::<_, proto::FsWriteResult>(&proto::FsWriteResult { ok: true });
+    }
+
+    #[test]
+    fn divergent_sync_session_drops_v3_fields() {
+        let v3 = proto::SyncSessionResult {
+            session_id: "s".into(),
+            session_token: [1u8; 32],
+            hostname: "h".into(),
+            workdir: "/w".into(),
+            username: "u".into(),
+            home_dir: None,
+            os: None,
+            arch: None,
+            os_version: None,
+            host_version: None,
+            delta_pubkey: [2u8; 32],
+            terminals: Vec::new(),
+        };
+        let v2: SyncSessionResult = v3.into();
+        // Re-encode under v2 and ensure it is self-consistent.
+        let bytes = postcard::to_stdvec(&v2).unwrap();
+        let _: SyncSessionResult = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(v2.session_token, [1u8; 32]);
+    }
+}

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -6,6 +6,19 @@
 - Prefer concrete reproduction steps and expected results over vague test descriptions.
 - When debugging, add targeted log instructions if the test depends on developer-run device validation.
 
+## 0-Compat. Legacy ALPN (`zedra/rpc/2`) Client
+
+Verifies a `zedra/rpc/3` host still serves a pre-bump app.
+
+1. Run the host from this branch; connect a `zedra/rpc/2` app (a `v0.2.5` build or
+   a client pinned to `ZEDRA_ALPN_V2`).
+2. Expected: host log shows `alpn=zedra/rpc/2`, auth succeeds (no `InvalidData`),
+   and terminals (open/type/resize/reconnect) and the agent list all work.
+   Claude/Codex/OpenCode render; agent live badges may be blank and `Pi`/`Hermes`
+   are absent (expected).
+3. Connect a current `zedra/rpc/3` app in parallel — both work concurrently, and
+   the `v3` client still shows full terminal/agent metadata.
+
 ## 0. Mobile Hover Styling
 
 1. Open the app on iOS or Android

--- a/docs/PROTOCOL_SPECS.md
+++ b/docs/PROTOCOL_SPECS.md
@@ -479,6 +479,60 @@ If a breaking change is unavoidable:
 - New variants may fail on old binaries; do not assume forwards compatibility across arbitrary versions.
 - Keep deployment pairs synchronized when introducing enum variants.
 
+### 7.4 Multi-ALPN Backward Compatibility
+
+Status: implemented. The host serves both `zedra/rpc/3` and `zedra/rpc/2`.
+
+A `ZEDRA_ALPN` bump strands shipped apps on the old ALPN (§2.4) until App Store
+review clears the new build, so the host keeps serving the previous version.
+This is a scoped exception to the "host does not tailor responses per client"
+rule, and it **recurs on every bump** (v4 keeps v3, …; a chain if review windows
+overlap). The `v2`→`v3` delta is response-only — requests are append-only and the
+`v2` request set is a prefix of `v3`'s, so the auth handshake is unchanged.
+
+How it works:
+
+- **Advertise both ALPNs** in `iroh_listener.rs`
+  (`.alpns(vec![ZEDRA_ALPN, ZEDRA_ALPN_V2])`).
+- **`read_zedra_message(conn)` is the only version seam** — it reads
+  `conn.alpn()`, decodes with the matching schema, and for a legacy ALPN calls
+  `into_live()` to lift the request into `ZedraMessage`. Auth and dispatch then
+  run one version-agnostic path; no version flag is threaded through.
+- **`proto_v2.rs`** freezes `ZedraProtoV2`/`ZEDRA_ALPN_V2` and only the diverged
+  types; byte-identical messages reuse `crate::proto` (pinned by roundtrip
+  tests). `into_live` rebuilds byte-identical variants via
+  `(m.inner, m.tx, m.rx).into()` and wraps diverged senders with
+  `with_map`/`with_filter_map` (running `From<live> for frozen`); diverged
+  requests lift `From<frozen> for live`.
+
+Behavioral degradation for `v2` clients (all non-fatal): agent `live`/`provider`/
+`counters`/`flags` fields removed at `v3` come back empty; `Pi`/`Hermes` agents
+and the `v3`-only `HostEvent` variants are filtered out (an unknown discriminant
+would be undecodable and kill the stream, §2.4).
+
+Exit: drop a frozen module + its `alpns(...)` entry once that version's traffic
+(tracked via the telemetry ALPN field) hits zero; record under §11. This is a
+stopgap, not a substitute for the forward-compatible encodings in issue #140.
+
+#### Adding the next version (recipe)
+
+1. Before bumping `ZEDRA_ALPN`, snapshot the outgoing schema from the pre-bump
+   commit into `proto_v{N}.rs`; freeze its enum, `ZEDRA_ALPN_V{N}`, and the
+   diverged types only.
+2. Diff old vs new by **transitive closure**, not struct decls — an unchanged
+   decl can hide a diverged nested type (this caused two v2 regressions:
+   `TermCreateV2` and the agent-session subtree).
+3. Implement `into_live`, add a `read_zedra_message` arm + an `alpns(...)` entry.
+4. Filter values unrepresentable on old clients (new enum variants/kinds) out of
+   frozen responses rather than emitting an undecodable discriminant.
+
+Frozen types `#[derive(Default)]` so synthesized defaults stay one line. Notable
+irpc facts: `Connection::alpn()` gives the negotiated value post-handshake;
+`Sender::with_map`/`with_filter_map` is the re-encode seam (`Receiver` has none,
+so `TermAttach`'s `rx` reuses the byte-identical `proto::TermInput`);
+`WithChannels` fields are public, so `into_live` re-tags a message across services
+without touching irpc internals.
+
 ---
 
 ## 8) Error Handling Conventions
@@ -540,6 +594,16 @@ Any protocol-layer change must include all applicable steps:
 ---
 
 ## 11) Protocol Changelog
+
+### 2026-06-20
+
+- Implemented §7.4 Multi-ALPN Backward Compatibility: the host serves both
+  `zedra/rpc/3` and `zedra/rpc/2` so shipped apps survive an App Store review
+  delay. New `crates/zedra-rpc/src/proto_v2.rs` freezes the old schema and lifts
+  legacy requests into the live `ZedraMessage` via `into_live`; one auth+dispatch
+  path serves both. `v2` clients get empty agent `live` fields and have
+  `Pi`/`Hermes` + the `v3`-only `HostEvent` variants filtered out. Response-only
+  delta; stopgap pending issue #140.
 
 ### 2026-06-11
 


### PR DESCRIPTION
## Summary

After the `zedra/rpc/2` → `zedra/rpc/3` ALPN bump, shipped apps on the old ALPN can no longer connect (the ALPN gate is exact-match, §2.4). This keeps the host serving `zedra/rpc/2` clients so they survive at least one App Store review delay while the `v3` build clears.

- Host advertises both ALPNs (`iroh_listener.rs`).
- New frozen `crates/zedra-rpc/src/proto_v2.rs` defines the old wire schema (`ZedraProtoV2`, `ZEDRA_ALPN_V2`) and only the types that diverged at `v3`; byte-identical messages reuse `crate::proto`.
- `ZedraMessageV2::into_live` lifts a decoded legacy request into the live `ZedraMessage`, wrapping diverged response channels with `Sender::with_map`/`with_filter_map` to re-encode to `zedra/rpc/2` bytes. Auth + dispatch run one version-agnostic path; `read_zedra_message` is the single version seam.
- `v2` clients get empty agent `live`/`provider`/`counters` fields, and `Pi`/`Hermes` agents + the two `v3`-only `HostEvent` variants are filtered out (an unknown discriminant would be undecodable).

## Notes

- This recurs on every ALPN bump (v4 keeps v3, …). `PROTOCOL_SPECS.md` §7.4 documents the mechanism + a per-release recipe; `MANUAL_TEST.md` adds a legacy-client verification.
