### PR TITLE
feat(terminal): auto-scroll selection at viewport edge (Phase 2)

### DIFF
--- a/crates/zedra-terminal/PROOF-01-select-survives-scroll.md
+++ b/crates/zedra-terminal/PROOF-01-select-survives-scroll.md
@@ -1,0 +1,78 @@
+# Proof of done: selection survives scroll (Phase 1, re-anchor)
+
+Sub-goal 01 of `zedra-select-scroll`. Fixes Phase 1 of tanlethanh/zedra#178.
+
+## Acceptance criteria
+
+| # | Criterion | Status |
+|---|-----------|--------|
+| 1 | `Terminal` stores the selection as absolute alacritty grid `Point`s (`Option<{anchor, focus}>`), not a viewport-relative `Range<usize>` | met |
+| 2 | `TerminalSelectionDocument` retains each char's grid `(line, col)` and exposes `utf16_for_abs_point` + `abs_point_for_utf16` | met |
+| 3 | The read API (`selection_range`) still yields a UTF-16 `Range<usize>`, now derived each frame by projecting `{anchor, focus}` onto the current document with edge-clamping | met |
+| 4 | Scroll paths no longer invalidate the selection; next frame's projection reflects the new viewport | met |
+| 5 | No `vendor/zed` change, no alacritty native `Selection`, no soft/hard-wrap copy-semantics change, IME/dictation branches untouched | met |
+| 6 | Existing `includes_scrolled_scrollback_viewport` + soft-wrap tests still pass | met |
+| 7 | Three new tests (survive-scroll / off-screen-clamp-and-resolve / soft-wrap-join) | met |
+| 8 | Negative control: reverting the per-frame re-derive turns test (a) RED | met |
+
+## Implementation summary
+
+- `crates/zedra-terminal/src/terminal.rs`
+  - New `TerminalSelection { anchor: Point, focus: Point }` (absolute alacritty grid points; `Point::line` is display-offset independent: `visible_row = line + display_offset`).
+  - Field `selection_range: Option<Range<usize>>` -> `selection: Option<TerminalSelection>`.
+  - `selection_range()` now DERIVES per call: builds a fresh document from current content (pixel origin irrelevant, `(0,0)`) and projects the stored points via `utf16_range_for_selection`.
+  - `set_selection_range(range)` keeps its UTF-16 signature but re-anchors: `anchor = abs_point_for_utf16(range.start)`, `focus = abs_point_for_utf16(range.end - 1)`. Empty range clears (nothing to anchor).
+  - `clear_selection_range` / `selection_active` retargeted to the new field.
+- `crates/zedra-terminal/src/selection.rs`
+  - `TerminalSelectionChar` gains `line: i32` (absolute) + `col: usize` (leading grid column; synthesized `\n` uses `grid_cols` as a virtual column so it sorts after real cells).
+  - Public `utf16_for_abs_point(Point) -> Option<usize>`, `abs_point_for_utf16(usize) -> Option<Point>`, and `utf16_range_for_selection(anchor, focus) -> Range<usize>` (normalizes order, clamps a start whose point is below the viewport to `len`, an end above to `0`, so an off-screen anchor projects onto the visible remainder and re-resolves exactly on scroll-back).
+- `input.rs`, `element.rs`, `view.rs`: **unchanged** for the selection path. The derive lives entirely in `terminal.rs`/`selection.rs`; the consumers still call `term.selection_range()` and get a UTF-16 range. IME/dictation/marked-text branches untouched.
+
+## Confirmation run-table
+
+| Command | Exit | Key output line |
+|---------|------|-----------------|
+| `cargo fmt --check -p zedra-terminal` | 0 | (no diff) |
+| `cargo check --workspace` | 0 | `cargo build: 0 errors ... (443 crates)` |
+| `cargo test -p zedra-terminal` | 0 | `178 passed (2 suites)` |
+| `cargo test -- <3 new tests + includes_scrolled + omits_newline>` | 0 | `5 passed, 173 filtered out` |
+| NC: `cargo test -- selection_survives_scroll_via_absolute_grid_points` (re-derive reverted) | 1 | `test result: FAILED. 0 passed; 1 failed` |
+
+## Run detail
+
+New tests (all in `crates/zedra-terminal/src/selection.rs` `mod tests`):
+
+- `selection_survives_scroll_via_absolute_grid_points`, (a) select `MARK` at top of scrollback, `scroll(-1)`; derived range still covers `"MARK"`.
+- `off_screen_anchor_clamps_and_resolves_exactly`, (b) select a 3-row span from `aaaa` through `MARK`; `scroll(-2)` pushes the anchor rows off-screen, derived range clamps to `start == 0` and covers `"cccc MARK"` (visible remainder); `scroll(2)` back re-resolves the EXACT original range and full text.
+- `soft_wrapped_selection_keeps_wrap_join_after_scroll`, (c) `helloworld` soft-wrapped across two 5-col rows; selected range reads `"helloworld"` (no `\n`); after `scroll(-1)` the visible remainder is `"world"` with no stray `\n`; `scroll(1)` back restores `"helloworld"`.
+
+Pre-existing guards re-run green: `includes_scrolled_scrollback_viewport`, `omits_newline_for_soft_wraps`.
+
+## Reproduce
+
+```
+cd crates/zedra-terminal   # from the worktree root
+cargo fmt --check -p zedra-terminal
+cargo check --workspace
+cargo test -p zedra-terminal
+```
+
+## Negative control (Rung 2), red on revert
+
+Temporarily reverted the per-frame re-derive: cached the set-time viewport
+`Range<usize>` in a scratch field and returned it from `selection_range()`
+instead of re-projecting the absolute points. Test (a) then failed:
+
+```
+thread 'selection::tests::selection_survives_scroll_via_absolute_grid_points' panicked
+  at crates/zedra-terminal/src/selection.rs:682:9:
+assertion `left == right` failed
+  left: Some("dddd")
+ right: Some("MARK")
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 177 filtered out
+```
+
+The stale range, after `scroll(-1)`, now covers `"dddd"` (the text that slid
+under those UTF-16 offsets) instead of the anchored `"MARK"`, exactly the
+display-offset-keyed invalidation this change removes. The scratch field was
+reverted (`git checkout`) and the suite re-run green afterward.

