### PR TITLE
feat(vfx): add draggable water droplet render effect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10112,6 +10112,7 @@ dependencies = [
  "jni",
  "log",
  "mermaid-rs-renderer",
+ "metal",
  "ndk",
  "ndk-context",
  "once_cell",

--- a/crates/zedra/Cargo.toml
+++ b/crates/zedra/Cargo.toml
@@ -76,6 +76,7 @@ ndk-context = "0.1"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 gpui_ios = { path = "../../vendor/zed/crates/gpui_ios", features = ["font-kit"] }
+metal = "0.33"
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -13,6 +13,7 @@ use crate::settings::{ThemeState, ThemeStateEvent};
 use crate::settings_view::{SettingsEvent, SettingsView};
 use crate::telemetry::view_telemetry::{self, ViewDescriptor};
 use crate::ui::{DrawerHost, DrawerSide};
+use crate::vfx::{self, overlay::DropletOverlay};
 use crate::workspace_action::ShowConnecting;
 use crate::workspaces::{Workspaces, WorkspacesEvent};
 
@@ -43,6 +44,7 @@ pub struct ZedraApp {
     settings_view: Entity<SettingsView>,
     workspaces: Entity<Workspaces>,
     quick_action_drawer: Entity<DrawerHost>,
+    droplet_overlay: Entity<DropletOverlay>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -68,7 +70,7 @@ impl ZedraApp {
 
         let settings_view =
             cx.new(|cx| SettingsView::new(theme_state.clone(), delta_state.clone(), cx));
-        let sub = cx.subscribe(&settings_view, Self::on_settings_event);
+        let sub = cx.subscribe_in(&settings_view, window, Self::on_settings_event);
         subscriptions.push(sub);
 
         let sub = cx.subscribe(&theme_state, Self::on_theme_changed);
@@ -97,6 +99,12 @@ impl ZedraApp {
             )
         });
 
+        // --- Water droplet effect ---
+        let droplet_enabled = crate::settings::read_droplet_enabled();
+        let droplet_overlay = cx.new(|cx| {
+            DropletOverlay::new(vfx::shared_droplet_state(), droplet_enabled, window, cx)
+        });
+
         let saved_count = workspaces.read(cx).states().len();
         zedra_telemetry::send(Event::AppOpen {
             saved_workspaces: saved_count,
@@ -112,6 +120,7 @@ impl ZedraApp {
             settings_view,
             workspaces,
             quick_action_drawer,
+            droplet_overlay,
             _subscriptions: subscriptions,
         };
         app.record_current_view(cx);
@@ -184,13 +193,20 @@ impl ZedraApp {
 
     fn on_settings_event(
         &mut self,
-        _: Entity<SettingsView>,
+        _: &Entity<SettingsView>,
         event: &SettingsEvent,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         match event {
             SettingsEvent::NavigateHome => {
                 self.set_screen(AppScreen::Home, cx);
+            }
+            SettingsEvent::DropletToggled(enabled) => {
+                let enabled = *enabled;
+                self.droplet_overlay.update(cx, |overlay, cx| {
+                    overlay.set_enabled(enabled, window, cx);
+                });
             }
         }
     }
@@ -451,6 +467,7 @@ impl Render for ZedraApp {
             .on_action(cx.listener(Self::handle_show_connecting))
             .font_family(fonts::MONO_FONT_FAMILY)
             .child(self.quick_action_drawer.clone())
+            .child(self.droplet_overlay.clone())
     }
 }
 

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -99,8 +99,8 @@ impl ZedraApp {
             )
         });
 
-        // --- Water droplet effect ---
-        let droplet_enabled = crate::settings::read_droplet_enabled();
+        // --- Water droplet effect (iOS-only; elsewhere the overlay would block touches invisibly) ---
+        let droplet_enabled = cfg!(target_os = "ios") && crate::settings::read_droplet_enabled();
         let droplet_overlay = cx.new(|cx| {
             DropletOverlay::new(vfx::shared_droplet_state(), droplet_enabled, window, cx)
         });

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -23,6 +23,7 @@ pub mod placeholder;
 pub mod settings;
 pub mod theme;
 pub mod ui;
+pub mod vfx;
 
 // Sceens
 pub mod home_view;

--- a/crates/zedra/src/settings.rs
+++ b/crates/zedra/src/settings.rs
@@ -17,6 +17,9 @@ struct AppSettings {
     /// Opt-out flag for anonymous telemetry. `None`/absent = enabled (default-on).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     telemetry_enabled: Option<bool>,
+    /// Water droplet effect. `None`/absent = enabled (default-on).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    droplet_enabled: Option<bool>,
 }
 
 pub enum ThemeStateEvent {
@@ -170,6 +173,25 @@ pub fn set_telemetry_enabled(enabled: bool) {
     settings.telemetry_enabled = Some(enabled);
     if let Err(err) = write_settings(&settings) {
         warn!(err = %err, "settings: failed to save telemetry preference");
+    }
+}
+
+/// Whether the water droplet effect is enabled. Default on.
+pub fn read_droplet_enabled() -> bool {
+    match read_settings() {
+        Ok(settings) => settings.droplet_enabled.unwrap_or(true),
+        Err(err) => {
+            info!(err = %err, "[debug:settings] using default droplet preference");
+            true
+        }
+    }
+}
+
+pub fn set_droplet_enabled(enabled: bool) {
+    let mut settings = read_settings().unwrap_or_default();
+    settings.droplet_enabled = Some(enabled);
+    if let Err(err) = write_settings(&settings) {
+        warn!(err = %err, "settings: failed to save droplet preference");
     }
 }
 

--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -655,16 +655,18 @@ impl Render for SettingsView {
                                     this.set_theme_preference(ThemePreference::Light, cx);
                                 }),
                             ))
