### PR TITLE
fix(terminal): selection survives scroll (Phase 1, re-anchor)

### DIFF
--- a/crates/zedra-terminal/PROOF-01-select-survives-scroll.md
+++ b/crates/zedra-terminal/PROOF-01-select-survives-scroll.md
@@ -1,0 +1,78 @@
+# Proof of done: selection survives scroll (Phase 1, re-anchor)
+
+Sub-goal 01 of `zedra-select-scroll`. Fixes Phase 1 of tanlethanh/zedra#178.
+
+## Acceptance criteria
+
+| # | Criterion | Status |
+|---|-----------|--------|
+| 1 | `Terminal` stores the selection as absolute alacritty grid `Point`s (`Option<{anchor, focus}>`), not a viewport-relative `Range<usize>` | met |
+| 2 | `TerminalSelectionDocument` retains each char's grid `(line, col)` and exposes `utf16_for_abs_point` + `abs_point_for_utf16` | met |
+| 3 | The read API (`selection_range`) still yields a UTF-16 `Range<usize>`, now derived each frame by projecting `{anchor, focus}` onto the current document with edge-clamping | met |
+| 4 | Scroll paths no longer invalidate the selection; next frame's projection reflects the new viewport | met |
+| 5 | No `vendor/zed` change, no alacritty native `Selection`, no soft/hard-wrap copy-semantics change, IME/dictation branches untouched | met |
+| 6 | Existing `includes_scrolled_scrollback_viewport` + soft-wrap tests still pass | met |
+| 7 | Three new tests (survive-scroll / off-screen-clamp-and-resolve / soft-wrap-join) | met |
+| 8 | Negative control: reverting the per-frame re-derive turns test (a) RED | met |
+
+## Implementation summary
+
+- `crates/zedra-terminal/src/terminal.rs`
+  - New `TerminalSelection { anchor: Point, focus: Point }` (absolute alacritty grid points; `Point::line` is display-offset independent: `visible_row = line + display_offset`).
+  - Field `selection_range: Option<Range<usize>>` -> `selection: Option<TerminalSelection>`.
+  - `selection_range()` now DERIVES per call: builds a fresh document from current content (pixel origin irrelevant, `(0,0)`) and projects the stored points via `utf16_range_for_selection`.
+  - `set_selection_range(range)` keeps its UTF-16 signature but re-anchors: `anchor = abs_point_for_utf16(range.start)`, `focus = abs_point_for_utf16(range.end - 1)`. Empty range clears (nothing to anchor).
+  - `clear_selection_range` / `selection_active` retargeted to the new field.
+- `crates/zedra-terminal/src/selection.rs`
+  - `TerminalSelectionChar` gains `line: i32` (absolute) + `col: usize` (leading grid column; synthesized `\n` uses `grid_cols` as a virtual column so it sorts after real cells).
+  - Public `utf16_for_abs_point(Point) -> Option<usize>`, `abs_point_for_utf16(usize) -> Option<Point>`, and `utf16_range_for_selection(anchor, focus) -> Range<usize>` (normalizes order, clamps a start whose point is below the viewport to `len`, an end above to `0`, so an off-screen anchor projects onto the visible remainder and re-resolves exactly on scroll-back).
+- `input.rs`, `element.rs`, `view.rs`: **unchanged** for the selection path. The derive lives entirely in `terminal.rs`/`selection.rs`; the consumers still call `term.selection_range()` and get a UTF-16 range. IME/dictation/marked-text branches untouched.
+
+## Confirmation run-table
+
+| Command | Exit | Key output line |
+|---------|------|-----------------|
+| `cargo fmt --check -p zedra-terminal` | 0 | (no diff) |
+| `cargo check --workspace` | 0 | `cargo build: 0 errors ... (443 crates)` |
+| `cargo test -p zedra-terminal` | 0 | `178 passed (2 suites)` |
+| `cargo test -- <3 new tests + includes_scrolled + omits_newline>` | 0 | `5 passed, 173 filtered out` |
+| NC: `cargo test -- selection_survives_scroll_via_absolute_grid_points` (re-derive reverted) | 1 | `test result: FAILED. 0 passed; 1 failed` |
+
+## Run detail
+
+New tests (all in `crates/zedra-terminal/src/selection.rs` `mod tests`):
+
+- `selection_survives_scroll_via_absolute_grid_points`, (a) select `MARK` at top of scrollback, `scroll(-1)`; derived range still covers `"MARK"`.
+- `off_screen_anchor_clamps_and_resolves_exactly`, (b) select a 3-row span from `aaaa` through `MARK`; `scroll(-2)` pushes the anchor rows off-screen, derived range clamps to `start == 0` and covers `"cccc MARK"` (visible remainder); `scroll(2)` back re-resolves the EXACT original range and full text.
+- `soft_wrapped_selection_keeps_wrap_join_after_scroll`, (c) `helloworld` soft-wrapped across two 5-col rows; selected range reads `"helloworld"` (no `\n`); after `scroll(-1)` the visible remainder is `"world"` with no stray `\n`; `scroll(1)` back restores `"helloworld"`.
+
+Pre-existing guards re-run green: `includes_scrolled_scrollback_viewport`, `omits_newline_for_soft_wraps`.
+
+## Reproduce
+
+```
+cd crates/zedra-terminal   # from the worktree root
+cargo fmt --check -p zedra-terminal
+cargo check --workspace
+cargo test -p zedra-terminal
+```
+
+## Negative control (Rung 2), red on revert
+
+Temporarily reverted the per-frame re-derive: cached the set-time viewport
+`Range<usize>` in a scratch field and returned it from `selection_range()`
+instead of re-projecting the absolute points. Test (a) then failed:
+
+```
+thread 'selection::tests::selection_survives_scroll_via_absolute_grid_points' panicked
+  at crates/zedra-terminal/src/selection.rs:682:9:
+assertion `left == right` failed
+  left: Some("dddd")
+ right: Some("MARK")
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 177 filtered out
+```
+
+The stale range, after `scroll(-1)`, now covers `"dddd"` (the text that slid
+under those UTF-16 offsets) instead of the anchored `"MARK"`, exactly the
+display-offset-keyed invalidation this change removes. The scratch field was
+reverted (`git checkout`) and the suite re-run green afterward.

