### PR TITLE
fix(terminal): improve fullscreen TUI scrolling

### DIFF
--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::cell::Cell as StdCell;
 use std::cmp::min;
 use std::ops::{Index, Range};
 use std::path::{Path, PathBuf};
@@ -209,6 +210,9 @@ pub struct Terminal {
     output_task: Option<Task<()>>,
     selection_range: Option<Range<usize>>,
     theme: TerminalTheme,
+    /// Last focus state reported (or observed while reporting was off); dedupes
+    /// the synchronous pre-click report against the deferred focus listener.
+    focus_reported: StdCell<bool>,
 }
 
 impl Terminal {
@@ -245,6 +249,7 @@ impl Terminal {
             output_task: None,
             selection_range: None,
             theme,
+            focus_reported: StdCell::new(true),
         };
         terminal
     }
@@ -2014,6 +2019,11 @@ impl Terminal {
     /// Report focus gain/loss to apps that enabled mode 1004 (e.g. vim, tmux),
     /// so they can redraw or pause when the terminal moves in and out of focus.
     pub fn send_focus_report(&self, focused: bool) {
+        // Track state even when reporting is off so a later mode-1004 enable
+        // still sees the real transition.
+        if self.focus_reported.replace(focused) == focused {
+            return;
+        }
         if self.input_tx.is_none() || !self.mode.contains(TermMode::FOCUS_IN_OUT) {
             return;
         }
@@ -2674,6 +2684,38 @@ mod tests {
 
         let bytes = String::from_utf8(input_rx.try_recv().unwrap()).unwrap();
         assert_eq!(bytes, "\x1b[200~one[31mtwo\x1b[201~");
+    }
+
+    #[test]
+    fn focus_report_dedupes_repeated_state() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+        let (input_tx, mut input_rx) = mpsc::channel(4);
+        terminal.input_tx = Some(input_tx);
+        terminal.mode.insert(TermMode::FOCUS_IN_OUT);
+
+        terminal.send_focus_report(false);
+        assert_eq!(input_rx.try_recv().unwrap(), b"\x1b[O");
+
+        // Synchronous pre-click report followed by the deferred focus listener.
+        terminal.send_focus_report(true);
+        terminal.send_focus_report(true);
+        assert_eq!(input_rx.try_recv().unwrap(), b"\x1b[I");
+        assert!(input_rx.try_recv().is_err(), "duplicate focus-in sent");
+    }
+
+    #[test]
+    fn focus_state_tracked_while_reporting_disabled() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+        let (input_tx, mut input_rx) = mpsc::channel(4);
+        terminal.input_tx = Some(input_tx);
+
+        // Blur observed before the app enables mode 1004.
+        terminal.send_focus_report(false);
+        assert!(input_rx.try_recv().is_err());
+
+        terminal.mode.insert(TermMode::FOCUS_IN_OUT);
+        terminal.send_focus_report(true);
+        assert_eq!(input_rx.try_recv().unwrap(), b"\x1b[I");
     }
 
     #[test]

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -14,7 +14,8 @@ use alacritty_terminal::term::color::COUNT as ALACRITTY_COLOR_COUNT;
 use alacritty_terminal::term::{Term, TermMode};
 use alacritty_terminal::vte::ansi::{Color as AlacColor, CursorShape, NamedColor, Processor};
 use gpui::{
-    Context, Keystroke, Pixels, Point as GpuiPoint, ScrollDelta, ScrollWheelEvent, Task, px,
+    Context, Keystroke, Modifiers, Pixels, Point as GpuiPoint, ScrollDelta, ScrollWheelEvent, Task,
+    px,
 };
 use tokio::sync::{broadcast, mpsc};
 use zedra_osc::{OscEvent, OscScanner};
@@ -1985,6 +1986,41 @@ impl Terminal {
         true
     }
 
