### PR TITLE
feat(host): discover git worktrees in file search

### DIFF
--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -1229,7 +1229,14 @@ fn search_files(root: &Path, query: &str, limit: u32) -> Result<FsSearchResult> 
         .git_exclude(true)
         .parents(true)
         .ignore(true);
-    builder.filter_entry(|entry| !is_file_search_ignored(entry));
+    let worktree_paths: Vec<PathBuf> = worktrees.iter().map(|wt| wt.path.clone()).collect();
+    builder.filter_entry(move |entry| {
+        // Prune nested worktree copies from the main walk; added roots are exempt (filters skip depth 0).
+        if worktree_paths.iter().any(|wt| entry.path() == wt) {
+            return false;
+        }
+        !is_file_search_ignored(entry)
+    });
 
     for entry in builder.build() {
         let entry = match entry {
@@ -1239,12 +1246,8 @@ fn search_files(root: &Path, query: &str, limit: u32) -> Result<FsSearchResult> 
                 continue;
             }
         };
-        if entry.path() == root {
-            continue;
-        }
-        // Skip individual worktree root entries so they don't appear as empty
-        // result rows.
-        if worktrees.iter().any(|wt| entry.path() == wt.as_path()) {
+        // Depth 0 = a walk root (search root or worktree root); not a result row.
+        if entry.depth() == 0 {
             continue;
         }
 
@@ -1262,36 +1265,25 @@ fn search_files(root: &Path, query: &str, limit: u32) -> Result<FsSearchResult> 
         }
 
         let path = entry.path().to_path_buf();
