### PR TITLE
fix(android): use MaterialAlertDialogBuilder for text input dialog

### DIFF
--- a/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
@@ -455,7 +455,7 @@ object NativePresentations {
                 ViewGroup.LayoutParams.WRAP_CONTENT,
             ))
         }
-        AlertDialog.Builder(requireActivity())
+        MaterialAlertDialogBuilder(requireActivity())
             .apply {
                 if (!title.isNullOrBlank()) setTitle(title)
                 setView(container)


### PR DESCRIPTION
## Summary

`showTextInput` (workspace rename prompt) used the appcompat `AlertDialog.Builder` under the MaterialComponents app theme, which inflated `mtrl_alert_dialog` without the required Material attributes and crashed with `You must supply a layout_width attribute`. Switched to `MaterialAlertDialogBuilder`, matching the other dialogs in the file.

Closes #159

## Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the text input dialog to use the app’s Material design dialog styling for a more consistent look and feel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->