### PR TITLE
feat: reconnect status banner and hole-punch connect observability

### DIFF
--- a/crates/zedra-session/src/connect.rs
+++ b/crates/zedra-session/src/connect.rs
@@ -855,16 +855,30 @@ impl Connector {
             let conn_established_at = Instant::now();
             let mut paths = conn.paths();
             let mut prev_path: Option<PathInfo> = None;
-            let mut prev_is_direct = false;
+            // Seed from the already-selected path: a connection that starts direct
+            // is not a relay → direct upgrade.
+            let mut prev_is_direct = paths
+                .get()
+                .iter()
+                .find(|p| p.is_selected())
+                .is_some_and(|p| p.is_ip());
             // One-shot latch: set once a direct path forms or the relay-only
             // timeout fires, after which the timeout branch stays dead.
-            let mut direct_decided = false;
+            let mut direct_decided = prev_is_direct;
             let mut idle_detector =
                 IdleDetector::with_recv_baseline(Instant::now(), conn.stats().udp_rx.bytes);
 
             loop {
+                let path_list = paths.get();
+                let selected = path_list.iter().find(|p| p.is_selected());
+
                 let since_connect = conn_established_at.elapsed();
-                if !direct_decided && since_connect >= DIRECT_UPGRADE_TIMEOUT {
+                // Recheck the current path first: a direct path selected right at the
+                // deadline must not emit a timeout the upgrade below then contradicts.
+                if !direct_decided
+                    && !selected.is_some_and(|p| p.is_ip())
+                    && since_connect >= DIRECT_UPGRADE_TIMEOUT
+                {
                     direct_decided = true;
                     let elapsed_ms = since_connect.as_millis() as u64;
                     info!(
@@ -876,8 +890,7 @@ impl Connector {
                         .await;
                 }
 
-                let path_list = paths.get();
-                if let Some(path) = path_list.iter().find(|p| p.is_selected()) {
+                if let Some(path) = selected {
                     let is_direct = path.is_ip();
                     let path_stats = path.stats();
                     let conn_stats = conn.stats();

--- a/crates/zedra-session/src/connect.rs
+++ b/crates/zedra-session/src/connect.rs
@@ -8,9 +8,10 @@ use iroh::{
     Endpoint, EndpointAddr, NetReport, PublicKey, RelayConfig, RelayMap, RelayMode,
     address_lookup::PkarrResolver,
     endpoint::{
-        AuthenticationError as IrohAuthenticationError, ConnectError as IrohConnectError,
-        ConnectingError as IrohConnectingError, Connection, ConnectionError as IrohConnectionError,
-        PathInfo, QuicTransportConfig, TransportErrorCode,
+        AuthenticationError as IrohAuthenticationError,
+        ConnectWithOptsError as IrohConnectWithOptsError, ConnectingError as IrohConnectingError,
+        Connection, ConnectionError as IrohConnectionError, PathInfo, QuicTransportConfig,
+        TransportErrorCode,
     },
 };
 use iroh_relay::RelayQuicConfig;
@@ -51,6 +52,39 @@ pub type ConnectedResult = (
 
 const IDLE_STALE_INTERVAL_MULTIPLIER: u32 = 2;
 const TLS_ALERT_NO_APPLICATION_PROTOCOL: u8 = 0x78;
+
+/// Heartbeat cadence while the otherwise-opaque connect future is pending, so
+/// the UI can show live elapsed time and tell a stall from an in-progress connect.
+const HOLE_PUNCH_HEARTBEAT: Duration = Duration::from_secs(1);
+
+/// Event-channel slots kept free for lifecycle events. Progress heartbeats
+/// never use them, so a stalled receiver (e.g. a backgrounded app) can't fill
+/// the queue and drop AddrResolved/HolePunchComplete/auth events. Sized above
+/// the lifecycle + network-change events one connect emits (channel holds 64).
+const PROGRESS_RESERVED_SLOTS: usize = 24;
+
+/// Window after connect for a direct path to form before we report relay-only.
+const DIRECT_UPGRADE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Sub-stage of the connect/hole-punch phase, surfaced for progress visibility.
+/// `endpoint.connect()` hides both behind a single await; we split them so the
+/// UI and telemetry can attribute slowness to discovery vs. the QUIC handshake.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HolePunchStage {
+    /// Resolving remote addresses via pkarr/DNS discovery.
+    Resolving,
+    /// QUIC + TLS handshake over the resolved path (relay first, usually).
+    Handshake,
+}
+
+impl HolePunchStage {
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Self::Resolving => "Finding host",
+            Self::Handshake => "Handshaking",
+        }
+    }
+}
 
 /// Tracks the last confirmed transport receive progress for UI idle state.
 ///
@@ -254,10 +288,22 @@ pub enum ConnectEvent {
         binding_ms: u64,
     },
     HolePunchStarted,
+    /// Heartbeat during the connect await; carries the live sub-stage + elapsed
+    /// so the UI can show progress and flag a stall.
+    HolePunchProgress {
+        stage: HolePunchStage,
+        elapsed_ms: u64,
+    },
+    /// Remote addresses resolved (pkarr/DNS); QUIC handshake begins next.
+    AddrResolved {
+        resolve_ms: u64,
+    },
     HolePunchComplete {
         remote_node_id: String,
         alpn: String,
         hole_punch_ms: u64,
+        resolve_ms: u64,
+        handshake_ms: u64,
     },
     Registering {
         session_id: String,
@@ -304,6 +350,12 @@ pub enum ConnectEvent {
     PathUpgraded {
         prev_path: Option<PathInfo>,
         new_path: PathInfo,
+        /// Time from connection establishment to this first direct path.
+        upgrade_ms: u64,
+    },
+    /// No direct path formed within DIRECT_UPGRADE_TIMEOUT; staying on relay.
+    DirectUpgradeTimeout {
+        elapsed_ms: u64,
     },
     NoActivePath,
 
@@ -460,29 +512,87 @@ impl Connector {
         self.emit(ConnectEvent::HolePunchStarted);
         let t = Instant::now();
 
-        let conn = endpoint
-            .connect(remote_addr, &self.config.alpn)
+        // Stage A: resolve remote addresses (pkarr/DNS) then start the QUIC connect.
+        // `remote_addr` is id-only, so this always pays a discovery round-trip.
+        let connecting = self
+            .await_with_heartbeat(
+                HolePunchStage::Resolving,
+                t,
+                endpoint.connect_with_opts(remote_addr, &self.config.alpn, Default::default()),
+            )
             .await
             .map_err(|e| {
-                let err = map_iroh_connect_error(&e);
+                let err = map_connect_with_opts_error(&e);
                 self.emit(ConnectEvent::Failed { error: err.clone() });
                 err
             })?;
+        let resolve_ms = t.elapsed().as_millis() as u64;
+        self.emit(ConnectEvent::AddrResolved { resolve_ms });
 
+        // Stage B: QUIC + TLS handshake, over the relay path first in most cases.
+        let t_handshake = Instant::now();
+        let conn = self
+            .await_with_heartbeat(HolePunchStage::Handshake, t_handshake, connecting)
+            .await
+            .map_err(|e| {
+                let err = map_connecting_error(&e);
+                self.emit(ConnectEvent::Failed { error: err.clone() });
+                err
+            })?;
+        let handshake_ms = t_handshake.elapsed().as_millis() as u64;
         let hole_punch_ms = t.elapsed().as_millis() as u64;
+
         let remote_node_id = conn.remote_id().fmt_short().to_string();
         let alpn = String::from_utf8_lossy(conn.alpn()).to_string();
+        let via_relay = initial_path_is_relay(&conn);
         info!(
-            "iroh: connected to {}, alpn: {} in {}ms",
-            remote_node_id, alpn, hole_punch_ms
+            "holepunch: connected to {} alpn {} resolve {}ms handshake {}ms via_relay {}",
+            remote_node_id, alpn, resolve_ms, handshake_ms, via_relay
         );
 
         self.emit(ConnectEvent::HolePunchComplete {
             remote_node_id,
             alpn,
             hole_punch_ms,
+            resolve_ms,
+            handshake_ms,
         });
         Ok(conn)
+    }
+
+    /// Await `fut` while emitting a heartbeat every `HOLE_PUNCH_HEARTBEAT`, so the
+    /// UI gets live elapsed time during an otherwise-opaque connect stage.
+    async fn await_with_heartbeat<F, T, E>(
+        &self,
+        stage: HolePunchStage,
+        started_at: Instant,
+        fut: F,
+    ) -> Result<T, E>
+    where
+        F: std::future::Future<Output = Result<T, E>>,
+    {
+        tokio::pin!(fut);
+        let mut ticker = tokio::time::interval(HOLE_PUNCH_HEARTBEAT);
+        ticker.tick().await; // first tick is immediate; skip it
+        loop {
+            tokio::select! {
+                res = &mut fut => return res,
+                _ = ticker.tick() => self.emit_progress(stage, started_at),
+            }
+        }
+    }
+
+    /// Emit a heartbeat, but only while the channel keeps `PROGRESS_RESERVED_SLOTS`
+    /// free. Progress is latest-wins, so dropping ticks is harmless — the invariant
+    /// that matters is that periodic heartbeats never evict lifecycle events.
+    fn emit_progress(&self, stage: HolePunchStage, started_at: Instant) {
+        if self.tx.capacity() <= PROGRESS_RESERVED_SLOTS {
+            return;
+        }
+        self.emit(ConnectEvent::HolePunchProgress {
+            stage,
+            elapsed_ms: started_at.elapsed().as_millis() as u64,
+        });
     }
 
     /// Full auth flow: Register (if ticket) → Connect → Prove (if challenge).
@@ -742,13 +852,30 @@ impl Connector {
         let idle_stale_timeout = idle_check_interval * IDLE_STALE_INTERVAL_MULTIPLIER;
 
         tokio::spawn(async move {
+            let conn_established_at = Instant::now();
             let mut paths = conn.paths();
             let mut prev_path: Option<PathInfo> = None;
             let mut prev_is_direct = false;
+            // One-shot latch: set once a direct path forms or the relay-only
+            // timeout fires, after which the timeout branch stays dead.
+            let mut direct_decided = false;
             let mut idle_detector =
                 IdleDetector::with_recv_baseline(Instant::now(), conn.stats().udp_rx.bytes);
 
             loop {
+                let since_connect = conn_established_at.elapsed();
+                if !direct_decided && since_connect >= DIRECT_UPGRADE_TIMEOUT {
+                    direct_decided = true;
+                    let elapsed_ms = since_connect.as_millis() as u64;
+                    info!(
+                        "holepunch: no direct path after {}ms, staying on relay",
+                        elapsed_ms
+                    );
+                    let _ = tx
+                        .send(ConnectEvent::DirectUpgradeTimeout { elapsed_ms })
+                        .await;
+                }
+
                 let path_list = paths.get();
                 if let Some(path) = path_list.iter().find(|p| p.is_selected()) {
                     let is_direct = path.is_ip();
@@ -768,8 +895,11 @@ impl Connector {
 
                     // Detect relay → direct upgrade
                     if !prev_is_direct && is_direct {
+                        direct_decided = true;
+                        let upgrade_ms = conn_established_at.elapsed().as_millis() as u64;
                         info!(
-                            "direct path upgrade detected: {:?} -> {:?}",
+                            "holepunch: direct path upgrade after {}ms: {:?} -> {:?}",
+                            upgrade_ms,
                             prev_path.as_ref().map(|p| p.remote_addr()),
                             path.remote_addr()
                         );
@@ -777,6 +907,7 @@ impl Connector {
                             .send(ConnectEvent::PathUpgraded {
                                 prev_path: prev_path,
                                 new_path: path.clone(),
+                                upgrade_ms,
                             })
                             .await;
                     }
@@ -973,19 +1104,28 @@ impl Connector {
     }
 }
 
-fn map_iroh_connect_error(error: &IrohConnectError) -> ConnectError {
-    if is_alpn_mismatch(error) {
+/// Initial selected path is the relay (a direct upgrade, if any, comes later).
+fn initial_path_is_relay(conn: &Connection) -> bool {
+    use iroh::Watcher;
+    conn.paths()
+        .get()
+        .iter()
+        .find(|p| p.is_selected())
+        .map(|p| !p.is_ip())
+        .unwrap_or(true)
+}
+
+/// Stage A error (discovery / QUIC setup): ALPN is not negotiated yet here.
+fn map_connect_with_opts_error(error: &IrohConnectWithOptsError) -> ConnectError {
+    ConnectError::QuicConnectFailed(error.to_string())
+}
+
+/// Stage B error (QUIC + TLS handshake): an ALPN mismatch surfaces here.
+fn map_connecting_error(error: &IrohConnectingError) -> ConnectError {
+    if is_alpn_mismatch_connecting(error) {
         ConnectError::AlpnMismatch
     } else {
         ConnectError::QuicConnectFailed(error.to_string())
-    }
-}
-
-fn is_alpn_mismatch(error: &IrohConnectError) -> bool {
-    match error {
-        IrohConnectError::Connecting { source, .. } => is_alpn_mismatch_connecting(source),
-        IrohConnectError::Connection { source, .. } => is_alpn_mismatch_connection(source),
-        _ => false,
     }
 }
 

--- a/crates/zedra-session/src/state.rs
+++ b/crates/zedra-session/src/state.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::ConnectEvent;
+use crate::{ConnectEvent, HolePunchStage};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ReconnectReason {
@@ -248,6 +248,18 @@ pub struct TransportSnapshot {
 pub struct ConnectSnapshot {
     pub binding_ms: Option<u64>,
     pub hole_punch_ms: Option<u64>,
+    /// Hole-punch sub-timing: pkarr/DNS discovery to resolve the host.
+    pub resolve_ms: Option<u64>,
+    /// Hole-punch sub-timing: QUIC + TLS handshake after resolve.
+    pub handshake_ms: Option<u64>,
+    /// Live sub-stage while connecting; cleared once the connection is up.
+    pub hole_punch_stage: Option<HolePunchStage>,
+    /// Live elapsed within the current connect stage, for stall detection.
+    pub hole_punch_elapsed_ms: Option<u64>,
+    /// Time from connect to the first direct path; None while relay-only.
+    pub direct_upgrade_ms: Option<u64>,
+    /// No direct path formed within the upgrade window; using relay.
+    pub relay_only: bool,
     pub rpc_ms: Option<u64>,
     pub register_ms: Option<u64>,
     /// Set once a Register handshake has been attempted this process. Sticky
@@ -357,15 +369,32 @@ impl SessionState {
             }
             ConnectEvent::HolePunchStarted => {
                 self.phase = ConnectPhase::HolePunching;
+                snap.hole_punch_stage = Some(HolePunchStage::Resolving);
+                snap.hole_punch_elapsed_ms = Some(0);
+            }
+            ConnectEvent::HolePunchProgress { stage, elapsed_ms } => {
+                snap.hole_punch_stage = Some(stage);
+                snap.hole_punch_elapsed_ms = Some(elapsed_ms);
+            }
+            ConnectEvent::AddrResolved { resolve_ms } => {
+                snap.resolve_ms = Some(resolve_ms);
+                snap.hole_punch_stage = Some(HolePunchStage::Handshake);
+                snap.hole_punch_elapsed_ms = Some(0);
             }
             ConnectEvent::HolePunchComplete {
                 remote_node_id,
                 alpn,
                 hole_punch_ms,
+                resolve_ms,
+                handshake_ms,
             } => {
                 snap.remote_node_id = Some(remote_node_id);
                 snap.alpn = Some(alpn);
                 snap.hole_punch_ms = Some(hole_punch_ms);
+                snap.resolve_ms = Some(resolve_ms);
+                snap.handshake_ms = Some(handshake_ms);
+                snap.hole_punch_stage = None;
+                snap.hole_punch_elapsed_ms = None;
             }
             ConnectEvent::EndpointAddrChanged { endpoint_addr } => {
                 snap.relay_connected = endpoint_addr.relay_urls().next().is_some();
@@ -475,10 +504,15 @@ impl SessionState {
                     last_alive_at,
                 });
             }
-            ConnectEvent::PathUpgraded { .. } => {
+            ConnectEvent::PathUpgraded { upgrade_ms, .. } => {
+                snap.direct_upgrade_ms = Some(upgrade_ms);
+                snap.relay_only = false;
                 if let Some(ref mut t) = snap.transport {
                     t.path_upgraded = true;
                 }
+            }
+            ConnectEvent::DirectUpgradeTimeout { .. } => {
+                snap.relay_only = true;
             }
             ConnectEvent::NoActivePath => {
                 // Keep the last transport metadata and last_alive_at so UI can
@@ -553,6 +587,12 @@ impl SessionState {
 fn reset_timing(snap: &mut ConnectSnapshot) {
     snap.binding_ms = None;
     snap.hole_punch_ms = None;
+    snap.resolve_ms = None;
+    snap.handshake_ms = None;
+    snap.hole_punch_stage = None;
+    snap.hole_punch_elapsed_ms = None;
+    snap.direct_upgrade_ms = None;
+    snap.relay_only = false;
     snap.rpc_ms = None;
     snap.register_ms = None;
     snap.auth_ms = None;

--- a/crates/zedra-telemetry/src/lib.rs
+++ b/crates/zedra-telemetry/src/lib.rs
@@ -71,6 +71,10 @@ pub enum Event {
         total_ms: u64,
         binding_ms: u64,
         hole_punch_ms: u64,
+        /// Sub-timing of hole_punch_ms: pkarr/DNS discovery to resolve the host.
+        resolve_ms: u64,
+        /// Sub-timing of hole_punch_ms: QUIC + TLS handshake after resolve.
+        handshake_ms: u64,
         auth_ms: u64,
         fetch_ms: u64,
         // Transport context
@@ -127,6 +131,8 @@ pub enum Event {
         // Phase timings (ms) for the successful attempt
         binding_ms: u64,
         hole_punch_ms: u64,
+        resolve_ms: u64,
+        handshake_ms: u64,
         auth_ms: u64,
         fetch_ms: u64,
         // Transport context
@@ -159,6 +165,17 @@ pub enum Event {
         rtt_ms: u64,
         /// Relay hostname the connection upgraded from.
         from_relay: String,
+        /// Time from connection establishment to the first direct path.
+        upgrade_ms: u64,
+    },
+    /// No direct path formed within the upgrade window; connection stays on relay.
+    /// The relay-only outcome we want to aggregate to find hole-punch failures.
+    DirectUpgradeTimeout {
+        elapsed_ms: u64,
+        relay: String,
+        /// "LAN", "Tailscale", "Internet", "unknown"
+        network: &'static str,
+        symmetric_nat: bool,
     },
     /// Periodic selected-path latency sample.
     ConnectionLatencySample {
@@ -361,6 +378,7 @@ impl Event {
             Self::ReconnectSuccess { .. } => "reconnect_success",
             Self::ReconnectExhausted { .. } => "reconnect_exhausted",
             Self::PathUpgraded { .. } => "path_upgraded",
+            Self::DirectUpgradeTimeout { .. } => "direct_upgrade_timeout",
             Self::ConnectionLatencySample { .. } => "connection_latency_sample",
             Self::TerminalOpened { .. } => "terminal_opened",
             Self::TerminalClosed { .. } => "terminal_closed",
@@ -410,6 +428,8 @@ impl Event {
                 total_ms,
                 binding_ms,
                 hole_punch_ms,
+                resolve_ms,
+                handshake_ms,
                 auth_ms,
                 fetch_ms,
                 path,
@@ -426,6 +446,8 @@ impl Event {
                 ("total_ms", total_ms.to_string()),
                 ("binding_ms", binding_ms.to_string()),
                 ("hole_punch_ms", hole_punch_ms.to_string()),
+                ("resolve_ms", resolve_ms.to_string()),
+                ("handshake_ms", handshake_ms.to_string()),
                 ("auth_ms", auth_ms.to_string()),
                 ("fetch_ms", fetch_ms.to_string()),
                 ("path", path.to_string()),
@@ -472,6 +494,8 @@ impl Event {
                 reason,
                 binding_ms,
                 hole_punch_ms,
+                resolve_ms,
+                handshake_ms,
                 auth_ms,
                 fetch_ms,
                 path,
@@ -487,6 +511,8 @@ impl Event {
                 ("reason", reason.to_string()),
                 ("binding_ms", binding_ms.to_string()),
                 ("hole_punch_ms", hole_punch_ms.to_string()),
+                ("resolve_ms", resolve_ms.to_string()),
+                ("handshake_ms", handshake_ms.to_string()),
                 ("auth_ms", auth_ms.to_string()),
                 ("fetch_ms", fetch_ms.to_string()),
                 ("path", path.to_string()),
@@ -517,10 +543,23 @@ impl Event {
                 network,
                 rtt_ms,
                 from_relay,
+                upgrade_ms,
             } => vec![
                 ("network", network.to_string()),
                 ("rtt_ms", rtt_ms.to_string()),
                 ("from_relay", from_relay.clone()),
+                ("upgrade_ms", upgrade_ms.to_string()),
+            ],
+            Self::DirectUpgradeTimeout {
+                elapsed_ms,
+                relay,
+                network,
+                symmetric_nat,
+            } => vec![
+                ("elapsed_ms", elapsed_ms.to_string()),
+                ("relay", relay.clone()),
+                ("network", network.to_string()),
+                ("symmetric_nat", bool_str(*symmetric_nat)),
             ],
             Self::ConnectionLatencySample {
                 source,

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -48,6 +48,7 @@ pub mod transport_badge;
 pub mod workspace;
 pub mod workspace_action;
 pub mod workspace_connecting;
+pub mod workspace_connection_banner;
 pub mod workspace_drawer;
 pub mod workspace_editor;
 pub mod workspace_gitdiff;

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -40,6 +40,7 @@ use crate::workspace_action::{
     SpawnAgentTerminal, ToggleDrawer,
 };
 use crate::workspace_connecting::WorkspaceConnecting;
+use crate::workspace_connection_banner::{BannerEvent, ConnectionBanner};
 use crate::workspace_drawer::WorkspaceDrawer;
 use crate::workspace_editor::{EditorSelection, WorkspaceEditor};
 use crate::workspace_gitdiff::{GitdiffHeaderChanged, WorkspaceGitdiff};
@@ -533,6 +534,8 @@ fn record_connect_telemetry(
                 total_ms: *total_ms,
                 binding_ms: snap.binding_ms.unwrap_or(0),
                 hole_punch_ms: snap.hole_punch_ms.unwrap_or(0),
+                resolve_ms: snap.resolve_ms.unwrap_or(0),
+                handshake_ms: snap.handshake_ms.unwrap_or(0),
                 auth_ms: snap.auth_ms.unwrap_or(0),
                 fetch_ms: snap.sync_ms.unwrap_or(0),
                 path: path_label(snap),
@@ -589,6 +592,8 @@ fn record_connect_telemetry(
                 reason,
                 binding_ms: snap.binding_ms.unwrap_or(0),
                 hole_punch_ms: snap.hole_punch_ms.unwrap_or(0),
+                resolve_ms: snap.resolve_ms.unwrap_or(0),
+                handshake_ms: snap.handshake_ms.unwrap_or(0),
                 auth_ms: snap.auth_ms.unwrap_or(0),
                 fetch_ms: snap.sync_ms.unwrap_or(0),
                 path: path_label(snap),
@@ -622,6 +627,7 @@ fn record_connect_telemetry(
         ConnectEvent::PathUpgraded {
             prev_path,
             new_path,
+            upgrade_ms,
         } => {
             zedra_telemetry::send(zedra_telemetry::Event::PathUpgraded {
                 network: path_network_label(new_path),
@@ -630,6 +636,15 @@ fn record_connect_telemetry(
                     .as_ref()
                     .and_then(path_relay_label)
                     .unwrap_or_else(|| relay_label(snap)),
+                upgrade_ms: *upgrade_ms,
+            });
+        }
+        ConnectEvent::DirectUpgradeTimeout { elapsed_ms } => {
+            zedra_telemetry::send(zedra_telemetry::Event::DirectUpgradeTimeout {
+                elapsed_ms: *elapsed_ms,
+                relay: relay_label(snap),
+                network: network_label(snap),
+                symmetric_nat: snap.mapping_varies.unwrap_or(false),
             });
         }
         ConnectEvent::PathReport { .. } => record_latency_sample(state, latency_sampler),
@@ -739,12 +754,14 @@ impl Workspace {
         let editor = cx.new(|cx| WorkspaceEditor::new(session.handle().clone(), cx));
         let gitdiff = cx.new(|cx| WorkspaceGitdiff::new(session.handle().clone(), cx));
 
+        let connection_banner = cx.new(|cx| ConnectionBanner::new(session_state.clone(), cx));
         let content = cx.new(|cx| {
             WorkspaceContent::new(
                 workspace_state.clone(),
                 terminal_state.clone(),
                 session_state.clone(),
                 session.handle().clone(),
+                connection_banner.clone(),
                 cx,
             )
         });
@@ -811,6 +828,8 @@ impl Workspace {
                 });
             },
         );
+        let connection_banner_subscription =
+            cx.subscribe(&connection_banner, Self::handle_banner_event);
 
         let mut host_event_rx = session.subscribe_host_events();
         let host_event_listener = cx.spawn(async move |workspace, cx| {
@@ -986,7 +1005,7 @@ impl Workspace {
                                     if ws.session_handle().user_disconnect() {
                                         return;
                                     }
-                                    ws.restart_connection(cx);
+                                    ws.restart_connection(true, cx);
                                 })
                                 .ok();
                             }
@@ -1103,6 +1122,7 @@ impl Workspace {
                 delta_state_subscription,
                 gitdiff_subscription,
                 file_search_subscription,
+                connection_banner_subscription,
             ],
         }
     }
@@ -1491,7 +1511,9 @@ impl Workspace {
         .detach();
     }
 
-    pub fn restart_connection(&mut self, cx: &mut Context<Self>) {
+    /// `reveal_detail` opens the connecting screen to show reconnect progress.
+    /// The banner refresh passes `false` so it reconnects in place.
+    pub fn restart_connection(&mut self, reveal_detail: bool, cx: &mut Context<Self>) {
         let Some(mut request) = self.connection_request.clone() else {
             warn!("restart connection requested without a connection request");
             return;
@@ -1511,7 +1533,9 @@ impl Workspace {
         self.active_reconnect_reason = None;
         self.latency_sampler.reset();
         self.start_connection(request);
-        self.content.update(cx, |c, cx| c.show_connecting_view(cx));
+        if reveal_detail {
+            self.content.update(cx, |c, cx| c.show_connecting_view(cx));
+        }
         self.record_current_view(cx);
     }
 
@@ -1842,7 +1866,24 @@ impl Workspace {
     ) {
         info!("handle RestartConnection from workspace");
         window.hide_soft_keyboard();
-        self.restart_connection(cx);
+        self.restart_connection(true, cx);
+    }
+
+    /// Banner taps arrive as entity events (not dispatched actions) so they work
+    /// regardless of where focus currently sits.
+    fn handle_banner_event(
+        &mut self,
+        _banner: Entity<ConnectionBanner>,
+        event: &BannerEvent,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            BannerEvent::OpenDetail => {
+                self.content.update(cx, |c, cx| c.show_connecting_view(cx));
+                self.record_current_view(cx);
+            }
+            BannerEvent::Refresh => self.restart_connection(false, cx),
+        }
     }
 
     fn handle_open_file(&mut self, action: &OpenFile, window: &mut Window, cx: &mut Context<Self>) {
@@ -3550,6 +3591,7 @@ pub struct WorkspaceContent {
     focus_handle: FocusHandle,
     show_connecting: bool,
     connecting_view: Entity<WorkspaceConnecting>,
+    connection_banner: Entity<ConnectionBanner>,
     mainview_bounds: Option<Bounds<Pixels>>,
     _subscriptions: Vec<Subscription>,
 }
@@ -3636,6 +3678,7 @@ impl WorkspaceContent {
         terminal_state: Entity<TerminalState>,
         session_state: Entity<SessionState>,
         session_handle: SessionHandle,
+        connection_banner: Entity<ConnectionBanner>,
         cx: &mut Context<Self>,
     ) -> Self {
         let empty_view = cx.new(|_cx| Empty);
@@ -3653,6 +3696,7 @@ impl WorkspaceContent {
             terminal_state,
             show_connecting: false,
             connecting_view: connecting,
+            connection_banner,
             mainview_bounds: None,
             _subscriptions: vec![terminal_state_sub, workspace_state_sub],
         }
@@ -3721,8 +3765,11 @@ impl WorkspaceContent {
         self.show_connecting
     }
 
-    fn open_connecting_view(&self, window: &mut Window, cx: &mut Context<Self>) {
-        window.dispatch_action(workspace_action::ShowConnecting.boxed_clone(), cx);
+    /// Show the connection detail directly. Not via `ShowConnecting` dispatch:
+    /// that action only reaches the workspace handler when a workspace element
+    /// holds focus, so it navigated only intermittently.
+    fn open_connecting_view(&mut self, cx: &mut Context<Self>) {
+        self.show_connecting_view(cx);
     }
 
     fn render_subtitle(&self, default_subtitle: &str, cx: &mut Context<Self>) -> AnyElement {
@@ -3867,8 +3914,8 @@ impl Render for WorkspaceContent {
                                                 )
                                                 .size(6.0)
                                                 .on_press(cx.listener(
-                                                    |this, _event, window, cx| {
-                                                        this.open_connecting_view(window, cx);
+                                                    |this, _event, _window, cx| {
+                                                        this.open_connecting_view(cx);
                                                     },
                                                 )),
                                             )
@@ -3916,12 +3963,20 @@ impl Render for WorkspaceContent {
                     .min_h_0()
                     .min_w_0()
                     .w_full()
+                    // Clip the overlaid banner at the header edge so it tucks under
+                    // the header on slide-out instead of painting over it.
+                    .overflow_hidden()
                     .child(mainview_measure)
                     .when_else(
                         self.show_connecting,
                         |d: Div| d.child(self.connecting_view.clone()),
                         |d: Div| d.child(self.main_view.clone()),
-                    ),
+                    )
+                    // Overlay the connection banner on top of the main view only —
+                    // the connecting detail already conveys full connection status.
+                    .when(!self.show_connecting, |d| {
+                        d.child(self.connection_banner.clone())
+                    }),
             )
     }
 }

--- a/crates/zedra/src/workspace_connecting.rs
+++ b/crates/zedra/src/workspace_connecting.rs
@@ -128,6 +128,25 @@ fn render_details_toggle(expanded: bool, cx: &mut Context<WorkspaceConnecting>) 
         )
 }
 
+/// Elapsed in a connect stage past which we hint the connection may be stalled.
+const HOLE_PUNCH_SLOW_MS: u64 = 8_000;
+
+/// Live badge label for the hole-punch phase: which sub-stage, elapsed, and a
+/// stall hint once it runs long. Answers "hanging or still in progress?".
+fn hole_punch_status_label(snap: &ConnectSnapshot) -> String {
+    let stage = snap
+        .hole_punch_stage
+        .map(|s| s.display_name())
+        .unwrap_or("Hole punching");
+    match snap.hole_punch_elapsed_ms {
+        Some(ms) if ms >= HOLE_PUNCH_SLOW_MS => {
+            format!("{stage}\u{2026} {}s \u{00b7} slow", ms / 1000)
+        }
+        Some(ms) if ms >= 1000 => format!("{stage}\u{2026} {}s", ms / 1000),
+        _ => format!("{stage}\u{2026}"),
+    }
+}
+
 fn render_phase_title(
     phase: &ConnectPhase,
     snap: &ConnectSnapshot,
@@ -135,6 +154,10 @@ fn render_phase_title(
     cx: &mut Context<WorkspaceConnecting>,
 ) -> Div {
     let (label, color) = transport_badge(&theme::palette(cx), phase, snap.transport.as_ref());
+    let label = match phase {
+        ConnectPhase::HolePunching => hole_punch_status_label(snap),
+        _ => label,
+    };
 
     let title = match phase {
         ConnectPhase::BindingEndpoint | ConnectPhase::HolePunching => "Connect",
@@ -507,7 +530,17 @@ fn build_timing_string(snap: &ConnectSnapshot) -> String {
         parts.push(format!("Bind {ms}ms"));
     }
     if let Some(ms) = snap.hole_punch_ms {
-        parts.push(format!("HolePunch {ms}ms"));
+        match (snap.resolve_ms, snap.handshake_ms) {
+            (Some(resolve), Some(handshake)) => parts.push(format!(
+                "HolePunch {ms}ms (find {resolve} + hs {handshake})"
+            )),
+            _ => parts.push(format!("HolePunch {ms}ms")),
+        }
+    }
+    if snap.relay_only {
+        parts.push("Relay-only (no direct)".to_string());
+    } else if let Some(ms) = snap.direct_upgrade_ms {
+        parts.push(format!("Direct +{ms}ms"));
     }
     if let Some(ms) = snap.rpc_ms {
         parts.push(format!("RPC {ms}ms"));

--- a/crates/zedra/src/workspace_connection_banner.rs
+++ b/crates/zedra/src/workspace_connection_banner.rs
@@ -1,0 +1,272 @@
+//! Animated status banner shown over the workspace main view while the session
+//! is not connected (idle, reconnecting, disconnected, or failed). It slides
+//! down under the header on appearance and, once the session reconnects, lingers
+//! briefly then slides back up and removes itself.
+//!
+//! Tapping the banner opens the connection detail; the refresh button restarts
+//! the connection.
+
+use std::time::Duration;
+
+use gpui::*;
+use zedra_session::{ConnectPhase, HolePunchStage, SessionState};
+
+use crate::platform_bridge::{self, HapticFeedback};
+use crate::theme;
+
+/// Emitted to the owning workspace. Delivered as an entity event rather than a
+/// dispatched action so it does not depend on focus being on a workspace
+/// element — `window.dispatch_action` silently misses the workspace handlers
+/// when focus is elsewhere (e.g. while idle), which made navigation flaky.
+#[derive(Clone, Copy, Debug)]
+pub enum BannerEvent {
+    /// Open the connection detail view.
+    OpenDetail,
+    /// Restart the connection.
+    Refresh,
+}
+
+const BANNER_HEIGHT: f32 = 32.0;
+/// How long the banner lingers after reconnecting before it slides away.
+const BANNER_LINGER: Duration = Duration::from_millis(1000);
+/// Slide/fade duration for both the enter and exit transitions.
+const BANNER_ANIM: Duration = Duration::from_millis(260);
+
+/// Gentle decelerate-in for the slide-down entrance (settles into place).
+fn ease_out_cubic(t: f32) -> f32 {
+    1.0 - (1.0 - t).powi(3)
+}
+
+/// Gentle accelerate-out for the slide-up dismissal (eases away).
+fn ease_in_cubic(t: f32) -> f32 {
+    t.powi(3)
+}
+
+/// Phases that warrant the banner: anything that is neither connected nor the
+/// pre-connection `Init` state (idle, connecting during a reconnect, reconnect
+/// backoff, disconnect, failure).
+fn is_bannerable(phase: &ConnectPhase) -> bool {
+    !matches!(phase, ConnectPhase::Connected | ConnectPhase::Init)
+}
+
+pub struct ConnectionBanner {
+    session_state: Entity<SessionState>,
+    /// Latched once the session first connects. The banner is a "connection
+    /// dropped" affordance over the workspace, so it stays hidden through the
+    /// initial connect (which the full connecting screen already covers).
+    has_connected: bool,
+    visible: bool,
+    /// True while playing the slide-up exit; kept in the tree until it removes.
+    dismissing: bool,
+    /// Bumped on each show so the enter animation re-fires (keyed ElementId).
+    enter_id: u64,
+    exit_id: u64,
+    /// Linger-then-remove task; dropping it cancels a pending auto-dismiss.
+    dismiss_task: Option<Task<()>>,
+    _session_sub: Subscription,
+}
+
+impl EventEmitter<BannerEvent> for ConnectionBanner {}
+
+impl ConnectionBanner {
+    pub fn new(session_state: Entity<SessionState>, cx: &mut Context<Self>) -> Self {
+        let session_sub = cx.observe(&session_state, |this, _, cx| this.sync(cx));
+        let mut banner = Self {
+            session_state,
+            has_connected: false,
+            visible: false,
+            dismissing: false,
+            enter_id: 0,
+            exit_id: 0,
+            dismiss_task: None,
+            _session_sub: session_sub,
+        };
+        banner.sync(cx);
+        banner
+    }
+
+    /// Reconcile visibility with the current phase.
+    fn sync(&mut self, cx: &mut Context<Self>) {
+        let phase = self.session_state.read(cx).phase.clone();
+
+        if phase.is_connected() {
+            self.has_connected = true;
+            // Linger, then slide up — only if a drop had shown the banner.
+            if self.visible && !self.dismissing && self.dismiss_task.is_none() {
+                self.schedule_dismiss(cx);
+                cx.notify(); // flip to the green "Connected" state during the linger
+            }
+        } else if self.has_connected && is_bannerable(&phase) {
+            // A drop after the initial connect: cancel any pending dismiss and show.
+            self.dismiss_task = None;
+            if !self.visible || self.dismissing {
+                self.visible = true;
+                self.dismissing = false;
+                self.enter_id = self.enter_id.wrapping_add(1);
+            }
+            cx.notify(); // refresh the message even when already visible
+        } else if self.visible {
+            // Pre-first-connect or non-bannerable state: hide without animating.
+            self.visible = false;
+            self.dismissing = false;
+            self.dismiss_task = None;
+            cx.notify();
+        }
+    }
+
+    /// After a reconnect, linger `BANNER_LINGER`, then start the exit slide.
+    fn schedule_dismiss(&mut self, cx: &mut Context<Self>) {
+        self.dismiss_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(BANNER_LINGER).await;
+            let _ = this.update(cx, |this, cx| this.begin_exit(cx));
+        }));
+    }
+
+    /// Play the slide-up exit, then remove the banner once the animation ends.
+    fn begin_exit(&mut self, cx: &mut Context<Self>) {
+        if !self.visible {
+            return;
+        }
+        self.dismissing = true;
+        self.exit_id = self.exit_id.wrapping_add(1);
+        cx.notify();
+        self.dismiss_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(BANNER_ANIM).await;
+            let _ = this.update(cx, |this, cx| {
+                this.visible = false;
+                this.dismissing = false;
+                this.dismiss_task = None;
+                cx.notify();
+            });
+        }));
+    }
+
+    fn banner_row(&self, message: String, accent: u32, cx: &mut Context<Self>) -> Stateful<Div> {
+        div()
+            .id("connection-banner")
+            .absolute()
+            .left_0()
+            .right_0()
+            .h(px(BANNER_HEIGHT))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(theme::SPACING_SM))
+            .px(px(theme::SPACING_MD))
+            .bg(rgb(theme::bg_card(cx)))
+            .border_b_1()
+            .border_color(rgb(theme::border_subtle(cx)))
+            .cursor_pointer()
+            .on_press(cx.listener(|_this, _event, _window, cx| {
+                cx.emit(BannerEvent::OpenDetail);
+            }))
+            .child(
+                svg()
+                    .path("icons/dot.svg")
+                    .size(px(theme::ICON_STATUS))
+                    .flex_shrink_0()
+                    .text_color(rgb(accent)),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .truncate()
+                    .text_size(px(theme::FONT_DETAIL))
+                    .text_color(rgb(theme::text_secondary(cx)))
+                    .child(message),
+            )
+            .child(render_refresh_button(cx))
+    }
+}
+
+impl Render for ConnectionBanner {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if !self.visible {
+            return div().into_any_element();
+        }
+
+        let phase = self.session_state.read(cx).phase.clone();
+        let stage = self.session_state.read(cx).snapshot.hole_punch_stage;
+        let (message, accent) = banner_content(&phase, stage, cx);
+        let row = self.banner_row(message, accent, cx);
+
+        if self.dismissing {
+            row.with_animation(
+                ElementId::NamedInteger("connection-banner-exit".into(), self.exit_id),
+                Animation::new(BANNER_ANIM).with_easing(ease_in_cubic),
+                |row, delta| row.top(px(-BANNER_HEIGHT * delta)).opacity(1.0 - delta),
+            )
+            .into_any_element()
+        } else {
+            row.with_animation(
+                ElementId::NamedInteger("connection-banner-enter".into(), self.enter_id),
+                Animation::new(BANNER_ANIM).with_easing(ease_out_cubic),
+                |row, delta| row.top(px(-BANNER_HEIGHT * (1.0 - delta))).opacity(delta),
+            )
+            .into_any_element()
+        }
+    }
+}
+
+/// Refresh button — stops propagation so tapping it restarts the connection
+/// without also opening the connection detail.
+fn render_refresh_button(cx: &mut Context<ConnectionBanner>) -> Stateful<Div> {
+    div()
+        .id("connection-banner-refresh")
+        .w(px(28.0))
+        .h(px(28.0))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(6.0))
+        .flex_shrink_0()
+        .hit_slop(px(10.0))
+        .on_pointer_down(|_, _, cx| cx.stop_propagation())
+        .on_press(cx.listener(|_this, _event, _window, cx| {
+            cx.stop_propagation();
+            platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
+            cx.emit(BannerEvent::Refresh);
+        }))
+        .child(
+            svg()
+                .path("icons/refresh-ccw.svg")
+                .size(px(theme::ICON_SM))
+                .text_color(rgb(theme::text_muted(cx))),
+        )
+}
+
+/// User-facing message and accent color for the current phase. `stage` is the
+/// live hole-punch sub-stage, surfaced as the connecting progress detail.
+fn banner_content(phase: &ConnectPhase, stage: Option<HolePunchStage>, cx: &App) -> (String, u32) {
+    let palette = theme::palette(cx);
+    match phase {
+        // Shown briefly during the linger after a reconnect, matching the header.
+        ConnectPhase::Connected => ("Connected".into(), palette.accent_green),
+        ConnectPhase::Reconnecting {
+            next_retry_secs, ..
+        } => {
+            let message = if *next_retry_secs > 0 {
+                format!("Reconnecting in {next_retry_secs}s")
+            } else {
+                "Reconnecting".into()
+            };
+            (message, palette.accent_yellow)
+        }
+        ConnectPhase::Idle { .. } => ("Connection idle".into(), palette.accent_yellow),
+        ConnectPhase::Disconnected => ("Disconnected".into(), palette.accent_red),
+        ConnectPhase::Failed(error) => (error.user_message(), palette.accent_red),
+        // Remaining bannerable states are the connecting steps during a reconnect;
+        // show the phase progress detail after a centered dot.
+        _ => {
+            let detail = match (phase, stage) {
+                (ConnectPhase::HolePunching, Some(stage)) => stage.display_name(),
+                _ => phase.display_name(),
+            };
+            (
+                format!("Connecting \u{00b7} {detail}"),
+                palette.accent_yellow,
+            )
+        }
+    }
+}

--- a/crates/zedra/src/workspaces.rs
+++ b/crates/zedra/src/workspaces.rs
@@ -271,7 +271,7 @@ impl Workspaces {
                     None | Some(ConnectPhase::Disconnected) | Some(ConnectPhase::Failed(_))
                 );
                 if stale {
-                    ws.restart_connection(cx);
+                    ws.restart_connection(true, cx);
                 }
                 if let Some(terminal_id) = terminal_id {
                     ws.open_terminal_after_sync(terminal_id, cx);

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1655,3 +1655,26 @@ the first step that can't resolve.
    `pid` and does *not* start `iproxy`. Switch the pref back to the simulator and re-run
    `bridge-ios` — expected: `/ping`'s `pid` matches the simulator's process, and no stray
    `iproxy` remains (`ps aux | grep iproxy`).
+
+## 25. Connection Banner (workspace, not-connected states)
+
+Covers the animated status banner overlaid at the top of the workspace main view
+(`workspace_connection_banner.rs`).
+
+1. Connect to a host and open the workspace main view. Expected: no banner while
+   connected.
+2. Drop the connection (stop the host daemon, or turn off Wi-Fi briefly). Expected:
+   the banner slides down under the header showing a yellow dot + "Reconnecting…"
+   (or "Connection idle" when idle), with a refresh button on the right.
+3. Tap the banner body (not the button). Expected: the connection detail
+   (connecting) screen opens; the banner is not shown over that screen.
+4. From the workspace, tap the refresh button on the banner. Expected: a reconnect
+   starts (haptic tick) and it does **not** open the connection detail — the tap is
+   consumed by the button.
+5. Restore the host / network so the session reconnects. Expected: the banner
+   lingers ~3s after "Connected", then slides up under the header and disappears.
+6. Drop the connection again during that 3s linger or slide-up. Expected: the
+   dismiss is cancelled and the banner stays/returns for the new not-connected
+   state.
+7. Toggle appearance (Settings → Appearance) while the banner is visible. Expected:
+   banner surface, border, text, and accent dot recolor with the theme.

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1672,8 +1672,8 @@ Covers the animated status banner overlaid at the top of the workspace main view
    starts (haptic tick) and it does **not** open the connection detail — the tap is
    consumed by the button.
 5. Restore the host / network so the session reconnects. Expected: the banner
-   lingers ~3s after "Connected", then slides up under the header and disappears.
-6. Drop the connection again during that 3s linger or slide-up. Expected: the
+   lingers ~1s after "Connected", then slides up under the header and disappears.
+6. Drop the connection again during that 1s linger or slide-up. Expected: the
    dismiss is cancelled and the banner stays/returns for the new not-connected
    state.
 7. Toggle appearance (Settings → Appearance) while the banner is visible. Expected:

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -100,15 +100,16 @@ Emitted by `zedra` (app crate) and `zedra-session`.
 | `app_open` | `saved_workspaces`, `app_version`, `platform`, `arch` | `app.rs` — cold start |
 | `screen_view` | `screen`, `screen_name`, `screen_class` | `app.rs`, `workspace.rs`, `workspace_drawer.rs`, `workspace_terminal.rs`, `settings_view.rs` — GPUI logical views |
 | `qr_scan_initiated` | — | `app.rs` — Scan QR tapped |
-| `connect_success` | `total_ms`, `binding_ms`, `hole_punch_ms`, `auth_ms`, `fetch_ms`, `path`, `network`, `rtt_ms`, `relay`, `relay_latency_ms`, `alpn`, `has_ipv4`, `has_ipv6`, `symmetric_nat`, `is_first_pairing` | `handle.rs` — connect() |
+| `connect_success` | `total_ms`, `binding_ms`, `hole_punch_ms`, `resolve_ms`, `handshake_ms`, `auth_ms`, `fetch_ms`, `path`, `network`, `rtt_ms`, `relay`, `relay_latency_ms`, `alpn`, `has_ipv4`, `has_ipv6`, `symmetric_nat`, `is_first_pairing` | `handle.rs` — connect() (`hole_punch_ms` = `resolve_ms` discovery + `handshake_ms` QUIC) |
 | `connect_failed` | `phase`, `error`, `elapsed_ms`, `relay`, `alpn`, `has_ipv4`, `has_ipv6`, `relay_connected` | `handle.rs` — set_failed() |
 | `session_resumed` | `terminal_count`, `resume_ms` | `app.rs` — reconnect to existing session |
 | `disconnect` | — | `app.rs` — user disconnect |
 | `workspace_selected` | `source` (`"active"` or `"saved"`) | `app.rs` — workspace tapped |
 | `reconnect_started` | `reason` | `handle.rs` — reconnect loop |
-| `reconnect_success` | `attempt`, `elapsed_ms`, `reason`, `binding_ms`, `hole_punch_ms`, `auth_ms`, `fetch_ms`, `path`, `network`, `rtt_ms`, `relay`, `alpn`, `has_ipv4`, `has_ipv6` | `handle.rs` |
+| `reconnect_success` | `attempt`, `elapsed_ms`, `reason`, `binding_ms`, `hole_punch_ms`, `resolve_ms`, `handshake_ms`, `auth_ms`, `fetch_ms`, `path`, `network`, `rtt_ms`, `relay`, `alpn`, `has_ipv4`, `has_ipv6` | `handle.rs` |
 | `reconnect_exhausted` | `attempts`, `elapsed_ms`, `reason`, `fatal_error` (optional) | `handle.rs` |
-| `path_upgraded` | `network`, `rtt_ms`, `from_relay` | `handle.rs` — path watcher |
+| `path_upgraded` | `network`, `rtt_ms`, `from_relay`, `upgrade_ms` (relay→direct time) | `handle.rs` — path watcher |
+| `direct_upgrade_timeout` | `elapsed_ms`, `relay`, `network`, `symmetric_nat` | `workspace.rs` — no direct path within the upgrade window (relay-only) |
 | `connection_latency_sample` | `source`, `connection_type`, `network_type`, `rtt_ms`, `relay`, `relay_region`, `nearest_relay_region`, `path_count`, `interval_secs`, `sample_reason` | `workspace.rs` — selected-path latency sample |
 | `terminal_opened` | `source`, `terminal_count` | `workspace_view.rs` |
 | `terminal_closed` | `remaining` | `workspace_view.rs` |


### PR DESCRIPTION
## Summary

Two connection-visibility improvements for the mobile app.

**Hole-punch / connect observability.** The opaque `endpoint.connect()` is split into observable stages — pkarr/DNS resolve vs QUIC+TLS handshake — each timed, plus a 1s heartbeat during the pending connect so a stall is distinguishable from progress. A relay-only outcome is reported when no direct path forms within the upgrade window. Exposed via new `ConnectEvent`s, `ConnectSnapshot` fields, and privacy-safe telemetry: `connect_success`/`reconnect_success` gain `resolve_ms`/`handshake_ms`, `path_upgraded` gains `upgrade_ms`, and a new `direct_upgrade_timeout` event captures the stuck-on-relay case. Progress heartbeats reserve channel headroom so they can never evict one-shot lifecycle events when the UI receiver stalls (e.g. app backgrounded).

**Connection status banner.** An animated banner appears over the workspace main view when the session drops after having connected (idle / reconnecting / disconnected / failed). It slides in under the header, shows the live connect-stage detail (`Connecting · Handshaking`), flips green `Connected` on reconnect to match the header dot, lingers briefly, then eases up and clips beneath the header. Tapping the banner opens the connection detail; the refresh button reconnects in place. Banner taps and the header status dot now route through entity events / direct method calls instead of `window.dispatch_action`, which is focus-dependent and only navigated intermittently.

## Notes

- No ALPN/protocol bump — `ConnectEvent` is internal, not RPC.
- Verified on device (iOS, Tan iPhone) across the reconnect flow; `cargo fmt`, `cargo check`/`test` for the touched crates, and the `aarch64-apple-ios` cross-compile all pass.
- Manual verification steps added in `docs/MANUAL_TEST.md` §25; telemetry table updated in `docs/TELEMETRY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an animated workspace connection banner for disconnected and reconnecting states.
  * Tap the banner to open connection details, or use the refresh action to retry without leaving the current view.
  * Connection details now show hole-punch stages, elapsed time, resolution and handshake timings, and direct connection upgrade timing.
* **Improvements**
  * Reconnection behavior now clearly indicates when the app remains on a relay connection after a direct upgrade times out.
  * Expanded connection telemetry captures more detailed timing and upgrade outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->