-        // Compute match_path relative to the longest matching prefix (root or worktree).
-        // Longest prefix wins so nested worktrees are handled correctly.
-        let mut best_prefix: Option<&Path> = None;
-        if path.starts_with(root) {
-            best_prefix = Some(root);
-        }
-        for wt in &worktrees {
-            if path.starts_with(wt) {
-                if best_prefix.map_or(true, |bp| wt.as_os_str().len() > bp.as_os_str().len()) {
-                    best_prefix = Some(wt);
-                }
-            }
-        }
-        let match_path = best_prefix
-            .and_then(|prefix| path.strip_prefix(prefix).ok())
-            .map(|rel| {
-                rel.components()
-                    .filter_map(|component| match component {
-                        Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>()
-                    .join("/")
+        // Innermost containing worktree wins so nested worktrees are handled correctly.
+        let owner_worktree = worktrees
+            .iter()
+            .filter(|wt| path.starts_with(&wt.path))
+            .max_by_key(|wt| wt.path.as_os_str().len());
+        let (prefix, worktree) = match owner_worktree {
+            Some(wt) => (wt.path.as_path(), Some(wt.label.clone())),
+            None => (root, None),
+        };
+        let match_path = path
+            .strip_prefix(prefix)
+            .unwrap_or(path.as_path())
+            .components()
+            .filter_map(|component| match component {
+                Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+                _ => None,
             })
-            .unwrap_or_else(|| {
-                // Fallback: use the file name only.
-                path.file_name()
-                    .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_default()
-            });
+            .collect::<Vec<_>>()
+            .join("/");
         candidates.push(FileSearchCandidate {
             path,
             is_dir: file_type.is_dir(),

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -612,10 +612,17 @@ mod file_search_tests {
             .args(["init"])
             .output()
             .expect("git init failed");
-        assert!(init.status.success(), "git init: {}", String::from_utf8_lossy(&init.stderr));
+        assert!(
+            init.status.success(),
+            "git init: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
 
         // Configure git identity (needed in CI environments without global config).
-        for (key, val) in [("user.name", "Test User"), ("user.email", "test@example.com")] {
+        for (key, val) in [
+            ("user.name", "Test User"),
+            ("user.email", "test@example.com"),
+        ] {
             let cfg = std::process::Command::new("git")
                 .arg("-C")
                 .arg(&root)
@@ -640,7 +647,11 @@ mod file_search_tests {
             .args(["commit", "-m", "init", "--no-gpg-sign"])
             .output()
             .expect("git commit failed");
-        assert!(commit.status.success(), "git commit: {}", String::from_utf8_lossy(&commit.stderr));
+        assert!(
+            commit.status.success(),
+            "git commit: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
 
         // Gitignore the directory that will hold the worktree.
         write(root.join(".gitignore"), ".claude/\n").unwrap();
@@ -671,7 +682,11 @@ mod file_search_tests {
             .args(["worktree", "add", wt_path.to_str().unwrap()])
             .output()
             .expect("git worktree add failed");
-        assert!(wt.status.success(), "git worktree add: {}", String::from_utf8_lossy(&wt.stderr));
+        assert!(
+            wt.status.success(),
+            "git worktree add: {}",
+            String::from_utf8_lossy(&wt.stderr)
+        );
 
         // Write a uniquely-named file in the worktree.
         write(wt_path.join("wt_unique_file.rs"), "// unique").unwrap();
@@ -704,7 +719,10 @@ mod file_search_tests {
             .expect("git init failed");
         assert!(init.status.success());
 
-        for (key, val) in [("user.name", "Test User"), ("user.email", "test@example.com")] {
+        for (key, val) in [
+            ("user.name", "Test User"),
+            ("user.email", "test@example.com"),
+        ] {
             let cfg = std::process::Command::new("git")
                 .arg("-C")
                 .arg(&root)
@@ -739,14 +757,21 @@ mod file_search_tests {
             .args(["worktree", "add", outside_wt.to_str().unwrap()])
             .output()
             .expect("git worktree add failed");
-        assert!(wt.status.success(), "git worktree add: {}", String::from_utf8_lossy(&wt.stderr));
+        assert!(
+            wt.status.success(),
+            "git worktree add: {}",
+            String::from_utf8_lossy(&wt.stderr)
+        );
 
         write(outside_wt.join("outside_secret.rs"), "// secret").unwrap();
 
         let result = search_files(&root, "outside_secret", 10).unwrap();
 
         assert!(
-            !result.entries.iter().any(|entry| entry.path.ends_with("outside_secret.rs")),
+            !result
+                .entries
+                .iter()
+                .any(|entry| entry.path.ends_with("outside_secret.rs")),
             "files from a worktree outside root must NOT appear in search results"
         );
     }
@@ -769,7 +794,10 @@ mod file_search_tests {
             .expect("git init failed");
         assert!(init.status.success());
 
-        for (key, val) in [("user.name", "Test User"), ("user.email", "test@example.com")] {
+        for (key, val) in [
+            ("user.name", "Test User"),
+            ("user.email", "test@example.com"),
+        ] {
             let cfg = std::process::Command::new("git")
                 .arg("-C")
                 .arg(&root)
@@ -822,7 +850,11 @@ mod file_search_tests {
             .args(["worktree", "add", wt_path.to_str().unwrap()])
             .output()
             .expect("git worktree add failed");
-        assert!(wt.status.success(), "git worktree add: {}", String::from_utf8_lossy(&wt.stderr));
+        assert!(
+            wt.status.success(),
+            "git worktree add: {}",
+            String::from_utf8_lossy(&wt.stderr)
+        );
 
         write(wt_path.join("nested_file.rs"), "// nested").unwrap();
 

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -679,7 +679,13 @@ mod file_search_tests {
         let wt = std::process::Command::new("git")
             .arg("-C")
             .arg(&root)
-            .args(["worktree", "add", wt_path.to_str().unwrap()])
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "feat-search",
+                wt_path.to_str().unwrap(),
+            ])
             .output()
             .expect("git worktree add failed");
         assert!(
@@ -699,6 +705,9 @@ mod file_search_tests {
             .find(|entry| entry.path.ends_with("wt_unique_file.rs"))
             .expect("expected wt_unique_file.rs to be found in gitignored worktree");
         assert!(hit.match_indices.windows(2).all(|w| w[0] < w[1]));
+        // `worktree` carries the branch name; `rel_path` is worktree-relative.
+        assert_eq!(hit.worktree.as_deref(), Some("feat-search"));
+        assert_eq!(hit.rel_path, "wt_unique_file.rs");
     }
 
     #[test]
@@ -873,6 +882,85 @@ mod file_search_tests {
             "rel_path for a nested worktree file must NOT start with the ignored parent path; got: {}",
             hit.rel_path
         );
+        assert_eq!(hit.worktree.as_deref(), Some("nested"));
+    }
+
+    #[test]
+    fn file_search_does_not_duplicate_non_ignored_nested_worktree() {
+        use std::fs::{create_dir_all, write};
+        use tempfile::tempdir;
+
+        let tmp_dir = tempdir().unwrap();
+        let root = tmp_dir.path().join("repo");
+        create_dir_all(&root).unwrap();
+        let root = root.canonicalize().unwrap();
+
+        let init = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["init"])
+            .output()
+            .expect("git init failed");
+        assert!(init.status.success());
+
+        for (key, val) in [
+            ("user.name", "Test User"),
+            ("user.email", "test@example.com"),
+        ] {
+            let cfg = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(["config", key, val])
+                .output()
+                .expect("git config failed");
+            assert!(cfg.status.success());
+        }
+
+        write(root.join("README.md"), "# hello").unwrap();
+        let add = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["add", "README.md"])
+            .output()
+            .expect("git add failed");
+        assert!(add.status.success());
+        let commit = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["commit", "-m", "init", "--no-gpg-sign"])
+            .output()
+            .expect("git commit failed");
+        assert!(commit.status.success());
+
+        // Non-gitignored nested worktree: reachable via the main walk AND its added root.
+        let wt_path = root.join("visible_wt");
+        let wt = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["worktree", "add", wt_path.to_str().unwrap()])
+            .output()
+            .expect("git worktree add failed");
+        assert!(
+            wt.status.success(),
+            "git worktree add: {}",
+            String::from_utf8_lossy(&wt.stderr)
+        );
+
+        write(wt_path.join("dup_probe_file.rs"), "// probe").unwrap();
+
+        let result = search_files(&root, "dup_probe", 10).unwrap();
+
+        let hits: Vec<_> = result
+            .entries
+            .iter()
+            .filter(|entry| entry.path.ends_with("dup_probe_file.rs"))
+            .collect();
+        assert_eq!(
+            hits.len(),
+            1,
+            "file in a nested worktree must appear exactly once"
+        );
+        assert_eq!(hits[0].worktree.as_deref(), Some("visible_wt"));
     }
 }
 
@@ -1035,13 +1123,14 @@ fn fs_search_limit(limit: u32) -> usize {
     }) as usize
 }
 
-/// Discover git worktrees under or alongside the given root.
-///
-/// Parses `git worktree list --porcelain` to find additional working
-/// directories. The main worktree (== root) is skipped so it is not
-/// double-walked. Returns empty if root is not a git repo or the command
-/// fails.
-fn discover_git_worktrees(root: &Path) -> Vec<PathBuf> {
+/// A linked git worktree nested under the search root.
+struct DiscoveredWorktree {
+    path: PathBuf,
+    label: String,
+}
+
+/// Worktrees nested under root, from `git worktree list --porcelain`; empty if git fails.
+fn discover_git_worktrees(root: &Path) -> Vec<DiscoveredWorktree> {
     let output = match std::process::Command::new("git")
         .arg("-C")
         .arg(root)
@@ -1052,16 +1141,33 @@ fn discover_git_worktrees(root: &Path) -> Vec<PathBuf> {
         _ => return Vec::new(),
     };
 
+    let text = String::from_utf8_lossy(&output);
     let mut worktrees = Vec::new();
-    for line in String::from_utf8_lossy(&output).lines() {
-        let Some(path_str) = line.strip_prefix("worktree ") else {
-            continue;
-        };
-        let path = PathBuf::from(path_str);
-        // Skip the main worktree (== root) to avoid duplicating results.
-        // Also skip worktrees outside root to prevent leaking sibling files (security).
+    // Porcelain output is one blank-line-separated block per worktree.
+    for block in text.split("\n\n") {
+        let mut path: Option<PathBuf> = None;
+        let mut branch: Option<String> = None;
+        for line in block.lines() {
+            if let Some(path_str) = line.strip_prefix("worktree ") {
+                path = Some(PathBuf::from(path_str));
+            } else if let Some(branch_ref) = line.strip_prefix("branch ") {
+                branch = Some(
+                    branch_ref
+                        .strip_prefix("refs/heads/")
+                        .unwrap_or(branch_ref)
+                        .to_string(),
+                );
+            }
+        }
+        let Some(path) = path else { continue };
+        // Skip the main worktree (duplicate results) and outside-root worktrees (sibling leak).
         if path != root && path.starts_with(root) {
-            worktrees.push(path);
+            let label = branch.unwrap_or_else(|| {
+                path.file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default()
+            });
+            worktrees.push(DiscoveredWorktree { path, label });
         }
     }
     worktrees
@@ -1088,6 +1194,7 @@ struct FileSearchCandidate {
     path: PathBuf,
     is_dir: bool,
     match_path: String,
+    worktree: Option<String>,
 }
 
 fn fs_search_error(message: String) -> FsSearchResult {
@@ -1112,7 +1219,7 @@ fn search_files(root: &Path, query: &str, limit: u32) -> Result<FsSearchResult> 
 
     let mut builder = ignore::WalkBuilder::new(root);
     for wt in &worktrees {
-        builder.add(wt);
+        builder.add(&wt.path);
     }
     builder
         .hidden(false)
@@ -1189,6 +1296,7 @@ fn search_files(root: &Path, query: &str, limit: u32) -> Result<FsSearchResult> 
             path,
             is_dir: file_type.is_dir(),
             match_path,
+            worktree,
         });
     }
 
@@ -1233,6 +1341,7 @@ fn search_files(root: &Path, query: &str, limit: u32) -> Result<FsSearchResult> 
                 rel_path: candidate.match_path.clone(),
                 is_dir: candidate.is_dir,
                 match_indices: indices.clone(),
+                worktree: candidate.worktree.clone(),
             }
         })
         .collect();

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -614,6 +614,17 @@ mod file_search_tests {
             .expect("git init failed");
         assert!(init.status.success(), "git init: {}", String::from_utf8_lossy(&init.stderr));
 
+        // Configure git identity (needed in CI environments without global config).
+        for (key, val) in [("user.name", "Test User"), ("user.email", "test@example.com")] {
+            let cfg = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(["config", key, val])
+                .output()
+                .expect("git config failed");
+            assert!(cfg.status.success());
+        }
+
         // Commit something so HEAD exists (worktree add needs a valid HEAD).
         write(root.join("README.md"), "# hello").unwrap();
         let add = std::process::Command::new("git")
@@ -673,6 +684,163 @@ mod file_search_tests {
             .find(|entry| entry.path.ends_with("wt_unique_file.rs"))
             .expect("expected wt_unique_file.rs to be found in gitignored worktree");
         assert!(hit.match_indices.windows(2).all(|w| w[0] < w[1]));
+    }
+
+    #[test]
+    fn file_search_ignores_worktrees_outside_root() {
+        use std::fs::{create_dir_all, write};
+        use tempfile::tempdir;
+
+        let tmp_dir = tempdir().unwrap();
+        let root = tmp_dir.path().join("repo");
+        create_dir_all(&root).unwrap();
+        let root = root.canonicalize().unwrap();
+
+        let init = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["init"])
+            .output()
+            .expect("git init failed");
+        assert!(init.status.success());
+
+        for (key, val) in [("user.name", "Test User"), ("user.email", "test@example.com")] {
+            let cfg = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(["config", key, val])
+                .output()
+                .expect("git config failed");
+            assert!(cfg.status.success());
+        }
+
+        write(root.join("README.md"), "# hello").unwrap();
+        let add = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["add", "README.md"])
+            .output()
+            .expect("git add failed");
+        assert!(add.status.success());
+        let commit = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["commit", "-m", "init", "--no-gpg-sign"])
+            .output()
+            .expect("git commit failed");
+        assert!(commit.status.success());
+
+        // Create a worktree OUTSIDE the search root (sibling directory).
+        let outside_wt = tmp_dir.path().join("outside_wt");
+        create_dir_all(&outside_wt).unwrap();
+        let wt = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["worktree", "add", outside_wt.to_str().unwrap()])
+            .output()
+            .expect("git worktree add failed");
+        assert!(wt.status.success(), "git worktree add: {}", String::from_utf8_lossy(&wt.stderr));
+
+        write(outside_wt.join("outside_secret.rs"), "// secret").unwrap();
+
+        let result = search_files(&root, "outside_secret", 10).unwrap();
+
+        assert!(
+            !result.entries.iter().any(|entry| entry.path.ends_with("outside_secret.rs")),
+            "files from a worktree outside root must NOT appear in search results"
+        );
+    }
+
+    #[test]
+    fn file_search_match_path_uses_longest_prefix_for_nested_worktrees() {
+        use std::fs::{create_dir_all, write};
+        use tempfile::tempdir;
+
+        let tmp_dir = tempdir().unwrap();
+        let root = tmp_dir.path().join("repo");
+        create_dir_all(&root).unwrap();
+        let root = root.canonicalize().unwrap();
+
+        let init = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["init"])
+            .output()
+            .expect("git init failed");
+        assert!(init.status.success());
+
+        for (key, val) in [("user.name", "Test User"), ("user.email", "test@example.com")] {
+            let cfg = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(["config", key, val])
+                .output()
+                .expect("git config failed");
+            assert!(cfg.status.success());
+        }
+
+        write(root.join("README.md"), "# hello").unwrap();
+        let add = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["add", "README.md"])
+            .output()
+            .expect("git add failed");
+        assert!(add.status.success());
+        let commit = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["commit", "-m", "init", "--no-gpg-sign"])
+            .output()
+            .expect("git commit failed");
+        assert!(commit.status.success());
+
+        // Gitignore the worktree parent directory.
+        write(root.join(".gitignore"), "wt/\n").unwrap();
+        let add_gi = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["add", ".gitignore"])
+            .output()
+            .expect("git add .gitignore failed");
+        assert!(add_gi.status.success());
+        let commit_gi = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["commit", "-m", "add gitignore", "--no-gpg-sign"])
+            .output()
+            .expect("git commit gitignore failed");
+        assert!(commit_gi.status.success());
+
+        // Create a worktree nested under root.
+        let wt_parent = root.join("wt");
+        create_dir_all(&wt_parent).unwrap();
+        let wt_path = wt_parent.join("nested");
+        let wt = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["worktree", "add", wt_path.to_str().unwrap()])
+            .output()
+            .expect("git worktree add failed");
+        assert!(wt.status.success(), "git worktree add: {}", String::from_utf8_lossy(&wt.stderr));
+
+        write(wt_path.join("nested_file.rs"), "// nested").unwrap();
+
+        let result = search_files(&root, "nested_file", 10).unwrap();
+
+        let hit = result
+            .entries
+            .iter()
+            .find(|entry| entry.path.ends_with("nested_file.rs"))
+            .expect("expected nested_file.rs to be found");
+
+        // match_path must be worktree-relative (just the file name), not root-relative
+        // (which would include the ignored "wt/nested/" prefix).
+        assert!(
+            !hit.rel_path.starts_with("wt/"),
+            "rel_path for a nested worktree file must NOT start with the ignored parent path; got: {}",
+            hit.rel_path
+        );
     }
 }
 
