### PR TITLE
feat: clipboard sync between host and iOS client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1169,15 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cmake"
@@ -2222,6 +2248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "etagere"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,6 +2769,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.3",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5123,6 +5165,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5136,6 +5190,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5146,6 +5213,17 @@ name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.0",
  "objc2",
@@ -9916,6 +9994,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.3",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10154,6 +10249,7 @@ name = "zedra-host"
 version = "0.3.1"
 dependencies = [
  "anyhow",
+ "arboard",
  "axum 0.7.9",
  "base64-url",
  "chrono",

--- a/crates/zedra-host/Cargo.toml
+++ b/crates/zedra-host/Cargo.toml
@@ -75,6 +75,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hostname = "0.4"
 sysinfo = "0.31.4"
 
+# System clipboard (text only for v1; enable default features for v1.1 images).
+arboard = { version = "3", default-features = false }
+
 # Error handling
 anyhow.workspace = true
 

--- a/crates/zedra-host/src/clipboard.rs
+++ b/crates/zedra-host/src/clipboard.rs
@@ -1,0 +1,314 @@
+//! Host system-clipboard bridge.
+//!
+//! A single dedicated OS thread owns the one `arboard::Clipboard` for the whole
+//! daemon and serves every clipboard operation: the periodic poll, `ClipboardGet`
+//! reads, and `ClipboardSet` writes. This matters for correctness, not just tidiness:
+//! on X11 a `Clipboard` must stay alive to keep serving paste requests, so a
+//! per-call throwaway instance would lose a written value moments later. Routing
+//! reads and writes through the same thread also serializes them with the poll, so
+//! there is no read/write interleave race on the dedup hash.
+//!
+//! Tradeoff: arboard calls are synchronous and unbounded. Because one thread now
+//! serves reads, writes, and the poll, a wedged OS clipboard call (notably an X11
+//! selection owner that stops responding) blocks all clipboard ops until the daemon
+//! restarts, whereas a per-call throwaway instance would scope a hang to that call.
+//! Accepted for v1 (macOS is the primary host, where NSPasteboard does not exhibit
+//! this); revisit with a watchdog/timeout if it bites on X11.
+//!
+//! Send-path dedup: after the thread writes a value (from `ClipboardSet`) it records
+//! that value's hash, so the next poll tick recognizes it and does not echo it back
+//! to clients as a `ClipboardChanged`. This is an optimization, not a correctness
+//! wall: clients never auto-send, so no echo loop can form.
+
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+use zedra_rpc::proto::{ClipboardContent, ClipboardPayload, HostEvent, CLIPBOARD_MAX_BYTES};
+
+use crate::session_registry::SessionRegistry;
+
+/// How often the host system clipboard is polled. arboard exposes no
+/// cross-platform change notification, so we poll. Tune here if it matters.
+const POLL_INTERVAL: Duration = Duration::from_millis(1000);
+
+/// A request handed to the clipboard thread. Each carries a channel for its reply.
+enum ClipboardCommand {
+    Read(oneshot::Sender<Result<Option<ClipboardContent>, String>>),
+    Write(ClipboardContent, oneshot::Sender<Result<(), String>>),
+}
+
+/// Shared handle to the clipboard thread plus the poll/write dedup hash.
+#[derive(Default)]
+pub struct ClipboardSync {
+    /// Hash of the last value observed or written by the host. `None` until the
+    /// first observation.
+    last_hash: Mutex<Option<u64>>,
+    /// Command channel into the clipboard thread. `None` until `spawn` runs, or
+    /// permanently `None` if the host has no reachable clipboard.
+    commands: Mutex<Option<mpsc::Sender<ClipboardCommand>>>,
+}
+
+impl ClipboardSync {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Record `hash` and report whether it is a change (so the poller broadcasts).
+    fn observe(&self, hash: u64) -> bool {
+        let mut guard = self.last_hash.lock().expect("clipboard hash mutex");
+        if *guard == Some(hash) {
+            return false;
+        }
+        *guard = Some(hash);
+        true
+    }
+
+    fn note_written(&self, hash: u64) {
+        *self.last_hash.lock().expect("clipboard hash mutex") = Some(hash);
+    }
+
+    /// Forget the last value so a later identical copy is seen as a fresh change,
+    /// not suppressed as an echo. Called when the clipboard goes empty/non-text.
+    fn clear(&self) {
+        *self.last_hash.lock().expect("clipboard hash mutex") = None;
+    }
+
+    fn sender(&self) -> Option<mpsc::Sender<ClipboardCommand>> {
+        self.commands
+            .lock()
+            .expect("clipboard commands mutex")
+            .clone()
+    }
+
+    /// Read the host system clipboard (backs `ClipboardGet`). `Ok(None)` when
+    /// empty/oversized; `Err` when the clipboard is unavailable.
+    pub async fn read(&self) -> Result<Option<ClipboardContent>, String> {
+        let Some(tx) = self.sender() else {
+            return Err("clipboard is unavailable on this host".to_string());
+        };
+        let (respond, rx) = oneshot::channel();
+        tx.send(ClipboardCommand::Read(respond))
+            .map_err(|_| "clipboard thread stopped".to_string())?;
+        rx.await
+            .map_err(|_| "clipboard thread dropped reply".to_string())?
+    }
+
+    /// Write to the host system clipboard (backs `ClipboardSet`).
+    pub async fn write(&self, content: ClipboardContent) -> Result<(), String> {
+        let Some(tx) = self.sender() else {
+            return Err("clipboard is unavailable on this host".to_string());
+        };
+        let (respond, rx) = oneshot::channel();
+        tx.send(ClipboardCommand::Write(content, respond))
+            .map_err(|_| "clipboard thread stopped".to_string())?;
+        rx.await
+            .map_err(|_| "clipboard thread dropped reply".to_string())?
+    }
+}
+
+/// Stable content hash for change detection (non-crypto; dedup only).
+fn hash_content(content: &ClipboardContent) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    match content {
+        ClipboardContent::Text(text) => {
+            0u8.hash(&mut hasher);
+            text.hash(&mut hasher);
+        }
+        ClipboardContent::Image { format, bytes } => {
+            1u8.hash(&mut hasher);
+            (*format as u8).hash(&mut hasher);
+            bytes.hash(&mut hasher);
+        }
+    }
+    hasher.finish()
+}
+
+/// Read text off a live clipboard, applying the size cap. Text only in v1.
+fn read_text(clipboard: &mut arboard::Clipboard) -> Result<Option<ClipboardContent>, String> {
+    match clipboard.get_text() {
+        Ok(text) if text.is_empty() || text.len() > CLIPBOARD_MAX_BYTES => Ok(None),
+        Ok(text) => Ok(Some(ClipboardContent::Text(text))),
+        // An empty or non-text clipboard is nothing to sync, not an error.
+        Err(_) => Ok(None),
+    }
+}
+
+/// Write to a live clipboard. Text only in v1.
+fn write_content(
+    clipboard: &mut arboard::Clipboard,
+    content: &ClipboardContent,
+) -> Result<(), String> {
+    let ClipboardContent::Text(text) = content else {
+        return Err("image clipboard is not supported yet".to_string());
+    };
+    if text.len() > CLIPBOARD_MAX_BYTES {
+        return Err("clipboard content exceeds the size limit".to_string());
+    }
+    clipboard.set_text(text.clone()).map_err(|e| e.to_string())
+}
+
+fn is_sync_disabled(value: Option<&str>) -> bool {
+    matches!(value, Some("0") | Some("false") | Some("off") | Some("no"))
+}
+
+/// Host-side kill switch. The client toggle only gates device-side *apply*; this
+/// is the host's own opt-out from *capturing* and broadcasting its clipboard,
+/// for a shared or privacy-sensitive host. Default on; unset means enabled.
+fn clipboard_sync_disabled_by_env() -> bool {
+    is_sync_disabled(std::env::var("ZEDRA_CLIPBOARD_SYNC").ok().as_deref())
+}
+
+/// Start the host clipboard watcher: one thread owning the clipboard plus an async
+/// broadcaster. If the host disabled sync (`ZEDRA_CLIPBOARD_SYNC=0`) or the system
+/// clipboard is unavailable, logs once and leaves `sync` without a command sender,
+/// so reads/writes return an error and no poll runs (sync disabled on this host).
+pub fn spawn(registry: Arc<SessionRegistry>, sync: Arc<ClipboardSync>) {
+    if clipboard_sync_disabled_by_env() {
+        tracing::info!("clipboard sync disabled by ZEDRA_CLIPBOARD_SYNC");
+        return;
+    }
+    let (cmd_tx, cmd_rx) = mpsc::channel::<ClipboardCommand>();
+    let (change_tx, mut change_rx) = tokio::sync::mpsc::unbounded_channel::<ClipboardContent>();
+
+    let thread_sync = sync.clone();
+    let spawn_result = std::thread::Builder::new()
+        .name("clipboard-watcher".to_string())
+        .spawn(move || {
+            let mut clipboard = match arboard::Clipboard::new() {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::info!("clipboard sync disabled: {e}");
+                    return;
+                }
+            };
+            loop {
+                match cmd_rx.recv_timeout(POLL_INTERVAL) {
+                    Ok(ClipboardCommand::Read(respond)) => {
+                        let _ = respond.send(read_text(&mut clipboard));
+                    }
+                    Ok(ClipboardCommand::Write(content, respond)) => {
+                        let result = write_content(&mut clipboard, &content);
+                        // Record only a successful write, so a failed write can't
+                        // make the poller swallow a later identical host-local copy.
+                        if result.is_ok() {
+                            thread_sync.note_written(hash_content(&content));
+                        }
+                        let _ = respond.send(result);
+                    }
+                    Err(RecvTimeoutError::Timeout) => {
+                        // First tick after startup broadcasts the pre-existing
+                        // clipboard (last_hash is None): a deliberate seed for
+                        // already-connected clients, not a stale-data echo.
+                        match read_text(&mut clipboard) {
+                            Ok(Some(content)) => {
+                                if thread_sync.observe(hash_content(&content))
+                                    && change_tx.send(content).is_err()
+                                {
+                                    return; // broadcaster gone; daemon shutting down
+                                }
+                            }
+                            // Emptied / non-text / oversized: forget the last hash so a
+                            // later re-copy of the same text reads as a change, not an echo.
+                            Ok(None) => thread_sync.clear(),
+                            Err(_) => {}
+                        }
+                    }
+                    Err(RecvTimeoutError::Disconnected) => return,
+                }
+            }
+        });
+    // A watcher that can't be spawned degrades like a missing clipboard: no
+    // sender is installed, so reads/writes return an error instead of panicking
+    // the daemon. The Ok(JoinHandle) is intentionally dropped (detached); the
+    // thread lives for the daemon's lifetime.
+    if let Err(e) = spawn_result {
+        tracing::warn!("clipboard sync disabled: cannot spawn watcher thread: {e}");
+        return;
+    }
+
+    *sync.commands.lock().expect("clipboard commands mutex") = Some(cmd_tx);
+
+    // Async broadcaster fans each change out to every subscribed session.
+    tokio::spawn(async move {
+        while let Some(content) = change_rx.recv().await {
+            registry
+                .broadcast_event(HostEvent::ClipboardChanged(ClipboardPayload { content }))
+                .await;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(s: &str) -> ClipboardContent {
+        ClipboardContent::Text(s.to_string())
+    }
+
+    #[test]
+    fn hash_distinguishes_content() {
+        assert_eq!(hash_content(&text("a")), hash_content(&text("a")));
+        assert_ne!(hash_content(&text("a")), hash_content(&text("b")));
+    }
+
+    #[test]
+    fn observe_fires_only_on_change() {
+        let sync = ClipboardSync::new();
+        assert!(sync.observe(hash_content(&text("first"))));
+        assert!(!sync.observe(hash_content(&text("first"))));
+        assert!(sync.observe(hash_content(&text("second"))));
+    }
+
+    #[test]
+    fn note_written_suppresses_echo() {
+        let sync = ClipboardSync::new();
+        // A client->host set records the hash; the next poll of the same value
+        // must not re-broadcast it back to clients.
+        sync.note_written(hash_content(&text("from client")));
+        assert!(!sync.observe(hash_content(&text("from client"))));
+    }
+
+    #[test]
+    fn clear_lets_identical_copy_rebroadcast() {
+        let sync = ClipboardSync::new();
+        assert!(sync.observe(hash_content(&text("keep"))));
+        // Clipboard goes empty / non-text -> dedup reset.
+        sync.clear();
+        // The same text copied again is a real change now, not a suppressed echo.
+        assert!(sync.observe(hash_content(&text("keep"))));
+    }
+
+    #[test]
+    fn re_copy_after_other_value_rebroadcasts() {
+        // A client push records X; the echo is suppressed, but a genuine host-local
+        // re-copy of X after copying Y is a real change and must broadcast again.
+        let sync = ClipboardSync::new();
+        sync.note_written(hash_content(&text("X")));
+        assert!(!sync.observe(hash_content(&text("X"))));
+        assert!(sync.observe(hash_content(&text("Y"))));
+        assert!(sync.observe(hash_content(&text("X"))));
+    }
+
+    #[test]
+    fn env_kill_switch_parsing() {
+        assert!(is_sync_disabled(Some("0")));
+        assert!(is_sync_disabled(Some("false")));
+        assert!(is_sync_disabled(Some("off")));
+        assert!(!is_sync_disabled(None)); // default: enabled
+        assert!(!is_sync_disabled(Some("1")));
+    }
+
+    #[tokio::test]
+    async fn degraded_host_read_write_error_cleanly() {
+        // No spawned thread => no clipboard on this host. Ops must error, not hang
+        // or panic, so a client just sees a failed ClipboardGet/Set.
+        let sync = ClipboardSync::new();
+        assert!(sync.sender().is_none());
+        assert!(sync.read().await.is_err());
+        assert!(sync.write(text("hi")).await.is_err());
+    }
+}

--- a/crates/zedra-host/src/lib.rs
+++ b/crates/zedra-host/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod agent;
 pub mod api;
 pub mod client;
+pub mod clipboard;
 pub mod delta;
 pub mod docs_tree;
 pub mod fs;

--- a/crates/zedra-host/src/main.rs
+++ b/crates/zedra-host/src/main.rs
@@ -1196,6 +1196,10 @@ async fn main() -> Result<()> {
             //     DNS re-registration when the endpoint address updates.
             net_monitor::spawn_net_monitor(&endpoint);
 
+            // 1c. Start the system clipboard watcher (host->client auto-sync).
+            //     Disables itself if the host has no reachable clipboard.
+            zedra_host::clipboard::spawn(registry.clone(), state.clipboard.clone());
+
             // 2. Generate startup QR code
             // Note: The QR encodes only endpoint_id (pubkey) — no IPs. The client
             // resolves addresses at connect time via pkarr. STUN runs in the

--- a/crates/zedra-host/src/rpc_daemon.rs
+++ b/crates/zedra-host/src/rpc_daemon.rs
@@ -1437,6 +1437,9 @@ pub struct DaemonState {
     /// Delta client; updated at runtime when a mobile client reports its
     /// Delta info via `SetClientDeltaInfo`. `None` if Delta is not configured.
     pub delta: Arc<tokio::sync::RwLock<Option<Arc<crate::delta::DeltaClient>>>>,
+    /// Shared clipboard state: dedup hash between the poll watcher and the
+    /// `ClipboardSet` handler so a manual send does not echo back to clients.
+    pub clipboard: Arc<crate::clipboard::ClipboardSync>,
 }
 
 impl std::fmt::Debug for DaemonState {
@@ -1462,6 +1465,7 @@ impl DaemonState {
             started_at: std::time::Instant::now(),
             agent_cache: agent_cache::AgentCache::new(),
             delta: Arc::new(tokio::sync::RwLock::new(delta)),
+            clipboard: crate::clipboard::ClipboardSync::new(),
         }
     }
 }
@@ -2739,6 +2743,26 @@ async fn dispatch(
             }
             *state.delta.write().await = None;
             let _ = msg.tx.send(ClearClientDeltaInfoResult {}).await;
+        }
+
+        ZedraMessage::ClipboardSet(msg) => {
+            // The clipboard thread records the written value's hash on success,
+            // so this write is not echoed back to clients as a ClipboardChanged.
+            let result = state.clipboard.write(msg.content.clone()).await;
+            let _ = msg
+                .tx
+                .send(ClipboardSetResult {
+                    error: result.err(),
+                })
+                .await;
+        }
+
+        ZedraMessage::ClipboardGet(msg) => {
+            let (content, error) = match state.clipboard.read().await {
+                Ok(content) => (content, None),
+                Err(e) => (None, Some(e)),
+            };
+            let _ = msg.tx.send(ClipboardGetResult { content, error }).await;
         }
 
         ZedraMessage::FsRead(msg) => {

--- a/crates/zedra-host/src/session_registry.rs
+++ b/crates/zedra-host/src/session_registry.rs
@@ -937,6 +937,17 @@ impl SessionRegistry {
         self.sessions.lock().await.len()
     }
 
+    /// Push a host-initiated event to every session with an active subscriber.
+    /// Sessions without a subscriber drop it silently (see `push_event`).
+    /// Used for host-global events like a system clipboard change.
+    pub async fn broadcast_event(&self, event: HostEvent) {
+        let sessions: Vec<Arc<ServerSession>> =
+            self.sessions.lock().await.values().cloned().collect();
+        for session in sessions {
+            session.push_event(event.clone()).await;
+        }
+    }
+
     /// Return the most recently active session, if any.
     /// Used by the REST API when no session_id is specified, so the request
     /// targets the session a user is actually working in rather than an

--- a/crates/zedra-rpc/src/proto.rs
+++ b/crates/zedra-rpc/src/proto.rs
@@ -219,6 +219,18 @@ pub enum ZedraProto {
     /// Kept at enum tail because protocol variants are append-only.
     #[rpc(tx = oneshot::Sender<ClearClientDeltaInfoResult>)]
     ClearClientDeltaInfo(ClearClientDeltaInfoReq),
+
+    /// Client pushes its device clipboard to the host; the host writes it to the
+    /// host system clipboard. Manual and user-initiated because iOS forbids
+    /// background pasteboard reads.
+    /// Kept at enum tail because protocol variants are append-only.
+    #[rpc(tx = oneshot::Sender<ClipboardSetResult>)]
+    ClipboardSet(ClipboardSetReq),
+
+    /// Client reads the host's current system clipboard, e.g. to seed on connect.
+    /// Kept at enum tail because protocol variants are append-only.
+    #[rpc(tx = oneshot::Sender<ClipboardGetResult>)]
+    ClipboardGet(ClipboardGetReq),
 }
 
 // ---------------------------------------------------------------------------
@@ -692,6 +704,63 @@ pub struct FsStatResult {
     pub error: Option<String>,
 }
 
+// ---------------------------------------------------------------------------
+// Clipboard types
+// ---------------------------------------------------------------------------
+
+/// Maximum clipboard payload size accepted on the wire (2 MiB). Larger content
+/// is dropped by the host and rejected by the client before it crosses the
+/// tunnel, so one oversized image cannot stall the stream.
+pub const CLIPBOARD_MAX_BYTES: usize = 2 * 1024 * 1024;
+
+/// Clipboard content carried in both directions.
+///
+/// `Image` is reserved for v1.1 and is neither produced nor consumed in v1
+/// (text only). It ships now so the wire stays append-only when image support
+/// lands after the `gpui_ios` image-clipboard spike.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ClipboardContent {
+    Text(String),
+    Image {
+        format: ClipboardImageFormat,
+        #[serde(with = "serde_bytes")]
+        bytes: Vec<u8>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ClipboardImageFormat {
+    Png,
+    Jpeg,
+}
+
+/// Latest host clipboard value pushed to the client via `HostEvent`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ClipboardPayload {
+    pub content: ClipboardContent,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClipboardSetReq {
+    pub content: ClipboardContent,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClipboardSetResult {
+    /// `None` on success; a message the client can surface on failure.
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClipboardGetReq {}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClipboardGetResult {
+    /// `None` when the host clipboard is empty or unsupported.
+    pub content: Option<ClipboardContent>,
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FsWatchReq {
     /// Relative directory path to observe (for example: ".", "src", "src/editor").
@@ -841,6 +910,10 @@ pub enum HostEvent {
         terminal_id: String,
         agent_slug: Option<String>,
     },
+    /// The host system clipboard changed. The client applies the value to the
+    /// device pasteboard when clipboard sync is enabled and the app is
+    /// foreground. Appended at `zedra/rpc/4`.
+    ClipboardChanged(ClipboardPayload),
 }
 
 // ---------------------------------------------------------------------------
@@ -1453,6 +1526,58 @@ mod tests {
         let encoded = postcard::to_allocvec(&req).unwrap();
         let decoded: PingReq = postcard::from_bytes(&encoded).unwrap();
         assert_eq!(decoded.timestamp_ms, 9_999_999);
+    }
+
+    #[test]
+    fn clipboard_set_req_text_roundtrip() {
+        let req = ClipboardSetReq {
+            content: ClipboardContent::Text("export TOKEN=abc123".to_string()),
+        };
+        let encoded = postcard::to_allocvec(&req).unwrap();
+        let decoded: ClipboardSetReq = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(decoded.content, req.content);
+    }
+
+    #[test]
+    fn clipboard_get_result_roundtrip() {
+        let result = ClipboardGetResult {
+            content: Some(ClipboardContent::Text("hello".to_string())),
+            error: None,
+        };
+        let encoded = postcard::to_allocvec(&result).unwrap();
+        let decoded: ClipboardGetResult = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(decoded.content, result.content);
+        assert!(decoded.error.is_none());
+    }
+
+    #[test]
+    fn clipboard_changed_event_roundtrip() {
+        let event = HostEvent::ClipboardChanged(ClipboardPayload {
+            content: ClipboardContent::Text("copied on host".to_string()),
+        });
+        let encoded = postcard::to_allocvec(&event).unwrap();
+        let decoded: HostEvent = postcard::from_bytes(&encoded).unwrap();
+        match decoded {
+            HostEvent::ClipboardChanged(p) => {
+                assert_eq!(
+                    p.content,
+                    ClipboardContent::Text("copied on host".to_string())
+                )
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    // The v1.1 image variant must survive the wire even though v1 never emits it.
+    #[test]
+    fn clipboard_image_variant_roundtrip() {
+        let content = ClipboardContent::Image {
+            format: ClipboardImageFormat::Png,
+            bytes: vec![0x89, 0x50, 0x4e, 0x47],
+        };
+        let encoded = postcard::to_allocvec(&content).unwrap();
+        let decoded: ClipboardContent = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(decoded, content);
     }
 
     #[test]

--- a/crates/zedra-rpc/src/proto_v3.rs
+++ b/crates/zedra-rpc/src/proto_v3.rs
@@ -608,6 +608,8 @@ fn host_event_v3(e: proto::HostEvent) -> Option<HostEvent> {
             state,
         }),
         proto::HostEvent::TerminalAgentChanged { .. } => None,
+        // v4-only: v3 clients have no clipboard support.
+        proto::HostEvent::ClipboardChanged(..) => None,
     }
 }
 
@@ -769,5 +771,16 @@ mod tests {
         // A newer actor slug has no `v3` enum variant and must be dropped.
         assert!(agent_kind("amp").is_none());
         assert_eq!(agent_kind("hermes"), Some(AgentKind::Hermes));
+    }
+
+    #[test]
+    fn clipboard_changed_is_dropped_for_v3() {
+        // v4-only event; a v3 client cannot decode it, so the filter drops it.
+        let event = proto::HostEvent::ClipboardChanged(proto::ClipboardPayload {
+            content: proto::ClipboardContent::Text("secret".into()),
+        });
+        assert!(host_event_v3(event).is_none());
+        // A shared event still passes through, proving we didn't over-filter.
+        assert!(host_event_v3(proto::HostEvent::GitChanged).is_some());
     }
 }

--- a/crates/zedra-session/src/handle.rs
+++ b/crates/zedra-session/src/handle.rs
@@ -412,6 +412,24 @@ impl SessionHandle {
         Ok(())
     }
 
+    /// Push local clipboard content to the host (client->host, manual).
+    pub async fn clipboard_set(&self, content: ClipboardContent) -> Result<()> {
+        let result: ClipboardSetResult = self.call(ClipboardSetReq { content }).await?;
+        if let Some(e) = result.error {
+            return Err(anyhow::anyhow!(e));
+        }
+        Ok(())
+    }
+
+    /// Read the host's current system clipboard, e.g. to seed on connect.
+    pub async fn clipboard_get(&self) -> Result<Option<ClipboardContent>> {
+        let result: ClipboardGetResult = self.call(ClipboardGetReq {}).await?;
+        if let Some(e) = result.error {
+            return Err(anyhow::anyhow!(e));
+        }
+        Ok(result.content)
+    }
+
     pub async fn fs_stat(&self, path: &str) -> Result<FsStatResult> {
         let result = self
             .call(FsStatReq {

--- a/crates/zedra-session/src/session.rs
+++ b/crates/zedra-session/src/session.rs
@@ -439,6 +439,11 @@ impl Session {
                     "HostEvent: terminal agent changed"
                 );
             }
+            HostEvent::ClipboardChanged(_) => {
+                // The app-side subscriber applies it to the device pasteboard
+                // when clipboard sync is enabled and the app is foreground.
+                info!("HostEvent: clipboard changed");
+            }
         }
 
         let _ = host_event_tx.send(event);

--- a/crates/zedra/src/session_panel.rs
+++ b/crates/zedra/src/session_panel.rs
@@ -162,6 +162,27 @@ impl Render for SessionPanel {
         // --- Phase timing section ---
         info = info.child(render_timing(cx, &snap));
 
+        // --- Send clipboard button ---
+        let send_pressed_bg = theme::row_pressed_bg(cx);
+        let send_clipboard_button = div()
+            .id("session-send-clipboard-btn")
+            .mt(px(8.0))
+            .px(px(12.0))
+            .py(px(8.0))
+            .rounded(px(6.0))
+            .border_1()
+            .border_color(rgb(theme::border_default(cx)))
+            .text_color(rgb(theme::text_secondary(cx)))
+            .text_size(px(theme::FONT_BODY))
+            .cursor_pointer()
+            // Touch-down feedback: the button previously gave no pressed state.
+            .hover(|s| s.bg(send_pressed_bg))
+            .active(|s| s.bg(send_pressed_bg))
+            .on_press(cx.listener(|_this, _event, window, cx| {
+                window.dispatch_action(workspace_action::SendClipboard.boxed_clone(), cx);
+            }))
+            .child(div().flex().justify_center().child("Send clipboard"));
+
         // --- Disconnect button ---
         let disconnect_button = div()
             .id("session-disconnect-btn")
@@ -179,7 +200,9 @@ impl Render for SessionPanel {
             }))
             .child(div().flex().justify_center().child("Disconnect"));
 
-        info.child(disconnect_button).child(div().h(px(16.0)))
+        info.child(send_clipboard_button)
+            .child(disconnect_button)
+            .child(div().h(px(16.0)))
     }
 }
 

--- a/crates/zedra/src/settings.rs
+++ b/crates/zedra/src/settings.rs
@@ -20,6 +20,11 @@ struct AppSettings {
     /// Water droplet effect. `None`/absent = enabled (default-on).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     droplet_enabled: Option<bool>,
+    /// Sync the host system clipboard to this device. `None`/absent = disabled
+    /// (default-off): auto-applying the host clipboard overwrites the device
+    /// pasteboard, so the user opts in.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    clipboard_sync_enabled: Option<bool>,
 }
 
 pub enum ThemeStateEvent {
@@ -192,6 +197,25 @@ pub fn set_droplet_enabled(enabled: bool) {
     settings.droplet_enabled = Some(enabled);
     if let Err(err) = write_settings(&settings) {
         warn!(err = %err, "settings: failed to save droplet preference");
+    }
+}
+
+/// Whether host->device clipboard sync is enabled. Default off.
+pub fn read_clipboard_sync_enabled() -> bool {
+    match read_settings() {
+        Ok(settings) => settings.clipboard_sync_enabled.unwrap_or(false),
+        Err(err) => {
+            info!(err = %err, "[debug:settings] using default clipboard-sync preference");
+            false
+        }
+    }
+}
+
+pub fn set_clipboard_sync_enabled(enabled: bool) {
+    let mut settings = read_settings().unwrap_or_default();
+    settings.clipboard_sync_enabled = Some(enabled);
+    if let Err(err) = write_settings(&settings) {
+        warn!(err = %err, "settings: failed to save clipboard-sync preference");
     }
 }
 

--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -77,6 +77,7 @@ pub struct SettingsView {
     delta_busy: bool,
     telemetry_enabled: bool,
     droplet_enabled: bool,
+    clipboard_sync_enabled: bool,
     _delta_observe: Subscription,
 }
 
@@ -102,6 +103,7 @@ impl SettingsView {
             delta_busy: false,
             telemetry_enabled: settings::read_telemetry_enabled(),
             droplet_enabled: settings::read_droplet_enabled(),
+            clipboard_sync_enabled: settings::read_clipboard_sync_enabled(),
             _delta_observe: observe,
         }
     }
@@ -430,6 +432,18 @@ impl SettingsView {
         cx.notify();
     }
 
+    fn set_clipboard_sync_enabled(&mut self, enabled: bool, cx: &mut Context<Self>) {
+        if self.clipboard_sync_enabled == enabled {
+            return;
+        }
+        platform_bridge::trigger_haptic(HapticFeedback::SelectionChanged);
+        self.clipboard_sync_enabled = enabled;
+        // No live event needed: the host-event handler reads the persisted flag
+        // synchronously each time a clipboard change arrives.
+        settings::set_clipboard_sync_enabled(enabled);
+        cx.notify();
+    }
+
     fn open_telemetry_docs(&self) {
         platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
         platform_bridge::bridge().open_url(TELEMETRY_DOCS_URL);
@@ -540,6 +554,7 @@ impl Render for SettingsView {
         let preference = self.theme_state.read(cx).preference();
         let telemetry_enabled = self.telemetry_enabled;
         let droplet_enabled = self.droplet_enabled;
+        let clipboard_sync_enabled = self.clipboard_sync_enabled;
 
         div()
             .id("settings-view")
@@ -668,6 +683,16 @@ impl Render for SettingsView {
                                 ))
                             })
                             .child(section_header(cx, "Privacy"))
+                            .child(clipboard_sync_toggle(
+                                cx,
+                                clipboard_sync_enabled,
+                                cx.listener(|this, _event, _window, cx| {
+                                    this.set_clipboard_sync_enabled(true, cx);
+                                }),
+                                cx.listener(|this, _event, _window, cx| {
+                                    this.set_clipboard_sync_enabled(false, cx);
+                                }),
+                            ))
                             .child(telemetry_toggle(
                                 cx,
                                 telemetry_enabled,
@@ -943,6 +968,30 @@ fn droplet_toggle(
         "settings-droplet-toggle",
         "Water droplet",
         "A playful droplet to flick around",
+        theme::text_secondary(cx),
+        control,
+    )
+}
+
+fn clipboard_sync_toggle(
+    cx: &App,
+    enabled: bool,
+    on_enable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+    on_disable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    let control = segmented_toggle(
+        cx,
+        "settings-clipboard-sync-on",
+        "settings-clipboard-sync-off",
+        enabled,
+        on_enable,
+        on_disable,
+    );
+    toggle_row(
+        cx,
+        "settings-clipboard-sync-toggle",
+        "Clipboard sync",
+        "Copy on the host, paste here. Overwrites this device's clipboard.",
         theme::text_secondary(cx),
         control,
     )

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -9,7 +9,7 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::*;
 use uuid::Uuid;
 use zedra_rpc::ZedraPairingTicket;
-use zedra_rpc::proto::{HostEvent, SyncSessionResult};
+use zedra_rpc::proto::{ClipboardContent, HostEvent, SyncSessionResult};
 use zedra_session::{
     ConnectEvent, ConnectPhase, ConnectSnapshot, ReconnectReason, Session, SessionHandle,
     SessionState, signer::ClientSigner,
@@ -31,7 +31,9 @@ use crate::terminal_state::TerminalState;
 use crate::theme;
 use crate::transport_badge::ConnectionStatusIndicator;
 use crate::ui::{DrawerEvent, DrawerHost, DrawerSide};
-use crate::workspace_action::{self, GoHome, OpenFileSearch, OpenQuickAction, RequestDisconnect};
+use crate::workspace_action::{
+    self, GoHome, OpenFileSearch, OpenQuickAction, RequestDisconnect, SendClipboard,
+};
 use crate::workspace_action::{
     AddSelectionToChat, CloseDrawer, CloseTerminal, CreateAgent, CreateNewTerminal, GitCommit,
     GitShowItemActions, GitStage, GitUnstage, HideConnecting, NavigateBack, OpenAgentDetail,
@@ -894,6 +896,26 @@ impl Workspace {
                             break;
                         }
                     }
+                    Ok(HostEvent::ClipboardChanged(payload)) => {
+                        // Auto-apply the host clipboard to the device pasteboard,
+                        // but only when the user opted in and the app is foreground
+                        // (iOS blocks background pasteboard writes, and silently
+                        // clobbering the pasteboard uninvited is undesirable).
+                        if platform_bridge::is_app_in_foreground()
+                            && crate::settings::read_clipboard_sync_enabled()
+                        {
+                            if let ClipboardContent::Text(text) = payload.content {
+                                let should_break = workspace
+                                    .update(cx, |_ws, cx| {
+                                        cx.write_to_clipboard(ClipboardItem::new_string(text));
+                                    })
+                                    .is_err();
+                                if should_break {
+                                    break;
+                                }
+                            }
+                        }
+                    }
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Lagged(skipped)) => {
                         tracing::warn!("workspace host event listener lagged by {}", skipped);
@@ -1213,6 +1235,7 @@ impl Workspace {
 
                         if is_initial_connect {
                             refresh_task.await;
+                            let _ = workspace.update(cx, |ws, cx| ws.spawn_clipboard_seed(cx));
                         } else {
                             refresh_task.detach();
                         }
@@ -1491,6 +1514,39 @@ impl Workspace {
         .detach();
     }
 
+    /// On connect, pull the host's current clipboard once so the device starts
+    /// in sync; later changes arrive via `HostEvent::ClipboardChanged`. No-op
+    /// unless clipboard sync is enabled, and only applied while foreground.
+    fn spawn_clipboard_seed(&self, cx: &mut Context<Self>) {
+        if !crate::settings::read_clipboard_sync_enabled() {
+            return;
+        }
+        // Caller invokes this only after the post-sync `has_client()` readiness
+        // gate, so no re-poll here; a dropped client just makes clipboard_get err.
+        let handle = self.session_handle().clone();
+        cx.spawn(
+            async move |workspace, cx| match handle.clipboard_get().await {
+                Ok(Some(ClipboardContent::Text(text))) => {
+                    // Re-check both gates after the await: the user may have toggled
+                    // sync off or backgrounded during the round trip. If a live
+                    // ClipboardChanged already applied a newer value in this window,
+                    // this one-shot seed can regress it to the older value; the race
+                    // is connect-window-only and self-heals on the next host copy.
+                    if platform_bridge::is_app_in_foreground()
+                        && crate::settings::read_clipboard_sync_enabled()
+                    {
+                        let _ = workspace.update(cx, |_ws, cx| {
+                            cx.write_to_clipboard(ClipboardItem::new_string(text));
+                        });
+                    }
+                }
+                Ok(_) => {}
+                Err(err) => tracing::warn!("clipboard seed on connect failed: {err:#}"),
+            },
+        )
+        .detach();
+    }
+
     pub fn restart_connection(&mut self, cx: &mut Context<Self>) {
         let Some(mut request) = self.connection_request.clone() else {
             warn!("restart connection requested without a connection request");
@@ -1764,6 +1820,54 @@ impl Workspace {
                 }
             },
         );
+    }
+
+    fn handle_send_clipboard(
+        &mut self,
+        _action: &SendClipboard,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) else {
+            platform_bridge::show_alert(
+                "Nothing to send",
+                "The clipboard is empty.",
+                vec![AlertButton::cancel("OK")],
+                |_| {},
+            );
+            return;
+        };
+        if text.len() > zedra_rpc::proto::CLIPBOARD_MAX_BYTES {
+            platform_bridge::show_alert(
+                "Clipboard too large",
+                "This clipboard content exceeds the size limit.",
+                vec![AlertButton::cancel("OK")],
+                |_| {},
+            );
+            return;
+        }
+        let handle = self.session_handle().clone();
+        cx.spawn(async move |_workspace, _cx| {
+            match handle.clipboard_set(ClipboardContent::Text(text)).await {
+                // Confirm the send happened; the push has no on-screen result, so
+                // without this the button press feels like nothing occurred.
+                Ok(()) => platform_bridge::trigger_haptic(HapticFeedback::NotificationSuccess),
+                Err(err) => {
+                    // Surface the failure: the empty/oversized pre-checks above alert,
+                    // so a silent network failure here would mislead the user into
+                    // thinking the paste reached the host.
+                    tracing::warn!("send clipboard to host failed: {err}");
+                    platform_bridge::trigger_haptic(HapticFeedback::NotificationError);
+                    platform_bridge::show_alert(
+                        "Send failed",
+                        "Could not send the clipboard to the host. Check the connection and try again.",
+                        vec![AlertButton::cancel("OK")],
+                        |_| {},
+                    );
+                }
+            }
+        })
+        .detach();
     }
 
     fn handle_toggle_drawer(
@@ -2924,6 +3028,7 @@ impl Render for Workspace {
             .on_action(cx.listener(Self::handle_open_quick_action))
             .on_action(cx.listener(Self::handle_open_file_search))
             .on_action(cx.listener(Self::handle_request_disconnect))
+            .on_action(cx.listener(Self::handle_send_clipboard))
             .on_action(cx.listener(Self::handle_toggle_drawer))
             .on_action(cx.listener(Self::handle_open_drawer))
             .on_action(cx.listener(Self::handle_close_drawer))

--- a/crates/zedra/src/workspace_action.rs
+++ b/crates/zedra/src/workspace_action.rs
@@ -59,6 +59,11 @@ pub struct GitCommit {
 #[action(namespace = workspace, no_json)]
 pub struct CloseDrawer;
 
+/// Send the device clipboard to the host system clipboard (manual push).
+#[derive(Clone, PartialEq, Action)]
+#[action(namespace = workspace, no_json)]
+pub struct SendClipboard;
+
 #[derive(Clone, PartialEq, Action)]
 #[action(namespace = workspace, no_json)]
 pub struct ShowConnecting;

--- a/docs/CLIPBOARD_SYNC.md
+++ b/docs/CLIPBOARD_SYNC.md
@@ -1,0 +1,131 @@
+# Zedra Clipboard Sync
+
+System-clipboard bridge between the host daemon and the mobile client over the existing iroh RPC tunnel. v1 is iOS + text. Images are reserved in the wire type but not implemented until a `gpui_ios` image-clipboard spike lands (see v1.1).
+
+## Architecture
+
+```
+                 macOS / Linux system clipboard
+                          ^          |
+                  arboard |          | arboard          one dedicated thread owns
+                          |          v                  the arboard handle and
+        +-----------------+----------------------+      serves poll + Get + Set
+        |  HOST daemon (zedra-host)              |      (serialized => race-free
+        |    clipboard::spawn thread             |       dedup, X11-safe writes)
+        |    - poll 1s -> hash -> ClipboardSync  |
+        |    - ClipboardGet / ClipboardSet arms  |
+        +-----------------+----------------------+
+                          |  iroh QUIC tunnel (e2e encrypted)
+                          |    HostEvent::ClipboardChanged  (host -> client, stream)
+                          |    ClipboardSet / ClipboardGet  (client -> host, unary)
+        +-----------------+----------------------+
+        |  iOS client (zedra, GPUI)             |
+        |    host-event loop -> auto-apply       |
+        |    "Send clipboard" action             |
+        +-----------------+----------------------+
+                          ^          |
+             UIPasteboard |          | UIPasteboard     via gpui_ios
+                          |          v                  cx.read/write_to_clipboard
+                     iOS device pasteboard
+```
+
+**Host -> device (automatic):**
+
+```
+host clipboard   watcher (poll 1s)         iOS app              device pasteboard
+   copy "X" ------->  hash != last_hash
+                      broadcast ==HostEvent::ClipboardChanged("X")==>  if foreground
+                                                                       && sync ON:
+                                                                       write "X" -------> "X"
+```
+
+**Device -> host (manual) + loop suppression:**
+
+```
+device pasteboard   "Send clipboard"        host dispatch            watcher
+   "Y" ----read---->  ClipboardSet("Y") ==>  note_written(hash "Y")
+                                             arboard.set_text("Y")
+                                             (next poll: hash == last_hash => NO echo back)
+```
+
+## Interaction model
+
+Two directions, deliberately asymmetric because iOS forbids background pasteboard reads:
+
+- **Host to client (automatic).** The host watches its own system clipboard and, on change, pushes the latest value to subscribed clients as a `HostEvent`. When the client app is foreground and the "Clipboard sync" setting is on, it writes the value into the device pasteboard.
+- **Client to host (manual).** A "Send clipboard" action reads the device pasteboard and issues a `ClipboardSet` RPC. The host writes it to its system clipboard.
+
+Single latest slot, last-write-wins. No history, no snippets.
+
+## Scope
+
+- **v1:** text only, iOS only. Auto host to client, manual client to host, OFF-by-default settings toggle, 2 MiB payload cap, content-hash loop suppression.
+- **v1.1 (deferred):** images (PNG/JPEG). The `ClipboardContent::Image` wire variant ships in v1 unused so v1.1 is purely additive, but image capture and apply are gated on verifying `gpui_ios` `ClipboardItem` image support (spike first; FFI `UIPasteboard.image` fallback if unsupported). Android is out of scope for both.
+
+## Wire protocol
+
+Postcard is positional, so these are appended at the tail of `ZedraProto` and `HostEvent` (never inserted/reordered). Following the repo's compatibility model (the live `zedra/rpc/4` line rolls forward with host and client shipping together; the frozen `proto_v3.rs` is the cross-version boundary), `zedra/rpc/4` is not bumped, matching the 2026-07-05 `FsSearch` precedent. The new v4-only request variants need no `proto_v3` work; `HostEvent::ClipboardChanged` gets a `host_event_v3` filter arm so v3 clients never receive it.
+
+Caveat, not a general decode-compat guarantee: a v4 client built *before* this variant existed cannot decode a `ClipboardChanged` on its Subscribe stream. Per the rolling-v4 model a host should not out-run its paired clients; if that ever becomes a real rollout hazard, gate the broadcast on a client-capability check rather than relying on lockstep.
+
+Shared payload type (in `crates/zedra-rpc/src/proto.rs`):
+
+```rust
+pub enum ClipboardContent {
+    Text(String),
+    // v1.1, unused in v1; keeps the wire additive.
+    Image { format: ClipboardImageFormat, bytes: Vec<u8> }, // serde_bytes
+}
+```
+
+RPC surface (appended to `ZedraProto`, after `ClearClientDeltaInfo`):
+
+- `ClipboardSet(ClipboardSetReq)` to `oneshot<ClipboardSetResult>`, client to host. `ClipboardSetReq { content: ClipboardContent }`, `ClipboardSetResult { error: Option<String> }` (mirrors `FsWriteResult`).
+- `ClipboardGet(ClipboardGetReq)` to `oneshot<ClipboardGetResult>`, seed on connect / explicit pull. `ClipboardGetResult { content: Option<ClipboardContent>, error: Option<String> }`.
+
+Host-initiated event (appended to `HostEvent`, streamed over `Subscribe`):
+
+- `HostEvent::ClipboardChanged(ClipboardPayload)` where `ClipboardPayload { content: ClipboardContent }`.
+
+The 2 MiB cap is enforced before anything crosses the tunnel: the host drops oversized content from `ClipboardChanged` and `ClipboardGet`; the client rejects oversized `ClipboardSet` locally with a user-facing notice.
+
+## Host watcher
+
+`crates/zedra-host` gains an `arboard` dependency (the daemon is headless, so it has no GPUI clipboard). A single watcher per host, not per client, reads the system clipboard, hashes the content, and polls every ~1 s. On a hash change it broadcasts `ClipboardChanged` to all subscribers. `ClipboardSet` writes via `arboard`; `ClipboardGet` reads via `arboard`.
+
+Graceful degradation: if `arboard` fails to initialize (headless host with no display server), clipboard sync is disabled, the watcher does not start and `ClipboardGet`/`ClipboardSet` return an `error` string instead of panicking.
+
+## Loop suppression (correctness-critical)
+
+Without this the feature echoes: client sends -> host writes its clipboard -> watcher sees a "change" -> pushes `ClipboardChanged` back -> client re-applies. The watcher tracks the hash of the last value it wrote or observed. A detected change whose hash equals the last-known hash is ignored and never broadcast. A `ClipboardSet` updates the last-known hash before writing, so the resulting watcher tick is a no-op.
+
+## iOS integration
+
+Clipboard I/O goes through GPUI, not the Swift FFI bridge (which is for keyboard/safe-area/version glue only). The mobile client:
+
+- Client RPC methods `clipboard_set` / `clipboard_get` in `crates/zedra-session/src/handle.rs`, consuming `ClipboardChanged` in the host event handler (`session.rs`).
+- On connect, calls `clipboard_get` once to seed the current host value.
+- On `ClipboardChanged` (or the seed), if the toggle is on and the app is foreground, applies via `cx.write_to_clipboard(ClipboardItem::new_string(...))`.
+- "Send clipboard" reads `cx.read_from_clipboard()`, enforces the cap, and calls `clipboard_set`.
+
+## Settings
+
+One "Clipboard sync" toggle, **default OFF**. It gates the automatic host-to-client pasteboard write (the invasive path: it clobbers whatever the user copied, and clipboards often hold secrets). The manual "Send clipboard" button is an explicit user action and is always available regardless of the toggle.
+
+## Security
+
+Clipboard content is end-to-end encrypted in transit by the existing tunnel. The residual risk is on-device: once auto-written, the iOS pasteboard is readable by other apps. The OFF-by-default toggle is the mitigation; users opt in knowingly.
+
+**Host-side opt-out.** The client toggle gates only device-side *apply*. The host also captures its own clipboard, so it has its own kill switch: set `ZEDRA_CLIPBOARD_SYNC=0` (`false`/`off`/`no`) in the daemon's environment to stop the watcher from starting at all, for a shared or privacy-sensitive host. Default is on. A fuller fix (host only captures when a paired client has sync on, via a capability bit at Connect) is planned for v1.1.
+
+**Broadcast scope (deliberate).** Clipboard is the first host-*global* event: a host clipboard change is delivered to every currently-subscribed session, whereas existing events (`GitChanged`, `FsChanged`, `TerminalAgentChanged`) target one session. This is inherent to "one host clipboard, N paired devices" and is intended. The value only reaches a device's *pasteboard* if that device has the setting on and is foreground; the delivery itself is bounded to live subscribers (no at-rest backlog). In a multi-device pairing, be aware every subscribed device receives the host clipboard.
+
+## Testing
+
+- Postcard roundtrip tests in `zedra-rpc` for every new type (required by `PROTOCOL_SPECS.md` §10).
+- Host watcher unit test with a fake clipboard: hash-change detection, cap enforcement, and loop-suppression (a set-then-tick produces no broadcast).
+- On-device manual test appended to `docs/MANUAL_TEST.md`: copy on host -> appears on device; send from device -> appears on host; toggle off -> no auto-write.
+
+## Protocol checklist (`PROTOCOL_SPECS.md` §10)
+
+1. `proto.rs`, new variants + structs. 2. `rpc_daemon.rs`, dispatch arms + watcher. 3. `handle.rs`, client methods + event consumption. 4. UI, toggle + send button. 5. Update `PROTOCOL_SPECS.md` §5 (RPC surface) and §11 (changelog). 6. Roundtrip + behavior tests. 7. Note the protocol change in the PR.

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1547,3 +1547,24 @@ id in production). The trailing shows the aggregate `done/total` rollup.
 1. With the droplet on, rotate the device.
 2. Expected: no crash, no stale grab artifacts; the droplet keeps rendering at its
    logical position and refraction stays sharp after the size change.
+
+## Clipboard Sync (host <-> iOS, text v1)
+
+Requires a paired host daemon with a reachable system clipboard (a normal macOS/Linux desktop session, not a headless server).
+
+### Host to device (auto)
+1. Open Settings and turn **Clipboard sync** on (it defaults off).
+2. On the host machine, copy some text with the OS clipboard tool (`pbcopy` on macOS, `xclip`/`wl-copy` on Linux) or select+copy.
+3. With the app foreground, expected: within ~1s the device pasteboard holds that text, paste into any iOS text field to confirm.
+4. Turn Clipboard sync **off**, copy new text on the host.
+5. Expected: the device pasteboard does NOT change (no auto-write when off).
+
+### Device to host (manual)
+1. Copy text on the device.
+2. Tap **Send clipboard**.
+3. Expected: the host system clipboard now holds that text (verify with the OS clipboard tool, e.g. `pbpaste`/`xclip -o`/`wl-paste`, or paste into another app).
+4. Expected: the send does not bounce back and overwrite the device pasteboard.
+
+### Degraded host
+1. Point the app at a headless host with no display server / clipboard.
+2. Expected: no crash; auto-sync is silently inactive and Send clipboard surfaces a clear error rather than hanging.

--- a/docs/PROTOCOL_SPECS.md
+++ b/docs/PROTOCOL_SPECS.md
@@ -233,7 +233,7 @@ Result types that carry `error: Option<String>`:
 `FsListResult`, `FsSearchResult`, `FsReadResult`, `FsStatResult`, `SessionSwitchResult`, `TermCreateResult`,
 `GitStatusResult`, `GitDiffResult`, `GitLogResult`, `GitCommitResult`, `GitStageResult`,
 `GitUnstageResult`, `GitBranchesResult`, `AgentListResult`, `AgentSessionsResult`,
-`AgentResumeResult`, `LspDiagnosticsResult`.
+`AgentResumeResult`, `LspDiagnosticsResult`, `ClipboardSetResult`, `ClipboardGetResult`.
 
 Types that use non-string status fields or enum variants instead:
 `FsWriteResult` (`ok: bool`), `GitCheckoutResult` (`ok: bool`), `FsWatchResult`/`FsUnwatchResult` (enum),
@@ -413,6 +413,19 @@ CLI `--version` probes are slow and cached separately from the synchronous agent
 4. **Background completion:** host pushes `HostEvent::AgentInfoChanged { info }` once per managed agent to every session with an active `Subscribe` stream. `info` is the full cached `AgentSummary` for that agent (including versions and live bindings for that session).
 5. **Client update:** replace the cached row for `info.kind` (do not treat the event as a partial patch).
 
+## 5.8 Clipboard
+
+- `ClipboardSet(ClipboardSetReq) -> ClipboardSetResult`, client pushes its device clipboard; host writes it to the host system clipboard. Manual, user-initiated (iOS forbids background pasteboard reads).
+- `ClipboardGet(ClipboardGetReq) -> ClipboardGetResult`, client reads the host's current system clipboard (e.g. to seed on connect).
+- Host-to-client changes arrive as `HostEvent::ClipboardChanged` (see §6), not a poll.
+
+Conventions:
+
+- `ClipboardContent` is `Text(String)` in v1. The `Image { format, bytes }` variant is reserved on the wire but neither produced nor consumed until v1.1.
+- Payloads over `CLIPBOARD_MAX_BYTES` (2 MiB) are dropped by the host and rejected by the client before crossing the tunnel.
+- The host runs one clipboard watcher and broadcasts a change to every subscribed session. A `ClipboardSet` records the written value's hash so it is not echoed back as a `ClipboardChanged`.
+- If the host has no reachable system clipboard (headless, no display server), the watcher does not start and `ClipboardGet`/`ClipboardSet` return `error`.
+
 ---
 
 ## 6) Host Events
@@ -424,6 +437,7 @@ Current host event variants:
 - `FsChanged { path }`
 - `AgentInfoChanged { info }`
 - `TerminalAgentChanged { terminal_id, agent_slug }`
+- `ClipboardChanged(ClipboardPayload)`
 
 Client rules:
 
@@ -431,7 +445,8 @@ Client rules:
 - `GitChanged`: invalidate cached git state and refresh when appropriate.
 - `FsChanged { path }`: invalidate cached file tree for the watched path and reload affected expanded nodes.
 - `AgentInfoChanged`: replace cached `AgentSummary` for `info.slug`. One event per managed agent per version refresh. Requires an active `Subscribe` stream.
-- `TerminalAgentChanged`: update the terminal's agent identity to `agent_slug` (`None` clears it). Emitted when the host-resolved foreground agent for a terminal changes (command start/end). Authoritative — clients render it instead of re-detecting locally. Requires an active `Subscribe` stream.
+- `TerminalAgentChanged`: update the terminal's agent identity to `agent_slug` (`None` clears it). Emitted when the host-resolved foreground agent for a terminal changes (command start/end). Authoritative, clients render it instead of re-detecting locally. Requires an active `Subscribe` stream.
+- `ClipboardChanged`: the host system clipboard changed. When clipboard sync is enabled and the app is foreground, write `content` to the device pasteboard. Requires an active `Subscribe` stream. v4-only: filtered out for v3 clients.
 
 ---
 
@@ -602,6 +617,10 @@ Any protocol-layer change must include all applicable steps:
 ---
 
 ## 11) Protocol Changelog
+
+### 2026-07-06
+
+- Added clipboard sync (host <-> client). Appended `ClipboardSet`/`ClipboardGet` request variants to `ZedraProto`, appended `HostEvent::ClipboardChanged`, and added `ClipboardContent`/`ClipboardPayload`/req+result structs plus `CLIPBOARD_MAX_BYTES`. Appended at each enum's tail; `zedra/rpc/4` is not bumped, following the rolling-v4 / frozen-v3 model used for the 2026-07-05 `FsSearch` change (host and client ship together; `proto_v3.rs` is the cross-version boundary). This is not a general decode-compat guarantee: a v4 client built before `ClipboardChanged` cannot decode it on its Subscribe stream, so a host should not out-run its paired clients. `proto_v3.rs` filters `ClipboardChanged` out for v3 clients; the v4-only request variants need no v3 lift. Text only in v1; the `ClipboardContent::Image` variant ships reserved for v1.1. See `docs/CLIPBOARD_SYNC.md`.
 
 ### 2026-07-05
 


### PR DESCRIPTION
## Summary

- Sync the system clipboard across the zedra tunnel, both directions.
- **Host to device (automatic):** the host watches its own clipboard and pushes changes as `HostEvent::ClipboardChanged`; the app writes them to the device pasteboard when foreground and the (default-OFF) "Clipboard sync" setting is on.
- **Device to host (manual):** a "Send clipboard" action issues `ClipboardSet`; the host writes its system clipboard.
- Single latest slot, last-write-wins, text only in v1, 2 MiB cap. The `ClipboardContent::Image` wire variant ships reserved so images (v1.1) are additive.
- Design + rationale: `docs/CLIPBOARD_SYNC.md` (architecture + sequence diagrams).

Implements the feature discussed in #174.

## Notes

**Protocol change** (per `PROTOCOL_SPECS.md` §10): appended `ClipboardSet`/`ClipboardGet` request variants and `HostEvent::ClipboardChanged` at the tail of `ZedraProto`/`HostEvent`, plus `ClipboardContent`/`ClipboardPayload`/req+result structs and `CLIPBOARD_MAX_BYTES`. No ALPN bump: this follows the rolling-v4 / frozen-v3 model of the 2026-07-05 `FsSearch` change; `proto_v3` filters `ClipboardChanged` for v3 clients. `PROTOCOL_SPECS.md` §5.8, §6, and the §11 changelog are updated; postcard roundtrip tests added.

**New host dependency (please confirm, #174):** the daemon has no clipboard access today, so host clipboard I/O uses `arboard` (text-only feature set). Happy to switch to `pbcopy`/`pbpaste` (+ `xclip`/`wl-copy`) or another approach if you prefer.

**Design:** one dedicated host thread owns the `arboard` handle and serves poll + Get + Set, so dedup is race-free and writes persist on X11. Host-side kill switch `ZEDRA_CLIPBOARD_SYNC=0` for a shared/privacy-sensitive host. `arboard` calls are synchronous (documented tradeoff: a wedged X11 clipboard can block sync until restart; macOS unaffected).

**Testing / verification:**
- `cargo test -p zedra-rpc -p zedra-host` green (postcard roundtrips, v3 filter, degraded-host, echo suppression). `cargo check --workspace` clean.
- Verified live on the iOS Simulator (iPhone 17 Pro, iOS 26.5), both directions, with a negative control confirming the Simulator's own pasteboard auto-sync was off.
- `docs/MANUAL_TEST.md` has the on-device steps ("Clipboard Sync"). Screenshots available on request.

**Open for your call (#174):** the `arboard` dependency above; whether the rolling-v4 wire model is acceptable here or you want a client-capability gate at Connect; and the host-global broadcast + kill-switch model.

No breaking changes (additive, no ALPN bump).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added host ↔ app clipboard sync for text, with automatic host-to-device updates in the foreground.
  * Added a “Send clipboard” button for manual device-to-host sharing.
  * Introduced a “Clipboard sync” setting (default off) and capped clipboard transfers to 2 MiB.
* **Bug Fixes**
  * Prevented echo/bounce-back from repeatedly overwriting the same clipboard value.
  * Improved degraded-mode handling when host clipboard access isn’t available (operations fail fast with clear errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->