-                            .child(droplet_toggle(
-                                cx,
-                                droplet_enabled,
-                                cx.listener(|this, _event, _window, cx| {
-                                    this.set_droplet_enabled(true, cx);
-                                }),
-                                cx.listener(|this, _event, _window, cx| {
-                                    this.set_droplet_enabled(false, cx);
-                                }),
-                            ))
+                            .when(cfg!(target_os = "ios"), |this| {
+                                this.child(droplet_toggle(
+                                    cx,
+                                    droplet_enabled,
+                                    cx.listener(|this, _event, _window, cx| {
+                                        this.set_droplet_enabled(true, cx);
+                                    }),
+                                    cx.listener(|this, _event, _window, cx| {
+                                        this.set_droplet_enabled(false, cx);
+                                    }),
+                                ))
+                            })
                             .child(section_header(cx, "Privacy"))
                             .child(telemetry_toggle(
                                 cx,
@@ -940,7 +942,7 @@ fn droplet_toggle(
         cx,
         "settings-droplet-toggle",
         "Water droplet",
-        "A playful droplet to flick around — it bends your screen like water",
+        "A playful droplet to flick around",
         theme::text_secondary(cx),
         control,
     )

--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -19,6 +19,7 @@ const PRIVACY_POLICY_URL: &str = "https://zedra.dev/privacy";
 #[derive(Clone, Debug)]
 pub enum SettingsEvent {
     NavigateHome,
+    DropletToggled(bool),
 }
 
 impl EventEmitter<SettingsEvent> for SettingsView {}
@@ -75,6 +76,7 @@ pub struct SettingsView {
     delta_message_target: DeltaMessageTarget,
     delta_busy: bool,
     telemetry_enabled: bool,
+    droplet_enabled: bool,
     _delta_observe: Subscription,
 }
 
@@ -99,6 +101,7 @@ impl SettingsView {
             delta_message_target: DeltaMessageTarget::Profile,
             delta_busy: false,
             telemetry_enabled: settings::read_telemetry_enabled(),
+            droplet_enabled: settings::read_droplet_enabled(),
             _delta_observe: observe,
         }
     }
@@ -416,6 +419,17 @@ impl SettingsView {
         cx.notify();
     }
 
+    fn set_droplet_enabled(&mut self, enabled: bool, cx: &mut Context<Self>) {
+        if self.droplet_enabled == enabled {
+            return;
+        }
+        platform_bridge::trigger_haptic(HapticFeedback::SelectionChanged);
+        self.droplet_enabled = enabled;
+        settings::set_droplet_enabled(enabled);
+        cx.emit(SettingsEvent::DropletToggled(enabled));
+        cx.notify();
+    }
+
     fn open_telemetry_docs(&self) {
         platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
         platform_bridge::bridge().open_url(TELEMETRY_DOCS_URL);
@@ -525,6 +539,7 @@ impl Render for SettingsView {
         };
         let preference = self.theme_state.read(cx).preference();
         let telemetry_enabled = self.telemetry_enabled;
+        let droplet_enabled = self.droplet_enabled;
 
         div()
             .id("settings-view")
@@ -638,6 +653,16 @@ impl Render for SettingsView {
                                 }),
                                 cx.listener(|this, _event, _window, cx| {
                                     this.set_theme_preference(ThemePreference::Light, cx);
+                                }),
+                            ))
+                            .child(droplet_toggle(
+                                cx,
+                                droplet_enabled,
+                                cx.listener(|this, _event, _window, cx| {
+                                    this.set_droplet_enabled(true, cx);
+                                }),
+                                cx.listener(|this, _event, _window, cx| {
+                                    this.set_droplet_enabled(false, cx);
                                 }),
                             ))
                             .child(section_header(cx, "Privacy"))
@@ -847,9 +872,8 @@ fn telemetry_toggle(
     on_enable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
     on_disable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
 ) -> impl IntoElement {
-    let compiled_out = cfg!(feature = "no-telemetry");
-    let control = if compiled_out {
-        div()
+    if cfg!(feature = "no-telemetry") {
+        let control = div()
             .flex_none()
             .rounded(px(8.0))
             .border_1()
@@ -869,41 +893,96 @@ fn telemetry_toggle(
                     .text_color(rgb(theme::text_muted(cx)))
                     .child("Off"),
             )
-            .into_any_element()
-    } else {
-        div()
-            .flex_none()
-            .rounded(px(8.0))
-            .border_1()
-            .border_color(rgb(theme::border_default(cx)))
-            .bg(rgb(theme::bg_surface(cx)))
-            .flex()
-            .flex_row()
-            .child(telemetry_toggle_segment(
-                cx,
-                "settings-telemetry-on",
-                "On",
-                enabled,
-                on_enable,
-            ))
-            .child(
-                div()
-                    .w(px(1.0))
-                    .h(px(22.0))
-                    .bg(rgb(theme::border_subtle(cx))),
-            )
-            .child(telemetry_toggle_segment(
-                cx,
-                "settings-telemetry-off",
-                "Off",
-                !enabled,
-                on_disable,
-            ))
-            .into_any_element()
-    };
+            .into_any_element();
+        return toggle_row(
+            cx,
+            "settings-telemetry-toggle",
+            "Telemetry metrics",
+            "Disabled by build flag",
+            theme::text_muted(cx),
+            control,
+        );
+    }
 
+    let control = segmented_toggle(
+        cx,
+        "settings-telemetry-on",
+        "settings-telemetry-off",
+        enabled,
+        on_enable,
+        on_disable,
+    );
+    toggle_row(
+        cx,
+        "settings-telemetry-toggle",
+        "Telemetry metrics",
+        "Send anonymous usage data",
+        theme::text_secondary(cx),
+        control,
+    )
+}
+
+fn droplet_toggle(
+    cx: &App,
+    enabled: bool,
+    on_enable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+    on_disable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    let control = segmented_toggle(
+        cx,
+        "settings-droplet-on",
+        "settings-droplet-off",
+        enabled,
+        on_enable,
+        on_disable,
+    );
+    toggle_row(
+        cx,
+        "settings-droplet-toggle",
+        "Water droplet",
+        "A playful droplet to flick around — it bends your screen like water",
+        theme::text_secondary(cx),
+        control,
+    )
+}
+
+fn segmented_toggle(
+    cx: &App,
+    on_id: &'static str,
+    off_id: &'static str,
+    enabled: bool,
+    on_enable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+    on_disable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+) -> AnyElement {
     div()
-        .id("settings-telemetry-toggle")
+        .flex_none()
+        .rounded(px(8.0))
+        .border_1()
+        .border_color(rgb(theme::border_default(cx)))
+        .bg(rgb(theme::bg_surface(cx)))
+        .flex()
+        .flex_row()
+        .child(toggle_segment(cx, on_id, "On", enabled, on_enable))
+        .child(
+            div()
+                .w(px(1.0))
+                .h(px(22.0))
+                .bg(rgb(theme::border_subtle(cx))),
+        )
+        .child(toggle_segment(cx, off_id, "Off", !enabled, on_disable))
+        .into_any_element()
+}
+
+fn toggle_row(
+    cx: &App,
+    id: &'static str,
+    title: &'static str,
+    description: &'static str,
+    title_color: u32,
+    control: AnyElement,
+) -> AnyElement {
+    div()
+        .id(id)
         .min_w_0()
         .min_h(px(32.0))
         .py(px(2.0))
@@ -921,32 +1000,25 @@ fn telemetry_toggle(
                 .overflow_hidden()
                 .child(
                     div()
-                        .text_color(rgb(if compiled_out {
-                            theme::text_muted(cx)
-                        } else {
-                            theme::text_secondary(cx)
-                        }))
+                        .text_color(rgb(title_color))
                         .text_size(px(theme::FONT_BODY))
                         .font_family(fonts::MONO_FONT_FAMILY)
                         .font_weight(FontWeight::MEDIUM)
-                        .child("Telemetry metrics"),
+                        .child(title),
                 )
                 .child(
                     div()
                         .text_color(rgb(theme::text_muted(cx)))
                         .text_size(px(theme::FONT_DETAIL))
                         .font_family(fonts::MONO_FONT_FAMILY)
-                        .child(if compiled_out {
-                            "Disabled by build flag"
-                        } else {
-                            "Send anonymous usage data"
-                        }),
+                        .child(description),
                 ),
         )
         .child(control)
+        .into_any_element()
 }
 