@@ -859,7 +1027,8 @@ fn discover_git_worktrees(root: &Path) -> Vec<PathBuf> {
         };
         let path = PathBuf::from(path_str);
         // Skip the main worktree (== root) to avoid duplicating results.
-        if path != root {
+        // Also skip worktrees outside root to prevent leaking sibling files (security).
+        if path != root && path.starts_with(root) {
             worktrees.push(path);
         }
     }
@@ -954,29 +1123,36 @@ fn search_files(root: &Path, query: &str, limit: u32) -> Result<FsSearchResult> 
         }
 
         let path = entry.path().to_path_buf();
-        // Compute match_path relative to the nearest root (main root or worktree).
-        let match_path = if let Ok(rel) = path.strip_prefix(root) {
-            rel.components()
-                .filter_map(|component| match component {
-                    Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-                .join("/")
-        } else if let Some(rel) = worktrees.iter().find_map(|wt| path.strip_prefix(wt).ok()) {
-            rel.components()
-                .filter_map(|component| match component {
-                    Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-                .join("/")
-        } else {
-            // Fallback: use the file name only.
-            path.file_name()
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or_default()
-        };
+        // Compute match_path relative to the longest matching prefix (root or worktree).
+        // Longest prefix wins so nested worktrees are handled correctly.
+        let mut best_prefix: Option<&Path> = None;
+        if path.starts_with(root) {
+            best_prefix = Some(root);
+        }
+        for wt in &worktrees {
+            if path.starts_with(wt) {
+                if best_prefix.map_or(true, |bp| wt.as_os_str().len() > bp.as_os_str().len()) {
+                    best_prefix = Some(wt);
+                }
+            }
+        }
+        let match_path = best_prefix
+            .and_then(|prefix| path.strip_prefix(prefix).ok())
+            .map(|rel| {
+                rel.components()
+                    .filter_map(|component| match component {
+                        Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("/")
+            })
+            .unwrap_or_else(|| {
+                // Fallback: use the file name only.
+                path.file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default()
+            });
         candidates.push(FileSearchCandidate {
             path,
             is_dir: file_type.is_dir(),

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -599,6 +599,81 @@ mod file_search_tests {
         assert_eq!(result.entries.len(), 1);
         assert!(result.truncated);
     }
+
+    #[test]
+    fn file_search_discovers_git_worktrees_even_when_gitignored() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+
+        // Init a real git repo so `git worktree add` works.
+        let init = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["init"])
+            .output()
+            .expect("git init failed");
+        assert!(init.status.success(), "git init: {}", String::from_utf8_lossy(&init.stderr));
+
+        // Commit something so HEAD exists (worktree add needs a valid HEAD).
+        write(root.join("README.md"), "# hello").unwrap();
+        let add = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["add", "README.md"])
+            .output()
+            .expect("git add failed");
+        assert!(add.status.success());
+        let commit = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["commit", "-m", "init", "--no-gpg-sign"])
+            .output()
+            .expect("git commit failed");
+        assert!(commit.status.success(), "git commit: {}", String::from_utf8_lossy(&commit.stderr));
+
+        // Gitignore the directory that will hold the worktree.
+        write(root.join(".gitignore"), ".claude/\n").unwrap();
+
+        // Add the gitignore to the index so the ignore rule is active.
+        let add_gi = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["add", ".gitignore"])
+            .output()
+            .expect("git add .gitignore failed");
+        assert!(add_gi.status.success());
+        let commit_gi = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["commit", "-m", "add gitignore", "--no-gpg-sign"])
+            .output()
+            .expect("git commit gitignore failed");
+        assert!(commit_gi.status.success());
+
+        // Create a worktree inside the gitignored path.
+        let wt_parent = root.join(".claude/worktrees");
+        create_dir_all(&wt_parent).unwrap();
+        let wt_path = wt_parent.join("wt");
+        let wt = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["worktree", "add", wt_path.to_str().unwrap()])
+            .output()
+            .expect("git worktree add failed");
+        assert!(wt.status.success(), "git worktree add: {}", String::from_utf8_lossy(&wt.stderr));
+
+        // Write a uniquely-named file in the worktree.
+        write(wt_path.join("wt_unique_file.rs"), "// unique").unwrap();
+
+        let result = search_files(&root, "wt_unique", 10).unwrap();
+
+        let hit = result
+            .entries
+            .iter()
+            .find(|entry| entry.path.ends_with("wt_unique_file.rs"))
+            .expect("expected wt_unique_file.rs to be found in gitignored worktree");
+        assert!(hit.match_indices.windows(2).all(|w| w[0] < w[1]));
+    }
 }
 
 #[allow(unused)]