--- a/crates/zedra-terminal/src/input.rs
+++ b/crates/zedra-terminal/src/input.rs
@@ -5,7 +5,7 @@ use smallvec::SmallVec;
 
 use crate::keyboard_accessory::AccessoryKey;
 use crate::selection::TerminalSelectionDocument;
-use crate::terminal::Terminal;
+use crate::terminal::{EdgeAutoScroll, Terminal};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct TextInputPreflight {
@@ -449,6 +449,24 @@ impl TerminalInputHandler {
 
     fn set_selection_candidate(&mut self, index: usize) {
         self.selection_candidate = Some(index);
+    }
+
+    /// Arm/refresh/disarm drag-to-edge selection auto-scroll from a hit-test.
+    /// Only fires while a selection is active (a live handle drag); the terminal
+    /// timer, not this call, keeps scrolling once the finger stops moving.
+    fn update_edge_autoscroll(&mut self, point: Point<Pixels>, cx: &mut App) {
+        let direction = if !self.selection_active(cx) {
+            None
+        } else if point.y <= self.bounds.top() + self.line_height {
+            Some(EdgeAutoScroll::Top)
+        } else if point.y >= self.bounds.bottom() - self.line_height {
+            Some(EdgeAutoScroll::Bottom)
+        } else {
+            None
+        };
+
+        let entity = self.entity.clone();
+        let _ = entity.update(cx, |term, cx| term.set_edge_autoscroll(direction, cx));
     }
 }
 
@@ -1028,6 +1046,11 @@ impl InputHandler for TerminalInputHandler {
         _window: &mut Window,
         cx: &mut App,
     ) -> Option<usize> {
+        // UIKit routes selection-handle drags through this callback. Feed the
+        // finger position to the edge auto-scroll so a drag held near the top or
+        // bottom edge keeps scrolling the terminal and extending the selection.
+        self.update_edge_autoscroll(point, cx);
+
         if self.using_selection_document(cx) {
             return self
                 .selection_document(cx)

--- a/crates/zedra-terminal/src/selection.rs
+++ b/crates/zedra-terminal/src/selection.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+use alacritty_terminal::index::{Column as AlacColumn, Line as AlacLine, Point as AlacPoint};
 use alacritty_terminal::term::cell::Flags as CellFlags;
 use gpui::{Bounds, Pixels, Point, point, px, size};
 use smallvec::SmallVec;
@@ -20,6 +21,10 @@ struct TerminalSelectionChar {
     end_utf16: usize,
     byte_start: usize,
     ch: char,
+    /// Absolute alacritty grid line (display-offset independent).
+    line: i32,
+    /// Leading grid column of this char (`grid_cols` for a synthesized `\n`).
+    col: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -105,6 +110,7 @@ impl TerminalSelectionDocument {
                 .max();
 
             let y = origin.y + line_height * row_idx as f32;
+            let abs_line = row_idx as i32 - content.display_offset as i32;
             let mut cells = Vec::new();
 
             if let Some(last_nonblank_col) = last_nonblank_col {
@@ -131,6 +137,8 @@ impl TerminalSelectionDocument {
                         end_utf16: len_utf16,
                         byte_start,
                         ch,
+                        line: abs_line,
+                        col,
                     });
                     let bounds = Bounds {
                         origin: point(origin.x + cell_width * col as f32, y),
@@ -155,6 +163,8 @@ impl TerminalSelectionDocument {
                     end_utf16: len_utf16,
                     byte_start,
                     ch: '\n',
+                    line: abs_line,
+                    col: content.grid_cols,
                 });
             }
 
@@ -297,6 +307,63 @@ impl TerminalSelectionDocument {
         start.min(end)..start.max(end)
     }
 
+    /// Absolute alacritty grid point of the char containing `offset_utf16`.
+    /// `None` when the offset lies at or past the end of the document.
+    pub fn abs_point_for_utf16(&self, offset_utf16: usize) -> Option<AlacPoint> {
+        self.chars
+            .iter()
+            .find(|ch| ch.start_utf16 <= offset_utf16 && offset_utf16 < ch.end_utf16)
+            .map(|ch| AlacPoint::new(AlacLine(ch.line), AlacColumn(ch.col)))
+    }
+
+    /// UTF-16 start offset of the char at absolute grid `point`.
+    /// `None` when no char occupies that point in the current viewport.
+    pub fn utf16_for_abs_point(&self, point: AlacPoint) -> Option<usize> {
+        self.chars
+            .iter()
+            .find(|ch| ch.line == point.line.0 && ch.col == point.column.0)
+            .map(|ch| ch.start_utf16)
+    }
+
+    /// Project a selection anchored at absolute grid points onto the current
+    /// visible document, yielding a UTF-16 range. `anchor`/`focus` are the
+    /// first/last selected cells (both inclusive), in absolute, display-offset
+    /// independent coordinates. Endpoints above the visible window clamp to the
+    /// document start; endpoints below clamp to the document end, so a selection
+    /// whose anchor has scrolled off-screen still projects onto its visible
+    /// remainder and re-resolves exactly once scrolled back.
+    pub fn utf16_range_for_selection(&self, anchor: AlacPoint, focus: AlacPoint) -> Range<usize> {
+        if self.chars.is_empty() {
+            return 0..0;
+        }
+        let (start_pt, end_pt) = if point_le(anchor, focus) {
+            (anchor, focus)
+        } else {
+            (focus, anchor)
+        };
+        let start = self.clamp_start_point(start_pt);
+        let end = self.clamp_end_point(end_pt);
+        start.min(end)..start.max(end)
+    }
+
+    /// UTF-16 start of the first char at or after `point` in grid order
+    /// (`len_utf16` when `point` is below every visible char).
+    fn clamp_start_point(&self, point: AlacPoint) -> usize {
+        match self.chars.iter().find(|ch| !char_lt_point(ch, point)) {
+            Some(ch) => ch.start_utf16,
+            None => self.len_utf16,
+        }
+    }
+
+    /// UTF-16 end of the last char at or before `point` in grid order
+    /// (`0` when `point` is above every visible char).
+    fn clamp_end_point(&self, point: AlacPoint) -> usize {
+        match self.chars.iter().rev().find(|ch| !char_gt_point(ch, point)) {
+            Some(ch) => ch.end_utf16,
+            None => 0,
+        }
+    }
+
     fn caret_bounds(&self, offset_utf16: usize) -> Option<Bounds<Pixels>> {
         if self.lines.is_empty() {
             return None;
@@ -404,6 +471,18 @@ fn cell_for_x(line: &TerminalSelectionLine, x: Pixels) -> Option<&TerminalSelect
     line.cells.get(index)
 }
 
+fn point_le(a: AlacPoint, b: AlacPoint) -> bool {
+    (a.line.0, a.column.0) <= (b.line.0, b.column.0)
+}
+
+fn char_lt_point(ch: &TerminalSelectionChar, point: AlacPoint) -> bool {
+    (ch.line, ch.col) < (point.line.0, point.column.0)
+}
+
+fn char_gt_point(ch: &TerminalSelectionChar, point: AlacPoint) -> bool {
+    (ch.line, ch.col) > (point.line.0, point.column.0)
+}
+
 fn is_selectable_cell(cell: &IndexedCell) -> bool {
     !cell
         .cell
@@ -433,10 +512,33 @@ fn row_soft_wraps(row: &[&IndexedCell], grid_cols: usize) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Range;
+
     use gpui::{point, px};
 
     use super::*;
     use crate::Terminal;
+
+    fn doc_now(terminal: &Terminal) -> TerminalSelectionDocument {
+        let content = terminal.content();
+        TerminalSelectionDocument::new(&content, point(px(0.0), px(0.0)), px(10.0), px(20.0))
+    }
+
+    /// UTF-16 range of `marker` within the current viewport (ASCII-safe).
+    fn marker_range(terminal: &Terminal, marker: &str) -> Range<usize> {
+        let doc = doc_now(terminal);
+        let text = doc.text_for_range(0..doc.len_utf16()).1;
+        let byte = text.find(marker).expect("marker must be visible");
+        let start = text[..byte].encode_utf16().count();
+        start..start + marker.encode_utf16().count()
+    }
+
+    /// Text covered by the terminal's derived selection range against the
+    /// current viewport, or `None` when nothing is selected.
+    fn selection_text_now(terminal: &Terminal) -> Option<String> {
+        let range = terminal.selection_range()?;
+        Some(doc_now(terminal).text_for_range(range).1)
+    }
 
     fn selection_text(output: &[u8], cols: usize, rows: usize) -> String {
         let mut terminal = Terminal::new(cols, rows, px(10.0), px(20.0));
@@ -554,5 +656,98 @@ mod tests {
                 .1
                 .contains("crates/foo/file_a.rs")
         );
+    }
+
+    // (a) A word selected while scrolled stays covered after a further scroll,
+    // because the selection is anchored to absolute grid points, not to
+    // viewport-relative UTF-16 offsets.
+    #[test]
+    fn selection_survives_scroll_via_absolute_grid_points() {
+        let mut terminal = Terminal::new(20, 4, px(10.0), px(20.0));
+        terminal.advance_bytes(b"aaaa\r\nbbbb\r\ncccc MARK dddd\r\n");
+        for line in 0..20 {
+            terminal.advance_bytes(format!("filler {line}\r\n").as_bytes());
+        }
+        terminal.scroll(1000); // to the top of scrollback
+
+        let range = marker_range(&terminal, "MARK");
+        terminal.set_selection_range(range.clone());
+        // Same viewport: exact round-trip through the absolute-point anchor.
+        assert_eq!(terminal.selection_range(), Some(range));
+        assert_eq!(selection_text_now(&terminal).as_deref(), Some("MARK"));
+
+        // Scroll down one row: MARK sits on a new visible row but the same
+        // absolute grid point, so the derived range still covers it.
+        terminal.scroll(-1);
+        assert_eq!(selection_text_now(&terminal).as_deref(), Some("MARK"));
+    }
+
+    // (b) When the anchor scrolls off the top, the projection clamps to the
+    // document edge (the visible remainder), and scrolling back re-resolves the
+    // EXACT original range.
+    #[test]
+    fn off_screen_anchor_clamps_and_resolves_exactly() {
+        let mut terminal = Terminal::new(20, 4, px(10.0), px(20.0));
+        terminal.advance_bytes(b"aaaa\r\nbbbb\r\ncccc MARK dddd\r\n");
+        for line in 0..20 {
+            terminal.advance_bytes(format!("filler {line}\r\n").as_bytes());
+        }
+        terminal.scroll(1000); // top: aaaa / bbbb / cccc MARK dddd / filler 0
+
+        // Select from the start of "aaaa" through "MARK" (spans three rows).
+        let doc = doc_now(&terminal);
+        let text = doc.text_for_range(0..doc.len_utf16()).1;
+        let end_byte = text.find("MARK").unwrap() + "MARK".len();
+        let range = 0..text[..end_byte].encode_utf16().count();
+        let expected_full = doc.text_for_range(range.clone()).1;
+        terminal.set_selection_range(range.clone());
+        assert_eq!(terminal.selection_range(), Some(range.clone()));
+
+        // Scroll down two rows: "aaaa" and "bbbb" (the anchor side) leave the
+        // viewport. The projection clamps to the top edge of the visible doc.
+        terminal.scroll(-2);
+        let clamped = terminal.selection_range().unwrap();
+        assert_eq!(clamped.start, 0);
+        assert_eq!(selection_text_now(&terminal).as_deref(), Some("cccc MARK"));
+
+        // Scroll back: the original three-row range resolves exactly.
+        terminal.scroll(2);
+        assert_eq!(terminal.selection_range(), Some(range));
+        assert_eq!(
+            selection_text_now(&terminal).as_deref(),
+            Some(expected_full.as_str())
+        );
+    }
+
+    // (c) A soft-wrapped logical line keeps its wrap-join (no stray '\n') across
+    // scroll, both fully visible and when partially clamped.
+    #[test]
+    fn soft_wrapped_selection_keeps_wrap_join_after_scroll() {
+        let mut terminal = Terminal::new(5, 4, px(10.0), px(20.0));
+        terminal.advance_bytes(b"helloworld\r\n");
+        for _ in 0..20 {
+            terminal.advance_bytes(b"x\r\n");
+        }
+        terminal.scroll(1000); // top: "hello" / "world" soft-wrapped across two rows
+
+        let range = marker_range(&terminal, "helloworld");
+        terminal.set_selection_range(range.clone());
+        assert_eq!(terminal.selection_range(), Some(range));
+        // Fully visible: the wrap-join means no '\n' between the two rows.
+        assert_eq!(selection_text_now(&terminal).as_deref(), Some("helloworld"));
+
+        // Scroll the first wrapped row off-screen: the visible remainder is
+        // "world", still with no stray '\n'.
+        terminal.scroll(-1);
+        let partial = selection_text_now(&terminal).unwrap();
+        assert!(
+            !partial.contains('\n'),
+            "wrap-join must not introduce a newline"
+        );
+        assert_eq!(partial, "world");
+
+        // Scroll back: the full soft-wrapped join resolves again.
+        terminal.scroll(1);
+        assert_eq!(selection_text_now(&terminal).as_deref(), Some("helloworld"));
     }
 }

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -3,6 +3,7 @@ use std::cmp::min;
 use std::ops::{Index, Range};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc as std_mpsc;
+use std::time::Duration;
 use tracing::{error, info};
 
 use alacritty_terminal::event::{Event as AlacTermEvent, EventListener};
@@ -20,6 +21,17 @@ use tokio::sync::{broadcast, mpsc};
 use zedra_osc::{OscEvent, OscScanner};
 
 const REMOTE_TOUCH_SCROLL_STEP_PX: f32 = 12.0;
+
+/// Cadence of the drag-to-edge selection auto-scroll tick. A GPUI timer drives
+/// it (rather than the hit-test stream) because UIKit stops issuing hit-tests
+/// once the drag finger is held stationary at the edge.
+const EDGE_AUTOSCROLL_INTERVAL: Duration = Duration::from_millis(60);
+/// Maximum consecutive timer ticks the auto-scroll runs without a fresh edge
+/// hit-test re-arming it. A moving finger keeps topping the leash back up; a
+/// lifted finger stops producing hit-tests, so the leash drains and the tick
+/// self-cancels instead of scrolling away on its own. This is the safety net
+/// for the missing touch-up signal (see `set_edge_autoscroll`).
+const EDGE_AUTOSCROLL_STATIONARY_LEASH: u32 = 40;
 
 use crate::keys::to_esc_str;
 use crate::selection::TerminalSelectionDocument;
@@ -206,6 +218,17 @@ pub struct TerminalSelection {
     pub focus: Point,
 }
 
+/// Which viewport edge a held selection handle is auto-scrolling toward.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EdgeAutoScroll {
+    /// Toward the top of the viewport: reveals older scrollback, so the
+    /// selection focus marches up onto each newly revealed top line.
+    Top,
+    /// Toward the bottom of the viewport: reveals newer output (down to the
+    /// live tail), so the focus marches down onto each newly revealed line.
+    Bottom,
+}
+
 /// Minimal terminal state wrapping alacritty_terminal::Term
 pub struct Terminal {
     term: Term<ZedraListener>,
@@ -221,6 +244,14 @@ pub struct Terminal {
     input_tx: Option<mpsc::Sender<Vec<u8>>>,
     output_task: Option<Task<()>>,
     selection: Option<TerminalSelection>,
+    /// Armed edge for drag-to-edge selection auto-scroll; `None` when idle.
+    edge_autoscroll: Option<EdgeAutoScroll>,
+    /// Cancel-on-drop handle for the running auto-scroll timer task. Dropping
+    /// it (via `stop_edge_autoscroll` or a re-arm) cancels the tick.
+    edge_autoscroll_task: Option<Task<()>>,
+    /// Remaining self-driven ticks before the auto-scroll stops itself; topped
+    /// up on every edge hit-test.
+    edge_autoscroll_leash: u32,
     theme: TerminalTheme,
 }
 
@@ -257,6 +288,9 @@ impl Terminal {
             input_tx: None,
             output_task: None,
             selection: None,
+            edge_autoscroll: None,
+            edge_autoscroll_task: None,
+            edge_autoscroll_leash: 0,
             theme,
         };
         terminal
@@ -611,6 +645,7 @@ impl Terminal {
     pub fn set_selection_range(&mut self, range: Range<usize>) {
         if range.is_empty() {
             self.selection = None;
+            self.stop_edge_autoscroll();
             return;
         }
         let document = self.selection_document();
@@ -622,11 +657,138 @@ impl Terminal {
     }
 
     pub fn clear_selection_range(&mut self) -> bool {
+        self.stop_edge_autoscroll();
         self.selection.take().is_some()
     }
 
     pub fn selection_active(&self) -> bool {
         self.selection.is_some()
+    }
+
+    /// Arm, refresh, or disarm drag-to-edge selection auto-scroll.
+    ///
+    /// Called from the selection hit-test path each time UIKit reports the drag
+    /// finger's position: `Some(edge)` while the finger sits within a line of a
+    /// viewport edge, `None` otherwise. Arming spawns a GPUI timer that scrolls
+    /// one line toward `edge` per tick and extends the selection focus onto the
+    /// newly revealed line, so the selection keeps growing even while the finger
+    /// is held perfectly still (UIKit stops issuing hit-tests then, so the tick,
+    /// not the hit-test stream, must drive it).
+    ///
+    /// There is no touch-up callback on this input path, so a lifted finger is
+    /// indistinguishable from a stationary one by the hit-test stream alone. The
+    /// stationary leash bridges that gap: every arming call tops it back up, and
+    /// once hit-tests stop arriving (finger lifted) the leash drains and the
+    /// tick cancels itself rather than scrolling to the scrollback bound. A
+    /// precise stop-on-lift would need a touch-end signal the current
+    /// `InputHandler` does not expose.
+    pub fn set_edge_autoscroll(
+        &mut self,
+        direction: Option<EdgeAutoScroll>,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(direction) = direction else {
+            self.stop_edge_autoscroll();
+            return;
+        };
+        // Only auto-scroll while there is a selection whose focus we can extend.
+        if self.selection.is_none() {
+            self.stop_edge_autoscroll();
+            return;
+        }
+
+        // Refresh the leash on every hit-test so a moving finger never expires.
+        self.edge_autoscroll_leash = EDGE_AUTOSCROLL_STATIONARY_LEASH;
+        if self.edge_autoscroll == Some(direction) && self.edge_autoscroll_task.is_some() {
+            // Already ticking toward this edge; leash refresh above is enough.
+            return;
+        }
+
+        self.edge_autoscroll = Some(direction);
+        let task = cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(EDGE_AUTOSCROLL_INTERVAL)
+                    .await;
+                let keep_going = this
+                    .update(cx, |this, cx| this.edge_autoscroll_tick(direction, cx))
+                    .unwrap_or(false);
+                if !keep_going {
+                    break;
+                }
+            }
+        });
+        self.edge_autoscroll_task = Some(task);
+    }
+
+    /// Cancel any running auto-scroll tick (dropping the task stops the timer).
+    pub fn stop_edge_autoscroll(&mut self) {
+        self.edge_autoscroll = None;
+        self.edge_autoscroll_leash = 0;
+        self.edge_autoscroll_task = None;
+    }
+
+    /// One auto-scroll step: scroll a line toward the armed edge and re-anchor
+    /// the selection focus to the newly revealed edge line. Returns `false` to
+    /// end the tick (selection gone, scrollback bound reached, or leash drained).
+    fn edge_autoscroll_tick(&mut self, direction: EdgeAutoScroll, cx: &mut Context<Self>) -> bool {
+        let Some(selection) = self.selection else {
+            self.stop_edge_autoscroll();
+            return false;
+        };
+        if self.edge_autoscroll_leash == 0 {
+            self.stop_edge_autoscroll();
+            return false;
+        }
+        self.edge_autoscroll_leash -= 1;
+
+        // `scroll` takes positive = up (older). Toward the bottom edge we reveal
+        // newer content, which is a downward (negative) scroll.
+        let scroll_lines = match direction {
+            EdgeAutoScroll::Top => 1,
+            EdgeAutoScroll::Bottom => -1,
+        };
+        let before = self.display_offset();
+        self.scroll(scroll_lines);
+        if self.display_offset() == before {
+            // Clamped at the top of history / the live tail: nothing revealed.
+            self.stop_edge_autoscroll();
+            return false;
+        }
+
+        // Extend the focus onto the freshly revealed edge line.
+        let focus = Self::edge_focus_point(
+            direction,
+            self.display_offset(),
+            self.size.rows,
+            self.size.columns,
+        );
+        self.selection = Some(TerminalSelection {
+            anchor: selection.anchor,
+            focus,
+        });
+        cx.notify();
+        true
+    }
+
+    /// Absolute grid point on the viewport edge row for `direction`, at the far
+    /// column of that edge so the whole newly revealed line is covered. Uses
+    /// `visible_row = line + display_offset`: the top row is `-display_offset`,
+    /// the bottom row is `rows - 1 - display_offset`.
+    fn edge_focus_point(
+        direction: EdgeAutoScroll,
+        display_offset: usize,
+        rows: usize,
+        cols: usize,
+    ) -> Point {
+        let display_offset = display_offset as i32;
+        match direction {
+            EdgeAutoScroll::Top => Point::new(Line(-display_offset), Column(0)),
+            EdgeAutoScroll::Bottom => Point::new(
+                Line(rows as i32 - 1 - display_offset),
+                Column(cols.saturating_sub(1)),
+            ),
+        }
     }
 
     /// Scroll the terminal by a number of lines (positive = up)
@@ -4627,5 +4789,34 @@ mod tests {
         let links = terminal.detect_plain_links();
         assert_eq!(links.len(), 1, "expected only URL match, got {:?}", links);
         assert_eq!(links[0].kind, super::DetectedLinkKind::Url);
+    }
+
+    // Drag-to-edge auto-scroll: the focus point each tick re-anchors to must
+    // land on the newly revealed edge row (`visible_row = line +
+    // display_offset`), at the far column of that edge so the whole new line is
+    // covered. This guards the direction/edge-line math that the on-device
+    // gesture depends on; the gesture itself has no host test.
+    #[test]
+    fn edge_focus_point_tracks_the_revealed_edge_line() {
+        use super::EdgeAutoScroll;
+
+        // 4 rows, 80 cols. Bottom edge = row 3 => abs line `3 - display_offset`.
+        assert_eq!(
+            Terminal::edge_focus_point(EdgeAutoScroll::Bottom, 5, 4, 80),
+            Point::new(Line(3 - 5), Column(79)),
+        );
+        assert_eq!(
+            Terminal::edge_focus_point(EdgeAutoScroll::Bottom, 0, 4, 80),
+            Point::new(Line(3), Column(79)),
+        );
+        // Top edge = row 0 => abs line `-display_offset`, column 0.
+        assert_eq!(
+            Terminal::edge_focus_point(EdgeAutoScroll::Top, 5, 4, 80),
+            Point::new(Line(-5), Column(0)),
+        );
+        assert_eq!(
+            Terminal::edge_focus_point(EdgeAutoScroll::Top, 0, 4, 80),
+            Point::new(Line(0), Column(0)),
+        );
     }
 }

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -22,6 +22,7 @@ use zedra_osc::{OscEvent, OscScanner};
 const REMOTE_TOUCH_SCROLL_STEP_PX: f32 = 12.0;
 
 use crate::keys::to_esc_str;
+use crate::selection::TerminalSelectionDocument;
 use crate::theme::TerminalTheme;
 /// Events emitted by the terminal to observers.
 #[derive(Debug, Clone)]
@@ -192,6 +193,19 @@ pub struct KeyboardInputContextEdit {
     pub selection_range: Range<usize>,
 }
 
+/// A text selection anchored to ABSOLUTE alacritty grid points. Because
+/// `Point::line` is display-offset independent (`visible_row = line +
+/// display_offset`), the selection survives scrolling: the visible UTF-16 range
+/// is re-derived from these points against each frame's document rather than
+/// being stored as viewport-relative offsets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TerminalSelection {
+    /// First selected cell (inclusive), absolute grid coordinates.
+    pub anchor: Point,
+    /// Last selected cell (inclusive), absolute grid coordinates.
+    pub focus: Point,
+}
+
 /// Minimal terminal state wrapping alacritty_terminal::Term
 pub struct Terminal {
     term: Term<ZedraListener>,
@@ -206,7 +220,7 @@ pub struct Terminal {
     alacritty_event_rx: std_mpsc::Receiver<AlacTermEvent>,
     input_tx: Option<mpsc::Sender<Vec<u8>>>,
     output_task: Option<Task<()>>,
-    selection_range: Option<Range<usize>>,
+    selection: Option<TerminalSelection>,
     theme: TerminalTheme,
 }
 
@@ -242,7 +256,7 @@ impl Terminal {
             alacritty_event_rx,
             input_tx: None,
             output_task: None,
-            selection_range: None,
+            selection: None,
             theme,
         };
         terminal
@@ -565,20 +579,54 @@ impl Terminal {
         }
     }
 
+    /// The selection as a UTF-16 range over the CURRENT visible viewport,
+    /// derived each call by projecting the stored absolute grid points onto a
+    /// freshly-built document. Returns `None` when nothing is selected. A stored
+    /// selection whose endpoints have scrolled off-screen still returns a range
+    /// (clamped to the document edge), and re-resolves exactly on scroll-back.
     pub fn selection_range(&self) -> Option<Range<usize>> {
-        self.selection_range.clone()
+        let selection = self.selection?;
+        let document = self.selection_document();
+        Some(document.utf16_range_for_selection(selection.anchor, selection.focus))
     }
 
+    /// Build the per-frame selection document for the current content. Pixel
+    /// origin is irrelevant to the grid<->UTF-16 translation, so it is `(0, 0)`.
+    fn selection_document(&self) -> TerminalSelectionDocument {
+        let content = self.content();
+        TerminalSelectionDocument::new(
+            &content,
+            GpuiPoint {
+                x: px(0.0),
+                y: px(0.0),
+            },
+            self.size.cell_width,
+            self.size.line_height,
+        )
+    }
+
+    /// Store a selection given as a UTF-16 range over the current viewport,
+    /// re-anchoring it to absolute grid points so it survives scrolling. An
+    /// empty range clears the selection (nothing to anchor).
     pub fn set_selection_range(&mut self, range: Range<usize>) {
-        self.selection_range = Some(range);
+        if range.is_empty() {
+            self.selection = None;
+            return;
+        }
+        let document = self.selection_document();
+        let anchor = document.abs_point_for_utf16(range.start);
+        let focus = document.abs_point_for_utf16(range.end - 1);
+        self.selection = anchor
+            .zip(focus)
+            .map(|(anchor, focus)| TerminalSelection { anchor, focus });
     }
 
     pub fn clear_selection_range(&mut self) -> bool {
-        self.selection_range.take().is_some()
+        self.selection.take().is_some()
     }
 
     pub fn selection_active(&self) -> bool {
-        self.selection_range.is_some()
+        self.selection.is_some()
     }
 
     /// Scroll the terminal by a number of lines (positive = up)

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1547,3 +1547,59 @@ id in production). The trailing shows the aggregate `done/total` rollup.
 1. With the droplet on, rotate the device.
 2. Expected: no crash, no stale grab artifacts; the droplet keeps rendering at its
    logical position and refraction stays sharp after the size change.
+
+## Selection Drag-To-Edge Auto-Scroll (iOS)
+
+Stacks on the selection-survives-scroll re-anchor (Phase 1): the selection is stored as
+absolute grid `{anchor, focus}` points, so extending the focus onto newly revealed lines
+keeps the selection correct after each scroll step. This gesture has NO host test (a headless
+agent cannot record an on-device drag); the host suite only regression-guards the terminal-side
+scroll + focus math. **On-device screen recording is required to sign this off.**
+
+Preconditions for every case below:
+- Run a command that produces well more than one screenful of output (e.g. `seq 1 400`) so
+  there is real scrollback above and below.
+- Scroll up into the scrollback so both the top and bottom edges have content to reveal.
+
+### Bottom edge auto-scroll and extend
+1. Long-press a word near the MIDDLE of the screen to start a selection, then drag the LOWER
+   selection handle down until your finger sits within about one line-height of the bottom edge.
+2. Hold the finger STATIONARY at the bottom edge (do not keep moving it).
+3. Expected: the terminal scrolls upward one line at a time on a steady tick (roughly 16
+   lines/second), and the selection keeps extending downward to cover each newly revealed
+   bottom line — the growth continues while the finger is held still, not only when it moves.
+4. Lift the finger. Expected: scrolling stops promptly (within a fraction of a second) and the
+   selection stays exactly where the last revealed line left it. It must NOT keep scrolling to
+   the bottom on its own after release.
+
+### Top edge auto-scroll and extend
+1. Long-press a word near the middle to start a selection, then drag the UPPER selection handle
+   up until the finger is within about one line-height of the top edge, and hold it still.
+2. Expected: the terminal scrolls downward into older scrollback one line per tick, and the
+   selection extends upward to cover each newly revealed top line while the finger is held.
+3. Lift the finger. Expected: scrolling stops promptly; the selection is preserved.
+
+### Bounds clamp (no runaway past history / live tail)
+1. Repeat the bottom-edge drag and hold until the terminal reaches the LIVE TAIL (newest output,
+   display offset 0). Expected: auto-scroll stops at the tail — it does not keep scrolling or
+   flicker past the bottom, and the selection endpoint rests on the last real line.
+2. Repeat the top-edge drag and hold until the terminal reaches the TOP of scrollback (oldest
+   history). Expected: auto-scroll stops at the top — no runaway, no empty rows synthesized
+   below/above the real content.
+
+### Normal (non-selecting) touch scroll is unaffected
+1. With NO selection active, swipe up and down anywhere in the terminal to scroll normally.
+2. Expected: scrolling feels exactly as before this change — smooth sub-line drag, snap-on-release
+   into scrollback, and normal clamping at the history/tail bounds. No auto-scroll tick engages,
+   and nothing gets selected by the swipe.
+3. Start a swipe that passes THROUGH the top or bottom edge region without a selection active.
+   Expected: still just a normal scroll; the edge auto-scroll must only ever engage while a
+   selection handle is being dragged.
+
+### Known limitation to watch for during sign-off
+- There is no touch-up callback on the iOS text-input hit-test path, so the tick self-cancels via
+  a stationary leash (about 40 ticks, ~2.4s) once hit-tests stop arriving. If, during the
+  bottom/top hold cases, a stationary finger stops auto-scrolling after ~2.4s even though it is
+  still held at the edge, that is the leash expiring: note it, because the proper fix is a
+  touch-end signal from the input handler (a GPUI/vendor change, tracked separately). The safety
+  property (no runaway after lift) must hold regardless.


### PR DESCRIPTION
Outcome: dragging a selection handle to the top/bottom edge auto-scrolls the terminal and extends the selection (iOS-standard). Stacks on the re-anchor (Phase 1, #179), the diff includes #179 until it merges.

Verification: host tests green as a regression guard (`cargo test -p zedra-terminal`); the drag-to-edge gesture has no host proof, so **on-device screen recording is PENDING author sign-off**, see `docs/MANUAL_TEST.md` for the repro. Draft until the on-device pass is attached.

Closes tanlethanh/zedra#178 (Phase 2).