+    /// Forward a tap as a left-click (press + release) when the app requested
+    /// mouse tracking. Shift is the escape hatch that keeps taps local.
+    pub fn send_mouse_click(
+        &self,
+        position: gpui::Point<Pixels>,
+        grid_origin: Option<gpui::Point<Pixels>>,
+        modifiers: Modifiers,
+    ) -> bool {
+        if self.input_tx.is_none() || modifiers.shift {
+            return false;
+        }
+        let Some(point) = self.grid_point_at(position, grid_origin) else {
+            return false;
+        };
+        let Some(press) = mouse_report_bytes(point, 0, modifiers, false, self.mode) else {
+            return false;
+        };
+        let Some(release) = mouse_report_bytes(point, 0, modifiers, true, self.mode) else {
+            return false;
+        };
+        self.send_bytes_sync(press);
+        self.send_bytes_sync(release);
+        true
+    }
+
+    /// Report focus gain/loss to apps that enabled mode 1004 (e.g. vim, tmux),
+    /// so they can redraw or pause when the terminal moves in and out of focus.
+    pub fn send_focus_report(&self, focused: bool) {
+        if self.input_tx.is_none() || !self.mode.contains(TermMode::FOCUS_IN_OUT) {
+            return;
+        }
+        let report = if focused { b"\x1b[I" } else { b"\x1b[O" };
+        self.send_bytes_sync(report.to_vec());
+    }
+
     pub fn commit_scroll_lines(
         &mut self,
         lines: i32,
@@ -2024,33 +2060,50 @@ fn alt_scroll_bytes(lines: i32) -> Vec<u8> {
 }
 
 fn scroll_report_bytes(point: Point, event: &ScrollWheelEvent, mode: TermMode) -> Option<Vec<u8>> {
+    let button = if scroll_is_up(event) { 64 } else { 65 };
+    mouse_report_bytes(point, button, event.modifiers, false, mode)
+}
+
+/// Encode a mouse event for the PTY. `button` is the raw button code
+/// (0/1/2 = left/middle/right, 64/65 = wheel up/down); wheel events never release.
+fn mouse_report_bytes(
+    point: Point,
+    button: u8,
+    modifiers: Modifiers,
+    released: bool,
+    mode: TermMode,
+) -> Option<Vec<u8>> {
     if !mode.intersects(TermMode::MOUSE_MODE) || point.line < Line(0) {
         return None;
     }
 
-    let mut button = if scroll_is_up(event) { 64 } else { 65 };
-    if event.modifiers.shift {
-        button += 4;
+    let mut cb = button;
+    if modifiers.shift {
+        cb += 4;
     }
-    if event.modifiers.alt {
-        button += 8;
+    if modifiers.alt {
+        cb += 8;
     }
-    if event.modifiers.control {
-        button += 16;
+    if modifiers.control {
+        cb += 16;
     }
 
     if mode.contains(TermMode::SGR_MOUSE) {
+        let action = if released { 'm' } else { 'M' };
         Some(
             format!(
-                "\x1b[<{};{};{}M",
-                button,
+                "\x1b[<{};{};{}{}",
+                cb,
                 point.column.0 + 1,
-                point.line.0 + 1
+                point.line.0 + 1,
+                action
             )
             .into_bytes(),
         )
     } else {
-        normal_mouse_scroll_report(point, button, mode.contains(TermMode::UTF8_MOUSE))
+        // Legacy encoding can't name the released button; button 3 means release.
+        let cb = if released { 3 + (cb & !0b11) } else { cb };
+        normal_mouse_report(point, cb, mode.contains(TermMode::UTF8_MOUSE))
     }
 }
 
@@ -2061,7 +2114,7 @@ fn scroll_is_up(event: &ScrollWheelEvent) -> bool {
     }
 }
 
-fn normal_mouse_scroll_report(point: Point, button: u8, utf8: bool) -> Option<Vec<u8>> {
+fn normal_mouse_report(point: Point, button: u8, utf8: bool) -> Option<Vec<u8>> {
     let line = point.line.0;
     let column = point.column.0;
     let max_point = if utf8 { 2015usize } else { 223usize };
@@ -4579,5 +4632,45 @@ mod tests {
         let links = terminal.detect_plain_links();
         assert_eq!(links.len(), 1, "expected only URL match, got {:?}", links);
         assert_eq!(links[0].kind, super::DetectedLinkKind::Url);
+    }
+
+    #[test]
+    fn mouse_report_bytes_encodes_sgr_click() {
+        let point = Point::new(Line(4), Column(9));
+        let mode = TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
+        let mods = gpui::Modifiers::default();
+        let press = super::mouse_report_bytes(point, 0, mods, false, mode).unwrap();
+        let release = super::mouse_report_bytes(point, 0, mods, true, mode).unwrap();
+        assert_eq!(press, b"\x1b[<0;10;5M");
+        assert_eq!(release, b"\x1b[<0;10;5m");
+    }
+
+    #[test]
+    fn mouse_report_bytes_adds_modifier_bits() {
+        let point = Point::new(Line(0), Column(0));
+        let mode = TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
+        let mods = gpui::Modifiers {
+            control: true,
+            ..Default::default()
+        };
+        let press = super::mouse_report_bytes(point, 0, mods, false, mode).unwrap();
+        assert_eq!(press, b"\x1b[<16;1;1M");
+    }
+
+    #[test]
+    fn mouse_report_bytes_legacy_release_uses_button_three() {
+        let point = Point::new(Line(0), Column(0));
+        let mode = TermMode::MOUSE_REPORT_CLICK;
+        let mods = gpui::Modifiers::default();
+        let release = super::mouse_report_bytes(point, 0, mods, true, mode).unwrap();
+        // ESC [ M, then 32+3 (button release), 32+1+col, 32+1+line.
+        assert_eq!(release, vec![0x1b, b'[', b'M', 35, 33, 33]);
+    }
+
+    #[test]
+    fn mouse_report_bytes_none_without_mouse_mode() {
+        let point = Point::new(Line(0), Column(0));
+        let mods = gpui::Modifiers::default();
+        assert!(super::mouse_report_bytes(point, 0, mods, false, TermMode::empty()).is_none());
     }
 }

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -12,7 +12,6 @@ use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::index::{Column, Line, Point};
 use alacritty_terminal::term::Config;
 use alacritty_terminal::term::cell::{Cell, Flags as CellFlags};
-use alacritty_terminal::term::color::COUNT as ALACRITTY_COLOR_COUNT;
 use alacritty_terminal::term::{Term, TermMode};
 use alacritty_terminal::vte::ansi::{Color as AlacColor, CursorShape, NamedColor, Processor};
 use gpui::{
@@ -208,11 +207,10 @@ pub struct Terminal {
     input_tx: Option<mpsc::Sender<Vec<u8>>>,
     output_task: Option<Task<()>>,
     pending_sync_deadline: Option<Instant>,
-    synchronized_update_generation: u64,
+    synchronized_update_timeout_task: Option<Task<()>>,
     selection_range: Option<Range<usize>>,
     theme: TerminalTheme,
-    /// Last focus state reported (or observed while reporting was off); dedupes
-    /// the synchronous pre-click report against the deferred focus listener.
+    /// Last observed focus state; dedupes repeated focus callbacks.
     focus_reported: StdCell<bool>,
 }
 
@@ -249,7 +247,7 @@ impl Terminal {
             input_tx: None,
             output_task: None,
             pending_sync_deadline: None,
-            synchronized_update_generation: 0,
+            synchronized_update_timeout_task: None,
             selection_range: None,
             theme,
             focus_reported: StdCell::new(true),
@@ -288,7 +286,7 @@ impl Terminal {
         let output_task = cx.spawn(async move |this, cx| {
             while let Some(bytes) = output_rx.recv().await {
                 let _ = this.update(cx, |this, cx| {
-                    let should_present = this.advance_bytes(&bytes);
+                    let should_present = this.advance_output_bytes(&bytes);
                     this.feed_osc_bytes(&bytes);
                     this.present_output_when_ready(should_present, cx);
                 });
@@ -313,8 +311,12 @@ impl Terminal {
         self.send_bytes(text.into_bytes()).await;
     }
 
-    /// Feed PTY output into the emulator, returning whether it is ready to present.
-    pub fn advance_bytes(&mut self, bytes: &[u8]) -> bool {
+    /// Feed bytes from PTY output buffer into the terminal emulator.
+    pub fn advance_bytes(&mut self, bytes: &[u8]) {
+        self.advance_output_bytes(bytes);
+    }
+
+    fn advance_output_bytes(&mut self, bytes: &[u8]) -> bool {
         let was_alt = self.mode.contains(TermMode::ALT_SCREEN);
         let previous_display_offset = self.display_offset();
         self.processor.advance(&mut self.term, bytes);
@@ -351,10 +353,9 @@ impl Terminal {
 
     fn present_output_when_ready(&mut self, should_present: bool, cx: &mut Context<Self>) {
         if should_present {
-            if self.pending_sync_deadline.take().is_some() {
-                self.synchronized_update_generation =
-                    self.synchronized_update_generation.wrapping_add(1);
-            }
+            self.pending_sync_deadline = None;
+            // Dropping the task cancels the fallback after a normal end marker.
+            self.synchronized_update_timeout_task.take();
             cx.notify();
             return;
         }
@@ -367,26 +368,20 @@ impl Terminal {
         }
 
         self.pending_sync_deadline = Some(deadline);
-        self.synchronized_update_generation = self.synchronized_update_generation.wrapping_add(1);
-        let generation = self.synchronized_update_generation;
         let delay = deadline.saturating_duration_since(Instant::now());
-        cx.spawn(async move |this, cx| {
+        self.synchronized_update_timeout_task = Some(cx.spawn(async move |this, cx| {
             cx.background_executor().timer(delay).await;
             let _ = this.update(cx, |this, cx| {
-                // A stale timeout must not flush a later synchronized frame.
-                if this.synchronized_update_generation != generation {
+                if this.pending_sync_deadline != Some(deadline) {
                     return;
                 }
 
                 if this.stop_synchronized_update() {
                     this.pending_sync_deadline = None;
-                    this.synchronized_update_generation =
-                        this.synchronized_update_generation.wrapping_add(1);
                     cx.notify();
                 }
             });
-        })
-        .detach();
+        }));
     }
 
     fn drain_alacritty_events(&mut self) {
@@ -2649,7 +2644,6 @@ mod tests {
     use std::path::Path;
     use std::time::Duration;
 
-    use crate::TerminalTheme;
     use alacritty_terminal::index::{Column, Line, Point};
     use alacritty_terminal::term::TermMode;
     use gpui::{AppContext, TestAppContext, px};
@@ -2764,7 +2758,7 @@ mod tests {
         terminal.send_focus_report(false);
         assert_eq!(input_rx.try_recv().unwrap(), b"\x1b[O");
 
-        // Synchronous pre-click report followed by the deferred focus listener.
+        // Repeated focus callbacks emit only one report.
         terminal.send_focus_report(true);
         terminal.send_focus_report(true);
         assert_eq!(input_rx.try_recv().unwrap(), b"\x1b[I");
@@ -2790,7 +2784,7 @@ mod tests {
     fn synchronized_output_presents_only_after_end_marker() {
         let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
 
-        assert!(!terminal.advance_bytes(b"\x1b[?2026hheld"));
+        assert!(!terminal.advance_output_bytes(b"\x1b[?2026hheld"));
         assert!(
             !terminal
                 .content()
@@ -2798,8 +2792,8 @@ mod tests {
                 .iter()
                 .any(|cell| cell.cell.c == 'h')
         );
-        assert!(!terminal.advance_bytes(b" output"));
-        assert!(terminal.advance_bytes(b"\x1b[?2026l"));
+        assert!(!terminal.advance_output_bytes(b" output"));
+        assert!(terminal.advance_output_bytes(b"\x1b[?2026l"));
 
         let text: String = terminal
             .content()
@@ -2814,10 +2808,10 @@ mod tests {
     fn synchronized_output_handles_split_markers() {
         let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
 
-        assert!(terminal.advance_bytes(b"\x1b[?20"));
-        assert!(!terminal.advance_bytes(b"26hsplit"));
-        assert!(!terminal.advance_bytes(b"\x1b[?202"));
-        assert!(terminal.advance_bytes(b"6l"));
+        assert!(terminal.advance_output_bytes(b"\x1b[?20"));
+        assert!(!terminal.advance_output_bytes(b"26hsplit"));
+        assert!(!terminal.advance_output_bytes(b"\x1b[?202"));
+        assert!(terminal.advance_output_bytes(b"6l"));
 
         let text: String = terminal
             .content()
@@ -2832,7 +2826,7 @@ mod tests {
     fn synchronized_output_timeout_releases_buffered_content() {
         let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
 
-        assert!(!terminal.advance_bytes(b"\x1b[?2026htimed out"));
+        assert!(!terminal.advance_output_bytes(b"\x1b[?2026htimed out"));
         assert!(terminal.stop_synchronized_update());
 
         let text: String = terminal

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::cell::Cell as StdCell;
 use std::cmp::min;
 use std::ops::{Index, Range};
 use std::path::{Path, PathBuf};
@@ -15,8 +14,7 @@ use alacritty_terminal::term::cell::{Cell, Flags as CellFlags};
 use alacritty_terminal::term::{Term, TermMode};
 use alacritty_terminal::vte::ansi::{Color as AlacColor, CursorShape, NamedColor, Processor};
 use gpui::{
-    Context, Keystroke, Modifiers, Pixels, Point as GpuiPoint, ScrollDelta, ScrollWheelEvent, Task,
-    px,
+    Context, Keystroke, Pixels, Point as GpuiPoint, ScrollDelta, ScrollWheelEvent, Task, px,
 };
 use tokio::sync::{broadcast, mpsc};
 use zedra_osc::{OscEvent, OscScanner};
@@ -210,8 +208,6 @@ pub struct Terminal {
     synchronized_update_timeout_task: Option<Task<()>>,
     selection_range: Option<Range<usize>>,
     theme: TerminalTheme,
-    /// Last observed focus state; dedupes repeated focus callbacks.
-    focus_reported: StdCell<bool>,
 }
 
 impl Terminal {
@@ -250,7 +246,6 @@ impl Terminal {
             synchronized_update_timeout_task: None,
             selection_range: None,
             theme,
-            focus_reported: StdCell::new(true),
         };
         terminal
     }
@@ -2053,46 +2048,6 @@ impl Terminal {
         true
     }
 
-    /// Forward a tap as a left-click (press + release) when the app requested
-    /// mouse tracking. Shift is the escape hatch that keeps taps local.
-    pub fn send_mouse_click(
-        &self,
-        position: gpui::Point<Pixels>,
-        grid_origin: Option<gpui::Point<Pixels>>,
-        modifiers: Modifiers,
-    ) -> bool {
-        if self.input_tx.is_none() || modifiers.shift {
-            return false;
-        }
-        let Some(point) = self.grid_point_at(position, grid_origin) else {
-            return false;
-        };
-        let Some(press) = mouse_report_bytes(point, 0, modifiers, false, self.mode) else {
-            return false;
-        };
-        let Some(release) = mouse_report_bytes(point, 0, modifiers, true, self.mode) else {
-            return false;
-        };
-        self.send_bytes_sync(press);
-        self.send_bytes_sync(release);
-        true
-    }
-
-    /// Report focus gain/loss to apps that enabled mode 1004 (e.g. vim, tmux),
-    /// so they can redraw or pause when the terminal moves in and out of focus.
-    pub fn send_focus_report(&self, focused: bool) {
-        // Track state even when reporting is off so a later mode-1004 enable
-        // still sees the real transition.
-        if self.focus_reported.replace(focused) == focused {
-            return;
-        }
-        if self.input_tx.is_none() || !self.mode.contains(TermMode::FOCUS_IN_OUT) {
-            return;
-        }
-        let report = if focused { b"\x1b[I" } else { b"\x1b[O" };
-        self.send_bytes_sync(report.to_vec());
-    }
-
     pub fn commit_scroll_lines(
         &mut self,
         lines: i32,
@@ -2132,50 +2087,33 @@ fn alt_scroll_bytes(lines: i32) -> Vec<u8> {
 }
 
 fn scroll_report_bytes(point: Point, event: &ScrollWheelEvent, mode: TermMode) -> Option<Vec<u8>> {
-    let button = if scroll_is_up(event) { 64 } else { 65 };
-    mouse_report_bytes(point, button, event.modifiers, false, mode)
-}
-
-/// Encode a mouse event for the PTY. `button` is the raw button code
-/// (0/1/2 = left/middle/right, 64/65 = wheel up/down); wheel events never release.
-fn mouse_report_bytes(
-    point: Point,
-    button: u8,
-    modifiers: Modifiers,
-    released: bool,
-    mode: TermMode,
-) -> Option<Vec<u8>> {
     if !mode.intersects(TermMode::MOUSE_MODE) || point.line < Line(0) {
         return None;
     }
 
-    let mut cb = button;
-    if modifiers.shift {
-        cb += 4;
+    let mut button = if scroll_is_up(event) { 64 } else { 65 };
+    if event.modifiers.shift {
+        button += 4;
     }
-    if modifiers.alt {
-        cb += 8;
+    if event.modifiers.alt {
+        button += 8;
     }
-    if modifiers.control {
-        cb += 16;
+    if event.modifiers.control {
+        button += 16;
     }
 
     if mode.contains(TermMode::SGR_MOUSE) {
-        let action = if released { 'm' } else { 'M' };
         Some(
             format!(
-                "\x1b[<{};{};{}{}",
-                cb,
+                "\x1b[<{};{};{}M",
+                button,
                 point.column.0 + 1,
-                point.line.0 + 1,
-                action
+                point.line.0 + 1
             )
             .into_bytes(),
         )
     } else {
-        // Legacy encoding can't name the released button; button 3 means release.
-        let cb = if released { 3 + (cb & !0b11) } else { cb };
-        normal_mouse_report(point, cb, mode.contains(TermMode::UTF8_MOUSE))
+        normal_mouse_scroll_report(point, button, mode.contains(TermMode::UTF8_MOUSE))
     }
 }
 
@@ -2186,7 +2124,7 @@ fn scroll_is_up(event: &ScrollWheelEvent) -> bool {
     }
 }
 
-fn normal_mouse_report(point: Point, button: u8, utf8: bool) -> Option<Vec<u8>> {
+fn normal_mouse_scroll_report(point: Point, button: u8, utf8: bool) -> Option<Vec<u8>> {
     let line = point.line.0;
     let column = point.column.0;
     let max_point = if utf8 { 2015usize } else { 223usize };
@@ -2746,38 +2684,6 @@ mod tests {
 
         let bytes = String::from_utf8(input_rx.try_recv().unwrap()).unwrap();
         assert_eq!(bytes, "\x1b[200~one[31mtwo\x1b[201~");
-    }
-
-    #[test]
-    fn focus_report_dedupes_repeated_state() {
-        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
-        let (input_tx, mut input_rx) = mpsc::channel(4);
-        terminal.input_tx = Some(input_tx);
-        terminal.mode.insert(TermMode::FOCUS_IN_OUT);
-
-        terminal.send_focus_report(false);
-        assert_eq!(input_rx.try_recv().unwrap(), b"\x1b[O");
-
-        // Repeated focus callbacks emit only one report.
-        terminal.send_focus_report(true);
-        terminal.send_focus_report(true);
-        assert_eq!(input_rx.try_recv().unwrap(), b"\x1b[I");
-        assert!(input_rx.try_recv().is_err(), "duplicate focus-in sent");
-    }
-
-    #[test]
-    fn focus_state_tracked_while_reporting_disabled() {
-        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
-        let (input_tx, mut input_rx) = mpsc::channel(4);
-        terminal.input_tx = Some(input_tx);
-
-        // Blur observed before the app enables mode 1004.
-        terminal.send_focus_report(false);
-        assert!(input_rx.try_recv().is_err());
-
-        terminal.mode.insert(TermMode::FOCUS_IN_OUT);
-        terminal.send_focus_report(true);
-        assert_eq!(input_rx.try_recv().unwrap(), b"\x1b[I");
     }
 
     #[test]
@@ -4829,45 +4735,5 @@ mod tests {
         let links = terminal.detect_plain_links();
         assert_eq!(links.len(), 1, "expected only URL match, got {:?}", links);
         assert_eq!(links[0].kind, super::DetectedLinkKind::Url);
-    }
-
-    #[test]
-    fn mouse_report_bytes_encodes_sgr_click() {
-        let point = Point::new(Line(4), Column(9));
-        let mode = TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
-        let mods = gpui::Modifiers::default();
-        let press = super::mouse_report_bytes(point, 0, mods, false, mode).unwrap();
-        let release = super::mouse_report_bytes(point, 0, mods, true, mode).unwrap();
-        assert_eq!(press, b"\x1b[<0;10;5M");
-        assert_eq!(release, b"\x1b[<0;10;5m");
-    }
-
-    #[test]
-    fn mouse_report_bytes_adds_modifier_bits() {
-        let point = Point::new(Line(0), Column(0));
-        let mode = TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
-        let mods = gpui::Modifiers {
-            control: true,
-            ..Default::default()
-        };
-        let press = super::mouse_report_bytes(point, 0, mods, false, mode).unwrap();
-        assert_eq!(press, b"\x1b[<16;1;1M");
-    }
-
-    #[test]
-    fn mouse_report_bytes_legacy_release_uses_button_three() {
-        let point = Point::new(Line(0), Column(0));
-        let mode = TermMode::MOUSE_REPORT_CLICK;
-        let mods = gpui::Modifiers::default();
-        let release = super::mouse_report_bytes(point, 0, mods, true, mode).unwrap();
-        // ESC [ M, then 32+3 (button release), 32+1+col, 32+1+line.
-        assert_eq!(release, vec![0x1b, b'[', b'M', 35, 33, 33]);
-    }
-
-    #[test]
-    fn mouse_report_bytes_none_without_mouse_mode() {
-        let point = Point::new(Line(0), Column(0));
-        let mods = gpui::Modifiers::default();
-        assert!(super::mouse_report_bytes(point, 0, mods, false, TermMode::empty()).is_none());
     }
 }

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -21,8 +21,6 @@ use gpui::{
 use tokio::sync::{broadcast, mpsc};
 use zedra_osc::{OscEvent, OscScanner};
 
-const REMOTE_TOUCH_SCROLL_STEP_PX: f32 = 12.0;
-
 use crate::keys::to_esc_str;
 use crate::theme::TerminalTheme;
 /// Events emitted by the terminal to observers.
@@ -507,16 +505,16 @@ impl Terminal {
             .contains(TermMode::ALT_SCREEN | TermMode::ALTERNATE_SCROLL)
     }
 
-    pub fn scroll_step_px(&self, event: &ScrollWheelEvent) -> f32 {
-        if self.mouse_mode(event) || self.should_send_alt_scroll(event) {
-            REMOTE_TOUCH_SCROLL_STEP_PX
-        } else {
-            (self.size.line_height / px(1.0)) as f32
-        }
+    pub(crate) fn uses_remote_scroll_input(&self, event: &ScrollWheelEvent) -> bool {
+        self.mouse_mode(event) || self.should_send_alt_scroll(event)
+    }
+
+    pub fn scroll_step_px(&self) -> f32 {
+        (self.size.line_height / px(1.0)) as f32
     }
 
     pub fn should_snap_touch_release(&self, event: &ScrollWheelEvent) -> bool {
-        !self.mouse_mode(event) && !self.should_send_alt_scroll(event)
+        !self.uses_remote_scroll_input(event)
     }
 
     fn scroll_point(
@@ -1984,9 +1982,11 @@ impl Terminal {
             return false;
         };
 
+        let mut bytes = Vec::new();
         for _ in 0..lines.unsigned_abs() {
-            self.send_bytes_sync(report.clone());
+            bytes.extend_from_slice(&report);
         }
+        self.send_bytes_sync(bytes);
 
         true
     }

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -334,6 +334,10 @@ impl Terminal {
         self.processor.sync_timeout().sync_timeout()
     }
 
+    pub(crate) fn synchronized_output_pending(&self) -> bool {
+        self.synchronized_update_deadline().is_some()
+    }
+
     fn stop_synchronized_update(&mut self) -> bool {
         if self.synchronized_update_deadline().is_none() {
             return false;

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -4,6 +4,7 @@ use std::cmp::min;
 use std::ops::{Index, Range};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc as std_mpsc;
+use std::time::Instant;
 use tracing::{error, info};
 
 use alacritty_terminal::event::{Event as AlacTermEvent, EventListener};
@@ -206,6 +207,8 @@ pub struct Terminal {
     alacritty_event_rx: std_mpsc::Receiver<AlacTermEvent>,
     input_tx: Option<mpsc::Sender<Vec<u8>>>,
     output_task: Option<Task<()>>,
+    pending_sync_deadline: Option<Instant>,
+    synchronized_update_generation: u64,
     selection_range: Option<Range<usize>>,
     theme: TerminalTheme,
     /// Last focus state reported (or observed while reporting was off); dedupes
@@ -245,6 +248,8 @@ impl Terminal {
             alacritty_event_rx,
             input_tx: None,
             output_task: None,
+            pending_sync_deadline: None,
+            synchronized_update_generation: 0,
             selection_range: None,
             theme,
             focus_reported: StdCell::new(true),
@@ -283,9 +288,9 @@ impl Terminal {
         let output_task = cx.spawn(async move |this, cx| {
             while let Some(bytes) = output_rx.recv().await {
                 let _ = this.update(cx, |this, cx| {
-                    this.advance_bytes(&bytes);
+                    let should_present = this.advance_bytes(&bytes);
                     this.feed_osc_bytes(&bytes);
-                    cx.notify();
+                    this.present_output_when_ready(should_present, cx);
                 });
             }
         });
@@ -308,11 +313,17 @@ impl Terminal {
         self.send_bytes(text.into_bytes()).await;
     }
 
-    /// Feed bytes from PTY output buffer into the terminal emulator
-    pub fn advance_bytes(&mut self, bytes: &[u8]) {
+    /// Feed PTY output into the emulator, returning whether it is ready to present.
+    pub fn advance_bytes(&mut self, bytes: &[u8]) -> bool {
         let was_alt = self.mode.contains(TermMode::ALT_SCREEN);
         let previous_display_offset = self.display_offset();
         self.processor.advance(&mut self.term, bytes);
+        self.finish_output_update(was_alt, previous_display_offset);
+
+        self.synchronized_update_deadline().is_none()
+    }
+
+    fn finish_output_update(&mut self, was_alt: bool, previous_display_offset: usize) {
         self.drain_alacritty_events();
         self.mode = *self.term.mode();
         let is_alt = self.mode.contains(TermMode::ALT_SCREEN);
@@ -320,6 +331,62 @@ impl Terminal {
             let _ = self.event_tx.send(TerminalEvent::AltScreenChanged(is_alt));
         }
         self.emit_scrollback_position_if_changed(previous_display_offset);
+    }
+
+    fn synchronized_update_deadline(&self) -> Option<Instant> {
+        self.processor.sync_timeout().sync_timeout()
+    }
+
+    fn stop_synchronized_update(&mut self) -> bool {
+        if self.synchronized_update_deadline().is_none() {
+            return false;
+        }
+
+        let was_alt = self.mode.contains(TermMode::ALT_SCREEN);
+        let previous_display_offset = self.display_offset();
+        self.processor.stop_sync(&mut self.term);
+        self.finish_output_update(was_alt, previous_display_offset);
+        true
+    }
+
+    fn present_output_when_ready(&mut self, should_present: bool, cx: &mut Context<Self>) {
+        if should_present {
+            if self.pending_sync_deadline.take().is_some() {
+                self.synchronized_update_generation =
+                    self.synchronized_update_generation.wrapping_add(1);
+            }
+            cx.notify();
+            return;
+        }
+
+        let Some(deadline) = self.synchronized_update_deadline() else {
+            return;
+        };
+        if self.pending_sync_deadline == Some(deadline) {
+            return;
+        }
+
+        self.pending_sync_deadline = Some(deadline);
+        self.synchronized_update_generation = self.synchronized_update_generation.wrapping_add(1);
+        let generation = self.synchronized_update_generation;
+        let delay = deadline.saturating_duration_since(Instant::now());
+        cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(delay).await;
+            let _ = this.update(cx, |this, cx| {
+                // A stale timeout must not flush a later synchronized frame.
+                if this.synchronized_update_generation != generation {
+                    return;
+                }
+
+                if this.stop_synchronized_update() {
+                    this.pending_sync_deadline = None;
+                    this.synchronized_update_generation =
+                        this.synchronized_update_generation.wrapping_add(1);
+                    cx.notify();
+                }
+            });
+        })
+        .detach();
     }
 
     fn drain_alacritty_events(&mut self) {
@@ -2580,11 +2647,12 @@ pub fn is_blank(cell: &IndexedCell) -> bool {
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::time::Duration;
 
     use crate::TerminalTheme;
     use alacritty_terminal::index::{Column, Line, Point};
     use alacritty_terminal::term::TermMode;
-    use gpui::px;
+    use gpui::{AppContext, TestAppContext, px};
     use tokio::sync::mpsc;
 
     use super::{Terminal, TerminalEvent, TerminalHyperlink, TerminalHyperlinkTarget};
@@ -2716,6 +2784,99 @@ mod tests {
         terminal.mode.insert(TermMode::FOCUS_IN_OUT);
         terminal.send_focus_report(true);
         assert_eq!(input_rx.try_recv().unwrap(), b"\x1b[I");
+    }
+
+    #[test]
+    fn synchronized_output_presents_only_after_end_marker() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        assert!(!terminal.advance_bytes(b"\x1b[?2026hheld"));
+        assert!(
+            !terminal
+                .content()
+                .cells
+                .iter()
+                .any(|cell| cell.cell.c == 'h')
+        );
+        assert!(!terminal.advance_bytes(b" output"));
+        assert!(terminal.advance_bytes(b"\x1b[?2026l"));
+
+        let text: String = terminal
+            .content()
+            .cells
+            .iter()
+            .map(|cell| cell.cell.c)
+            .collect();
+        assert!(text.contains("held output"));
+    }
+
+    #[test]
+    fn synchronized_output_handles_split_markers() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        assert!(terminal.advance_bytes(b"\x1b[?20"));
+        assert!(!terminal.advance_bytes(b"26hsplit"));
+        assert!(!terminal.advance_bytes(b"\x1b[?202"));
+        assert!(terminal.advance_bytes(b"6l"));
+
+        let text: String = terminal
+            .content()
+            .cells
+            .iter()
+            .map(|cell| cell.cell.c)
+            .collect();
+        assert!(text.contains("split"));
+    }
+
+    #[test]
+    fn synchronized_output_timeout_releases_buffered_content() {
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+
+        assert!(!terminal.advance_bytes(b"\x1b[?2026htimed out"));
+        assert!(terminal.stop_synchronized_update());
+
+        let text: String = terminal
+            .content()
+            .cells
+            .iter()
+            .map(|cell| cell.cell.c)
+            .collect();
+        assert!(text.contains("timed out"));
+    }
+
+    #[test]
+    fn attached_channel_releases_synchronized_output_after_timeout() {
+        let mut cx = TestAppContext::single();
+        let terminal = cx.new(|_| Terminal::new(80, 4, px(10.0), px(20.0)));
+        let (input_tx, _input_rx) = mpsc::channel(4);
+        let (output_tx, output_rx) = mpsc::channel(4);
+        terminal.update(&mut cx, |terminal, cx| {
+            terminal.attach_channel(input_tx, output_rx, cx);
+        });
+
+        output_tx
+            .try_send(b"\x1b[?2026htimed out".to_vec())
+            .unwrap();
+        cx.run_until_parked();
+        assert!(!terminal.read_with(&cx, |terminal, _| {
+            terminal
+                .content()
+                .cells
+                .iter()
+                .any(|cell| cell.cell.c == 't')
+        }));
+
+        cx.executor().advance_clock(Duration::from_millis(200));
+        cx.run_until_parked();
+        let text: String = terminal.read_with(&cx, |terminal, _| {
+            terminal
+                .content()
+                .cells
+                .iter()
+                .map(|cell| cell.cell.c)
+                .collect()
+        });
+        assert!(text.contains("timed out"));
     }
 
     #[test]

--- a/crates/zedra-terminal/src/view.rs
+++ b/crates/zedra-terminal/src/view.rs
@@ -100,6 +100,7 @@ pub struct TerminalView {
     terminal: Entity<Terminal>,
     focus_handle: FocusHandle,
     scroll_offset_px: f32,
+    remote_scroll_offset_px: f32,
     keyboard_top_reveal_px: f32,
     last_remote_size: Option<(u16, u16)>,
     /// Top-left origin of the painted terminal grid within the window.
@@ -184,6 +185,7 @@ impl TerminalView {
             terminal_id,
             focus_handle,
             scroll_offset_px: 0.0,
+            remote_scroll_offset_px: 0.0,
             keyboard_top_reveal_px: 0.0,
             last_remote_size: None,
             grid_origin: None,
@@ -393,6 +395,7 @@ impl TerminalView {
     pub fn scroll_to_bottom(&mut self, cx: &mut Context<Self>) {
         let previous_display_offset = self.display_offset(cx);
         self.scroll_offset_px = 0.0;
+        self.remote_scroll_offset_px = 0.0;
         self.keyboard_top_reveal_px = 0.0;
         self.suppress_touch_scroll_until =
             Some(Instant::now() + TOUCH_SCROLL_SUPPRESSION_AFTER_SCROLL_TO_BOTTOM);
@@ -484,6 +487,8 @@ impl TerminalView {
 
         if matches!(event.touch_phase, TouchPhase::Started) {
             self.suppress_touch_scroll_until = None;
+            self.scroll_offset_px = 0.0;
+            self.remote_scroll_offset_px = 0.0;
             return false;
         }
 
@@ -497,6 +502,7 @@ impl TerminalView {
         }
 
         self.scroll_offset_px = 0.0;
+        self.remote_scroll_offset_px = 0.0;
         true
     }
 
@@ -667,6 +673,7 @@ impl Render for TerminalView {
                     ScrollDelta::Lines(l) => {
                         // Line-based scroll (e.g. mouse wheel): commit immediately
                         this.scroll_offset_px = 0.0;
+                        this.remote_scroll_offset_px = 0.0;
                         let mut lines = l.y as i32;
                         if lines < 0 {
                             let step_px =
@@ -703,7 +710,7 @@ impl Render for TerminalView {
                         if matches!(event.touch_phase, TouchPhase::Ended) {
                             let (snap, step_px) = {
                                 let t = this.terminal.read(cx);
-                                (t.should_snap_touch_release(event), t.scroll_step_px(event))
+                                (t.should_snap_touch_release(event), t.scroll_step_px())
                             };
                             if snap && this.scroll_offset_px.abs() > step_px * 0.5 {
                                 // Local scrollback benefits from snapping the partial drag
@@ -716,51 +723,67 @@ impl Render for TerminalView {
                                 });
                             }
                             this.scroll_offset_px = 0.0;
+                            this.remote_scroll_offset_px = 0.0;
                         } else {
-                            let step_px = this.terminal.read(cx).scroll_step_px(event);
+                            let (step_px, uses_remote_scroll_input) = {
+                                let terminal = this.terminal.read(cx);
+                                (
+                                    terminal.scroll_step_px(),
+                                    terminal.uses_remote_scroll_input(event),
+                                )
+                            };
                             let mut py: f32 = (pixels.y / px(1.0)) as f32;
                             if py < 0.0 {
                                 py = -this.consume_keyboard_top_reveal_px(-py);
                             }
-                            this.scroll_offset_px += py;
-
-                            // Remote terminal scroll should emit small, repeated wheel
-                            // ticks while dragging; local scrollback keeps line-based steps.
                             let grid_origin = this.grid_origin;
-                            while this.scroll_offset_px >= step_px {
-                                let moved = this.terminal.update(cx, |terminal, _| {
-                                    terminal.commit_scroll_lines(1, event, grid_origin)
-                                });
-                                if !moved {
-                                    // Keep the keyboard lift scrollable at the top boundary so
-                                    // the oldest rows can be revealed instead of clipped.
-                                    break;
+                            if uses_remote_scroll_input {
+                                // The remote TUI redraws in response to wheel reports. Keep its
+                                // fractional input separate from the local paint translation.
+                                this.scroll_offset_px = 0.0;
+                                this.remote_scroll_offset_px += py;
+                                let lines = (this.remote_scroll_offset_px / step_px).trunc() as i32;
+                                if lines != 0 {
+                                    let moved = this.terminal.update(cx, |terminal, _| {
+                                        terminal.commit_scroll_lines(lines, event, grid_origin)
+                                    });
+                                    if moved {
+                                        this.remote_scroll_offset_px -= lines as f32 * step_px;
+                                    }
                                 }
-                                this.scroll_offset_px -= step_px;
-                            }
-                            while this.scroll_offset_px <= -step_px {
-                                let moved = this.terminal.update(cx, |terminal, _| {
-                                    terminal.commit_scroll_lines(-1, event, grid_origin)
-                                });
-                                if !moved {
-                                    // Hit bottom of scrollback — clamp offset
-                                    this.scroll_offset_px = 0.0;
-                                    break;
+                            } else {
+                                this.remote_scroll_offset_px = 0.0;
+                                this.scroll_offset_px += py;
+                                while this.scroll_offset_px >= step_px {
+                                    let moved = this.terminal.update(cx, |terminal, _| {
+                                        terminal.commit_scroll_lines(1, event, grid_origin)
+                                    });
+                                    if !moved {
+                                        // Keep the keyboard lift scrollable at the top boundary so
+                                        // the oldest rows can be revealed instead of clipped.
+                                        break;
+                                    }
+                                    this.scroll_offset_px -= step_px;
                                 }
-                                this.scroll_offset_px += step_px;
+                                while this.scroll_offset_px <= -step_px {
+                                    let moved = this.terminal.update(cx, |terminal, _| {
+                                        terminal.commit_scroll_lines(-1, event, grid_origin)
+                                    });
+                                    if !moved {
+                                        // Hit bottom of scrollback — clamp offset
+                                        this.scroll_offset_px = 0.0;
+                                        break;
+                                    }
+                                    this.scroll_offset_px += step_px;
+                                }
                             }
 
-                            // Local scrollback clamps at the history bounds, but alt-screen
-                            // scroll should keep producing cursor-up/down bytes for the PTY.
-                            let (alt_scroll, offset, history) = {
-                                let t = this.terminal.read(cx);
-                                (
-                                    t.should_send_alt_scroll(event),
-                                    t.display_offset(),
-                                    t.history_size(),
-                                )
-                            };
-                            if !alt_scroll {
+                            // Local scrollback clamps its visual offset at the history bounds.
+                            if !uses_remote_scroll_input {
+                                let (offset, history) = {
+                                    let t = this.terminal.read(cx);
+                                    (t.display_offset(), t.history_size())
+                                };
                                 if offset == 0 && history == 0 && this.scroll_offset_px > 0.0 {
                                     // With no real scrollback, top and bottom are the same boundary;
                                     // keep touch overscroll from creating fake empty history.
@@ -811,11 +834,30 @@ mod tests {
         PointerMoveEvent, PointerUpEvent, TestAppContext, TouchPhase, VisualTestContext,
         WindowHandle, point, px, size,
     };
+    use tokio::sync::mpsc;
 
     fn open_terminal_window(cx: &mut TestAppContext) -> WindowHandle<TerminalView> {
         cx.open_window(size(px(320.0), px(240.0)), |window, cx| {
             TerminalView::new("term-1".to_string(), window, size(px(320.0), px(240.0)), cx)
         })
+    }
+
+    fn attach_mouse_tracking_channel(
+        window: WindowHandle<TerminalView>,
+        cx: &mut TestAppContext,
+    ) -> mpsc::Receiver<Vec<u8>> {
+        let (input_tx, input_rx) = mpsc::channel(256);
+        let (output_tx, output_rx) = mpsc::channel(4);
+        window
+            .update(cx, |terminal_view, _window, cx| {
+                terminal_view.attach_channel(input_tx, output_rx, cx);
+            })
+            .unwrap();
+        output_tx
+            .try_send(b"\x1b[?1049h\x1b[?1003h\x1b[?1006h".to_vec())
+            .unwrap();
+        cx.run_until_parked();
+        input_rx
     }
 
     fn tap_terminal(window: WindowHandle<TerminalView>, cx: &mut TestAppContext) {
@@ -1281,6 +1323,62 @@ mod tests {
             .update(&mut cx, |terminal, window, _| {
                 assert!(terminal.focus_handle.is_focused(window));
                 assert!(window.is_soft_keyboard_visible());
+            })
+            .unwrap();
+        cx.quit();
+    }
+
+    #[test]
+    fn remote_touch_scroll_batches_ticks_per_event() {
+        let mut cx = TestAppContext::single();
+        let window = open_terminal_window(&mut cx);
+        let mut input_rx = attach_mouse_tracking_channel(window, &mut cx);
+
+        scroll_terminal_touch_delta(window, &mut cx, px(120.0), TouchPhase::Moved);
+
+        let bytes = input_rx.try_recv().expect("expected remote scroll input");
+        assert_eq!(
+            bytes
+                .windows(b"\x1b[<64;".len())
+                .filter(|window| *window == b"\x1b[<64;")
+                .count(),
+            7
+        );
+        assert!(input_rx.try_recv().is_err(), "scroll input was not batched");
+        cx.quit();
+    }
+
+    #[test]
+    fn remote_touch_scroll_accumulates_partial_ticks() {
+        let mut cx = TestAppContext::single();
+        let window = open_terminal_window(&mut cx);
+        let mut input_rx = attach_mouse_tracking_channel(window, &mut cx);
+
+        scroll_terminal_touch_delta(window, &mut cx, px(8.0), TouchPhase::Moved);
+        assert!(input_rx.try_recv().is_err());
+        window
+            .update(&mut cx, |terminal_view, _window, _cx| {
+                assert_eq!(terminal_view.scroll_offset_px, 0.0);
+                assert_eq!(terminal_view.remote_scroll_offset_px, 8.0);
+            })
+            .unwrap();
+        scroll_terminal_touch_delta(window, &mut cx, px(8.0), TouchPhase::Moved);
+
+        let bytes = input_rx
+            .try_recv()
+            .expect("expected accumulated scroll input");
+        assert_eq!(
+            bytes
+                .windows(b"\x1b[<64;".len())
+                .filter(|window| *window == b"\x1b[<64;")
+                .count(),
+            1
+        );
+        assert!(input_rx.try_recv().is_err());
+        window
+            .update(&mut cx, |terminal_view, _window, _cx| {
+                assert_eq!(terminal_view.scroll_offset_px, 0.0);
+                assert_eq!(terminal_view.remote_scroll_offset_px, 0.0);
             })
             .unwrap();
         cx.quit();

--- a/crates/zedra-terminal/src/view.rs
+++ b/crates/zedra-terminal/src/view.rs
@@ -530,39 +530,38 @@ impl TerminalView {
             return;
         }
 
-        // Mouse-tracking TUIs consume the tap as a click; keep the keyboard as-is.
-        let clicked = self.terminal.update(cx, |terminal, _| {
-            terminal.send_mouse_click(position, self.grid_origin, event.modifiers())
-        });
-        if clicked {
-            window.prevent_default();
-            if !self.focus_handle.is_focused(window) {
-                self.focus_handle.focus(window, cx);
-            }
+        let is_focused = self.focus_handle.is_focused(window);
+        let keyboard_visible = window.is_soft_keyboard_visible();
+        window.prevent_default();
+
+        // Keyboard-up tap dismisses even in mouse mode, so fullscreen TUIs keep a
+        // way to hide the keyboard; clicks resume once it is down.
+        if is_focused && keyboard_visible {
+            // window.blur only blurs focus, not the keyboard — hide it explicitly.
+            window.hide_soft_keyboard();
+            window.blur();
             cx.notify();
             return;
         }
 
-        let is_focused = self.focus_handle.is_focused(window);
-        let keyboard_visible = window.is_soft_keyboard_visible();
-
-        window.prevent_default();
-
-        if is_focused && keyboard_visible {
-            // Must explicitly hide the keyboard, window.blur only blurs the focus, not the keyboard.
-            window.hide_soft_keyboard();
-            window.blur();
-            cx.notify();
-        } else if is_focused {
-            // Keyboard might not be visible when already focused.
-            // It does nothing if the keyboard is already visible.
-            window.show_soft_keyboard();
-            cx.notify();
-        } else if !is_focused {
+        // Unfocused tap raises the keyboard and focuses; it does not click, so a
+        // TUI is reached in the keyboard-down state where taps become clicks.
+        if !is_focused {
             self.focus_handle.focus(window, cx);
             window.show_soft_keyboard();
             cx.notify();
+            return;
         }
+
+        // Focused with the keyboard down: mouse-tracking TUIs consume the tap as a
+        // click; otherwise fall back to raising the keyboard.
+        let clicked = self.terminal.update(cx, |terminal, _| {
+            terminal.send_mouse_click(position, self.grid_origin, event.modifiers())
+        });
+        if !clicked {
+            window.show_soft_keyboard();
+        }
+        cx.notify();
     }
 
     fn handle_terminal_long_press(

--- a/crates/zedra-terminal/src/view.rs
+++ b/crates/zedra-terminal/src/view.rs
@@ -170,20 +170,10 @@ impl TerminalView {
             }
         });
 
-        let focus_handle = cx.focus_handle();
-        let subscriptions = vec![
-            cx.on_focus(&focus_handle, window, |this, _window, cx| {
-                this.terminal.read(cx).send_focus_report(true);
-            }),
-            cx.on_blur(&focus_handle, window, |this, _window, cx| {
-                this.terminal.read(cx).send_focus_report(false);
-            }),
-        ];
-
         Self {
             terminal,
             terminal_id,
-            focus_handle,
+            focus_handle: cx.focus_handle(),
             scroll_offset_px: 0.0,
             remote_scroll_offset_px: 0.0,
             keyboard_top_reveal_px: 0.0,
@@ -196,7 +186,7 @@ impl TerminalView {
             is_alt_screen: false,
             terminal_theme: TerminalTheme::dark(),
             _event_task: event_task,
-            _subscriptions: subscriptions,
+            _subscriptions: vec![],
         }
     }
 
@@ -540,8 +530,6 @@ impl TerminalView {
         let keyboard_visible = window.is_soft_keyboard_visible();
         window.prevent_default();
 
-        // Keyboard-up tap dismisses even in mouse mode, so fullscreen TUIs keep a
-        // way to hide the keyboard; clicks resume once it is down.
         if is_focused && keyboard_visible {
             // window.blur only blurs focus, not the keyboard — hide it explicitly.
             window.hide_soft_keyboard();
@@ -550,8 +538,6 @@ impl TerminalView {
             return;
         }
 
-        // Unfocused tap raises the keyboard and focuses; it does not click, so a
-        // TUI is reached in the keyboard-down state where taps become clicks.
         if !is_focused {
             self.focus_handle.focus(window, cx);
             window.show_soft_keyboard();
@@ -559,14 +545,7 @@ impl TerminalView {
             return;
         }
 
-        // Focused with the keyboard down: mouse-tracking TUIs consume the tap as a
-        // click; otherwise fall back to raising the keyboard.
-        let clicked = self.terminal.update(cx, |terminal, _| {
-            terminal.send_mouse_click(position, self.grid_origin, event.modifiers())
-        });
-        if !clicked {
-            window.show_soft_keyboard();
-        }
+        window.show_soft_keyboard();
         cx.notify();
     }
 

--- a/crates/zedra-terminal/src/view.rs
+++ b/crates/zedra-terminal/src/view.rs
@@ -169,10 +169,20 @@ impl TerminalView {
             }
         });
 
+        let focus_handle = cx.focus_handle();
+        let subscriptions = vec![
+            cx.on_focus(&focus_handle, window, |this, _window, cx| {
+                this.terminal.read(cx).send_focus_report(true);
+            }),
+            cx.on_blur(&focus_handle, window, |this, _window, cx| {
+                this.terminal.read(cx).send_focus_report(false);
+            }),
+        ];
+
         Self {
             terminal,
             terminal_id,
-            focus_handle: cx.focus_handle(),
+            focus_handle,
             scroll_offset_px: 0.0,
             keyboard_top_reveal_px: 0.0,
             last_remote_size: None,
@@ -184,7 +194,7 @@ impl TerminalView {
             is_alt_screen: false,
             terminal_theme: TerminalTheme::dark(),
             _event_task: event_task,
-            _subscriptions: vec![],
+            _subscriptions: subscriptions,
         }
     }
 
@@ -508,10 +518,7 @@ impl TerminalView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let position = event
-            .up
-            .as_ref()
-            .map_or(event.down.position, |up| up.position);
+        let position = event.position();
 
         let hyperlink = self.terminal.read(cx).hyperlink_at(
             position,
@@ -520,6 +527,19 @@ impl TerminalView {
         );
         if let Some(hyperlink) = hyperlink {
             cx.emit(TerminalEvent::OpenHyperlink(hyperlink));
+            return;
+        }
+
+        // Mouse-tracking TUIs consume the tap as a click; keep the keyboard as-is.
+        let clicked = self.terminal.update(cx, |terminal, _| {
+            terminal.send_mouse_click(position, self.grid_origin, event.modifiers())
+        });
+        if clicked {
+            window.prevent_default();
+            if !self.focus_handle.is_focused(window) {
+                self.focus_handle.focus(window, cx);
+            }
+            cx.notify();
             return;
         }
 

--- a/crates/zedra-terminal/src/view.rs
+++ b/crates/zedra-terminal/src/view.rs
@@ -154,7 +154,9 @@ impl TerminalView {
                                 this.workdir = Some(cwd.clone());
                             }
                             cx.emit(event);
-                            cx.notify();
+                            if !this.terminal.read(cx).synchronized_output_pending() {
+                                cx.notify();
+                            }
                         }) {
                             error!("failed to emit terminal event: {:?}", e);
                         }
@@ -723,12 +725,10 @@ impl Render for TerminalView {
                                 this.remote_scroll_offset_px += py;
                                 let lines = (this.remote_scroll_offset_px / step_px).trunc() as i32;
                                 if lines != 0 {
-                                    let moved = this.terminal.update(cx, |terminal, _| {
+                                    this.terminal.update(cx, |terminal, _| {
                                         terminal.commit_scroll_lines(lines, event, grid_origin)
                                     });
-                                    if moved {
-                                        this.remote_scroll_offset_px -= lines as f32 * step_px;
-                                    }
+                                    this.remote_scroll_offset_px -= lines as f32 * step_px;
                                 }
                             } else {
                                 this.remote_scroll_offset_px = 0.0;
@@ -821,10 +821,10 @@ mod tests {
         })
     }
 
-    fn attach_mouse_tracking_channel(
+    fn attach_terminal_channel(
         window: WindowHandle<TerminalView>,
         cx: &mut TestAppContext,
-    ) -> mpsc::Receiver<Vec<u8>> {
+    ) -> (mpsc::Receiver<Vec<u8>>, mpsc::Sender<Vec<u8>>) {
         let (input_tx, input_rx) = mpsc::channel(256);
         let (output_tx, output_rx) = mpsc::channel(4);
         window
@@ -832,6 +832,14 @@ mod tests {
                 terminal_view.attach_channel(input_tx, output_rx, cx);
             })
             .unwrap();
+        (input_rx, output_tx)
+    }
+
+    fn attach_mouse_tracking_channel(
+        window: WindowHandle<TerminalView>,
+        cx: &mut TestAppContext,
+    ) -> mpsc::Receiver<Vec<u8>> {
+        let (input_rx, output_tx) = attach_terminal_channel(window, cx);
         output_tx
             .try_send(b"\x1b[?1049h\x1b[?1003h\x1b[?1006h".to_vec())
             .unwrap();
@@ -1046,6 +1054,47 @@ mod tests {
             },
             event => panic!("expected hyperlink event, got {event:?}"),
         }
+        cx.quit();
+    }
+
+    #[test]
+    fn synchronized_osc_event_does_not_notify_before_frame_end() {
+        let mut cx = TestAppContext::single();
+        let window = open_terminal_window(&mut cx);
+        let root = window.root(&mut cx).unwrap();
+        let mut notifications = cx.notifications(&root);
+        let (_input_rx, output_tx) = attach_terminal_channel(window, &mut cx);
+
+        root.update(&mut cx, |_, cx| cx.notify());
+        cx.run_until_parked();
+        assert!(notifications.next().now_or_never().flatten().is_some());
+
+        output_tx
+            .try_send(b"\x1b[?2026h\x1b]7;file:///repo\x1b\\held".to_vec())
+            .unwrap();
+        cx.run_until_parked();
+        window
+            .update(&mut cx, |terminal_view, _window, _cx| {
+                assert_eq!(terminal_view.workdir.as_deref(), Some("/repo"));
+            })
+            .unwrap();
+        assert!(notifications.next().now_or_never().is_none());
+
+        output_tx.try_send(b"\x1b[?2026l".to_vec()).unwrap();
+        cx.run_until_parked();
+        assert!(
+            window
+                .update(&mut cx, |terminal_view, _window, cx| {
+                    terminal_view
+                        .terminal
+                        .read(cx)
+                        .content()
+                        .cells
+                        .iter()
+                        .any(|cell| cell.cell.c == 'h')
+                })
+                .unwrap()
+        );
         cx.quit();
     }
 
@@ -1360,6 +1409,41 @@ mod tests {
                 assert_eq!(terminal_view.remote_scroll_offset_px, 0.0);
             })
             .unwrap();
+        cx.quit();
+    }
+
+    #[test]
+    fn rejected_remote_touch_scroll_does_not_accumulate_debt() {
+        let mut cx = TestAppContext::single();
+        let window = open_terminal_window(&mut cx);
+        let (mut input_rx, output_tx) = attach_terminal_channel(window, &mut cx);
+        output_tx
+            .try_send(b"\x1b[?1003h\x1b[?1006h".to_vec())
+            .unwrap();
+        cx.run_until_parked();
+
+        window
+            .update(&mut cx, |terminal_view, _window, cx| {
+                terminal_view.terminal.update(cx, |terminal, _| {
+                    for line in 0..40 {
+                        terminal.advance_bytes(format!("line {line}\r\n").as_bytes());
+                    }
+                    terminal.scroll(100);
+                });
+                let terminal = terminal_view.terminal.read(cx);
+                assert!(terminal.display_offset() > terminal.size().rows / 2);
+            })
+            .unwrap();
+
+        scroll_terminal_touch_delta(window, &mut cx, px(120.0), TouchPhase::Moved);
+
+        window
+            .update(&mut cx, |terminal_view, _window, cx| {
+                let step_px = terminal_view.terminal.read(cx).scroll_step_px();
+                assert!(terminal_view.remote_scroll_offset_px.abs() < step_px);
+            })
+            .unwrap();
+        assert!(input_rx.try_recv().is_err());
         cx.quit();
     }
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -583,6 +583,16 @@ or beyond.
 3. Expected: the row entering at the top edge (and the row leaving at the bottom edge) slides in pixel by pixel
 4. Expected: rows do not pop in only once fully visible, and the edge gap never shows a blank partial row
 
+## 3d. Remote Fullscreen Terminal Scroll
+
+1. Connect via QR and start OpenCode or Claude Code in fullscreen mode
+2. Slowly drag through the TUI with several small, continuous finger movements
+3. Expected: partial movements accumulate into steady scrolling; content does not bounce or translate back between remote redraws
+4. Drag quickly through about one screen of content
+5. Expected: the TUI follows the finger at roughly one terminal row per row of drag, without catching up in a burst after the drag
+6. Repeat in both directions and with the software keyboard visible
+7. Expected: scrolling remains responsive without dismissing the keyboard or changing terminal focus
+
 ## 4. Reconnect After Host Restart
 
 1. Connect via QR, note session ID

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -590,8 +590,9 @@ or beyond.
 3. Expected: partial movements accumulate into steady scrolling; content does not bounce or translate back between remote redraws
 4. Drag quickly through about one screen of content
 5. Expected: the TUI follows the finger at roughly one terminal row per row of drag, without catching up in a burst after the drag
-6. Repeat in both directions and with the software keyboard visible
-7. Expected: scrolling remains responsive without dismissing the keyboard or changing terminal focus
+6. Expected: each remote redraw appears as one complete frame without intermediate partial-screen redraws
+7. Repeat in both directions and with the software keyboard visible
+8. Expected: scrolling remains responsive without dismissing the keyboard or changing terminal focus
 
 ## 4. Reconnect After Host Restart
 


### PR DESCRIPTION
## Summary

- Accumulate remote touch deltas using the terminal's actual row height and batch wheel or alternate-scroll reports into one terminal input write per event.
- Keep remote fractional input separate from local visual scrollback so fullscreen TUIs do not bounce, over-scroll, catch up in bursts, or defer rejected input.
- Present synchronized TUI output as complete frames, with VTE's 150 ms fallback when an end marker is missing, without redundant event-driven repaints during an active frame.

## Notes

- Remote fullscreen scrolling remains row-based because TUIs consume wheel or alternate-scroll input; native scrollback remains pixel-smooth.
- Tap behavior remains keyboard-owned; this PR does not add click or focus reports to remote TUIs.
- Validated with 183 `zedra-terminal` tests, `cargo check -p zedra-terminal -p zedra-session -p zedra-host`, formatting, and diff checks.