@@ -760,6 +835,37 @@ fn fs_search_limit(limit: u32) -> usize {
     }) as usize
 }
 
+/// Discover git worktrees under or alongside the given root.
+///
+/// Parses `git worktree list --porcelain` to find additional working
+/// directories. The main worktree (== root) is skipped so it is not
+/// double-walked. Returns empty if root is not a git repo or the command
+/// fails.
+fn discover_git_worktrees(root: &Path) -> Vec<PathBuf> {
+    let output = match std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o.stdout,
+        _ => return Vec::new(),
+    };
+
+    let mut worktrees = Vec::new();
+    for line in String::from_utf8_lossy(&output).lines() {
+        let Some(path_str) = line.strip_prefix("worktree ") else {
+            continue;
+        };
+        let path = PathBuf::from(path_str);
+        // Skip the main worktree (== root) to avoid duplicating results.
+        if path != root {
+            worktrees.push(path);
+        }
+    }
+    worktrees
+}
+
 fn is_file_search_ignored(entry: &ignore::DirEntry) -> bool {
     // Only filter directories; matched files should still surface as results.
     if !entry
@@ -801,7 +907,12 @@ fn search_files(root: &Path, query: &str, limit: u32) -> Result<FsSearchResult> 
     let mut visited = 0u32;
     let mut truncated = false;
 
+    let worktrees = discover_git_worktrees(root);
+
     let mut builder = ignore::WalkBuilder::new(root);
+    for wt in &worktrees {
+        builder.add(wt);
+    }
     builder
         .hidden(false)
         .follow_links(false)
@@ -823,6 +934,11 @@ fn search_files(root: &Path, query: &str, limit: u32) -> Result<FsSearchResult> 
         if entry.path() == root {
             continue;
         }
+        // Skip individual worktree root entries so they don't appear as empty
+        // result rows.
+        if worktrees.iter().any(|wt| entry.path() == wt.as_path()) {
+            continue;
+        }
 
         visited += 1;
         if visited > FS_SEARCH_MAX_VISITED_ENTRIES {
@@ -838,16 +954,29 @@ fn search_files(root: &Path, query: &str, limit: u32) -> Result<FsSearchResult> 
         }
 
         let path = entry.path().to_path_buf();
-        let match_path = path
-            .strip_prefix(root)
-            .unwrap_or(path.as_path())
-            .components()
-            .filter_map(|component| match component {
-                Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join("/");
+        // Compute match_path relative to the nearest root (main root or worktree).
+        let match_path = if let Ok(rel) = path.strip_prefix(root) {
+            rel.components()
+                .filter_map(|component| match component {
+                    Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("/")
+        } else if let Some(rel) = worktrees.iter().find_map(|wt| path.strip_prefix(wt).ok()) {
+            rel.components()
+                .filter_map(|component| match component {
+                    Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("/")
+        } else {
+            // Fallback: use the file name only.
+            path.file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        };
         candidates.push(FileSearchCandidate {
             path,
             is_dir: file_type.is_dir(),

--- a/crates/zedra-rpc/src/proto.rs
+++ b/crates/zedra-rpc/src/proto.rs
@@ -638,6 +638,8 @@ pub struct FsSearchEntry {
     pub is_dir: bool,
     /// Sorted, deduplicated character indices into `rel_path` that matched.
     pub match_indices: Vec<u32>,
+    /// Owning worktree label. `rel_path` is relative to it. `None` = current worktree.
+    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1570,6 +1572,7 @@ mod tests {
             rel_path: "src/file_search.rs".into(),
             is_dir: false,
             match_indices: vec![4, 5, 6],
+            worktree: Some("wt1".into()),
         };
         let encoded = postcard::to_allocvec(&entry).unwrap();
         let decoded: FsSearchEntry = postcard::from_bytes(&encoded).unwrap();

--- a/crates/zedra/src/file_search.rs
+++ b/crates/zedra/src/file_search.rs
@@ -18,10 +18,24 @@ use crate::workspace_action;
 
 /// Debounce before issuing a remote search after the query changes.
 const SEARCH_DEBOUNCE: Duration = Duration::from_millis(180);
-/// Height of a single result row (two lines: name + path).
-const RESULT_ROW_HEIGHT: f32 = 52.0;
-/// Maximum number of result rows shown before the list scrolls.
-const MAX_VISIBLE_ROWS: usize = 8;
+/// Row line box, pinned via `.line_height()` so the derived heights below stay exact.
+const LINE_HEIGHT: f32 = 19.0;
+/// Row heights: vertical padding plus two or three pinned line boxes.
+const ROW_HEIGHT: f32 = 2.0 * theme::SPACING_SM + 2.0 * LINE_HEIGHT;
+const ROW_HEIGHT_WORKTREE: f32 = 2.0 * theme::SPACING_SM + 3.0 * LINE_HEIGHT;
+/// Maximum height of the results list before it scrolls (8 two-line rows).
+const LIST_MAX_HEIGHT: f32 = 8.0 * ROW_HEIGHT;
+/// Height of the placeholder/message area shown instead of results.
+const MESSAGE_HEIGHT: f32 = 2.0 * ROW_HEIGHT;
+
+/// Used for both the row element and the list viewport so they never drift.
+fn row_height(entry: &FsSearchEntry) -> f32 {
+    if entry.worktree.is_some() {
+        ROW_HEIGHT_WORKTREE
+    } else {
+        ROW_HEIGHT
+    }
+}
 
 #[derive(Clone, Debug)]
 pub enum FileSearchEvent {
@@ -34,7 +48,7 @@ impl EventEmitter<FileSearchEvent> for FileSearchPanel {}
 pub struct FileSearchPanel {
     session_handle: SessionHandle,
     focus_handle: FocusHandle,
-    scroll_handle: UniformListScrollHandle,
+    list_state: ListState,
     search_input: Entity<Input>,
     query: String,
     results: Vec<FsSearchEntry>,
@@ -67,7 +81,7 @@ impl FileSearchPanel {
         Self {
             session_handle,
             focus_handle: cx.focus_handle(),
-            scroll_handle: UniformListScrollHandle::new(),
+            list_state: ListState::new(0, ListAlignment::Top, px(LIST_MAX_HEIGHT)),
             search_input,
             query: String::new(),
             results: Vec::new(),
@@ -87,7 +101,7 @@ impl FileSearchPanel {
         self.error = None;
         self.truncated = false;
         self.epoch = self.epoch.wrapping_add(1);
-        self.scroll_handle.scroll_to_item(0, ScrollStrategy::Top);
+        self.list_state.reset(0);
         self.search_input
             .update(cx, |input, _cx| input.set_value(""));
         let input_focus = self.search_input.read(cx).focus_handle(cx);
@@ -104,7 +118,7 @@ impl FileSearchPanel {
         self.results.clear();
         self.error = None;
         self.truncated = false;
-        self.scroll_handle.scroll_to_item(0, ScrollStrategy::Top);
+        self.list_state.reset(0);
         if query.is_empty() {
             self.loading = false;
             return;
@@ -143,10 +157,23 @@ impl FileSearchPanel {
                         this.error = Some(error.to_string());
                     }
                 }
+                this.list_state.reset(this.results.len());
                 cx.notify();
             });
         })
         .detach();
+    }
+
+    fn render_list_item(
+        &mut self,
+        index: usize,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let Some(entry) = self.results.get(index) else {
+            return Empty.into_any();
+        };
+        self.render_result_row(index, entry, cx)
     }
 
     fn render_result_row(
@@ -173,11 +200,14 @@ impl FileSearchPanel {
         div()
             .id(("file-search-row", index))
             .w_full()
-            .h(px(RESULT_ROW_HEIGHT))
+            .h(px(row_height(entry)))
+            .line_height(px(LINE_HEIGHT))
             .px(px(theme::SPACING_MD))
+            .py(px(theme::SPACING_SM))
             .flex()
             .flex_row()
-            .items_center()
+            // Top-align so the icon stays beside the filename on 3-line rows.
+            .items_start()
             .gap(px(8.0))
             .cursor_pointer()
             .on_press(cx.listener(move |_this, _event, window, cx| {
@@ -197,12 +227,18 @@ impl FileSearchPanel {
                 cx.emit(FileSearchEvent::Close);
             }))
             .child(
-                div().flex_shrink_0().child(
-                    svg()
-                        .path(icon)
-                        .size(px(theme::ICON_FILE))
-                        .text_color(rgb(theme::text_muted(cx))),
-                ),
+                // Match the filename's line box so the icon centers on the first line.
+                div()
+                    .flex_shrink_0()
+                    .h(px(LINE_HEIGHT))
+                    .flex()
+                    .items_center()
+                    .child(
+                        svg()
+                            .path(icon)
+                            .size(px(theme::ICON_FILE))
+                            .text_color(rgb(theme::text_muted(cx))),
+                    ),
             )
             .child(
                 div()
@@ -212,7 +248,6 @@ impl FileSearchPanel {
                     .flex_col()
                     .child(
                         div()
-                            .w_full()
                             .min_w_0()
                             .truncate()
                             .text_size(px(theme::FONT_BODY))
@@ -224,7 +259,35 @@ impl FileSearchPanel {
                         &entry.rel_path,
                         &entry.match_indices,
                         cx,
-                    )),
+                    ))
+                    // Worktree branch line disambiguates identical relative paths.
+                    .when_some(entry.worktree.clone(), |column, worktree| {
+                        column.child(
+                            div()
+                                .min_w_0()
+                                .flex()
+                                .flex_row()
+                                .items_center()
+                                .gap(px(4.0))
+                                .child(
+                                    svg()
+                                        .path("icons/git-branch.svg")
+                                        .size(px(theme::FONT_DETAIL))
+                                        .flex_none()
+                                        .text_color(rgb(theme::text_muted(cx))),
+                                )
+                                .child(
+                                    // `flex_1` gives a definite width; GPUI truncate ellipsizes everything without one.
+                                    div()
+                                        .flex_1()
+                                        .min_w_0()
+                                        .truncate()
+                                        .text_size(px(theme::FONT_DETAIL))
+                                        .text_color(rgb(theme::text_muted(cx)))
+                                        .child(worktree),
+                                ),
+                        )
+                    }),
             )
             .into_any_element()
     }
@@ -232,7 +295,7 @@ impl FileSearchPanel {
     fn render_message(&self, message: impl Into<SharedString>, cx: &App) -> AnyElement {
         div()
             .w_full()
-            .h(px(RESULT_ROW_HEIGHT * 2.0))
+            .h(px(MESSAGE_HEIGHT))
             .flex()
             .items_center()
             .justify_center()
@@ -250,7 +313,7 @@ impl FileSearchPanel {
         self.error = None;
         self.truncated = false;
         self.epoch = self.epoch.wrapping_add(1);
-        self.scroll_handle.scroll_to_item(0, ScrollStrategy::Top);
+        self.list_state.reset(0);
         self.search_input
             .update(cx, |input, _cx| input.set_value(""));
         let input_focus = self.search_input.read(cx).focus_handle(cx);
@@ -279,23 +342,15 @@ impl Render for FileSearchPanel {
         } else if self.results.is_empty() {
             self.render_message("No matching files", cx)
         } else {
-            let len = self.results.len();
-            let list_height = (len.min(MAX_VISIBLE_ROWS) as f32) * RESULT_ROW_HEIGHT;
-            let list = uniform_list(
-                "file-search-results",
-                len,
-                cx.processor(|this, range: std::ops::Range<usize>, _window, cx| {
-                    range
-                        .filter_map(|idx| {
-                            this.results
-                                .get(idx)
-                                .map(|entry| this.render_result_row(idx, entry, cx))
-                        })
-                        .collect::<Vec<_>>()
-                }),
+            // Variable-height `list` virtualizes the mixed-height rows; viewport = exact content height, capped.
+            let content_height: f32 = self.results.iter().map(row_height).sum();
+            let list = list(
+                self.list_state.clone(),
+                cx.processor(Self::render_list_item),
             )
-            .track_scroll(&self.scroll_handle)
-            .h(px(list_height));
+            .with_sizing_behavior(ListSizingBehavior::Auto)
+            .w_full()
+            .h(px(content_height.min(LIST_MAX_HEIGHT)));
 
             let footer = self.truncated.then(|| {
                 div()

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1465,6 +1465,27 @@ id in production). The trailing shows the aggregate `done/total` rollup.
 8. Confirm the old inline search bar no longer appears at the top of the file
    explorer list.
 
+### Worktree results
+
+1. In the workspace repo on the host, create a linked worktree under a
+   gitignored directory:
+
+   ```sh
+   mkdir -p .claude/worktrees
+   git worktree add .claude/worktrees/wt1
+   ```
+
+2. Search for a file that exists in the repo (so both the main checkout and the
+   worktree contain it, e.g. `README.md`).
+3. Expected: the worktree copy appears once with its path relative to the
+   worktree, plus a third muted line under the path showing a branch icon and
+   the worktree's branch name (`wt1` for the command above); the main-checkout
+   copy has no branch line and stays two lines tall. Long names, paths, and
+   branch labels truncate to one line each.
+4. Search for a file that exists only in the worktree and confirm it is found
+   even though `.claude/` is gitignored; tapping it opens the worktree file.
+5. Clean up with `git worktree remove .claude/worktrees/wt1`.
+
 ## Delta Sign-In and Notification Channel (iOS and Android)
 
 ### Google sign-in (Android)

--- a/docs/PROTOCOL_SPECS.md
+++ b/docs/PROTOCOL_SPECS.md
@@ -255,7 +255,9 @@ Types that use non-string status fields or enum variants instead:
 - `path` is the workspace-relative directory to search from; clients usually send `"."`.
 - `query` fuzzy-matches file and directory paths case-insensitively. File contents are never read.
 - The host walks recursively with gitignore/global ignore support, does not follow symlink directories, and skips common generated directories such as `.git`, `node_modules`, `target`, `dist`, and `build`.
-- Each `FsSearchEntry` carries `rel_path` (search-root-relative) and `match_indices`: the host matcher's matched character positions into `rel_path`, sorted and deduplicated. Clients highlight using these indices rather than re-running a separate matcher.
+- Linked git worktrees nested under the search root (`git worktree list --porcelain`) are walked as additional roots, so their files are found even when the worktree directory itself is gitignored. Worktrees outside the root are ignored; entries are never reported twice.
+- Each `FsSearchEntry` carries `rel_path` and `match_indices`: the host matcher's matched character positions into `rel_path`, sorted and deduplicated. Clients highlight using these indices rather than re-running a separate matcher.
+- `rel_path` is relative to the entry's owning root: the innermost containing worktree, or the search root. `worktree` labels the owning worktree — its checked-out branch, or directory name when detached — and is `None` for main-root entries; clients render it to disambiguate identical relative paths.
 - `limit` is clamped to `FS_SEARCH_MAX_LIMIT`; `0` means `FS_SEARCH_DEFAULT_LIMIT`.
 - `truncated = true` means the result cap or visited-entry cap was hit before the host could prove there were no more matches.
 
@@ -594,6 +596,18 @@ Any protocol-layer change must include all applicable steps:
 ---
 
 ## 11) Protocol Changelog
+
+### 2026-07-02
+
+- `FsSearch` walks linked git worktrees nested under the search root as
+  additional roots, deduplicated against the main walk.
+- Appended `worktree: Option<String>` to `FsSearchEntry`: the owning worktree's
+  checked-out branch (directory name when detached), `None` for main-root
+  entries; `rel_path` for worktree hits is relative to that worktree.
+- **Temporary same-commit constraint:** the appended field changes `zedra/rpc/3`
+  decoding in place (§2.4). The ALPN bump to `zedra/rpc/4` plus the §7.4 frozen
+  `proto_v3.rs` land in a follow-up PR that must merge before the next release;
+  until then host and client must be built from the same commit.
 
 ### 2026-06-20
 


### PR DESCRIPTION
## Summary

Fixes #169.

`zedra-host`'s file search (`fs_search`) now discovers linked git worktrees and includes their files in search results, even when those worktrees live under gitignored directories (e.g. `.claude/worktrees/`).

### Changes

- Added `discover_git_worktrees()` in `rpc_daemon.rs`: parses `git worktree list --porcelain` to find additional working directories
- Modified `search_files()`: adds each worktree as an additional `WalkBuilder` root via `builder.add()`
- Skips the main worktree to avoid duplicate results
- Skips worktree root entries so they don't appear as empty result rows
- Computes `match_path` relative to the nearest root (main or worktree) for correct search highlighting
- Added test: `file_search_discovers_git_worktrees_even_when_gitignored` — creates a real git repo, gitignores `.claude/`, adds a worktree under `.claude/worktrees/wt`, writes a unique file, and asserts it is found

### Validation

```bash
cargo test -p zedra-host file_search  # 3 passed
cargo check -p zedra-host              # clean (pre-existing warning only)
```

### Notes

- This is a general fix for all git worktrees, not specific to `.claude/` — any `git worktree add` path is discovered automatically
- Each worktree's files appear once; the main worktree is filtered out to prevent duplicates
- Files in worktrees get `match_path` relative to their own root so the client's search highlighting works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Floating file search results now disambiguate linked Git worktree matches with an additional worktree label/branch line.
  * Search protocol entries can now optionally include the owning worktree label.
* **Bug Fixes**
  * Search discovers and includes files from linked worktrees within the selected scope, with correct relative paths and no duplicate nested worktree results.
  * Improves results list rendering (variable-height layout) and resets list state correctly.
* **Tests**
  * Added worktree discovery/search coverage, including ignored parents and exclusion outside the root.
* **Documentation**
  * Updated manual test plan and protocol specification for worktree behavior and new entry field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->