-fn telemetry_toggle_segment(
+fn toggle_segment(
     cx: &App,
     id: &'static str,
     label: &'static str,

--- a/crates/zedra/src/vfx/droplet.metal
+++ b/crates/zedra/src/vfx/droplet.metal
@@ -1,0 +1,111 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// Injected by droplet.rs at compile time; the default keeps offline builds working.
+#ifndef TRAIL_LEN
+#define TRAIL_LEN 5u
+#endif
+
+struct DropletUniforms {
+    float2 viewport_size;
+    float2 bbox_origin;
+    float2 bbox_size;
+    float2 grab_size;
+    float2 center;
+    float radius;
+    float _pad;
+    float2 trail[TRAIL_LEN];
+    float2 _pad2;
+    float4 base_color;
+};
+
+struct DropletVaryings {
+    float4 position [[position]];
+    float2 px;
+};
+
+vertex DropletVaryings droplet_vertex(
+    uint vertex_id [[vertex_id]],
+    constant DropletUniforms &u [[buffer(0)]]
+) {
+    float2 corner = float2(float(vertex_id & 1u), float(vertex_id >> 1u));
+    float2 px = u.bbox_origin + corner * u.bbox_size;
+    float2 ndc = px / u.viewport_size * 2.0 - 1.0;
+    DropletVaryings out;
+    out.position = float4(ndc.x, -ndc.y, 0.0, 1.0);
+    out.px = px;
+    return out;
+}
+
+// Polynomial smooth min (Inigo Quilez); joins blobs into one liquid surface.
+static float smin(float a, float b, float k) {
+    float h = clamp(0.5 + 0.5 * (b - a) / k, 0.0, 1.0);
+    return mix(b, a, h) - k * h * (1.0 - h);
+}
+
+// Head blob unioned with tapered followers; followers sit on past positions.
+static float droplet_sdf(float2 px, constant DropletUniforms &u) {
+    float k = u.radius * 0.55;
+    float d = length(px - u.center) - u.radius;
+    float taper = 0.72;
+    for (uint i = 0; i < TRAIL_LEN; i++) {
+        float follower_radius = u.radius * taper;
+        // Shrink caught-up followers so a resting droplet reads as one circle.
+        float lag = length(u.trail[i] - u.center);
+        follower_radius *= smoothstep(0.0, u.radius * 0.8, lag) * 0.85 + 0.15;
+        float di = length(px - u.trail[i]) - follower_radius;
+        d = smin(d, di, k);
+        taper *= 0.78;
+    }
+    return d;
+}
+
+fragment float4 droplet_fragment(
+    DropletVaryings in [[stage_in]],
+    constant DropletUniforms &u [[buffer(0)]],
+    texture2d<float> grab [[texture(0)]]
+) {
+    constexpr sampler grab_sampler(address::clamp_to_edge, filter::linear);
+
+    float d = droplet_sdf(in.px, u);
+
+    float aa = max(fwidth(d), 0.5);
+    float coverage = 1.0 - smoothstep(-aa, aa, d);
+    if (coverage <= 0.001) {
+        discard_fragment();
+    }
+
+    // Fake a spherical surface: flat in the middle, steep at the rim.
+    float depth = clamp(-d / u.radius, 0.0, 1.0);
+    float rim = 1.0 - depth;
+    float2 gradient = float2(dfdx(d), dfdy(d));
+    float gradient_len = length(gradient);
+    float2 outward = gradient_len > 0.0001 ? gradient / gradient_len : float2(0.0, 0.0);
+    float3 normal = normalize(float3(outward * rim, mix(0.35, 1.0, depth)));
+
+    // Rim lensing. Grab texture is bucket-sized: clamp to the blitted bbox,
+    // normalize by texture size.
+    float2 refract_offset = -outward * rim * rim * u.radius * 0.32;
+    float2 base_px = in.px + refract_offset - u.bbox_origin;
+    float2 sample_max = u.bbox_size - 1.0;
+    float2 uv_r = clamp(base_px + refract_offset * -0.06, float2(0.0), sample_max) / u.grab_size;
+    float2 uv_g = clamp(base_px, float2(0.0), sample_max) / u.grab_size;
+    float2 uv_b = clamp(base_px + refract_offset * 0.06, float2(0.0), sample_max) / u.grab_size;
+    float3 color = float3(
+        grab.sample(grab_sampler, uv_r).r,
+        grab.sample(grab_sampler, uv_g).g,
+        grab.sample(grab_sampler, uv_b).b
+    );
+
+    // Near-clear water tinted toward the theme-inverse base, strongest at the rim.
+    float3 base = u.base_color.rgb;
+    color = mix(color, base, 0.03 + rim * 0.08);
+    color *= 1.0 - rim * 0.05;
+
+    float3 light = normalize(float3(-0.4, -0.55, 0.75));
+    float specular = pow(max(dot(normal, light), 0.0), 64.0);
+    float sheen = pow(max(dot(normal, light), 0.0), 8.0);
+    color += (specular * 0.28 + sheen * 0.04) * mix(base, float3(1.0), 0.4);
+
+    return float4(color, coverage);
+}

--- a/crates/zedra/src/vfx/droplet.rs
+++ b/crates/zedra/src/vfx/droplet.rs
@@ -1,0 +1,246 @@
+use super::{DropletState, SharedDropletState, TRAIL_LEN};
+use gpui_ios::{MetalEffectContext, MetalRenderEffect};
+use metal::{
+    CompileOptions, MTLBlendFactor, MTLBlendOperation, MTLOrigin, MTLPrimitiveType, MTLSize,
+    MTLTextureUsage,
+};
+
+const DROPLET_SHADER: &str = include_str!("droplet.metal");
+// Padding around each blob, in radii; covers blob size, refraction offset, and AA.
+const GRAB_PADDING: f32 = 2.0;
+// Bucket grab-texture dims so per-frame bbox changes don't reallocate the texture.
+const GRAB_BUCKET: u64 = 128;
+
+#[repr(C)]
+struct DropletUniforms {
+    viewport_size: [f32; 2],
+    bbox_origin: [f32; 2],
+    bbox_size: [f32; 2],
+    grab_size: [f32; 2],
+    center: [f32; 2],
+    radius: f32,
+    _pad: f32,
+    trail: [[f32; 2]; TRAIL_LEN],
+    // float4 in MSL; offset must stay 16-aligned (pad if fields change).
+    _pad2: [f32; 2],
+    base_color: [f32; 4],
+}
+
+pub struct DropletEffect {
+    state: SharedDropletState,
+    pipeline: Option<metal::RenderPipelineState>,
+    pipeline_format: metal::MTLPixelFormat,
+    grab_texture: Option<metal::Texture>,
+    compile_failed: bool,
+}
+
+impl DropletEffect {
+    pub fn new(state: SharedDropletState) -> Self {
+        Self {
+            state,
+            pipeline: None,
+            pipeline_format: metal::MTLPixelFormat::Invalid,
+            grab_texture: None,
+            compile_failed: false,
+        }
+    }
+
+    fn ensure_pipeline(
+        &mut self,
+        device: &metal::DeviceRef,
+        format: metal::MTLPixelFormat,
+    ) -> Option<&metal::RenderPipelineState> {
+        if self.compile_failed {
+            return None;
+        }
+        if self.pipeline.is_none() || self.pipeline_format != format {
+            match build_pipeline(device, format) {
+                Ok(pipeline) => {
+                    self.pipeline = Some(pipeline);
+                    self.pipeline_format = format;
+                }
+                Err(error) => {
+                    tracing::error!("[debug:vfx] droplet pipeline compile failed: {error}");
+                    self.compile_failed = true;
+                    return None;
+                }
+            }
+        }
+        self.pipeline.as_ref()
+    }
+
+    fn ensure_grab_texture(
+        &mut self,
+        device: &metal::DeviceRef,
+        format: metal::MTLPixelFormat,
+        width: u64,
+        height: u64,
+    ) -> &metal::TextureRef {
+        let stale = self.grab_texture.as_ref().is_none_or(|texture| {
+            texture.width() < width || texture.height() < height || texture.pixel_format() != format
+        });
+        if stale {
+            let descriptor = metal::TextureDescriptor::new();
+            descriptor.set_pixel_format(format);
+            descriptor.set_width(width.div_ceil(GRAB_BUCKET) * GRAB_BUCKET);
+            descriptor.set_height(height.div_ceil(GRAB_BUCKET) * GRAB_BUCKET);
+            descriptor.set_usage(MTLTextureUsage::ShaderRead);
+            self.grab_texture = Some(device.new_texture(&descriptor));
+        }
+        self.grab_texture
+            .as_ref()
+            .expect("grab texture was created above")
+    }
+}
+
+impl MetalRenderEffect for DropletEffect {
+    fn encode(&mut self, cx: &MetalEffectContext) {
+        let snapshot: DropletState = match self.state.lock() {
+            Ok(state) => *state,
+            Err(_) => return,
+        };
+        if !snapshot.active || snapshot.radius <= 0.0 {
+            return;
+        }
+
+        let scale = if snapshot.scale_factor > 0.0 {
+            snapshot.scale_factor
+        } else {
+            1.0
+        };
+        let viewport_width = cx.viewport_size.width.0 as f32;
+        let viewport_height = cx.viewport_size.height.0 as f32;
+        let center = (snapshot.center.0 * scale, snapshot.center.1 * scale);
+        let radius = snapshot.radius * scale;
+        let trail = snapshot.trail.map(|(x, y)| [x * scale, y * scale]);
+
+        // Bounding box over the head and every trail blob.
+        let padding = radius * GRAB_PADDING;
+        let mut min_x = center.0;
+        let mut min_y = center.1;
+        let mut max_x = center.0;
+        let mut max_y = center.1;
+        for [x, y] in trail {
+            min_x = min_x.min(x);
+            min_y = min_y.min(y);
+            max_x = max_x.max(x);
+            max_y = max_y.max(y);
+        }
+        let left = (min_x - padding).max(0.0).floor();
+        let top = (min_y - padding).max(0.0).floor();
+        let right = (max_x + padding).min(viewport_width).ceil();
+        let bottom = (max_y + padding).min(viewport_height).ceil();
+        let bbox_width = (right - left) as u64;
+        let bbox_height = (bottom - top) as u64;
+        if bbox_width < 2 || bbox_height < 2 {
+            return;
+        }
+
+        let format = cx.drawable_texture.pixel_format();
+        if self.ensure_pipeline(cx.device, format).is_none() {
+            return;
+        }
+
+        let grab_texture = self
+            .ensure_grab_texture(cx.device, format, bbox_width, bbox_height)
+            .to_owned();
+        let blit_encoder = cx.command_buffer.new_blit_command_encoder();
+        blit_encoder.copy_from_texture(
+            cx.drawable_texture,
+            0,
+            0,
+            MTLOrigin {
+                x: left as u64,
+                y: top as u64,
+                z: 0,
+            },
+            MTLSize {
+                width: bbox_width,
+                height: bbox_height,
+                depth: 1,
+            },
+            &grab_texture,
+            0,
+            0,
+            MTLOrigin { x: 0, y: 0, z: 0 },
+        );
+        blit_encoder.end_encoding();
+
+        let uniforms = DropletUniforms {
+            viewport_size: [viewport_width, viewport_height],
+            bbox_origin: [left, top],
+            bbox_size: [bbox_width as f32, bbox_height as f32],
+            grab_size: [grab_texture.width() as f32, grab_texture.height() as f32],
+            center: [center.0, center.1],
+            radius,
+            _pad: 0.0,
+            trail,
+            _pad2: [0.0, 0.0],
+            base_color: [
+                snapshot.base_color.0,
+                snapshot.base_color.1,
+                snapshot.base_color.2,
+                0.0,
+            ],
+        };
+
+        let render_pass = metal::RenderPassDescriptor::new();
+        let Some(color_attachment) = render_pass.color_attachments().object_at(0) else {
+            return;
+        };
+        color_attachment.set_texture(Some(cx.drawable_texture));
+        color_attachment.set_load_action(metal::MTLLoadAction::Load);
+        color_attachment.set_store_action(metal::MTLStoreAction::Store);
+
+        // ensure_pipeline succeeded above, so the pipeline is present.
+        let Some(pipeline) = self.pipeline.as_ref() else {
+            return;
+        };
+        let encoder = cx.command_buffer.new_render_command_encoder(render_pass);
+        encoder.set_render_pipeline_state(pipeline);
+        let uniforms_ptr = std::ptr::from_ref(&uniforms).cast();
+        let uniforms_len = std::mem::size_of::<DropletUniforms>() as u64;
+        encoder.set_vertex_bytes(0, uniforms_len, uniforms_ptr);
+        encoder.set_fragment_bytes(0, uniforms_len, uniforms_ptr);
+        encoder.set_fragment_texture(0, Some(&grab_texture));
+        encoder.draw_primitives(MTLPrimitiveType::TriangleStrip, 0, 4);
+        encoder.end_encoding();
+    }
+}
+
+fn build_pipeline(
+    device: &metal::DeviceRef,
+    format: metal::MTLPixelFormat,
+) -> anyhow::Result<metal::RenderPipelineState> {
+    // Inject TRAIL_LEN so the MSL array length can't drift from DropletUniforms.
+    let source = format!("#define TRAIL_LEN {TRAIL_LEN}u\n{DROPLET_SHADER}");
+    let library = device
+        .new_library_with_source(&source, &CompileOptions::new())
+        .map_err(|error| anyhow::anyhow!("shader compile: {error}"))?;
+    let vertex_function = library
+        .get_function("droplet_vertex", None)
+        .map_err(|error| anyhow::anyhow!("vertex fn: {error}"))?;
+    let fragment_function = library
+        .get_function("droplet_fragment", None)
+        .map_err(|error| anyhow::anyhow!("fragment fn: {error}"))?;
+
+    let descriptor = metal::RenderPipelineDescriptor::new();
+    descriptor.set_vertex_function(Some(&vertex_function));
+    descriptor.set_fragment_function(Some(&fragment_function));
+    let color_attachment = descriptor
+        .color_attachments()
+        .object_at(0)
+        .ok_or_else(|| anyhow::anyhow!("missing color attachment slot"))?;
+    color_attachment.set_pixel_format(format);
+    color_attachment.set_blending_enabled(true);
+    color_attachment.set_rgb_blend_operation(MTLBlendOperation::Add);
+    color_attachment.set_alpha_blend_operation(MTLBlendOperation::Add);
+    color_attachment.set_source_rgb_blend_factor(MTLBlendFactor::SourceAlpha);
+    color_attachment.set_destination_rgb_blend_factor(MTLBlendFactor::OneMinusSourceAlpha);
+    color_attachment.set_source_alpha_blend_factor(MTLBlendFactor::One);
+    color_attachment.set_destination_alpha_blend_factor(MTLBlendFactor::OneMinusSourceAlpha);
+
+    device
+        .new_render_pipeline_state(&descriptor)
+        .map_err(|error| anyhow::anyhow!("pipeline state: {error}"))
+}

--- a/crates/zedra/src/vfx/mod.rs
+++ b/crates/zedra/src/vfx/mod.rs
@@ -1,0 +1,41 @@
+use std::sync::{Arc, Mutex};
+
+#[cfg(target_os = "ios")]
+pub mod droplet;
+pub mod overlay;
+
+/// Trailing followers behind the droplet; each chases the one ahead of it.
+pub const TRAIL_LEN: usize = 5;
+
+/// Droplet display state in logical pixels; the overlay writes, the effect reads.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DropletState {
+    pub active: bool,
+    pub center: (f32, f32),
+    pub radius: f32,
+    pub trail: [(f32, f32); TRAIL_LEN],
+    pub scale_factor: f32,
+    /// Body tint, inverse of the theme: white on dark, ink on light.
+    pub base_color: (f32, f32, f32),
+}
+
+pub type SharedDropletState = Arc<Mutex<DropletState>>;
+
+pub fn shared_droplet_state() -> SharedDropletState {
+    Arc::new(Mutex::new(DropletState::default()))
+}
+
+/// Install or remove the droplet render effect on the window. No-op off iOS.
+fn apply_droplet_effect(window: &mut gpui::Window, enabled: bool, state: &SharedDropletState) {
+    #[cfg(target_os = "ios")]
+    {
+        if enabled {
+            let effect = droplet::DropletEffect::new(state.clone());
+            window.set_render_effect(Some(Box::new(gpui_ios::IosRenderEffect(Box::new(effect)))));
+        } else {
+            window.set_render_effect(None);
+        }
+    }
+    #[cfg(not(target_os = "ios"))]
+    let _ = (window, enabled, state);
+}

--- a/crates/zedra/src/vfx/overlay.rs
+++ b/crates/zedra/src/vfx/overlay.rs
@@ -1,0 +1,259 @@
+use std::time::Instant;
+
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+
+use super::{SharedDropletState, TRAIL_LEN};
+use crate::platform_bridge::{self, HapticFeedback};
+use crate::settings::{ThemeStateEvent, theme_state};
+use crate::theme::ThemePreference;
+
+pub const DROPLET_RADIUS: f32 = 26.0;
+const HIT_RADIUS: f32 = 34.0;
+const SPRING_STIFFNESS: f32 = 170.0;
+const SPRING_DAMPING: f32 = 14.0;
+const SETTLE_SPEED: f32 = 3.0;
+const SETTLE_DISTANCE: f32 = 0.5;
+const MAX_TICK_SECONDS: f32 = 1.0 / 30.0;
+// First-follower chase rate; falls off down the chain so the trail follows the drag path.
+const TRAIL_CHASE_RATE: f32 = 26.0;
+const TRAIL_CHASE_FALLOFF: f32 = 0.72;
+// Press feedback: the droplet swells toward this scale while touched.
+const PRESSED_SCALE: f32 = 1.25;
+const SCALE_RATE: f32 = 18.0;
+
+/// Invisible drag surface; `DropletEffect` draws the visual, this runs the spring.
+pub struct DropletOverlay {
+    state: SharedDropletState,
+    enabled: bool,
+    position: Point<f32>,
+    velocity: Point<f32>,
+    target: Point<f32>,
+    trail: [Point<f32>; TRAIL_LEN],
+    drag_pointer: Option<PointerId>,
+    animating: bool,
+    last_tick: Option<Instant>,
+    scale_factor: f32,
+    radius_scale: f32,
+    base_color: (f32, f32, f32),
+    _theme_observe: Option<Subscription>,
+}
+
+fn theme_base_color(cx: &App) -> (f32, f32, f32) {
+    let preference = theme_state(cx)
+        .map(|theme| theme.read(cx).preference())
+        .unwrap_or_default();
+    // Near-neutral, low-contrast tints: a slight lift on dark, a slight shade on light.
+    match preference {
+        ThemePreference::Dark => (0.22, 0.23, 0.25),
+        ThemePreference::Light => (0.86, 0.86, 0.87),
+    }
+}
+
+impl DropletOverlay {
+    /// Owns the effect lifecycle: installs/removes it and publishes on `enabled` changes.
+    pub fn new(
+        state: SharedDropletState,
+        enabled: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        // Recolor on theme switch so a resting droplet picks up the new base.
+        let theme_observe = theme_state(cx).map(|theme| {
+            cx.subscribe(&theme, |this: &mut Self, _, _: &ThemeStateEvent, cx| {
+                this.base_color = theme_base_color(cx);
+                this.publish_state();
+                cx.notify();
+            })
+        });
+        let start = point(80.0, 160.0);
+        let overlay = Self {
+            state,
+            enabled,
+            position: start,
+            velocity: point(0.0, 0.0),
+            target: start,
+            trail: [start; TRAIL_LEN],
+            drag_pointer: None,
+            animating: false,
+            last_tick: None,
+            scale_factor: window.scale_factor(),
+            radius_scale: 1.0,
+            base_color: theme_base_color(cx),
+            _theme_observe: theme_observe,
+        };
+        super::apply_droplet_effect(window, enabled, &overlay.state);
+        overlay.publish_state();
+        overlay
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool, window: &mut Window, cx: &mut Context<Self>) {
+        if self.enabled == enabled {
+            return;
+        }
+        self.enabled = enabled;
+        self.drag_pointer = None;
+        self.velocity = point(0.0, 0.0);
+        self.target = self.position;
+        self.trail = [self.position; TRAIL_LEN];
+        self.radius_scale = 1.0;
+        self.scale_factor = window.scale_factor();
+        super::apply_droplet_effect(window, enabled, &self.state);
+        self.publish_state();
+        cx.notify();
+    }
+
+    fn publish_state(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.active = self.enabled;
+            state.center = (self.position.x, self.position.y);
+            state.radius = DROPLET_RADIUS * self.radius_scale;
+            for (slot, follower) in state.trail.iter_mut().zip(self.trail.iter()) {
+                *slot = (follower.x, follower.y);
+            }
+            state.scale_factor = self.scale_factor;
+            state.base_color = self.base_color;
+        }
+    }
+
+    fn start_animation(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.animating {
+            return;
+        }
+        self.animating = true;
+        self.last_tick = Some(Instant::now());
+        self.schedule_tick(window, cx);
+        // The tick chain only advances when frames render; request the first one.
+        cx.notify();
+    }
+
+    fn schedule_tick(&self, window: &mut Window, cx: &mut Context<Self>) {
+        cx.on_next_frame(window, |overlay, window, cx| overlay.tick(window, cx));
+    }
+
+    fn tick(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let now = Instant::now();
+        let dt = self
+            .last_tick
+            .map(|last| ((now - last).as_secs_f32()).min(MAX_TICK_SECONDS))
+            .unwrap_or(MAX_TICK_SECONDS);
+        self.last_tick = Some(now);
+
+        let displacement = self.target - self.position;
+        let acceleration = displacement * SPRING_STIFFNESS - self.velocity * SPRING_DAMPING;
+        self.velocity += acceleration * dt;
+        self.position += self.velocity * dt;
+
+        // Swell while touched, relax on release.
+        let target_scale = if self.drag_pointer.is_some() {
+            PRESSED_SCALE
+        } else {
+            1.0
+        };
+        self.radius_scale += (target_scale - self.radius_scale) * (1.0 - (-SCALE_RATE * dt).exp());
+
+        // Each follower chases the one ahead, so the trail traces the drag path.
+        let mut leader = self.position;
+        let mut chase_rate = TRAIL_CHASE_RATE;
+        for follower in self.trail.iter_mut() {
+            let blend = 1.0 - (-chase_rate * dt).exp();
+            *follower += (leader - *follower) * blend;
+            leader = *follower;
+            chase_rate *= TRAIL_CHASE_FALLOFF;
+        }
+
+        let length = |p: Point<f32>| (p.x * p.x + p.y * p.y).sqrt();
+        let settled = self.drag_pointer.is_none()
+            && length(self.velocity) < SETTLE_SPEED
+            && length(displacement) < SETTLE_DISTANCE
+            && length(self.trail[TRAIL_LEN - 1] - self.position) < SETTLE_DISTANCE
+            && (self.radius_scale - 1.0).abs() < 0.005;
+        if settled {
+            self.position = self.target;
+            self.velocity = point(0.0, 0.0);
+            self.trail = [self.position; TRAIL_LEN];
+            self.radius_scale = 1.0;
+            self.animating = false;
+            self.last_tick = None;
+        }
+
+        self.scale_factor = window.scale_factor();
+        self.publish_state();
+        cx.notify();
+        if self.animating {
+            self.schedule_tick(window, cx);
+        }
+    }
+
+    fn handle_pointer_down(
+        &mut self,
+        event: &PointerDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.drag_pointer.is_some() {
+            return;
+        }
+        // The droplet claims this touch; nothing beneath should react to it.
+        cx.stop_propagation();
+        self.drag_pointer = Some(event.pointer_id);
+        self.target = point(f32::from(event.position.x), f32::from(event.position.y));
+        platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
+        self.start_animation(window, cx);
+    }
+
+    fn handle_pointer_move(&mut self, event: &PointerMoveEvent) {
+        if self.drag_pointer == Some(event.pointer_id) {
+            self.target = point(f32::from(event.position.x), f32::from(event.position.y));
+        }
+    }
+
+    fn handle_pointer_release(&mut self, pointer_id: PointerId) {
+        if self.drag_pointer == Some(pointer_id) {
+            self.drag_pointer = None;
+        }
+    }
+}
+
+impl Render for DropletOverlay {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let position = self.position;
+        div()
+            .absolute()
+            .inset_0()
+            .when(self.enabled, |el| {
+                el.child(
+                    div()
+                        .absolute()
+                        .left(px(position.x - HIT_RADIUS))
+                        .top(px(position.y - HIT_RADIUS))
+                        .size(px(HIT_RADIUS * 2.0))
+                        .rounded_full()
+                        // Suppress hover/press/scroll for UI under the hit circle.
+                        .occlude()
+                        .on_pointer_down(cx.listener(|this, event, window, cx| {
+                            this.handle_pointer_down(event, window, cx);
+                        })),
+                )
+            })
+            .when(self.enabled && self.drag_pointer.is_some(), |el| {
+                el.child(
+                    div()
+                        .absolute()
+                        .inset_0()
+                        .occlude()
+                        .on_pointer_move(cx.listener(|this, event: &PointerMoveEvent, _, _cx| {
+                            this.handle_pointer_move(event);
+                        }))
+                        .on_pointer_up(cx.listener(|this, event: &PointerUpEvent, _, _cx| {
+                            this.handle_pointer_release(event.pointer_id);
+                        }))
+                        .on_pointer_cancel(cx.listener(
+                            |this, event: &PointerCancelEvent, _, _cx| {
+                                this.handle_pointer_release(event.pointer_id);
+                            },
+                        )),
+                )
+            })
+    }
+}