--- a/crates/zedra-terminal/src/selection.rs
+++ b/crates/zedra-terminal/src/selection.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+use alacritty_terminal::index::{Column as AlacColumn, Line as AlacLine, Point as AlacPoint};
 use alacritty_terminal::term::cell::Flags as CellFlags;
 use gpui::{Bounds, Pixels, Point, point, px, size};
 use smallvec::SmallVec;
@@ -20,6 +21,10 @@ struct TerminalSelectionChar {
     end_utf16: usize,
     byte_start: usize,
     ch: char,
+    /// Absolute alacritty grid line (display-offset independent).
+    line: i32,
+    /// Leading grid column of this char (`grid_cols` for a synthesized `\n`).
+    col: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -105,6 +110,7 @@ impl TerminalSelectionDocument {
                 .max();
 
             let y = origin.y + line_height * row_idx as f32;
+            let abs_line = row_idx as i32 - content.display_offset as i32;
             let mut cells = Vec::new();
 
             if let Some(last_nonblank_col) = last_nonblank_col {
@@ -131,6 +137,8 @@ impl TerminalSelectionDocument {
                         end_utf16: len_utf16,
                         byte_start,
                         ch,
+                        line: abs_line,
+                        col,
                     });
                     let bounds = Bounds {
                         origin: point(origin.x + cell_width * col as f32, y),
@@ -155,6 +163,8 @@ impl TerminalSelectionDocument {
                     end_utf16: len_utf16,
                     byte_start,
                     ch: '\n',
+                    line: abs_line,
+                    col: content.grid_cols,
                 });
             }
 
@@ -297,6 +307,63 @@ impl TerminalSelectionDocument {
         start.min(end)..start.max(end)
     }
 
+    /// Absolute alacritty grid point of the char containing `offset_utf16`.
+    /// `None` when the offset lies at or past the end of the document.
+    pub fn abs_point_for_utf16(&self, offset_utf16: usize) -> Option<AlacPoint> {
+        self.chars
+            .iter()
+            .find(|ch| ch.start_utf16 <= offset_utf16 && offset_utf16 < ch.end_utf16)
+            .map(|ch| AlacPoint::new(AlacLine(ch.line), AlacColumn(ch.col)))
+    }
+
+    /// UTF-16 start offset of the char at absolute grid `point`.
+    /// `None` when no char occupies that point in the current viewport.
+    pub fn utf16_for_abs_point(&self, point: AlacPoint) -> Option<usize> {
+        self.chars
+            .iter()
+            .find(|ch| ch.line == point.line.0 && ch.col == point.column.0)
+            .map(|ch| ch.start_utf16)
+    }
+
+    /// Project a selection anchored at absolute grid points onto the current
+    /// visible document, yielding a UTF-16 range. `anchor`/`focus` are the
+    /// first/last selected cells (both inclusive), in absolute, display-offset
+    /// independent coordinates. Endpoints above the visible window clamp to the
+    /// document start; endpoints below clamp to the document end, so a selection
+    /// whose anchor has scrolled off-screen still projects onto its visible
+    /// remainder and re-resolves exactly once scrolled back.
+    pub fn utf16_range_for_selection(&self, anchor: AlacPoint, focus: AlacPoint) -> Range<usize> {
+        if self.chars.is_empty() {
+            return 0..0;
+        }
+        let (start_pt, end_pt) = if point_le(anchor, focus) {
+            (anchor, focus)
+        } else {
+            (focus, anchor)
+        };
+        let start = self.clamp_start_point(start_pt);
+        let end = self.clamp_end_point(end_pt);
+        start.min(end)..start.max(end)
+    }
+
+    /// UTF-16 start of the first char at or after `point` in grid order
+    /// (`len_utf16` when `point` is below every visible char).
+    fn clamp_start_point(&self, point: AlacPoint) -> usize {
+        match self.chars.iter().find(|ch| !char_lt_point(ch, point)) {
+            Some(ch) => ch.start_utf16,
+            None => self.len_utf16,
+        }
+    }
+
+    /// UTF-16 end of the last char at or before `point` in grid order
+    /// (`0` when `point` is above every visible char).
+    fn clamp_end_point(&self, point: AlacPoint) -> usize {
+        match self.chars.iter().rev().find(|ch| !char_gt_point(ch, point)) {
+            Some(ch) => ch.end_utf16,
+            None => 0,
+        }
+    }
+
     fn caret_bounds(&self, offset_utf16: usize) -> Option<Bounds<Pixels>> {
         if self.lines.is_empty() {
             return None;
@@ -404,6 +471,18 @@ fn cell_for_x(line: &TerminalSelectionLine, x: Pixels) -> Option<&TerminalSelect
     line.cells.get(index)
 }
 
+fn point_le(a: AlacPoint, b: AlacPoint) -> bool {
+    (a.line.0, a.column.0) <= (b.line.0, b.column.0)
+}
+
+fn char_lt_point(ch: &TerminalSelectionChar, point: AlacPoint) -> bool {
+    (ch.line, ch.col) < (point.line.0, point.column.0)
+}
+
+fn char_gt_point(ch: &TerminalSelectionChar, point: AlacPoint) -> bool {
+    (ch.line, ch.col) > (point.line.0, point.column.0)
+}
+
 fn is_selectable_cell(cell: &IndexedCell) -> bool {
     !cell
         .cell
@@ -433,10 +512,33 @@ fn row_soft_wraps(row: &[&IndexedCell], grid_cols: usize) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Range;
+
     use gpui::{point, px};
 
     use super::*;
     use crate::Terminal;
+
+    fn doc_now(terminal: &Terminal) -> TerminalSelectionDocument {
+        let content = terminal.content();
+        TerminalSelectionDocument::new(&content, point(px(0.0), px(0.0)), px(10.0), px(20.0))
+    }
+
+    /// UTF-16 range of `marker` within the current viewport (ASCII-safe).
+    fn marker_range(terminal: &Terminal, marker: &str) -> Range<usize> {
+        let doc = doc_now(terminal);
+        let text = doc.text_for_range(0..doc.len_utf16()).1;
+        let byte = text.find(marker).expect("marker must be visible");
+        let start = text[..byte].encode_utf16().count();
+        start..start + marker.encode_utf16().count()
+    }
+
+    /// Text covered by the terminal's derived selection range against the
+    /// current viewport, or `None` when nothing is selected.
+    fn selection_text_now(terminal: &Terminal) -> Option<String> {
+        let range = terminal.selection_range()?;
+        Some(doc_now(terminal).text_for_range(range).1)
+    }
 
     fn selection_text(output: &[u8], cols: usize, rows: usize) -> String {
         let mut terminal = Terminal::new(cols, rows, px(10.0), px(20.0));
@@ -554,5 +656,98 @@ mod tests {
                 .1
                 .contains("crates/foo/file_a.rs")
         );
+    }
+
+    // (a) A word selected while scrolled stays covered after a further scroll,
+    // because the selection is anchored to absolute grid points, not to
+    // viewport-relative UTF-16 offsets.
+    #[test]
+    fn selection_survives_scroll_via_absolute_grid_points() {
+        let mut terminal = Terminal::new(20, 4, px(10.0), px(20.0));
+        terminal.advance_bytes(b"aaaa\r\nbbbb\r\ncccc MARK dddd\r\n");
+        for line in 0..20 {
+            terminal.advance_bytes(format!("filler {line}\r\n").as_bytes());
+        }
+        terminal.scroll(1000); // to the top of scrollback
+
+        let range = marker_range(&terminal, "MARK");
+        terminal.set_selection_range(range.clone());
+        // Same viewport: exact round-trip through the absolute-point anchor.
+        assert_eq!(terminal.selection_range(), Some(range));
+        assert_eq!(selection_text_now(&terminal).as_deref(), Some("MARK"));
+
+        // Scroll down one row: MARK sits on a new visible row but the same
+        // absolute grid point, so the derived range still covers it.
+        terminal.scroll(-1);
+        assert_eq!(selection_text_now(&terminal).as_deref(), Some("MARK"));
+    }
+
+    // (b) When the anchor scrolls off the top, the projection clamps to the
+    // document edge (the visible remainder), and scrolling back re-resolves the
+    // EXACT original range.
+    #[test]
+    fn off_screen_anchor_clamps_and_resolves_exactly() {
+        let mut terminal = Terminal::new(20, 4, px(10.0), px(20.0));
+        terminal.advance_bytes(b"aaaa\r\nbbbb\r\ncccc MARK dddd\r\n");
+        for line in 0..20 {
+            terminal.advance_bytes(format!("filler {line}\r\n").as_bytes());
+        }
+        terminal.scroll(1000); // top: aaaa / bbbb / cccc MARK dddd / filler 0
+
+        // Select from the start of "aaaa" through "MARK" (spans three rows).
+        let doc = doc_now(&terminal);
+        let text = doc.text_for_range(0..doc.len_utf16()).1;
+        let end_byte = text.find("MARK").unwrap() + "MARK".len();
+        let range = 0..text[..end_byte].encode_utf16().count();
+        let expected_full = doc.text_for_range(range.clone()).1;
+        terminal.set_selection_range(range.clone());
+        assert_eq!(terminal.selection_range(), Some(range.clone()));
+
+        // Scroll down two rows: "aaaa" and "bbbb" (the anchor side) leave the
+        // viewport. The projection clamps to the top edge of the visible doc.
+        terminal.scroll(-2);
+        let clamped = terminal.selection_range().unwrap();
+        assert_eq!(clamped.start, 0);
+        assert_eq!(selection_text_now(&terminal).as_deref(), Some("cccc MARK"));
+
+        // Scroll back: the original three-row range resolves exactly.
+        terminal.scroll(2);
+        assert_eq!(terminal.selection_range(), Some(range));
+        assert_eq!(
+            selection_text_now(&terminal).as_deref(),
+            Some(expected_full.as_str())
+        );
+    }
+
+    // (c) A soft-wrapped logical line keeps its wrap-join (no stray '\n') across
+    // scroll, both fully visible and when partially clamped.
+    #[test]
+    fn soft_wrapped_selection_keeps_wrap_join_after_scroll() {
+        let mut terminal = Terminal::new(5, 4, px(10.0), px(20.0));
+        terminal.advance_bytes(b"helloworld\r\n");
+        for _ in 0..20 {
+            terminal.advance_bytes(b"x\r\n");
+        }
+        terminal.scroll(1000); // top: "hello" / "world" soft-wrapped across two rows
+
+        let range = marker_range(&terminal, "helloworld");
+        terminal.set_selection_range(range.clone());
+        assert_eq!(terminal.selection_range(), Some(range));
+        // Fully visible: the wrap-join means no '\n' between the two rows.
+        assert_eq!(selection_text_now(&terminal).as_deref(), Some("helloworld"));
+
+        // Scroll the first wrapped row off-screen: the visible remainder is
+        // "world", still with no stray '\n'.
+        terminal.scroll(-1);
+        let partial = selection_text_now(&terminal).unwrap();
+        assert!(
+            !partial.contains('\n'),
+            "wrap-join must not introduce a newline"
+        );
+        assert_eq!(partial, "world");
+
+        // Scroll back: the full soft-wrapped join resolves again.
+        terminal.scroll(1);
+        assert_eq!(selection_text_now(&terminal).as_deref(), Some("helloworld"));
     }
 }

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -22,6 +22,7 @@ use zedra_osc::{OscEvent, OscScanner};
 const REMOTE_TOUCH_SCROLL_STEP_PX: f32 = 12.0;
 
 use crate::keys::to_esc_str;
+use crate::selection::TerminalSelectionDocument;
 use crate::theme::TerminalTheme;
 /// Events emitted by the terminal to observers.
 #[derive(Debug, Clone)]
@@ -192,6 +193,19 @@ pub struct KeyboardInputContextEdit {
     pub selection_range: Range<usize>,
 }
 
+/// A text selection anchored to ABSOLUTE alacritty grid points. Because
+/// `Point::line` is display-offset independent (`visible_row = line +
+/// display_offset`), the selection survives scrolling: the visible UTF-16 range
+/// is re-derived from these points against each frame's document rather than
+/// being stored as viewport-relative offsets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TerminalSelection {
+    /// First selected cell (inclusive), absolute grid coordinates.
+    pub anchor: Point,
+    /// Last selected cell (inclusive), absolute grid coordinates.
+    pub focus: Point,
+}
+
 /// Minimal terminal state wrapping alacritty_terminal::Term
 pub struct Terminal {
     term: Term<ZedraListener>,
@@ -206,7 +220,7 @@ pub struct Terminal {
     alacritty_event_rx: std_mpsc::Receiver<AlacTermEvent>,
     input_tx: Option<mpsc::Sender<Vec<u8>>>,
     output_task: Option<Task<()>>,
-    selection_range: Option<Range<usize>>,
+    selection: Option<TerminalSelection>,
     theme: TerminalTheme,
 }
 
@@ -242,7 +256,7 @@ impl Terminal {
             alacritty_event_rx,
             input_tx: None,
             output_task: None,
-            selection_range: None,
+            selection: None,
             theme,
         };
         terminal
@@ -565,20 +579,54 @@ impl Terminal {
         }
     }
 
+    /// The selection as a UTF-16 range over the CURRENT visible viewport,
+    /// derived each call by projecting the stored absolute grid points onto a
+    /// freshly-built document. Returns `None` when nothing is selected. A stored
+    /// selection whose endpoints have scrolled off-screen still returns a range
+    /// (clamped to the document edge), and re-resolves exactly on scroll-back.
     pub fn selection_range(&self) -> Option<Range<usize>> {
-        self.selection_range.clone()
+        let selection = self.selection?;
+        let document = self.selection_document();
+        Some(document.utf16_range_for_selection(selection.anchor, selection.focus))
     }
 
+    /// Build the per-frame selection document for the current content. Pixel
+    /// origin is irrelevant to the grid<->UTF-16 translation, so it is `(0, 0)`.
+    fn selection_document(&self) -> TerminalSelectionDocument {
+        let content = self.content();
+        TerminalSelectionDocument::new(
+            &content,
+            GpuiPoint {
+                x: px(0.0),
+                y: px(0.0),
+            },
+            self.size.cell_width,
+            self.size.line_height,
+        )
+    }
+
+    /// Store a selection given as a UTF-16 range over the current viewport,
+    /// re-anchoring it to absolute grid points so it survives scrolling. An
+    /// empty range clears the selection (nothing to anchor).
     pub fn set_selection_range(&mut self, range: Range<usize>) {
-        self.selection_range = Some(range);
+        if range.is_empty() {
+            self.selection = None;
+            return;
+        }
+        let document = self.selection_document();
+        let anchor = document.abs_point_for_utf16(range.start);
+        let focus = document.abs_point_for_utf16(range.end - 1);
+        self.selection = anchor
+            .zip(focus)
+            .map(|(anchor, focus)| TerminalSelection { anchor, focus });
     }
 
     pub fn clear_selection_range(&mut self) -> bool {
-        self.selection_range.take().is_some()
+        self.selection.take().is_some()
     }
 
     pub fn selection_active(&self) -> bool {
-        self.selection_range.is_some()
+        self.selection.is_some()
     }
 
     /// Scroll the terminal by a number of lines (positive = up)


### PR DESCRIPTION
Outcome: terminal selection persists across scroll by anchoring to absolute grid points and projecting to UTF-16 per frame.

The selection was stored as a viewport-relative UTF-16 `Range<usize>` keyed off `content.display_offset`, so any scroll left the offsets pointing at different text and silently invalidated the selection. It is now re-anchored to absolute alacritty grid `Point`s (`Point::line` is display-offset independent: `visible_row = line + display_offset`). `Terminal` stores `Option<{ anchor, focus }>` and derives the visible UTF-16 range each frame by projecting those points onto the current document, clamping endpoints that have scrolled above/below the viewport to the document edge and re-resolving them exactly on scroll-back.

Verification: `cargo test -p zedra-terminal` (178 passed) plus three new select->scroll tests (survive-scroll, off-screen-anchor clamp-and-resolve, soft-wrap join). Full run-table + negative control in the proof-of-done on this branch (`crates/zedra-terminal/PROOF-01-select-survives-scroll.md`).

No `vendor/zed` change; no alacritty native `Selection`; soft/hard-wrap copy semantics unchanged; IME/dictation branches untouched.

Fixes part of tanlethanh/zedra#178 (Phase 1; Phase 2 = edge auto-scroll follows).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selection now stays intact when scrolling in the terminal.
  * Visible selection updates correctly as the viewport changes, including wrapped lines and off-screen content.
  * Clearing an empty selection still works as expected.

* **Documentation**
  * Added a proof-of-completion note covering the scrolling selection fix and its expected behavior.
  * Included verification steps and test coverage notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->