### PR TITLE
docs: simplify Windows install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ zedra start --detach
 **Windows**
 
 ```powershell
-powershell -c "irm zedra.dev/install.ps1 | iex"
+irm https://zedra.dev/install.ps1 | iex
 zedra start --detach
 ```
 

--- a/crates/zedra/src/home_view.rs
+++ b/crates/zedra/src/home_view.rs
@@ -640,7 +640,7 @@ static WINDOWS_INSTALL_LINES: &[GuideLine] = &[
         comment: true,
     },
     GuideLine {
-        text: "powershell -c \"irm https://zedra.dev/install.ps1 | iex\"",
+        text: "irm https://zedra.dev/install.ps1 | iex",
         comment: false,
     },
 ];

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -91,7 +91,7 @@ Scan the printed QR from the app, or pass the URL during development:
 Windows support is for the host daemon, not a native desktop client.
 
 ```powershell
-powershell -c "irm https://zedra.dev/install.ps1 | iex"
+irm https://zedra.dev/install.ps1 | iex
 zedra start --workdir C:\path\to\project --detach
 zedra qr --workdir C:\path\to\project
 zedra status --workdir C:\path\to\project

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -460,7 +460,7 @@ app still builds, but push registration reports an error instead of a token.
 
 ## 1d. Windows Host CLI
 
-1. On an x86_64 Windows machine, run `powershell -c "irm https://zedra.dev/install.ps1 | iex"` from Command Prompt or Windows Terminal
+1. On an x86_64 Windows machine, run `irm https://zedra.dev/install.ps1 | iex` from PowerShell
 2. Expected: `zedra.exe` is installed under `%LOCALAPPDATA%\Programs\zedra\bin`, the directory is added to the user `Path`, and `zedra --help` works from the current shell
 3. Start the daemon from PowerShell: `zedra start --workdir C:\path\to\repo --detach`
 4. Expected: startup succeeds, Windows may show a firewall prompt, and `daemon.lock` plus `daemon.log` are written under `%APPDATA%\zedra\workspaces\` using their respective workspace hashes

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,7 +34,7 @@ curl -fsSL https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/insta
 
 **First install on Windows:**
 ```powershell
-powershell -c "irm https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/install.ps1 | iex"
+irm https://raw.githubusercontent.com/tanlethanh/zedra/main/scripts/install.ps1 | iex
 ```
 
 **Specific version:**

--- a/packages/landing/src/content/docs/docs/installation.mdx
+++ b/packages/landing/src/content/docs/docs/installation.mdx
@@ -20,7 +20,7 @@ curl -fsSL zedra.dev/install.sh | sh
   <TabItem label="Windows">
 
 ```powershell
-powershell -c "irm zedra.dev/install.ps1 | iex"
+irm https://zedra.dev/install.ps1 | iex
 ```
 
   </TabItem>

--- a/packages/landing/src/pages/index.astro
+++ b/packages/landing/src/pages/index.astro
@@ -20,7 +20,7 @@ const installTabs = [
     label: "windows",
     icon: `<svg class="tab-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3 5.4 10.6 4.3v7.2H3V5.4Zm8.6-1.2L21 2.8v8.7h-9.4V4.2ZM3 12.5h7.6v7.2L3 18.6v-6.1Zm8.6 0H21v8.7l-9.4-1.4v-7.3Z"></path></svg>`,
     blocks: [
-      [{ text: 'powershell -c "irm zedra.dev/install.ps1 | iex"' }],
+      [{ text: "irm https://zedra.dev/install.ps1 | iex" }],
       [{ text: "# Install agent hooks for notification", comment: true }, { text: "zedra setup" }],
       [
         { text: "# Start daemon in working directory", comment: true },

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,7 +52,7 @@ detect_platform() {
         Linux)  os="unknown-linux-gnu" ;;
         MINGW*|MSYS*|CYGWIN*)
             echo "Error: use the Windows PowerShell installer instead:"
-            echo "  powershell -c \"irm https://zedra.dev/install.ps1 | iex\""
+            echo "  irm https://zedra.dev/install.ps1 | iex"
             exit 1
             ;;
         *)      echo "Error: unsupported OS: $os"; exit 1 ;;


### PR DESCRIPTION
## Summary
- Drop redundant `powershell -c "..."` wrap around the install one-liner (docs already say run from PowerShell)
- Force `https://` scheme instead of relying on scheme-less URL

## Notes
Touches README, GET_STARTED, MANUAL_TEST, RELEASE docs, and landing site (installation.mdx, index.astro).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Windows install/start instructions across the README, getting started guide, manual test guide, release notes, and website docs.
  * Simplified the PowerShell install command by removing the `powershell -c` wrapper and using `irm https://zedra.dev/install.ps1 | iex` directly.
  * Kept the subsequent `zedra start --detach` step unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->