--- a/docs/GPUI_CUSTOM_EFFECT.md
+++ b/docs/GPUI_CUSTOM_EFFECT.md
@@ -1,0 +1,226 @@
+# GPUI Custom Render Effect
+
+Design for a generic post-scene render effect seam in GPUI, and for its first
+consumer: the Zedra water droplet, a draggable blob that refracts and recolors
+the UI beneath it.
+
+Status: implemented on iOS (`feat/gpui-mobile` in `vendor/zed`, `crates/zedra/src/vfx/`).
+Android remains deferred; see the Android section.
+
+## Overview
+
+GPUI renders each frame's scene into the drawable, then presents. The seam adds
+one step between those two: an app-provided effect object receives the frame's
+command buffer and drawable texture and encodes extra GPU work. GPUI stays
+neutral — it defines when the effect runs and what it receives, never what it
+draws. The effect brings its own shaders and pipelines.
+
+Zedra uses the seam to draw the water droplet. The same seam supports any
+full-frame effect: blur, CRT, color grading.
+
+Prior art shaping this design:
+
+- Godot [`CompositorEffect`](https://docs.godotengine.org/en/stable/tutorials/rendering/compositor.html):
+  engine-neutral effect objects registered on the compositor; the engine hands
+  a render context, the effect records its own passes.
+- egui_wgpu [`CallbackTrait`](https://docs.rs/egui-wgpu/latest/egui_wgpu/trait.CallbackTrait.html):
+  app callback with device/encoder access and persistent cached resources.
+- Bevy [custom post-processing](https://bevy.org/examples/shaders/custom-post-processing/):
+  post pass samples the rendered view and writes the output target.
+
+Upstream GPUI has no custom-render hook
+([discussion #45996](https://github.com/zed-industries/zed/discussions/45996)),
+and gpui-ce has no render-pass work. This seam is net-new in the
+`feat/gpui-mobile` fork.
+
+## GPUI core seam
+
+The core carries an opaque object; backends define the real contract.
+
+`vendor/zed`, branch `feat/gpui-mobile`:
+
+- `crates/gpui/src/platform.rs` — add to `PlatformWindow`, next to the existing
+  boxed-callback setters (`on_request_frame` at `platform.rs:693`):
+
+  ```rust
+  fn set_render_effect(&self, _effect: Option<Box<dyn Any>>) {}
+  ```
+
+  The default no-op body leaves macOS, Linux, and every other backend
+  untouched.
+
+- `crates/gpui/src/window.rs` — public forwarder:
+
+  ```rust
+  impl Window {
+      pub fn set_render_effect(&mut self, effect: Option<Box<dyn Any>>) {
+          self.platform_window.set_render_effect(effect);
+      }
+  }
+  ```
+
+One effect slot, one insertion point: after the scene, before present. A stage
+enum (Godot-style pre/post stages) is additive later if a second insertion
+point earns its keep.
+
+## iOS backend contract
+
+New `crates/gpui_ios/src/render_effect.rs`:
+
+```rust
+pub trait MetalRenderEffect: 'static {
+    fn encode(&mut self, cx: &MetalEffectContext);
+}
+
+pub struct MetalEffectContext<'a> {
+    pub device: &'a metal::DeviceRef,
+    pub command_buffer: &'a metal::CommandBufferRef,
+    pub drawable_texture: &'a metal::TextureRef,
+    pub viewport_size: Size<DevicePixels>,
+}
+
+// Concrete wrapper: Box<dyn Any> cannot downcast trait-to-trait.
+pub struct IosRenderEffect(pub Box<dyn MetalRenderEffect>);
+```
+
+`encode` is the only method. The effect builds pipelines lazily on first call
+and rebuilds size-dependent resources when `viewport_size` changes. This keeps
+the seam smaller than the Godot/egui lifecycles; caching is the effect's job.
+
+Wiring:
+
+- `IosWindow::set_render_effect` downcasts the `Box<dyn Any>` to
+  `IosRenderEffect` and stores it in the renderer (new
+  `effect: Option<Box<dyn MetalRenderEffect>>` field on `MetalRenderer`).
+- `MetalRenderer::draw` calls `effect.encode(&ctx)` after `draw_primitives`
+  returns (`metal_renderer.rs:428`) and before present (`:447`). Both the
+  command buffer and the drawable are live at that point. The effect creates
+  its own blit and render encoders on the command buffer.
+- The drawable texture is readable: the layer sets `framebuffer_only(false)`
+  (`metal_renderer.rs:198`).
+- `render_to_image` skips the effect. Screenshots capture the raw scene.
+
+## Zedra droplet effect
+
+Lives in `crates/zedra/src/vfx/`: `mod.rs`, `droplet.rs`, `droplet.metal`
+(embedded with `include_str!`, compiled at runtime with
+`device.new_library_with_source` on first `encode`).
+
+`DropletEffect` implements `MetalRenderEffect` (iOS-only via `cfg`). Per frame:
+
+1. Read shared `DropletState` (center in pixels, radius, velocity, active).
+   Inactive → return. No encoders, no cost.
+2. Blit the padded droplet bounding box from `drawable_texture` into a small
+   cached grab texture. Recreate the texture only when its size changes.
+3. Encode one render pass (`Load` action) drawing a single quad:
+   - SDF metaball: main blob plus a trailing blob scaled by velocity — the
+     drip. Velocity also stretches the SDF along the motion vector.
+   - Refraction: surface normal from the SDF gradient distorts the UV used to
+     sample the grab texture.
+   - Specular highlight, edge darkening, slight chromatic aberration.
+
+Params flow through an `Arc<Mutex<DropletState>>` shared between the UI element
+and the effect object. No per-frame GPUI API traffic.
+
+UI side: an overlay element at the workspace root handles touch drag
+(`.on_press`/touch handlers, not `on_click`). Spring physics drives the wobble
+through an animation-frame loop. Droplet position is ephemeral gesture state
+and stays element-local, like existing drag interactions — it is not
+`WorkspaceState` display data.
+
+## Settings toggle
+
+The droplet ships as a user-facing setting, default on.
+
+- `crates/zedra/src/settings.rs`: `read_droplet_enabled()` /
+  `set_droplet_enabled()`, copying the `telemetry_enabled` pattern.
+- `crates/zedra/src/settings_view.rs`: one toggle row.
+- Registration at root-window creation (`crates/zedra/src/app.rs`):
+
+  ```rust
+  window.set_render_effect(Some(Box::new(IosRenderEffect(Box::new(
+      DropletEffect::new(state),
+  )))));
+  ```
+
+  Toggle off → `window.set_render_effect(None)`.
+
+No telemetry event; the toggle carries no personal data either way.
+
+## Performance
+
+- No effect registered: one `Option` check per frame in `MetalRenderer::draw`.
+  No extra passes, no textures. Renderer output is byte-identical to today.
+- Effect registered, droplet inactive: `encode` locks the shared state, sees
+  inactive, returns. One mutex lock and a branch per frame.
+- Droplet active, per frame:
+  - Bbox blit: ~250×250 BGRA ≈ 250 KB on the blit engine — microseconds.
+  - The extra render pass with `Load` action is the dominant GPU cost. On
+    Apple TBDR it reloads and re-stores the full drawable through tile memory
+    (~12 MB each way at 1179×2556). This is the same cost class the renderer
+    already pays whenever a scene contains paths — `draw_paths_to_intermediate`
+    ends the encoder and reopens with `Load` (`metal_renderer.rs:602-634`) — so
+    the budget is known-acceptable.
+  - Fragment work is bounded to the droplet quad, not the screen.
+  - The grab texture is small, cached, and recreated only on size change.
+- The dominant system cost is CPU-side: the animation loop. A wobbling droplet
+  forces continuous full redraws where the UI is otherwise on-demand. The
+  element must request animation frames only while dragging or while the spring
+  is above a settle threshold, and stop when settled. Toggle off removes the
+  effect entirely — zero residual cost.
+
+## Blending model
+
+The droplet pass is not a translucent overlay. The fragment shader samples the
+rendered scene from the grab texture and outputs an arbitrary function of it.
+Refraction chooses where to sample — UV distortion via the SDF-gradient normal.
+The color transform chooses what to output: tint, hue rotation, saturation
+boost, brightness lift, inversion. Recoloring text under the droplet (glass-blue
+tint, magnified and hue-shifted glyphs) needs no extra plumbing.
+
+Fixed-function Metal blend states (multiply, screen, alpha) are also available
+on the effect's pipeline, but sample-and-transform is strictly more expressive
+and is the default.
+
+Limits:
+
+- The effect sees final composited pixels, not primitives. It recolors whatever
+  is under it — glyphs, images, chrome alike. Per-primitive selective effects
+  (text only) are a scene-level feature, out of scope for a post-scene seam.
+- Full-frame color effects cannot sample the drawable while writing it. Two
+  future options: a full-screen grab copy (extra ~12 MB blit), or restructuring
+  the frame to render the scene into a sampleable intermediate first. The
+  droplet needs neither; the seam precludes neither.
+
+## Android
+
+Deferred. The wgpu surface is created `RENDER_ATTACHMENT`-only
+(`wgpu_renderer.rs:429`) and cannot be sampled. The future approach: render the
+scene into a full-frame intermediate created with
+`RENDER_ATTACHMENT | TEXTURE_BINDING` (the path intermediate at
+`wgpu_renderer.rs:1064` is the template), let the effect sample it into the
+surface, and port the shader to WGSL. The Android draw path's off-thread
+present worker must be respected. The seam mirrors iOS: a `WgpuRenderEffect`
+trait in `gpui_wgpu`.
+
+## Implementation phases
+
+1. GPUI seam: `gpui` + `gpui_ios` changes on `vendor/zed` `feat/gpui-mobile`,
+   then the submodule pointer bump here.
+2. `DropletEffect` + Metal shader in Zedra, driven by hardcoded test state.
+3. Draggable overlay element, spring physics, shared state.
+4. Settings toggle + registration.
+5. Polish: shape tuning, aberration, trail. Android parity as separate work.
+
+## Validation
+
+```sh
+cargo check --manifest-path vendor/zed/Cargo.toml -p gpui_ios -p gpui
+cargo test -p zedra --features ios-platform
+./scripts/run-ios.sh device
+```
+
+On device: drag the droplet over terminal and editor content; verify
+refraction, shape stretch on fast drags, and no frame drops. With the toggle
+off, rendering behavior must be unchanged. Add manual steps to
+[MANUAL_TEST.md](./MANUAL_TEST.md): drag, toggle off/on, rotate/resize.

--- a/docs/GPUI_CUSTOM_EFFECT.md
+++ b/docs/GPUI_CUSTOM_EFFECT.md
@@ -108,16 +108,20 @@ Lives in `crates/zedra/src/vfx/`: `mod.rs`, `droplet.rs`, `droplet.metal`
 
 `DropletEffect` implements `MetalRenderEffect` (iOS-only via `cfg`). Per frame:
 
-1. Read shared `DropletState` (center in pixels, radius, velocity, active).
-   Inactive → return. No encoders, no cost.
-2. Blit the padded droplet bounding box from `drawable_texture` into a small
-   cached grab texture. Recreate the texture only when its size changes.
+1. Read shared `DropletState` (center in logical pixels, radius, trail
+   positions, scale factor, base color, active). Inactive → return. No
+   encoders, no cost.
+2. Blit the bounding box over the head and trail blobs from `drawable_texture`
+   into a cached grab texture. Dimensions round up to buckets so per-frame
+   bbox changes do not reallocate.
 3. Encode one render pass (`Load` action) drawing a single quad:
-   - SDF metaball: main blob plus a trailing blob scaled by velocity — the
-     drip. Velocity also stretches the SDF along the motion vector.
+   - SDF metaball: the head blob smooth-min-joined with tapered followers
+     sitting on past positions — dragging separates them into a drip and
+     curved paths produce a curved tail.
    - Refraction: surface normal from the SDF gradient distorts the UV used to
      sample the grab texture.
-   - Specular highlight, edge darkening, slight chromatic aberration.
+   - Specular highlight, rim shading, slight chromatic aberration, and a
+     near-neutral tint toward the theme-inverse `base_color`.
 
 Params flow through an `Arc<Mutex<DropletState>>` shared between the UI element
 and the effect object. No per-frame GPUI API traffic.

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1518,3 +1518,32 @@ id in production). The trailing shows the aggregate `done/total` rollup.
 1. Present a native selection/list picker whose Google action image is passed as `"Google.svg"`
    or a path-prefixed name.
 2. Expected: the Google glyph keeps its 2pt inset (the inset lookup now uses the normalized name).
+
+## Water Droplet Effect (iOS)
+
+### Toggle and basic refraction
+1. Open **Settings → Appearance** and switch **Water droplet** to **On**.
+2. Expected: a droplet appears near the top left, magnifying and tinting the UI
+   beneath it with a specular highlight.
+3. Switch the toggle to **Off**. Expected: the droplet disappears immediately and
+   rendering behaves exactly as before the toggle existed.
+
+### Drag and shape
+1. With the droplet on, drag it slowly over terminal or editor text.
+2. Expected: text under the droplet appears refracted (bent toward the center),
+   slightly magnified and cool-tinted; the droplet lags the finger like liquid.
+3. Flick the droplet fast across the screen.
+4. Expected: the shape stretches along the motion and shows a trailing drip blob;
+   on release it springs to rest and the wobble settles (no permanent animation
+   loop — frame updates stop once it rests).
+
+### Touch suppression
+1. Rest the droplet on top of a button or terminal, then tap and drag it.
+2. Expected: the UI underneath never reacts — no button press, no terminal
+   focus, no scroll — while the finger interacts with the droplet. Content
+   under a resting droplet is reachable again after dragging the droplet aside.
+
+### Rotation and resize
+1. With the droplet on, rotate the device.
+2. Expected: no crash, no stale grab artifacts; the droplet keeps rendering at its
+   logical position and refraction stays sharp after the size change.


### PR DESCRIPTION
## Summary

- GPUI gains a generic post-scene render-effect seam (`vendor/zed` bump: `Window::set_render_effect` → backend downcast → encode before present).
- Zedra ships the first consumer: a draggable water droplet that refracts the UI — SDF metaball chain with a follow-the-leader trail, spring drag physics, press swell, theme-inverse tint.
- Settings toggle under Appearance, default on. Design doc: `docs/GPUI_CUSTOM_EFFECT.md`.

## Notes

- iOS only; Android path documented in the design doc.
- Manual steps added to `docs/MANUAL_TEST.md` (drag, toggle, touch suppression, rotation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an iOS-only “Water droplet” effect with drag, stretch, and smooth settle-to-rest motion.
  * Added an Appearance toggle to enable/disable the droplet effect, with the preference saved across launches.
  * Improved the effect’s visuals using refraction with a trailing follower motion and subtle touch feedback.
* **Documentation**
  * Updated manual iOS test instructions to cover enabling/disabling, drag/settling visuals, touch suppression, and behavior across rotation/resize.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->