### PR TITLE
feat(app): terminal keypad — always visible, plus an extended layout

### DIFF
--- a/android/app/src/main/kotlin/dev/zedra/app/KeyboardAccessoryBar.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/KeyboardAccessoryBar.kt
@@ -1,26 +1,56 @@
 package dev.zedra.app
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.os.Handler
 import android.os.Looper
+import android.text.InputType
 import android.view.Gravity
+import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
+import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import kotlin.math.abs
+
+/**
+ * Terminal key bar. Renders either the compact single row or the extended
+ * two-row keypad, with an IME composing field parked one page to the right:
+ * a horizontal drag slides between them and follows the finger.
+ *
+ * Modifier state is owned by Rust (`zedra_terminal::keyboard_accessory`) because
+ * it must also apply to characters committed by the software keyboard; this view
+ * only renders the mask it is given.
+ */
+private const val MOD_SHIFT = 1
+private const val MOD_CTRL = 2
+private const val MOD_ALT = 4
+private const val MOD_CMD = 8
+
+/** Locked modifiers sit this far above the armed bits; see `sticky_modifier_mask`. */
+private const val MOD_LOCK_SHIFT = 4
 
 class KeyboardAccessoryBar(
     context: Context,
     private val sendKey: (String) -> Unit,
-) : LinearLayout(context) {
+    private val sendComposedText: (String) -> Unit,
+    // Hand the keyboard back to the terminal when the user leaves the composer.
+    private val requestTerminalKeyboard: () -> Unit,
+) : FrameLayout(context) {
     private data class KeySpec(
         val label: String,
         val key: String,
-        val repeats: Boolean,
+        val repeats: Boolean = false,
         val iconRes: Int? = null,
+        val modifierBit: Int? = null,
     )
 
     private val topBorderPaint =
@@ -29,44 +59,135 @@ class KeyboardAccessoryBar(
             strokeWidth = context.resources.displayMetrics.density.coerceAtLeast(1f)
         }
 
-    private val keySpecs =
+    private val compactRow =
         listOf(
-            KeySpec("Esc", "escape", false),
-            KeySpec("Tab", "tab", false),
-            KeySpec("←", "left", true, R.drawable.ic_key_arrow_left),
-            KeySpec("↓", "down", true, R.drawable.ic_key_arrow_down),
-            KeySpec("↑", "up", true, R.drawable.ic_key_arrow_up),
-            KeySpec("→", "right", true, R.drawable.ic_key_arrow_right),
-            KeySpec("⏎", "enter", false, R.drawable.ic_key_return),
+            KeySpec("Esc", "escape"),
+            KeySpec("Tab", "tab"),
+            KeySpec("←", "left", repeats = true, iconRes = R.drawable.ic_key_arrow_left),
+            KeySpec("↓", "down", repeats = true, iconRes = R.drawable.ic_key_arrow_down),
+            KeySpec("↑", "up", repeats = true, iconRes = R.drawable.ic_key_arrow_up),
+            KeySpec("→", "right", repeats = true, iconRes = R.drawable.ic_key_arrow_right),
+            KeySpec("⏎", "enter", iconRes = R.drawable.ic_key_return),
         )
+
+    private val extendedTopRow =
+        listOf(
+            KeySpec("Esc", "escape"),
+            KeySpec("Shift", "mod:shift", modifierBit = MOD_SHIFT),
+            KeySpec("Tab", "tab"),
+            KeySpec("/", "char:/"),
+            KeySpec("-", "char:-"),
+            KeySpec("↑", "up", repeats = true, iconRes = R.drawable.ic_key_arrow_up),
+            KeySpec("⏎", "enter", iconRes = R.drawable.ic_key_return),
+        )
+
+    // Cmd only means anything to a macOS host; every other host gets a pipe,
+    // which is real shell syntax and awkward to reach on a phone keyboard.
+    private val platformSlot: KeySpec
+        get() =
+            if (cmdSlot) {
+                KeySpec("Cmd", "mod:cmd", modifierBit = MOD_CMD)
+            } else {
+                KeySpec("|", "char:|")
+            }
+
+    private val extendedBottomRow: List<KeySpec>
+        get() =
+            listOf(
+                KeySpec("⌫", "backspace", repeats = true, iconRes = R.drawable.ic_key_backspace),
+                KeySpec("Ctrl", "mod:ctrl", modifierBit = MOD_CTRL),
+                KeySpec("Alt", "mod:alt", modifierBit = MOD_ALT),
+                platformSlot,
+                KeySpec("←", "left", repeats = true, iconRes = R.drawable.ic_key_arrow_left),
+                KeySpec("↓", "down", repeats = true, iconRes = R.drawable.ic_key_arrow_down),
+                KeySpec("→", "right", repeats = true, iconRes = R.drawable.ic_key_arrow_right),
+            )
 
     private val repeatInitialDelayMs = 350L
     private val repeatIntervalMs = 60L
+    private val snapDurationMs = 180L
     private val handler = Handler(Looper.getMainLooper())
     private var repeatingKey: String? = null
+    private var repeatFired = false
     private var isDarkTheme = true
+    private var extended = false
+    private var cmdSlot = false
+    private var composing = false
+    private var modifierMask = 0
+    private val modifierViews = mutableListOf<Pair<Int, TextView>>()
+    private val density = context.resources.displayMetrics.density
+    private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop
+    private var dragging = false
+    private var dragStartX = 0f
+    private var dragStartY = 0f
+
+    private val keysPage =
+        LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            setBaselineAligned(false)
+        }
+
+    private val composePage =
+        LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            setBaselineAligned(false)
+        }
+
+    private val composeField =
+        EditText(context).apply {
+            hint = "Compose, then send"
+            textSize = 15f
+            maxLines = 4
+            background = null
+            setPadding((12 * density).toInt(), 0, (8 * density).toInt(), 0)
+            // TYPE_TEXT_FLAG_MULTI_LINE would turn the IME's action key into a
+            // newline key and swallow IME_ACTION_SEND; wrapping comes from
+            // maxLines + no horizontal scrolling instead.
+            inputType = InputType.TYPE_CLASS_TEXT
+            setHorizontallyScrolling(false)
+            imeOptions = EditorInfo.IME_ACTION_SEND
+            setOnEditorActionListener { _, actionId, event ->
+                // Some IMEs report the action, others just send the Enter key.
+                val enterPressed =
+                    event?.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN
+                if (actionId == EditorInfo.IME_ACTION_SEND ||
+                    actionId == EditorInfo.IME_ACTION_DONE ||
+                    enterPressed
+                ) {
+                    submitComposedText()
+                    true
+                } else {
+                    false
+                }
+            }
+        }
 
     private val repeatRunnable =
         object : Runnable {
             override fun run() {
                 val key = repeatingKey ?: return
+                repeatFired = true
                 sendKey(key)
                 handler.postDelayed(this, repeatIntervalMs)
             }
         }
 
+    /** Bar height in px for the current mode; the host reserves this much space. */
+    val desiredHeightPx: Int
+        // Two stacked rows would eat too much of the screen at full row height.
+        // The composer keeps the same height so sliding never resizes the bar.
+        get() = ((if (extended) 64f else 44f) * density).toInt()
+
     init {
-        orientation = HORIZONTAL
-        setBaselineAligned(false)
         isFocusable = false
         isFocusableInTouchMode = false
         setWillNotDraw(false)
-        applyTheme(isDark = true)
         visibility = GONE
-
-        keySpecs.forEach { spec ->
-            addView(makeButton(spec), LayoutParams(0, LayoutParams.MATCH_PARENT, 1f))
-        }
+        addView(keysPage, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+        addView(composePage, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+        buildComposePage()
+        rebuildKeys()
+        applyTheme(isDark = true)
     }
 
     override fun onDetachedFromWindow() {
@@ -74,48 +195,286 @@ class KeyboardAccessoryBar(
         super.onDetachedFromWindow()
     }
 
+    override fun onSizeChanged(
+        w: Int,
+        h: Int,
+        oldw: Int,
+        oldh: Int,
+    ) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        settlePages(animated = false)
+    }
+
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         canvas.drawLine(0f, 0f, width.toFloat(), 0f, topBorderPaint)
     }
 
+    /** Drop the composer and its keyboard: the field owns the IME, which GPUI's own
+     * keyboard dismissal cannot reach. */
+    fun cancelComposing() {
+        if (!composing) return
+        setComposing(false, animated = false)
+    }
+
     fun stopRepeating() {
         repeatingKey = null
+        repeatFired = false
         handler.removeCallbacks(repeatRunnable)
     }
 
-    fun applyTheme(isDark: Boolean) {
-        isDarkTheme = isDark
-        val foreground = if (isDark) 0xFFFFFFFF.toInt() else 0xFF1A1A1A.toInt()
-        setBackgroundColor(if (isDark) 0xF50E0C0C.toInt() else 0xF5FFFFFF.toInt())
-        topBorderPaint.color = if (isDark) 0x33FFFFFF else 0x22000000
-        for (index in 0 until childCount) {
-            when (val child = getChildAt(index)) {
-                is ImageView -> child.imageTintList = android.content.res.ColorStateList.valueOf(foreground)
-                is TextView -> child.setTextColor(foreground)
+    /** Returns true when the reserved height changed, so the host can re-measure. */
+    fun setLayout(
+        enabled: Boolean,
+        useCmdSlot: Boolean,
+    ): Boolean {
+        if (extended == enabled && cmdSlot == useCmdSlot) return false
+        val heightChanged = extended != enabled
+        extended = enabled
+        cmdSlot = useCmdSlot
+        if (!enabled && composing) {
+            setComposing(false, animated = false)
+        }
+        rebuildKeys()
+        return heightChanged
+    }
+
+    fun setModifierMask(mask: Int) {
+        if (modifierMask == mask) return
+        modifierMask = mask
+        applyModifierHighlights()
+    }
+
+    // The two pages sit side by side: the keys occupy [-width, 0] and the composer
+    // [0, width], so a drag reveals the composer progressively instead of swapping
+    // it in at the end of a gesture.
+    private fun pageOffset() = if (composing) -width.toFloat() else 0f
+
+    private fun settlePages(animated: Boolean) {
+        val target = pageOffset()
+        if (animated) {
+            keysPage.animate().translationX(target).setDuration(snapDurationMs).start()
+            composePage.animate().translationX(target + width).setDuration(snapDurationMs).start()
+        } else {
+            applyDragOffset(0f)
+        }
+    }
+
+    private fun applyDragOffset(dx: Float) {
+        val offset = (pageOffset() + dx).coerceIn(-width.toFloat(), 0f)
+        keysPage.translationX = offset
+        composePage.translationX = offset + width
+    }
+
+    override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
+        if (!extended) return false
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                dragStartX = event.x
+                dragStartY = event.y
+                dragging = false
+            }
+            MotionEvent.ACTION_MOVE -> {
+                val dx = event.x - dragStartX
+                val dy = event.y - dragStartY
+                if (abs(dx) > touchSlop && abs(dx) > abs(dy)) {
+                    dragging = true
+                    dragStartX = event.x
+                    stopRepeating()
+                    return true
+                }
             }
         }
+        return false
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (!dragging) return super.onTouchEvent(event)
+        when (event.actionMasked) {
+            MotionEvent.ACTION_MOVE -> applyDragOffset(event.x - dragStartX)
+            MotionEvent.ACTION_UP,
+            MotionEvent.ACTION_CANCEL,
+            -> {
+                val dx = event.x - dragStartX
+                dragging = false
+                // Past halfway the page flips; anything short of that springs back.
+                val flipped = abs(dx) > width / 2f
+                setComposing(composing != flipped, animated = true, keepKeyboard = true)
+            }
+        }
+        return true
+    }
+
+    private fun submitComposedText() {
+        val text = composeField.text.toString()
+        if (text.isNotEmpty()) {
+            android.util.Log.i("KeyboardAccessoryBar", "key-bar: submitting composed text (${text.length} chars)")
+            // Text only: the composer fills the prompt, and the user decides when to run it.
+            sendComposedText(text)
+            composeField.setText("")
+        }
+    }
+
+    /// `keepKeyboard` distinguishes the user stepping back to the keys — where the
+    /// keyboard should stay up, now typing into the terminal — from a forced cancel
+    /// (drawer, navigation, terminal tap), where it must go away with the composer.
+    private fun setComposing(
+        enabled: Boolean,
+        animated: Boolean,
+        keepKeyboard: Boolean = false,
+    ) {
+        val changed = composing != enabled
+        composing = enabled
+        settlePages(animated)
+        if (!changed) return
+
+        val ime = context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+        if (enabled) {
+            composeField.requestFocus()
+            // The field is useless without a keyboard, and the pinned bar runs with
+            // the IME down by definition.
+            ime?.showSoftInput(composeField, InputMethodManager.SHOW_IMPLICIT)
+            return
+        }
+
+        composeField.clearFocus()
+        if (keepKeyboard) {
+            requestTerminalKeyboard()
+        } else {
+            ime?.hideSoftInputFromWindow(windowToken, 0)
+        }
+    }
+
+    private fun buildComposePage() {
+        composePage.removeAllViews()
+        composePage.addView(
+            composeField,
+            LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f),
+        )
+        // The IME's own send action submits, so this is the way out, not a second
+        // submit control.
+        composePage.addView(
+            makeLabelButton("✕") { setComposing(false, animated = true, keepKeyboard = true) }.apply {
+                contentDescription = "Close composer"
+            },
+            LinearLayout.LayoutParams(
+                (52 * density).toInt(),
+                LinearLayout.LayoutParams.MATCH_PARENT,
+            ),
+        )
+    }
+
+    private fun rebuildKeys() {
+        stopRepeating()
+        keysPage.removeAllViews()
+        modifierViews.clear()
+
+        if (extended) {
+            keysPage.addView(makeRow(extendedTopRow), rowParams())
+            keysPage.addView(makeRow(extendedBottomRow), rowParams())
+        } else {
+            keysPage.addView(makeRow(compactRow), rowParams())
+        }
+        applyTheme(isDarkTheme)
+        applyModifierHighlights()
+    }
+
+    private fun rowParams() = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, 0, 1f)
+
+    private fun makeLabelButton(
+        label: String,
+        onPress: () -> Unit,
+    ): TextView =
+        TextView(context).apply {
+            text = label
+            textSize = 15f
+            gravity = Gravity.CENTER
+            isClickable = true
+            setOnClickListener { onPress() }
+        }
+
+    private fun makeRow(specs: List<KeySpec>): View {
+        val row =
+            LinearLayout(context).apply {
+                orientation = LinearLayout.HORIZONTAL
+                setBaselineAligned(false)
+            }
+        specs.forEach { spec ->
+            row.addView(
+                makeButton(spec),
+                LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f),
+            )
+        }
+        return row
+    }
+
+    private fun applyModifierHighlights() {
+        modifierViews.forEach { (bit, view) ->
+            val armed = modifierMask and bit != 0
+            val locked = modifierMask and (bit shl MOD_LOCK_SHIFT) != 0
+            // Accent blue marks an active modifier; a locked one is fully opaque,
+            // an armed one dimmer, so the two stay distinguishable without a fill.
+            val accent = NativePresentations.currentAccentBlueColor()
+            view.setTextColor(
+                when {
+                    locked -> accent
+                    armed -> (accent and 0x00FFFFFF) or 0x99000000.toInt()
+                    else -> foregroundColor
+                },
+            )
+        }
+    }
+
+    private val foregroundColor: Int
+        get() = if (isDarkTheme) 0xFFFFFFFF.toInt() else 0xFF1A1A1A.toInt()
+
+    fun applyTheme(isDark: Boolean) {
+        isDarkTheme = isDark
+        val foreground = foregroundColor
+        setBackgroundColor(if (isDark) 0xF50E0C0C.toInt() else 0xF5FFFFFF.toInt())
+        topBorderPaint.color = if (isDark) 0x33FFFFFF else 0x22000000
+        composeField.setTextColor(foreground)
+        composeField.setHintTextColor(if (isDark) 0x80FFFFFF.toInt() else 0x80000000.toInt())
+        tintChildren(keysPage, foreground)
+        tintChildren(composePage, foreground)
+        applyModifierHighlights()
         invalidate()
     }
 
+    private fun tintChildren(
+        group: LinearLayout,
+        foreground: Int,
+    ) {
+        for (index in 0 until group.childCount) {
+            when (val child = group.getChildAt(index)) {
+                is LinearLayout -> tintChildren(child, foreground)
+                is ImageView -> child.imageTintList = ColorStateList.valueOf(foreground)
+                is EditText -> Unit
+                is TextView -> child.setTextColor(foreground)
+            }
+        }
+    }
+
     private fun makeButton(spec: KeySpec): View {
-        val foreground = if (isDarkTheme) 0xFFFFFFFF.toInt() else 0xFF1A1A1A.toInt()
+        val foreground = foregroundColor
         val view =
             if (spec.iconRes != null) {
                 ImageView(context).apply {
                     setImageResource(spec.iconRes)
-                    imageTintList = android.content.res.ColorStateList.valueOf(foreground)
+                    imageTintList = ColorStateList.valueOf(foreground)
                     scaleType = ImageView.ScaleType.CENTER
                     contentDescription = spec.label
                 }
             } else {
                 TextView(context).apply {
                     text = spec.label
-                    textSize = 16f
+                    textSize = if (extended) 14f else 16f
                     gravity = Gravity.CENTER
                     setTextColor(foreground)
                 }
             }
+
+        spec.modifierBit?.let { bit -> modifierViews.add(bit to (view as TextView)) }
 
         view.isClickable = true
         view.isFocusable = false
@@ -123,22 +482,25 @@ class KeyboardAccessoryBar(
         view.setOnTouchListener { _, event ->
             when (event.actionMasked) {
                 MotionEvent.ACTION_DOWN -> {
+                    // Nothing is sent yet: a horizontal drag starting on this key
+                    // belongs to the pager, and a key already sent cannot be taken
+                    // back. Holds emit from the repeat timer, taps on release.
                     if (spec.repeats) {
-                        sendKey(spec.key)
                         startRepeating(spec.key)
                     }
                     true
                 }
                 MotionEvent.ACTION_UP -> {
-                    if (spec.repeats) {
-                        stopRepeating()
-                    } else {
+                    val repeated = repeatFired
+                    stopRepeating()
+                    if (!repeated) {
                         sendKey(spec.key)
                     }
                     true
                 }
                 MotionEvent.ACTION_CANCEL,
-                MotionEvent.ACTION_OUTSIDE -> {
+                MotionEvent.ACTION_OUTSIDE,
+                -> {
                     stopRepeating()
                     true
                 }

--- a/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
@@ -62,6 +62,7 @@ class MainActivity : AppCompatActivity() {
     private var keyBarPollActive = false
     private var lastAccessoryHeight = -1
     private var lastPinnedHeight = -1
+    private var lastComposerCancelSeq = 0
     // GPUI draws into the SurfaceView's own surface, so the Android view tree does
     // not invalidate when the terminal mounts the bar or a drawer opens. Poll per
     // vsync instead; a view-tree pre-draw listener only fires on IME inset changes.
@@ -119,14 +120,18 @@ class MainActivity : AppCompatActivity() {
 
         rootView = FrameLayout(this)
         surfaceView = runtime.attach(rootView)
-        keyboardAccessoryBar = KeyboardAccessoryBar(this) { key ->
-            nativeKeyboardAccessoryKey(key)
-        }
+        keyboardAccessoryBar =
+            KeyboardAccessoryBar(
+                this,
+                sendKey = { key -> nativeKeyboardAccessoryKey(key) },
+                sendComposedText = { text -> nativeKeyBarComposedText(text) },
+                requestTerminalKeyboard = { surfaceView.requestKeyboard() },
+            )
         rootView.addView(
             keyboardAccessoryBar,
             FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT,
-                (44 * resources.displayMetrics.density).toInt(),
+                keyboardAccessoryBar.desiredHeightPx,
                 Gravity.BOTTOM,
             ),
         )
@@ -317,6 +322,14 @@ class MainActivity : AppCompatActivity() {
         val pinned = keyboardImeBottom == 0 && nativePinnedKeyBarVisible()
         val visible = ridesKeyboard || pinned
 
+        val layout = nativeKeypadLayout()
+        if (keyboardAccessoryBar.setLayout(layout and 1 != 0, layout and 2 != 0)) {
+            val params = keyboardAccessoryBar.layoutParams as FrameLayout.LayoutParams
+            params.height = keyboardAccessoryBar.desiredHeightPx
+            keyboardAccessoryBar.layoutParams = params
+        }
+        keyboardAccessoryBar.setModifierMask(nativeKeyBarModifierMask())
+
         val bottomMargin = if (pinned) navigationBarBottom else keyboardImeBottom
         val params = keyboardAccessoryBar.layoutParams as FrameLayout.LayoutParams
         if (params.bottomMargin != bottomMargin) {
@@ -342,6 +355,11 @@ class MainActivity : AppCompatActivity() {
         }
         if (!visible) {
             keyboardAccessoryBar.stopRepeating()
+        }
+        val cancelSeq = nativeKeypadComposerCancelSeq()
+        if (cancelSeq != lastComposerCancelSeq) {
+            lastComposerCancelSeq = cancelSeq
+            keyboardAccessoryBar.cancelComposing()
         }
     }
 
@@ -446,6 +464,15 @@ class MainActivity : AppCompatActivity() {
         @JvmStatic external fun nativeKeyboardAccessoryVisible(): Boolean
 
         @JvmStatic external fun nativePinnedKeyBarVisible(): Boolean
+
+        @JvmStatic external fun nativeKeypadComposerCancelSeq(): Int
+
+        /** Bit 0 = extended rows, bit 1 = Cmd in the platform slot. */
+        @JvmStatic external fun nativeKeypadLayout(): Int
+
+        @JvmStatic external fun nativeKeyBarModifierMask(): Int
+
+        @JvmStatic external fun nativeKeyBarComposedText(text: String)
 
         @JvmStatic external fun nativeSetPinnedKeyBarHeight(heightPx: Int)
 

--- a/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
@@ -20,6 +20,7 @@ import android.os.VibratorManager
 import android.util.Log
 import org.json.JSONObject
 import java.io.File
+import android.view.Choreographer
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.View
@@ -57,6 +58,21 @@ class MainActivity : AppCompatActivity() {
     private lateinit var surfaceView: GpuiSurfaceView
     private lateinit var keyboardAccessoryBar: KeyboardAccessoryBar
     private var keyboardImeBottom = 0
+    private var navigationBarBottom = 0
+    private var keyBarPollActive = false
+    private var lastAccessoryHeight = -1
+    private var lastPinnedHeight = -1
+    // GPUI draws into the SurfaceView's own surface, so the Android view tree does
+    // not invalidate when the terminal mounts the bar or a drawer opens. Poll per
+    // vsync instead; a view-tree pre-draw listener only fires on IME inset changes.
+    private val keyBarFrameCallback =
+        object : Choreographer.FrameCallback {
+            override fun doFrame(frameTimeNanos: Long) {
+                if (!keyBarPollActive) return
+                updateKeyboardAccessoryVisibility()
+                Choreographer.getInstance().postFrameCallback(this)
+            }
+        }
     private var pendingDeltaPushTokenCallbackId: Int? = null
     private val notificationPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
@@ -115,10 +131,6 @@ class MainActivity : AppCompatActivity() {
             ),
         )
         installKeyboardAccessoryInsets()
-        rootView.viewTreeObserver.addOnPreDrawListener {
-            updateKeyboardAccessoryVisibility()
-            true
-        }
         sSurfaceView = surfaceView
         sActivity = this
         NativePresentations.register(this, rootView)
@@ -147,6 +159,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        startKeyBarPolling()
         runtime.onResume()
         nativeSetAppForeground(true)
         if (::surfaceView.isInitialized) {
@@ -156,6 +169,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onPause() {
         super.onPause()
+        stopKeyBarPolling()
         if (::keyboardAccessoryBar.isInitialized) {
             keyboardAccessoryBar.stopRepeating()
         }
@@ -169,6 +183,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        stopKeyBarPolling()
         if (::keyboardAccessoryBar.isInitialized) {
             keyboardAccessoryBar.stopRepeating()
         }
@@ -271,17 +286,23 @@ class MainActivity : AppCompatActivity() {
         return super.dispatchKeyEvent(event)
     }
 
+    private fun startKeyBarPolling() {
+        if (keyBarPollActive) return
+        keyBarPollActive = true
+        Choreographer.getInstance().postFrameCallback(keyBarFrameCallback)
+    }
+
+    private fun stopKeyBarPolling() {
+        keyBarPollActive = false
+        Choreographer.getInstance().removeFrameCallback(keyBarFrameCallback)
+    }
+
     private fun installKeyboardAccessoryInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(rootView) { _, insets ->
-            val imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
-            keyboardImeBottom = imeBottom
-            val params = keyboardAccessoryBar.layoutParams as FrameLayout.LayoutParams
-            if (params.bottomMargin != imeBottom) {
-                params.bottomMargin = imeBottom
-                keyboardAccessoryBar.layoutParams = params
-            }
+            keyboardImeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+            navigationBarBottom = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
             updateKeyboardAccessoryVisibility()
-            if (imeBottom == 0) {
+            if (keyboardImeBottom == 0) {
                 keyboardAccessoryBar.stopRepeating()
             }
             insets
@@ -289,12 +310,36 @@ class MainActivity : AppCompatActivity() {
         ViewCompat.requestApplyInsets(rootView)
     }
 
+    // The same bar serves both roles: riding the IME, or pinned above the
+    // navigation bar once the IME is gone.
     private fun updateKeyboardAccessoryVisibility() {
-        val visible = keyboardImeBottom > 0 && nativeKeyboardAccessoryVisible()
+        val ridesKeyboard = keyboardImeBottom > 0 && nativeKeyboardAccessoryVisible()
+        val pinned = keyboardImeBottom == 0 && nativePinnedKeyBarVisible()
+        val visible = ridesKeyboard || pinned
+
+        val bottomMargin = if (pinned) navigationBarBottom else keyboardImeBottom
+        val params = keyboardAccessoryBar.layoutParams as FrameLayout.LayoutParams
+        if (params.bottomMargin != bottomMargin) {
+            params.bottomMargin = bottomMargin
+            keyboardAccessoryBar.layoutParams = params
+        }
+
         keyboardAccessoryBar.visibility = if (visible) View.VISIBLE else View.GONE
-        surfaceView.setKeyboardAccessoryHeight(
-            if (visible) keyboardAccessoryBar.layoutParams.height else 0,
-        )
+
+        // Runs every vsync, so push heights only when they actually move.
+        val barHeight = keyboardAccessoryBar.layoutParams.height
+        // GPUI's keyboard avoidance only covers the IME-attached case; the pinned
+        // bar is reported separately so the terminal insets itself instead.
+        val accessoryHeight = if (ridesKeyboard) barHeight else 0
+        if (accessoryHeight != lastAccessoryHeight) {
+            lastAccessoryHeight = accessoryHeight
+            surfaceView.setKeyboardAccessoryHeight(accessoryHeight)
+        }
+        val pinnedHeight = if (pinned) barHeight + navigationBarBottom else 0
+        if (pinnedHeight != lastPinnedHeight) {
+            lastPinnedHeight = pinnedHeight
+            nativeSetPinnedKeyBarHeight(pinnedHeight)
+        }
         if (!visible) {
             keyboardAccessoryBar.stopRepeating()
         }
@@ -399,6 +444,10 @@ class MainActivity : AppCompatActivity() {
         @JvmStatic external fun nativeKeyboardAccessoryKey(key: String)
 
         @JvmStatic external fun nativeKeyboardAccessoryVisible(): Boolean
+
+        @JvmStatic external fun nativePinnedKeyBarVisible(): Boolean
+
+        @JvmStatic external fun nativeSetPinnedKeyBarHeight(heightPx: Int)
 
         @JvmStatic external fun nativeSystemBackPressed(): Boolean
 

--- a/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
@@ -68,6 +68,7 @@ object NativePresentations {
         val accentRed: Int,
         val accentGreen: Int,
         val accentYellow: Int,
+        val accentBlue: Int,
     ) {
         companion object {
             fun dark() = NativeTheme(
@@ -81,6 +82,7 @@ object NativePresentations {
                 accentRed = Color.rgb(224, 108, 117),
                 accentGreen = Color.rgb(152, 195, 121),
                 accentYellow = Color.rgb(229, 192, 123),
+                accentBlue = Color.rgb(97, 175, 239),
             )
 
             fun light() = NativeTheme(
@@ -94,6 +96,7 @@ object NativePresentations {
                 accentRed = Color.rgb(207, 34, 46),
                 accentGreen = Color.rgb(26, 127, 55),
                 accentYellow = Color.rgb(154, 103, 0),
+                accentBlue = Color.rgb(9, 105, 218),
             )
         }
     }
@@ -138,6 +141,8 @@ object NativePresentations {
     fun currentTextPrimaryColor(): Int = nativeTheme.textPrimary
 
     fun currentTextSecondaryColor(): Int = nativeTheme.textSecondary
+
+    fun currentAccentBlueColor(): Int = nativeTheme.accentBlue
 
     @JvmStatic
     fun showAlert(

--- a/android/app/src/main/res/drawable/ic_key_backspace.xml
+++ b/android/app/src/main/res/drawable/ic_key_backspace.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M20,5 H9 l-7,7 7,7 h11 a2,2 0 0 0 2,-2 V7 a2,2 0 0 0 -2,-2 z M18,9 l-6,6 M12,9 l6,6"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+</vector>

--- a/crates/zedra-terminal/src/input.rs
+++ b/crates/zedra-terminal/src/input.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use gpui::*;
 use smallvec::SmallVec;
 
-use crate::keyboard_accessory::AccessoryKey;
+use crate::keyboard_accessory::{self, AccessoryKey};
 use crate::selection::TerminalSelectionDocument;
 use crate::terminal::Terminal;
 
@@ -619,6 +619,27 @@ impl InputHandler for TerminalInputHandler {
     }
 
     fn insert_text(&mut self, text: &str, _window: &mut Window, cx: &mut App) {
+        // A modifier armed on the keypad turns the next committed character into a
+        // keystroke, so Ctrl on the bar + `c` on the IME reaches the PTY as Ctrl+C.
+        if let Some(ch) = keyboard_accessory::single_char(text) {
+            let armed = self
+                .entity
+                .read_with(cx, |term, _cx| term.sticky_modifier_mask() != 0)
+                .unwrap_or(false);
+            if armed {
+                let entity = self.entity.clone();
+                let _ = entity.update(cx, |term, cx| {
+                    let keystroke =
+                        term.sticky_keystroke(keyboard_accessory::literal_keystroke(ch));
+                    term.clear_text_input_context();
+                    term.handle_keystroke(&keystroke);
+                    term.consume_sticky_modifiers();
+                    cx.notify();
+                });
+                return;
+            }
+        }
+
         let text = text.to_string();
         if self.clear_selection_for_text_input(cx) {
             if text.is_empty() {
@@ -1090,13 +1111,34 @@ impl InputHandler for TerminalInputHandler {
         _window: &mut Window,
         cx: &mut App,
     ) -> bool {
-        let Some(keystroke) = AccessoryKey::from_name(action).map(|action| action.keystroke())
-        else {
+        let entity = self.entity.clone();
+
+        // Modifier keys only mutate sticky state; nothing reaches the PTY yet.
+        if let Some(modifier) = action
+            .strip_prefix("mod:")
+            .and_then(keyboard_accessory::ModifierKey::from_name)
+        {
+            return entity
+                .update(cx, |term, _cx| term.cycle_sticky_modifier(modifier))
+                .is_ok();
+        }
+
+        let keystroke = if let Some(literal) = action.strip_prefix("char:") {
+            match keyboard_accessory::single_char(literal) {
+                Some(ch) => keyboard_accessory::literal_keystroke(ch),
+                None => return false,
+            }
+        } else if let Some(key) = AccessoryKey::from_name(action) {
+            key.keystroke()
+        } else {
             return false;
         };
-        let entity = self.entity.clone();
+
         entity
-            .update(cx, |term, _cx| term.handle_keystroke(&keystroke))
+            .update(cx, |term, _cx| {
+                term.handle_keystroke(&term.sticky_keystroke(keystroke));
+                term.consume_sticky_modifiers();
+            })
             .is_ok()
     }
 

--- a/crates/zedra-terminal/src/keyboard_accessory.rs
+++ b/crates/zedra-terminal/src/keyboard_accessory.rs
@@ -7,6 +7,7 @@ use crate::keys::to_esc_str;
 pub enum AccessoryKey {
     Escape,
     Tab,
+    Backspace,
     Left,
     Down,
     Up,
@@ -20,6 +21,7 @@ impl AccessoryKey {
         Some(match name {
             "escape" => Self::Escape,
             "tab" => Self::Tab,
+            "backspace" => Self::Backspace,
             "left" => Self::Left,
             "down" => Self::Down,
             "up" => Self::Up,
@@ -34,6 +36,7 @@ impl AccessoryKey {
         let (key, modifiers) = match self {
             Self::Escape => ("escape", Modifiers::default()),
             Self::Tab => ("tab", Modifiers::default()),
+            Self::Backspace => ("backspace", Modifiers::default()),
             Self::Left => ("left", Modifiers::default()),
             Self::Down => ("down", Modifiers::default()),
             Self::Up => ("up", Modifiers::default()),
@@ -60,15 +63,115 @@ impl AccessoryKey {
     }
 }
 
+/// Sticky modifiers held by the extended keypad.
+///
+/// State lives here rather than in the native bar because it must apply to two
+/// input paths that never meet natively: keys pressed on the bar itself, and
+/// characters committed by the software keyboard's IME. A one-shot modifier is
+/// consumed by the next key from either path; a locked one persists.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ModifierKey {
+    Shift,
+    Ctrl,
+    Alt,
+    Cmd,
+}
+
+impl ModifierKey {
+    pub fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "shift" => Self::Shift,
+            "ctrl" => Self::Ctrl,
+            "alt" => Self::Alt,
+            "cmd" => Self::Cmd,
+            _ => return None,
+        })
+    }
+
+    fn armed_bit(self) -> u32 {
+        match self {
+            Self::Shift => 1,
+            Self::Ctrl => 2,
+            Self::Alt => 4,
+            Self::Cmd => 8,
+        }
+    }
+
+    fn modifiers(self) -> Modifiers {
+        match self {
+            Self::Shift => Modifiers::shift(),
+            Self::Ctrl => Modifiers::control(),
+            Self::Alt => Modifiers::alt(),
+            Self::Cmd => Modifiers::command(),
+        }
+    }
+
+    fn locked_bit(self) -> u32 {
+        self.armed_bit() << MODIFIER_LOCK_SHIFT
+    }
+}
+
+/// How far the locked bits sit above the armed ones.
+const MODIFIER_LOCK_SHIFT: u32 = 4;
+const MODIFIER_BITS: u32 = 0b1111;
+
+/// Bits 0-3 armed (shift, ctrl, alt, cmd), bits 4-7 locked. Native bars read this
+/// to render key highlights, so the encoding is part of the platform contract.
+pub fn modifiers_from_mask(mask: u32) -> Modifiers {
+    [
+        ModifierKey::Shift,
+        ModifierKey::Ctrl,
+        ModifierKey::Alt,
+        ModifierKey::Cmd,
+    ]
+    .into_iter()
+    .filter(|key| mask & key.armed_bit() != 0)
+    .fold(Modifiers::none(), |acc, key| acc | key.modifiers())
+}
+
+pub fn cycled_mask(mask: u32, key: ModifierKey) -> u32 {
+    let armed = mask & key.armed_bit() != 0;
+    let locked = mask & key.locked_bit() != 0;
+    match (armed, locked) {
+        (false, _) => mask | key.armed_bit(),
+        (true, false) => mask | key.locked_bit(),
+        (true, true) => mask & !(key.armed_bit() | key.locked_bit()),
+    }
+}
+
+/// Drop every armed modifier that is not locked.
+pub fn consumed_mask(mask: u32) -> u32 {
+    let locked = (mask >> MODIFIER_LOCK_SHIFT) & MODIFIER_BITS;
+    (locked << MODIFIER_LOCK_SHIFT) | locked
+}
+
+/// A single character typed on the extended keypad, e.g. `char:@`.
+pub fn literal_keystroke(ch: char) -> Keystroke {
+    Keystroke {
+        modifiers: Modifiers::default(),
+        key: ch.to_string(),
+        key_char: Some(ch.to_string()),
+    }
+}
+
+/// Whether a committed string is a single character a modifier can fold into.
+/// Multi-character commits stay on the normal IME path.
+pub fn single_char(text: &str) -> Option<char> {
+    let mut chars = text.chars();
+    let ch = chars.next()?;
+    chars.next().is_none().then_some(ch)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::AccessoryKey;
+    use super::*;
 
     #[test]
     fn parses_terminal_keyboard_accessory_actions() {
         for name in [
             "escape",
             "tab",
+            "backspace",
             "left",
             "down",
             "up",
@@ -100,5 +203,45 @@ mod tests {
                 .unwrap();
             assert_eq!(bytes, expected);
         }
+    }
+
+    #[test]
+    fn sticky_modifier_cycles_armed_locked_cleared() {
+        let armed = cycled_mask(0, ModifierKey::Ctrl);
+        assert!(modifiers_from_mask(armed).control);
+
+        // An armed modifier survives nothing but the next key.
+        assert!(!modifiers_from_mask(consumed_mask(armed)).control);
+
+        // Second tap locks: the modifier now outlives the keys it applies to.
+        let locked = cycled_mask(armed, ModifierKey::Ctrl);
+        assert!(modifiers_from_mask(consumed_mask(locked)).control);
+
+        // Third tap clears it entirely.
+        assert_eq!(cycled_mask(locked, ModifierKey::Ctrl), 0);
+    }
+
+    #[test]
+    fn consuming_clears_armed_modifiers_but_keeps_locked_ones() {
+        let locked_ctrl = cycled_mask(cycled_mask(0, ModifierKey::Ctrl), ModifierKey::Ctrl);
+        let with_armed_alt = cycled_mask(locked_ctrl, ModifierKey::Alt);
+
+        let after = modifiers_from_mask(consumed_mask(with_armed_alt));
+        assert!(after.control, "locked ctrl survives");
+        assert!(!after.alt, "armed alt is consumed");
+    }
+
+    #[test]
+    fn literal_keystroke_carries_the_character() {
+        let keystroke = literal_keystroke('@');
+        assert_eq!(keystroke.key, "@");
+        assert_eq!(keystroke.key_char.as_deref(), Some("@"));
+    }
+
+    #[test]
+    fn accessory_keys_accept_modifiers() {
+        let keystroke = AccessoryKey::Left.keystroke();
+        assert_eq!(keystroke.key, "left");
+        assert!(!keystroke.modifiers.control);
     }
 }

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -32,6 +32,11 @@ pub enum TerminalEvent {
     OscEvent(OscEvent),
     OpenHyperlink(TerminalHyperlink),
     AltScreenChanged(bool),
+    /// The user tapped the terminal surface.
+    SurfaceTapped,
+    /// Armed/locked keypad modifiers changed; the encoding is documented on
+    /// `keyboard_accessory::sticky_modifier_mask`.
+    StickyModifiersChanged(u32),
     DictationPreviewChanged(Option<String>),
     ScrollbackPositionChanged {
         display_offset: usize,
@@ -208,6 +213,9 @@ pub struct Terminal {
     synchronized_update_timeout_task: Option<Task<()>>,
     selection_range: Option<Range<usize>>,
     theme: TerminalTheme,
+    /// Armed/locked keypad modifiers for this terminal. Per-terminal rather than
+    /// process-wide so arming Ctrl in one terminal cannot leak into another.
+    sticky_modifiers: u32,
 }
 
 impl Terminal {
@@ -245,6 +253,7 @@ impl Terminal {
             pending_sync_deadline: None,
             synchronized_update_timeout_task: None,
             selection_range: None,
+            sticky_modifiers: 0,
             theme,
         };
         terminal
@@ -499,6 +508,44 @@ impl Terminal {
     }
 
     /// Handle a keystroke, converting to escape sequence and sending via SSH or RPC session
+    pub fn sticky_modifier_mask(&self) -> u32 {
+        self.sticky_modifiers
+    }
+
+    /// Tap arms a modifier, tapping again locks it, a third tap clears it.
+    pub fn cycle_sticky_modifier(&mut self, key: crate::keyboard_accessory::ModifierKey) {
+        self.set_sticky_modifiers(crate::keyboard_accessory::cycled_mask(
+            self.sticky_modifiers,
+            key,
+        ));
+    }
+
+    /// Drop armed modifiers once a key has consumed them; locked ones persist.
+    pub fn consume_sticky_modifiers(&mut self) {
+        self.set_sticky_modifiers(crate::keyboard_accessory::consumed_mask(
+            self.sticky_modifiers,
+        ));
+    }
+
+    fn set_sticky_modifiers(&mut self, mask: u32) {
+        if self.sticky_modifiers == mask {
+            return;
+        }
+        self.sticky_modifiers = mask;
+        let _ = self
+            .event_tx
+            .send(TerminalEvent::StickyModifiersChanged(mask));
+    }
+
+    /// A keystroke with this terminal's armed modifiers folded in.
+    pub fn sticky_keystroke(&self, keystroke: Keystroke) -> Keystroke {
+        Keystroke {
+            modifiers: keystroke.modifiers
+                | crate::keyboard_accessory::modifiers_from_mask(self.sticky_modifiers),
+            ..keystroke
+        }
+    }
+
     pub fn handle_keystroke(&mut self, keystroke: &Keystroke) {
         // Try to convert keystroke to terminal escape sequence
         if let Some(bytes) = self.try_keystroke(keystroke) {
@@ -4739,5 +4786,60 @@ mod tests {
         let links = terminal.detect_plain_links();
         assert_eq!(links.len(), 1, "expected only URL match, got {:?}", links);
         assert_eq!(links[0].kind, super::DetectedLinkKind::Url);
+    }
+
+    #[test]
+    fn sticky_modifiers_clear_once_a_key_consumes_them() {
+        use crate::keyboard_accessory::ModifierKey;
+
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+        terminal.cycle_sticky_modifier(ModifierKey::Ctrl);
+        assert!(
+            terminal
+                .sticky_keystroke(plain_keystroke("c"))
+                .modifiers
+                .control
+        );
+
+        terminal.consume_sticky_modifiers();
+        assert_eq!(
+            terminal.sticky_modifier_mask(),
+            0,
+            "armed modifier is consumed"
+        );
+        assert!(
+            !terminal
+                .sticky_keystroke(plain_keystroke("c"))
+                .modifiers
+                .control
+        );
+    }
+
+    #[test]
+    fn locked_sticky_modifier_survives_consumption() {
+        use crate::keyboard_accessory::ModifierKey;
+
+        let mut terminal = Terminal::new(80, 4, px(10.0), px(20.0));
+        // Two taps lock it; a third clears it outright.
+        terminal.cycle_sticky_modifier(ModifierKey::Ctrl);
+        terminal.cycle_sticky_modifier(ModifierKey::Ctrl);
+        terminal.consume_sticky_modifiers();
+        assert!(
+            terminal
+                .sticky_keystroke(plain_keystroke("c"))
+                .modifiers
+                .control
+        );
+
+        terminal.cycle_sticky_modifier(ModifierKey::Ctrl);
+        assert_eq!(terminal.sticky_modifier_mask(), 0);
+    }
+
+    fn plain_keystroke(key: &str) -> gpui::Keystroke {
+        gpui::Keystroke {
+            modifiers: gpui::Modifiers::default(),
+            key: key.to_string(),
+            key_char: Some(key.to_string()),
+        }
     }
 }

--- a/crates/zedra-terminal/src/view.rs
+++ b/crates/zedra-terminal/src/view.rs
@@ -117,6 +117,9 @@ pub struct TerminalView {
     /// Cached from terminal mode; updated each render so parent views can read without
     /// creating a GPUI dependency on the inner terminal entity.
     pub is_alt_screen: bool,
+    /// With a key bar pinned below the terminal, dismissing the keyboard must not
+    /// drop focus — the bar keeps sending keystrokes to this terminal.
+    pub retains_focus_without_keyboard: bool,
     terminal_theme: TerminalTheme,
     _event_task: Task<()>,
     _subscriptions: Vec<Subscription>,
@@ -186,6 +189,7 @@ impl TerminalView {
             keyboard_content_offset: px(0.0),
             suppress_touch_scroll_until: None,
             is_alt_screen: false,
+            retains_focus_without_keyboard: false,
             terminal_theme: TerminalTheme::dark(),
             _event_task: event_task,
             _subscriptions: vec![],
@@ -284,6 +288,12 @@ impl TerminalView {
 
     pub fn is_focused(&self, window: &Window) -> bool {
         self.focus_handle.is_focused(window)
+    }
+
+    /// Focus without raising the software keyboard — the terminal uses manual focus,
+    /// so the keyboard only appears where it is requested explicitly.
+    pub fn focus_without_keyboard(&self, window: &mut Window, cx: &mut Context<Self>) {
+        self.focus_handle.focus(window, cx);
     }
 
     pub fn dismiss_dictation_preview(&mut self, cx: &mut Context<Self>) {
@@ -535,7 +545,9 @@ impl TerminalView {
         if is_focused && keyboard_visible {
             // window.blur only blurs focus, not the keyboard — hide it explicitly.
             window.hide_soft_keyboard();
-            window.blur();
+            if !self.retains_focus_without_keyboard {
+                window.blur();
+            }
             cx.notify();
             return;
         }

--- a/crates/zedra-terminal/src/view.rs
+++ b/crates/zedra-terminal/src/view.rs
@@ -541,6 +541,7 @@ impl TerminalView {
         let is_focused = self.focus_handle.is_focused(window);
         let keyboard_visible = window.is_soft_keyboard_visible();
         window.prevent_default();
+        cx.emit(TerminalEvent::SurfaceTapped);
 
         if is_focused && keyboard_visible {
             // window.blur only blurs focus, not the keyboard — hide it explicitly.

--- a/crates/zedra/src/android/bridge.rs
+++ b/crates/zedra/src/android/bridge.rs
@@ -32,6 +32,14 @@ impl PlatformBridge for AndroidBridge {
         jni::get_keyboard_height() > 0
     }
 
+    fn set_pinned_key_bar_visible(&self, visible: bool) {
+        jni::set_pinned_key_bar_visible(visible)
+    }
+
+    fn pinned_key_bar_height(&self) -> u32 {
+        jni::get_pinned_key_bar_height()
+    }
+
     fn launch_qr_scanner(&self) {
         jni::launch_qr_scanner()
     }

--- a/crates/zedra/src/android/bridge.rs
+++ b/crates/zedra/src/android/bridge.rs
@@ -36,6 +36,14 @@ impl PlatformBridge for AndroidBridge {
         jni::set_pinned_key_bar_visible(visible)
     }
 
+    fn set_keypad_layout(&self, extended: bool, cmd_slot: bool) {
+        jni::set_keypad_layout(extended, cmd_slot)
+    }
+
+    fn cancel_keypad_composer(&self) {
+        jni::cancel_keypad_composer()
+    }
+
     fn pinned_key_bar_height(&self) -> u32 {
         jni::get_pinned_key_bar_height()
     }

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -44,6 +44,10 @@ static FILES_DIR: Mutex<Option<String>> = Mutex::new(None);
 /// Whether the terminal wants the pinned key bar on screen. Polled from Kotlin.
 static PINNED_KEY_BAR_REQUESTED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
+/// Keypad layout pushed from Rust: bit 0 extended, bit 1 Cmd slot.
+static KEYPAD_LAYOUT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+/// Incremented whenever the composer should be dropped.
+static KEYPAD_COMPOSER_CANCEL: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 /// Height of the pinned key bar in physical pixels, including safe-area padding.
 /// 0 = hidden. Pushed by `MainActivity` once the bar is laid out.
 static PINNED_KEY_BAR_HEIGHT_PX: std::sync::atomic::AtomicU32 =
@@ -609,6 +613,49 @@ pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeKeyboardAccessoryKe
 }
 
 #[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeKeypadComposerCancelSeq(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jint {
+    KEYPAD_COMPOSER_CANCEL.load(std::sync::atomic::Ordering::Relaxed) as jint
+}
+
+/// Layout pushed by `set_keypad_layout`, encoded as extended | cmd_slot << 1.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeKeypadLayout(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jint {
+    KEYPAD_LAYOUT.load(std::sync::atomic::Ordering::Relaxed) as jint
+}
+
+/// Armed/locked keypad modifiers. Bit layout is documented on
+/// `zedra_terminal::keyboard_accessory::sticky_modifier_mask`.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeKeyBarModifierMask(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jint {
+    crate::key_bar::modifier_mask() as jint
+}
+
+/// Text composed in the keypad's IME field, submitted as one edit.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeKeyBarComposedText(
+    mut env: JNIEnv,
+    _class: JClass,
+    text: jni::objects::JString,
+) {
+    let Some(text) = jstring_to_string(&mut env, &text) else {
+        return;
+    };
+    if text.is_empty() {
+        return;
+    }
+    gpui_android::with_platform(|platform| platform.insert_text(&text));
+}
+
+#[unsafe(no_mangle)]
 pub extern "system" fn Java_dev_zedra_app_MainActivity_nativePinnedKeyBarVisible(
     _env: JNIEnv,
     _class: JClass,
@@ -773,8 +820,19 @@ pub fn hide_keyboard() {
 /// Stores the request only. `MainActivity` polls it from its per-frame accessory
 /// update, matching `nativeKeyboardAccessoryVisible` — a Rust→Java push can be
 /// dropped when the call lands at a bad moment, and a lost show never recovers.
+pub fn set_keypad_layout(extended: bool, cmd_slot: bool) {
+    let encoded = extended as u32 | ((cmd_slot as u32) << 1);
+    KEYPAD_LAYOUT.store(encoded, std::sync::atomic::Ordering::Relaxed);
+}
+
 pub fn set_pinned_key_bar_visible(visible: bool) {
     PINNED_KEY_BAR_REQUESTED.store(visible, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Bumped to ask Kotlin to drop the composer. A counter rather than a flag so the
+/// per-frame poll sees every request, matching how the keypad state is read.
+pub fn cancel_keypad_composer() {
+    KEYPAD_COMPOSER_CANCEL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 }
 
 pub fn get_pinned_key_bar_height() -> u32 {

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -41,6 +41,13 @@ static MAIN_ACTIVITY_CLASS: Mutex<Option<GlobalRef>> = Mutex::new(None);
 const MAIN_ACTIVITY_CLASS_NAME: &str = "dev/zedra/app/MainActivity";
 static INIT: Once = Once::new();
 static FILES_DIR: Mutex<Option<String>> = Mutex::new(None);
+/// Whether the terminal wants the pinned key bar on screen. Polled from Kotlin.
+static PINNED_KEY_BAR_REQUESTED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+/// Height of the pinned key bar in physical pixels, including safe-area padding.
+/// 0 = hidden. Pushed by `MainActivity` once the bar is laid out.
+static PINNED_KEY_BAR_HEIGHT_PX: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
 static APP_VERSION: Mutex<Option<String>> = Mutex::new(None);
 static APP_BUILD_NUMBER: Mutex<Option<String>> = Mutex::new(None);
 static OS_VERSION: Mutex<Option<String>> = Mutex::new(None);
@@ -602,6 +609,26 @@ pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeKeyboardAccessoryKe
 }
 
 #[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_zedra_app_MainActivity_nativePinnedKeyBarVisible(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jboolean {
+    PINNED_KEY_BAR_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) as jboolean
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeSetPinnedKeyBarHeight(
+    _env: JNIEnv,
+    _class: JClass,
+    height_px: jint,
+) {
+    PINNED_KEY_BAR_HEIGHT_PX.store(
+        height_px.max(0) as u32,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+}
+
+#[unsafe(no_mangle)]
 pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeKeyboardAccessoryVisible(
     _env: JNIEnv,
     _class: JClass,
@@ -738,6 +765,17 @@ pub fn hide_keyboard() {
             }
         });
     });
+}
+
+/// Stores the request only. `MainActivity` polls it from its per-frame accessory
+/// update, matching `nativeKeyboardAccessoryVisible` — a Rust→Java push can be
+/// dropped when the call lands at a bad moment, and a lost show never recovers.
+pub fn set_pinned_key_bar_visible(visible: bool) {
+    PINNED_KEY_BAR_REQUESTED.store(visible, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn get_pinned_key_bar_height() -> u32 {
+    PINNED_KEY_BAR_HEIGHT_PX.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 pub fn launch_qr_scanner() {

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -622,10 +622,13 @@ pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeSetPinnedKeyBarHeig
     _class: JClass,
     height_px: jint,
 ) {
-    PINNED_KEY_BAR_HEIGHT_PX.store(
-        height_px.max(0) as u32,
-        std::sync::atomic::Ordering::Relaxed,
-    );
+    let height = height_px.max(0) as u32;
+    if PINNED_KEY_BAR_HEIGHT_PX.swap(height, std::sync::atomic::Ordering::Relaxed) == height {
+        return;
+    }
+    // The terminal insets itself by this value, so a static screen would keep a
+    // stale inset until some unrelated redraw. iOS notifies for the same reason.
+    gpui_android::with_platform(|platform| platform.request_frame_forced());
 }
 
 #[unsafe(no_mangle)]

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -17,6 +17,10 @@ static SCREEN_SCALE: AtomicU32 = AtomicU32::new(f32::to_bits(3.0));
 /// Updated by UIKeyboardWillShow/WillHide notifications via Obj-C → FFI.
 static KEYBOARD_HEIGHT_PX: AtomicU32 = AtomicU32::new(0);
 
+/// Height of the pinned key bar in physical pixels, including safe-area padding.
+/// 0 = hidden. Pushed by UIKit once the bar is laid out.
+static PINNED_KEY_BAR_HEIGHT_PX: AtomicU32 = AtomicU32::new(0);
+
 /// Safe area insets in physical pixels (points × scale), matching the Android convention.
 static SAFE_AREA_TOP: AtomicU32 = AtomicU32::new(0);
 static SAFE_AREA_BOTTOM: AtomicU32 = AtomicU32::new(0);
@@ -37,6 +41,15 @@ pub extern "C" fn zedra_ios_set_screen_scale(scale: f32) {
 #[unsafe(no_mangle)]
 pub extern "C" fn zedra_ios_set_keyboard_height(height_px: u32) {
     KEYBOARD_HEIGHT_PX.store(height_px, Ordering::Relaxed);
+    super::app::notify_main_window();
+}
+
+/// Called from Swift when the pinned key bar is shown, hidden, or re-laid out.
+///
+/// `height_px` is the bar's full height (including safe-area padding) × scale, 0 when hidden.
+#[unsafe(no_mangle)]
+pub extern "C" fn zedra_ios_set_pinned_key_bar_height(height_px: u32) {
+    PINNED_KEY_BAR_HEIGHT_PX.store(height_px, Ordering::Relaxed);
     super::app::notify_main_window();
 }
 
@@ -192,6 +205,8 @@ unsafe extern "C" {
     fn ios_system_prefers_dark_theme() -> i32;
     /// Apply the app appearance to the native keyboard accessory bar.
     fn ios_set_keyboard_accessory_theme(is_dark: bool);
+    /// Show or hide the key bar pinned above the safe area when the keyboard is down.
+    fn ios_set_pinned_key_bar_visible(visible: bool);
     /// Acquire an image natively. source: 0 = photo library, 1 = clipboard.
     /// Delivers exactly one of zedra_ios_image_acquire_{result,cancel,error}(callback_id, ..).
     fn ios_acquire_image(callback_id: u32, source: i32);
@@ -228,6 +243,14 @@ impl PlatformBridge for IosBridge {
             }
             gpui_ios_is_keyboard_visible(window)
         }
+    }
+
+    fn set_pinned_key_bar_visible(&self, visible: bool) {
+        unsafe { ios_set_pinned_key_bar_visible(visible) };
+    }
+
+    fn pinned_key_bar_height(&self) -> u32 {
+        PINNED_KEY_BAR_HEIGHT_PX.load(Ordering::Relaxed)
     }
 
     fn launch_qr_scanner(&self) {

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -44,6 +44,13 @@ pub extern "C" fn zedra_ios_set_keyboard_height(height_px: u32) {
     super::app::notify_main_window();
 }
 
+/// Armed/locked keypad modifiers, for rendering key highlights. Bit layout is
+/// documented on `zedra_terminal::keyboard_accessory::sticky_modifier_mask`.
+#[unsafe(no_mangle)]
+pub extern "C" fn zedra_ios_key_bar_modifier_mask() -> u32 {
+    crate::key_bar::modifier_mask()
+}
+
 /// Called from Swift when the pinned key bar is shown, hidden, or re-laid out.
 ///
 /// `height_px` is the bar's full height (including safe-area padding) × scale, 0 when hidden.
@@ -207,6 +214,10 @@ unsafe extern "C" {
     fn ios_set_keyboard_accessory_theme(is_dark: bool);
     /// Show or hide the key bar pinned above the safe area when the keyboard is down.
     fn ios_set_pinned_key_bar_visible(visible: bool);
+    /// Switch the keypad layout and its platform slot.
+    fn ios_set_keypad_layout(extended: bool, cmd_slot: bool);
+    /// Drop the keypad composer and the keyboard it owns.
+    fn ios_cancel_keypad_composer();
     /// Acquire an image natively. source: 0 = photo library, 1 = clipboard.
     /// Delivers exactly one of zedra_ios_image_acquire_{result,cancel,error}(callback_id, ..).
     fn ios_acquire_image(callback_id: u32, source: i32);
@@ -247,6 +258,14 @@ impl PlatformBridge for IosBridge {
 
     fn set_pinned_key_bar_visible(&self, visible: bool) {
         unsafe { ios_set_pinned_key_bar_visible(visible) };
+    }
+
+    fn cancel_keypad_composer(&self) {
+        unsafe { ios_cancel_keypad_composer() };
+    }
+
+    fn set_keypad_layout(&self, extended: bool, cmd_slot: bool) {
+        unsafe { ios_set_keypad_layout(extended, cmd_slot) };
     }
 
     fn pinned_key_bar_height(&self) -> u32 {

--- a/crates/zedra/src/ios_stub.c
+++ b/crates/zedra/src/ios_stub.c
@@ -99,6 +99,7 @@ __attribute__((weak)) void ios_present_text_input(
     const char *initial_value) {}
 __attribute__((weak)) int ios_system_prefers_dark_theme(void) { return -1; }
 __attribute__((weak)) void ios_set_keyboard_accessory_theme(_Bool is_dark) {}
+__attribute__((weak)) void ios_set_pinned_key_bar_visible(_Bool visible) {}
 __attribute__((weak)) void ios_acquire_image(unsigned int callback_id, int source) {}
 __attribute__((weak)) _Bool ios_clipboard_has_image(void) { return 0; }
 __attribute__((weak)) void ios_present_native_progress(unsigned int id, const char *message) {}

--- a/crates/zedra/src/ios_stub.c
+++ b/crates/zedra/src/ios_stub.c
@@ -100,6 +100,8 @@ __attribute__((weak)) void ios_present_text_input(
 __attribute__((weak)) int ios_system_prefers_dark_theme(void) { return -1; }
 __attribute__((weak)) void ios_set_keyboard_accessory_theme(_Bool is_dark) {}
 __attribute__((weak)) void ios_set_pinned_key_bar_visible(_Bool visible) {}
+__attribute__((weak)) void ios_set_keypad_layout(_Bool extended, _Bool cmd_slot) {}
+__attribute__((weak)) void ios_cancel_keypad_composer(void) {}
 __attribute__((weak)) void ios_acquire_image(unsigned int callback_id, int source) {}
 __attribute__((weak)) _Bool ios_clipboard_has_image(void) { return 0; }
 __attribute__((weak)) void ios_present_native_progress(unsigned int id, const char *message) {}

--- a/crates/zedra/src/key_bar.rs
+++ b/crates/zedra/src/key_bar.rs
@@ -1,0 +1,121 @@
+//! Zero-size element that owns the pinned key bar's native lifetime.
+//!
+//! The bar itself is the native keyboard accessory view, re-hosted above the
+//! safe area while the keyboard is collapsed. Tying it to element state means
+//! GPUI hides it as soon as the terminal stops being painted (navigation,
+//! terminal close), which no `WorkspaceTerminal` callback covers on its own.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use gpui::*;
+
+use crate::platform_bridge;
+
+pub fn pinned_key_bar(id: impl Into<ElementId>) -> PinnedKeyBar {
+    PinnedKeyBar { id: id.into() }
+}
+
+/// Last non-zero bar height in physical pixels, so the space stays reserved while
+/// the bar is temporarily hidden.
+static LAST_HEIGHT_PX: AtomicU32 = AtomicU32::new(0);
+
+/// Height the terminal reserves for the pinned key bar, in logical pixels.
+///
+/// Falls back to the last known height while the bar is hidden: with the setting
+/// on, the bar is coming straight back, and collapsing the inset in between makes
+/// terminal content jump on every drawer toggle.
+pub fn pinned_key_bar_inset() -> Pixels {
+    let bridge = platform_bridge::bridge();
+    let height = bridge.pinned_key_bar_height();
+    if height > 0 {
+        LAST_HEIGHT_PX.store(height, Ordering::Relaxed);
+    }
+    let height = if height > 0 {
+        height
+    } else {
+        LAST_HEIGHT_PX.load(Ordering::Relaxed)
+    };
+
+    let density = bridge.density();
+    if density > 0.0 {
+        px(height as f32 / density)
+    } else {
+        px(0.0)
+    }
+}
+
+pub struct PinnedKeyBar {
+    id: ElementId,
+}
+
+struct PinnedKeyBarState;
+
+impl Drop for PinnedKeyBarState {
+    fn drop(&mut self) {
+        platform_bridge::bridge().set_pinned_key_bar_visible(false);
+    }
+}
+
+impl Element for PinnedKeyBar {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.id.clone())
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        (window.request_layout(Style::default(), [], cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        _cx: &mut App,
+    ) -> Self::PrepaintState {
+        let Some(id) = id else {
+            return;
+        };
+        window.with_element_state(id, |state: Option<PinnedKeyBarState>, _window| {
+            let state = state.unwrap_or_else(|| {
+                platform_bridge::bridge().set_pinned_key_bar_visible(true);
+                PinnedKeyBarState
+            });
+            ((), state)
+        });
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) {
+    }
+}
+
+impl IntoElement for PinnedKeyBar {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}

--- a/crates/zedra/src/key_bar.rs
+++ b/crates/zedra/src/key_bar.rs
@@ -5,7 +5,7 @@
 //! GPUI hides it as soon as the terminal stops being painted (navigation,
 //! terminal close), which no `WorkspaceTerminal` callback covers on its own.
 
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI8, AtomicU32, Ordering};
 
 use gpui::*;
 
@@ -18,6 +18,52 @@ pub fn pinned_key_bar(id: impl Into<ElementId>) -> PinnedKeyBar {
 /// Last non-zero bar height in physical pixels, so the space stays reserved while
 /// the bar is temporarily hidden.
 static LAST_HEIGHT_PX: AtomicU32 = AtomicU32::new(0);
+
+/// Whether the keypad's platform slot shows Cmd instead of `|`. Cmd only means
+/// anything to a macOS host, so it follows the connected host's OS.
+static CMD_SLOT: AtomicBool = AtomicBool::new(false);
+/// Last layout pushed to the native bars, encoded as extended | cmd << 1.
+/// `-1` forces the first push.
+static PUSHED_LAYOUT: AtomicI8 = AtomicI8::new(-1);
+/// Last key-row visibility pushed to the native bars. `-1` forces the first push.
+static PUSHED_KEYS_VISIBLE: AtomicI8 = AtomicI8::new(-1);
+
+/// Show or hide the key rows. Separate from availability: the composer raises its
+/// own keyboard, which hides the rows without tearing the keypad down.
+pub fn sync_keys_visible(visible: bool) {
+    if PUSHED_KEYS_VISIBLE.swap(visible as i8, Ordering::Relaxed) != visible as i8 {
+        platform_bridge::bridge().set_pinned_key_bar_visible(visible);
+    }
+}
+
+pub fn host_uses_cmd_slot() -> bool {
+    CMD_SLOT.load(Ordering::Relaxed)
+}
+
+/// Armed/locked modifiers of the active terminal, mirrored for the native bars.
+/// The terminal entity owns the state; this is only the FFI-visible copy.
+static MODIFIER_MASK: AtomicU32 = AtomicU32::new(0);
+
+pub fn modifier_mask() -> u32 {
+    MODIFIER_MASK.load(Ordering::Relaxed)
+}
+
+pub fn set_modifier_mask(mask: u32) {
+    MODIFIER_MASK.store(mask, Ordering::Relaxed);
+}
+
+/// Reconcile the native keypad layout with the current setting and host OS.
+/// Cheap enough to call every render; only a change reaches the platform.
+pub fn sync_keypad_layout(host_os: Option<&str>) {
+    let cmd_slot = host_os.is_some_and(|os| os.eq_ignore_ascii_case("macos"));
+    CMD_SLOT.store(cmd_slot, Ordering::Relaxed);
+
+    let extended = crate::settings::extended_keypad();
+    let encoded = extended as i8 | ((cmd_slot as i8) << 1);
+    if PUSHED_LAYOUT.swap(encoded, Ordering::Relaxed) != encoded {
+        platform_bridge::bridge().set_keypad_layout(extended, cmd_slot);
+    }
+}
 
 /// Height the terminal reserves for the pinned key bar, in logical pixels.
 ///
@@ -52,7 +98,15 @@ struct PinnedKeyBarState;
 
 impl Drop for PinnedKeyBarState {
     fn drop(&mut self) {
-        platform_bridge::bridge().set_pinned_key_bar_visible(false);
+        // Leaving the terminal takes the composer's keyboard with it; merely hiding
+        // the rows for a keyboard must not, which is why this lives on unmount.
+        let bridge = platform_bridge::bridge();
+        bridge.set_pinned_key_bar_visible(false);
+        bridge.cancel_keypad_composer();
+        PUSHED_KEYS_VISIBLE.store(-1, Ordering::Relaxed);
+        PUSHED_LAYOUT.store(-1, Ordering::Relaxed);
+        CMD_SLOT.store(false, Ordering::Relaxed);
+        MODIFIER_MASK.store(0, Ordering::Relaxed);
     }
 }
 
@@ -91,10 +145,7 @@ impl Element for PinnedKeyBar {
             return;
         };
         window.with_element_state(id, |state: Option<PinnedKeyBarState>, _window| {
-            let state = state.unwrap_or_else(|| {
-                platform_bridge::bridge().set_pinned_key_bar_visible(true);
-                PinnedKeyBarState
-            });
+            let state = state.unwrap_or_else(|| PinnedKeyBarState);
             ((), state)
         });
     }

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -19,6 +19,7 @@ pub mod button;
 pub mod docs_tree;
 pub mod editor;
 pub mod fonts;
+pub mod key_bar;
 pub mod placeholder;
 pub mod settings;
 pub mod theme;

--- a/crates/zedra/src/platform_bridge.rs
+++ b/crates/zedra/src/platform_bridge.rs
@@ -1026,6 +1026,14 @@ pub trait PlatformBridge: Send + Sync + 'static {
     fn system_inset_bottom(&self) -> u32;
     fn keyboard_height(&self) -> u32;
     fn is_keyboard_visible(&self) -> bool;
+    /// Show or hide the key bar pinned above the safe area while the keyboard is
+    /// collapsed. The native side reuses the keyboard accessory bar's own view.
+    fn set_pinned_key_bar_visible(&self, _visible: bool) {}
+    /// Height in physical pixels of the pinned key bar, including safe-area
+    /// padding. 0 when hidden.
+    fn pinned_key_bar_height(&self) -> u32 {
+        0
+    }
     fn launch_qr_scanner(&self);
     /// Returns the native user-facing app version (e.g. Android versionName / iOS CFBundleShortVersionString).
     fn app_version(&self) -> Option<String> {

--- a/crates/zedra/src/platform_bridge.rs
+++ b/crates/zedra/src/platform_bridge.rs
@@ -1029,6 +1029,12 @@ pub trait PlatformBridge: Send + Sync + 'static {
     /// Show or hide the key bar pinned above the safe area while the keyboard is
     /// collapsed. The native side reuses the keyboard accessory bar's own view.
     fn set_pinned_key_bar_visible(&self, _visible: bool) {}
+    /// Drop the keypad composer and the keyboard it owns. Raised when the terminal
+    /// stops owning the screen, and when the terminal surface is tapped.
+    fn cancel_keypad_composer(&self) {}
+    /// Switch the keypad between the single-row and extended two-row layouts, and
+    /// choose whether its platform slot is Cmd (macOS host) or `|`.
+    fn set_keypad_layout(&self, _extended: bool, _cmd_slot: bool) {}
     /// Height in physical pixels of the pinned key bar, including safe-area
     /// padding. 0 when hidden.
     fn pinned_key_bar_height(&self) -> u32 {

--- a/crates/zedra/src/session_panel.rs
+++ b/crates/zedra/src/session_panel.rs
@@ -243,17 +243,19 @@ fn disconnect_button(cx: &mut Context<SessionPanel>) -> impl IntoElement {
     div()
         .id("session-disconnect-btn")
         .flex_shrink_0()
-        .p(px(6.0))
+        .py(px(6.0))
+        .pl(px(6.0))
+        // No right padding: keeps the icon flush with the chevron below it.
         .rounded(px(6.0))
         .cursor_pointer()
-        .hit_slop(px(8.0))
+        .hit_slop(px(12.0))
         .on_press(cx.listener(|_this, _event, window, cx| {
             window.dispatch_action(workspace_action::RequestDisconnect.boxed_clone(), cx);
         }))
         .child(
             svg()
                 .path("icons/log-out.svg")
-                .size(px(theme::ICON_SM))
+                .size(px(theme::ICON_XS))
                 .text_color(rgb(theme::accent_red(cx))),
         )
 }

--- a/crates/zedra/src/settings.rs
+++ b/crates/zedra/src/settings.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicI8, Ordering};
 
 use gpui::{App, Context, Entity, EventEmitter, Global, WeakEntity};
 use serde::{Deserialize, Serialize};
@@ -20,6 +21,10 @@ struct AppSettings {
     /// Water droplet effect. `None`/absent = disabled (default-off).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     droplet_enabled: Option<bool>,
+    /// Keep the terminal key bar on screen while the keyboard is collapsed.
+    /// `None`/absent = enabled (default-on).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    key_bar_always_visible: Option<bool>,
 }
 
 pub enum ThemeStateEvent {
@@ -192,6 +197,42 @@ pub fn set_droplet_enabled(enabled: bool) {
     settings.droplet_enabled = Some(enabled);
     if let Err(err) = write_settings(&settings) {
         warn!(err = %err, "settings: failed to save droplet preference");
+    }
+}
+
+/// Runtime gate for the pinned key bar. `-1` = not loaded from disk yet.
+static KEY_BAR_ALWAYS_VISIBLE: AtomicI8 = AtomicI8::new(-1);
+
+/// Whether the terminal key bar stays on screen once the keyboard collapses.
+/// Default on. Cached in an atomic because the terminal reads it every render.
+pub fn key_bar_always_visible() -> bool {
+    match KEY_BAR_ALWAYS_VISIBLE.load(Ordering::Relaxed) {
+        0 => false,
+        1 => true,
+        _ => {
+            let enabled = read_key_bar_always_visible();
+            KEY_BAR_ALWAYS_VISIBLE.store(enabled as i8, Ordering::Relaxed);
+            enabled
+        }
+    }
+}
+
+fn read_key_bar_always_visible() -> bool {
+    match read_settings() {
+        Ok(settings) => settings.key_bar_always_visible.unwrap_or(true),
+        Err(err) => {
+            info!(err = %err, "settings: using default key bar preference");
+            true
+        }
+    }
+}
+
+pub fn set_key_bar_always_visible(enabled: bool) {
+    KEY_BAR_ALWAYS_VISIBLE.store(enabled as i8, Ordering::Relaxed);
+    let mut settings = read_settings().unwrap_or_default();
+    settings.key_bar_always_visible = Some(enabled);
+    if let Err(err) = write_settings(&settings) {
+        warn!(err = %err, "settings: failed to save key bar preference");
     }
 }
 

--- a/crates/zedra/src/settings.rs
+++ b/crates/zedra/src/settings.rs
@@ -25,6 +25,10 @@ struct AppSettings {
     /// `None`/absent = enabled (default-on).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     key_bar_always_visible: Option<bool>,
+    /// Two-row keypad with modifiers and a composing field.
+    /// `None`/absent = disabled (default-off).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    extended_keypad: Option<bool>,
 }
 
 pub enum ThemeStateEvent {
@@ -200,30 +204,57 @@ pub fn set_droplet_enabled(enabled: bool) {
     }
 }
 
-/// Runtime gate for the pinned key bar. `-1` = not loaded from disk yet.
-static KEY_BAR_ALWAYS_VISIBLE: AtomicI8 = AtomicI8::new(-1);
-
-/// Whether the terminal key bar stays on screen once the keyboard collapses.
-/// Default on. Cached in an atomic because the terminal reads it every render.
-pub fn key_bar_always_visible() -> bool {
-    match KEY_BAR_ALWAYS_VISIBLE.load(Ordering::Relaxed) {
+/// Reads a boolean setting once and caches it. `-1` means "not loaded yet"; the
+/// keypad and terminal read these on paths that run every frame, so the disk read
+/// must not repeat.
+fn cached_flag(cache: &AtomicI8, read: impl FnOnce() -> bool) -> bool {
+    match cache.load(Ordering::Relaxed) {
         0 => false,
         1 => true,
         _ => {
-            let enabled = read_key_bar_always_visible();
-            KEY_BAR_ALWAYS_VISIBLE.store(enabled as i8, Ordering::Relaxed);
+            let enabled = read();
+            cache.store(enabled as i8, Ordering::Relaxed);
             enabled
         }
     }
 }
 
-fn read_key_bar_always_visible() -> bool {
+fn read_flag(name: &str, default: bool, field: impl FnOnce(&AppSettings) -> Option<bool>) -> bool {
     match read_settings() {
-        Ok(settings) => settings.key_bar_always_visible.unwrap_or(true),
+        Ok(settings) => field(&settings).unwrap_or(default),
         Err(err) => {
-            info!(err = %err, "settings: using default key bar preference");
-            true
+            info!(err = %err, setting = name, "settings: using default preference");
+            default
         }
+    }
+}
+
+static KEY_BAR_ALWAYS_VISIBLE: AtomicI8 = AtomicI8::new(-1);
+
+/// Whether the terminal key bar stays on screen once the keyboard collapses.
+/// Default on.
+pub fn key_bar_always_visible() -> bool {
+    cached_flag(&KEY_BAR_ALWAYS_VISIBLE, || {
+        read_flag("key_bar_always_visible", true, |s| s.key_bar_always_visible)
+    })
+}
+
+static EXTENDED_KEYPAD: AtomicI8 = AtomicI8::new(-1);
+
+/// Whether the terminal keypad shows the two-row layout with modifier keys and
+/// the composing field. Default off.
+pub fn extended_keypad() -> bool {
+    cached_flag(&EXTENDED_KEYPAD, || {
+        read_flag("extended_keypad", false, |s| s.extended_keypad)
+    })
+}
+
+pub fn set_extended_keypad(enabled: bool) {
+    EXTENDED_KEYPAD.store(enabled as i8, Ordering::Relaxed);
+    let mut settings = read_settings().unwrap_or_default();
+    settings.extended_keypad = Some(enabled);
+    if let Err(err) = write_settings(&settings) {
+        warn!(err = %err, "settings: failed to save extended keypad preference");
     }
 }
 

--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -78,6 +78,7 @@ pub struct SettingsView {
     delta_busy: bool,
     telemetry_enabled: bool,
     droplet_enabled: bool,
+    key_bar_always_visible: bool,
     _delta_observe: Subscription,
 }
 
@@ -103,6 +104,7 @@ impl SettingsView {
             delta_busy: false,
             telemetry_enabled: settings::read_telemetry_enabled(),
             droplet_enabled: settings::read_droplet_enabled(),
+            key_bar_always_visible: settings::key_bar_always_visible(),
             _delta_observe: observe,
         }
     }
@@ -431,6 +433,16 @@ impl SettingsView {
         cx.notify();
     }
 
+    fn set_key_bar_always_visible(&mut self, enabled: bool, cx: &mut Context<Self>) {
+        if self.key_bar_always_visible == enabled {
+            return;
+        }
+        platform_bridge::trigger_haptic(HapticFeedback::SelectionChanged);
+        self.key_bar_always_visible = enabled;
+        settings::set_key_bar_always_visible(enabled);
+        cx.notify();
+    }
+
     fn open_telemetry_docs(&self) {
         platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
         platform_bridge::bridge().open_url(TELEMETRY_DOCS_URL);
@@ -592,6 +604,7 @@ impl Render for SettingsView {
         let preference = self.theme_state.read(cx).preference();
         let telemetry_enabled = self.telemetry_enabled;
         let droplet_enabled = self.droplet_enabled;
+        let key_bar_always_visible = self.key_bar_always_visible;
 
         div()
             .id("settings-view")
@@ -719,6 +732,17 @@ impl Render for SettingsView {
                                     }),
                                 ))
                             })
+                            .child(section_header(cx, "Terminal"))
+                            .child(key_bar_toggle(
+                                cx,
+                                key_bar_always_visible,
+                                cx.listener(|this, _event, _window, cx| {
+                                    this.set_key_bar_always_visible(true, cx);
+                                }),
+                                cx.listener(|this, _event, _window, cx| {
+                                    this.set_key_bar_always_visible(false, cx);
+                                }),
+                            ))
                             .child(section_header(cx, "Privacy"))
                             .child(telemetry_toggle(
                                 cx,
@@ -1017,6 +1041,30 @@ fn droplet_toggle(
         "settings-droplet-toggle",
         "Water droplet",
         "A playful droplet to flick around",
+        theme::text_secondary(cx),
+        control,
+    )
+}
+
+fn key_bar_toggle(
+    cx: &App,
+    enabled: bool,
+    on_enable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+    on_disable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    let control = segmented_toggle(
+        cx,
+        "settings-key-bar-on",
+        "settings-key-bar-off",
+        enabled,
+        on_enable,
+        on_disable,
+    );
+    toggle_row(
+        cx,
+        "settings-key-bar-toggle",
+        "Always show keypad",
+        "Esc, Tab, and arrows stay up when the keyboard is down",
         theme::text_secondary(cx),
         control,
     )

--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -79,6 +79,7 @@ pub struct SettingsView {
     telemetry_enabled: bool,
     droplet_enabled: bool,
     key_bar_always_visible: bool,
+    extended_keypad: bool,
     _delta_observe: Subscription,
 }
 
@@ -105,6 +106,7 @@ impl SettingsView {
             telemetry_enabled: settings::read_telemetry_enabled(),
             droplet_enabled: settings::read_droplet_enabled(),
             key_bar_always_visible: settings::key_bar_always_visible(),
+            extended_keypad: settings::extended_keypad(),
             _delta_observe: observe,
         }
     }
@@ -433,6 +435,17 @@ impl SettingsView {
         cx.notify();
     }
 
+    fn set_extended_keypad(&mut self, enabled: bool, cx: &mut Context<Self>) {
+        if self.extended_keypad == enabled {
+            return;
+        }
+        platform_bridge::trigger_haptic(HapticFeedback::SelectionChanged);
+        self.extended_keypad = enabled;
+        settings::set_extended_keypad(enabled);
+        platform_bridge::bridge().set_keypad_layout(enabled, crate::key_bar::host_uses_cmd_slot());
+        cx.notify();
+    }
+
     fn set_key_bar_always_visible(&mut self, enabled: bool, cx: &mut Context<Self>) {
         if self.key_bar_always_visible == enabled {
             return;
@@ -605,6 +618,7 @@ impl Render for SettingsView {
         let telemetry_enabled = self.telemetry_enabled;
         let droplet_enabled = self.droplet_enabled;
         let key_bar_always_visible = self.key_bar_always_visible;
+        let extended_keypad = self.extended_keypad;
 
         div()
             .id("settings-view")
@@ -721,8 +735,13 @@ impl Render for SettingsView {
                                 }),
                             ))
                             .when(cfg!(target_os = "ios"), |this| {
-                                this.child(droplet_toggle(
+                                this.child(bool_setting_toggle(
                                     cx,
+                                    "settings-droplet-on",
+                                    "settings-droplet-off",
+                                    "settings-droplet-toggle",
+                                    "Water droplet",
+                                    "A playful droplet to flick around",
                                     droplet_enabled,
                                     cx.listener(|this, _event, _window, cx| {
                                         this.set_droplet_enabled(true, cx);
@@ -733,14 +752,34 @@ impl Render for SettingsView {
                                 ))
                             })
                             .child(section_header(cx, "Terminal"))
-                            .child(key_bar_toggle(
+                            .child(bool_setting_toggle(
                                 cx,
+                                "settings-key-bar-on",
+                                "settings-key-bar-off",
+                                "settings-key-bar-toggle",
+                                "Always show keypad",
+                                "Esc, Tab, and arrows stay up when the keyboard is down",
                                 key_bar_always_visible,
                                 cx.listener(|this, _event, _window, cx| {
                                     this.set_key_bar_always_visible(true, cx);
                                 }),
                                 cx.listener(|this, _event, _window, cx| {
                                     this.set_key_bar_always_visible(false, cx);
+                                }),
+                            ))
+                            .child(bool_setting_toggle(
+                                cx,
+                                "settings-extended-keypad-on",
+                                "settings-extended-keypad-off",
+                                "settings-extended-keypad-toggle",
+                                "Extended keypad",
+                                "Adds modifiers, symbols, and a swipe-left composer",
+                                extended_keypad,
+                                cx.listener(|this, _event, _window, cx| {
+                                    this.set_extended_keypad(true, cx);
+                                }),
+                                cx.listener(|this, _event, _window, cx| {
+                                    this.set_extended_keypad(false, cx);
                                 }),
                             ))
                             .child(section_header(cx, "Privacy"))
@@ -915,12 +954,7 @@ fn appearance_theme_toggle(
                     is_dark,
                     on_dark,
                 ))
-                .child(
-                    div()
-                        .w(px(1.0))
-                        .h(px(22.0))
-                        .bg(rgb(theme::border_subtle(cx))),
-                )
+                .child(div().w(px(1.0)).h_full().bg(rgb(theme::border_subtle(cx))))
                 .child(theme_toggle_segment(
                     cx,
                     "settings-theme-light",
@@ -971,7 +1005,7 @@ fn telemetry_toggle(
     enabled: bool,
     on_enable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
     on_disable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
-) -> impl IntoElement {
+) -> AnyElement {
     if cfg!(feature = "no-telemetry") {
         let control = div()
             .flex_none()
@@ -1001,70 +1035,42 @@ fn telemetry_toggle(
             "Disabled by build flag",
             theme::text_muted(cx),
             control,
-        );
+        )
+        .into_any_element();
     }
 
-    let control = segmented_toggle(
+    bool_setting_toggle(
         cx,
         "settings-telemetry-on",
         "settings-telemetry-off",
-        enabled,
-        on_enable,
-        on_disable,
-    );
-    toggle_row(
-        cx,
         "settings-telemetry-toggle",
         "Telemetry metrics",
         "Send anonymous usage data",
-        theme::text_secondary(cx),
-        control,
+        enabled,
+        on_enable,
+        on_disable,
     )
+    .into_any_element()
 }
 
-fn droplet_toggle(
+/// A settings row whose control is an On/Off segmented toggle.
+fn bool_setting_toggle(
     cx: &App,
+    on_id: &'static str,
+    off_id: &'static str,
+    row_id: &'static str,
+    title: &'static str,
+    description: &'static str,
     enabled: bool,
     on_enable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
     on_disable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
 ) -> impl IntoElement {
-    let control = segmented_toggle(
-        cx,
-        "settings-droplet-on",
-        "settings-droplet-off",
-        enabled,
-        on_enable,
-        on_disable,
-    );
+    let control = segmented_toggle(cx, on_id, off_id, enabled, on_enable, on_disable);
     toggle_row(
         cx,
-        "settings-droplet-toggle",
-        "Water droplet",
-        "A playful droplet to flick around",
-        theme::text_secondary(cx),
-        control,
-    )
-}
-
-fn key_bar_toggle(
-    cx: &App,
-    enabled: bool,
-    on_enable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
-    on_disable: impl Fn(&PressEvent, &mut Window, &mut App) + 'static,
-) -> impl IntoElement {
-    let control = segmented_toggle(
-        cx,
-        "settings-key-bar-on",
-        "settings-key-bar-off",
-        enabled,
-        on_enable,
-        on_disable,
-    );
-    toggle_row(
-        cx,
-        "settings-key-bar-toggle",
-        "Always show keypad",
-        "Esc, Tab, and arrows stay up when the keyboard is down",
+        row_id,
+        title,
+        description,
         theme::text_secondary(cx),
         control,
     )
@@ -1087,12 +1093,7 @@ fn segmented_toggle(
         .flex()
         .flex_row()
         .child(toggle_segment(cx, on_id, "On", enabled, on_enable))
-        .child(
-            div()
-                .w(px(1.0))
-                .h(px(22.0))
-                .bg(rgb(theme::border_subtle(cx))),
-        )
+        .child(div().w(px(1.0)).h_full().bg(rgb(theme::border_subtle(cx))))
         .child(toggle_segment(cx, off_id, "Off", !enabled, on_disable))
         .into_any_element()
 }

--- a/crates/zedra/src/ui/drawer_host.rs
+++ b/crates/zedra/src/ui/drawer_host.rs
@@ -69,6 +69,8 @@ pub struct DrawerHost {
     drawer: AnyView,
     drawer_side: DrawerSide,
     drawer_state: DrawerState,
+    /// Mirrors this host's contribution to `OPEN_DRAWERS`.
+    counted_open: bool,
     drawer_width: Pixels,
     /// Current visual offset: 0.0 = fully closed, drawer_width px = fully open.
     drawer_offset: f32,
@@ -108,6 +110,7 @@ impl DrawerHost {
             backdrop_opacity: 0.4,
             focus_handle: cx.focus_handle(),
             drawer_state: DrawerState::Closed,
+            counted_open: false,
             drawer_offset: 0.0,
             edge_inset: theme::DRAWER_EDGE_ZONE,
             snap_from: 0.0,
@@ -170,24 +173,30 @@ impl DrawerHost {
         cx.emit(DrawerEvent::Closed);
     }
 
-    fn state_is_open(state: DrawerState) -> bool {
-        matches!(state, DrawerState::Opened | DrawerState::Snapping)
+    /// Anything the user can see counts as open, including a drawer being dragged
+    /// out of `Closed` and one still animating shut. `any_drawer_open` drives
+    /// terminal focus and the native keypad, which must not reappear over a
+    /// visible drawer.
+    fn is_visually_open(&self) -> bool {
+        self.drawer_offset > 0.0 || matches!(self.drawer_state, DrawerState::Opened)
     }
 
     /// Single writer for `drawer_state` so the global open count stays accurate.
-    /// A flip refreshes every window: views that gate on `any_drawer_open` observe
-    /// no entity of ours.
     fn set_drawer_state(&mut self, state: DrawerState, cx: &mut App) {
-        if self.drawer_state == state {
-            return;
-        }
-        let was_open = Self::state_is_open(self.drawer_state);
         self.drawer_state = state;
-        let is_open = Self::state_is_open(state);
-        if was_open == is_open {
+        self.sync_open_count(cx);
+    }
+
+    /// Reconcile the global count after any change to state or offset. A flip
+    /// refreshes every window: views that gate on `any_drawer_open` observe no
+    /// entity of ours.
+    fn sync_open_count(&mut self, cx: &mut App) {
+        let open = self.is_visually_open();
+        if open == self.counted_open {
             return;
         }
-        if is_open {
+        self.counted_open = open;
+        if open {
             OPEN_DRAWERS.fetch_add(1, Ordering::Relaxed);
         } else {
             OPEN_DRAWERS.fetch_sub(1, Ordering::Relaxed);
@@ -373,6 +382,7 @@ impl DrawerHost {
         };
         let width = f32::from(self.drawer_width);
         self.drawer_offset = (self.drawer_offset + eff_dx).clamp(0.0, width);
+        self.sync_open_count(cx);
         self.last_drag_dx = eff_dx;
         self.last_drag_x = position_x;
         cx.notify();
@@ -463,7 +473,7 @@ impl DrawerHost {
 
 impl Drop for DrawerHost {
     fn drop(&mut self) {
-        if Self::state_is_open(self.drawer_state) {
+        if self.counted_open {
             OPEN_DRAWERS.fetch_sub(1, Ordering::Relaxed);
         }
     }

--- a/crates/zedra/src/ui/drawer_host.rs
+++ b/crates/zedra/src/ui/drawer_host.rs
@@ -1,9 +1,19 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use gpui::prelude::FluentBuilder;
 use gpui::*;
 
 use crate::theme;
+
+/// Drawer hosts currently open, across every host in the app. Views that must
+/// yield to a drawer (the pinned terminal key bar) hold no handle to each host,
+/// so open-ness is tracked globally.
+static OPEN_DRAWERS: AtomicUsize = AtomicUsize::new(0);
+
+pub fn any_drawer_open() -> bool {
+    OPEN_DRAWERS.load(Ordering::Relaxed) > 0
+}
 
 const DRAWER_DRAG_START_THRESHOLD: f32 = 10.0;
 const DRAWER_VERTICAL_CANCEL_RATIO: f32 = 1.25;
@@ -158,6 +168,31 @@ impl DrawerHost {
         }
         self.start_snap(0.0, window, cx);
         cx.emit(DrawerEvent::Closed);
+    }
+
+    fn state_is_open(state: DrawerState) -> bool {
+        matches!(state, DrawerState::Opened | DrawerState::Snapping)
+    }
+
+    /// Single writer for `drawer_state` so the global open count stays accurate.
+    /// A flip refreshes every window: views that gate on `any_drawer_open` observe
+    /// no entity of ours.
+    fn set_drawer_state(&mut self, state: DrawerState, cx: &mut App) {
+        if self.drawer_state == state {
+            return;
+        }
+        let was_open = Self::state_is_open(self.drawer_state);
+        self.drawer_state = state;
+        let is_open = Self::state_is_open(state);
+        if was_open == is_open {
+            return;
+        }
+        if is_open {
+            OPEN_DRAWERS.fetch_add(1, Ordering::Relaxed);
+        } else {
+            OPEN_DRAWERS.fetch_sub(1, Ordering::Relaxed);
+        }
+        cx.refresh_windows();
     }
 
     pub fn is_open(&self) -> bool {
@@ -378,11 +413,12 @@ impl DrawerHost {
 
         if (current_offset - target).abs() < 1.0 {
             self.drawer_offset = target;
-            self.drawer_state = if target > 0.0 {
+            let state = if target > 0.0 {
                 DrawerState::Opened
             } else {
                 DrawerState::Closed
             };
+            self.set_drawer_state(state, cx);
             self.snap_target = None;
             self.snap_started_at = None;
             self._snap_task = None;
@@ -395,11 +431,12 @@ impl DrawerHost {
         self.snap_target = Some(target);
         self.snap_started_at = Some(std::time::Instant::now());
         self.animation_id += 1;
-        self.drawer_state = if target > 0.0 {
+        let state = if target > 0.0 {
             DrawerState::Snapping
         } else {
             DrawerState::Closing
         };
+        self.set_drawer_state(state, cx);
 
         self._snap_task = Some(cx.spawn(async move |this, cx| {
             cx.background_executor()
@@ -407,11 +444,12 @@ impl DrawerHost {
                 .await;
             this.update(cx, |this, cx| {
                 this.drawer_offset = target;
-                this.drawer_state = if target > 0.0 {
+                let state = if target > 0.0 {
                     DrawerState::Opened
                 } else {
                     DrawerState::Closed
                 };
+                this.set_drawer_state(state, cx);
                 this.snap_target = None;
                 this.snap_started_at = None;
                 cx.notify();
@@ -420,6 +458,14 @@ impl DrawerHost {
         }));
 
         cx.notify();
+    }
+}
+
+impl Drop for DrawerHost {
+    fn drop(&mut self) {
+        if Self::state_is_open(self.drawer_state) {
+            OPEN_DRAWERS.fetch_sub(1, Ordering::Relaxed);
+        }
     }
 }
 
@@ -754,7 +800,7 @@ mod tests {
             .update(&mut cx, |drawer_host, window, cx| {
                 let width = f32::from(drawer_host.drawer_width);
                 drawer_host.drawer_offset = width;
-                drawer_host.drawer_state = DrawerState::Opened;
+                drawer_host.set_drawer_state(DrawerState::Opened, cx);
                 drawer_host.set_pending_gesture(1, point(px(255.0), px(212.0)), DragOrigin::Panel);
 
                 assert!(matches!(

--- a/crates/zedra/src/ui/mod.rs
+++ b/crates/zedra/src/ui/mod.rs
@@ -5,7 +5,7 @@ pub mod input;
 pub mod subscreen_header;
 pub mod subscreen_layout;
 
-pub use drawer_host::{DrawerEvent, DrawerHost, DrawerSide};
+pub use drawer_host::{DrawerEvent, DrawerHost, DrawerSide, any_drawer_open};
 pub use input::{InputChanged, InputSubmit};
 pub use subscreen_header::{chevron_back_button, subscreen_refresh_button};
 pub use subscreen_layout::{

--- a/crates/zedra/src/workspace_state.rs
+++ b/crates/zedra/src/workspace_state.rs
@@ -205,6 +205,9 @@ pub struct WorkspaceState {
     pub workdir: String,
     pub homedir: String,
     pub hostname: String,
+    /// Host operating system as reported by sync, e.g. `macos`. Drives the
+    /// platform-specific keypad slot.
+    pub host_os: Option<String>,
     #[serde(default)]
     pub username: String,
     // Workspace-relative docs tree directories hidden by the user.
@@ -246,6 +249,7 @@ struct WorkspaceStateSyncSnapshot {
     workdir: String,
     homedir: String,
     hostname: String,
+    host_os: Option<String>,
     username: String,
     connect_phase: Option<ConnectPhase>,
     active_terminal_id: Option<String>,
@@ -323,6 +327,7 @@ impl WorkspaceState {
             workdir: self.workdir.clone(),
             homedir: self.homedir.clone(),
             hostname: self.hostname.clone(),
+            host_os: self.host_os.clone(),
             username: self.username.clone(),
             connect_phase: self.connect_phase.clone(),
             active_terminal_id: self.active_terminal_id.clone(),
@@ -408,6 +413,9 @@ impl WorkspaceState {
         let snap = &session_state.snapshot;
         if !snap.hostname.is_empty() {
             self.hostname = snap.hostname.clone();
+        }
+        if snap.os.is_some() {
+            self.host_os = snap.os.clone();
         }
         if !snap.username.is_empty() {
             self.username = snap.username.clone();

--- a/crates/zedra/src/workspace_terminal.rs
+++ b/crates/zedra/src/workspace_terminal.rs
@@ -20,6 +20,7 @@ use crate::platform_bridge::{
 use crate::settings::{ThemeStateEvent, theme_state as theme_entity};
 use crate::telemetry::view_telemetry;
 use crate::terminal_state::TerminalState;
+use crate::ui::any_drawer_open;
 use crate::workspace_state::{WorkspaceState, WorkspaceStateEvent};
 
 pub const TERMINAL_PENDING_ID: &str = "___PENDING___";
@@ -126,6 +127,33 @@ impl WorkspaceTerminal {
             force,
             cx,
         );
+    }
+
+    /// Keeps terminal focus in step with the pinned key bar: the bar sends keystrokes
+    /// to whatever the terminal input handler is attached to, so the terminal holds
+    /// focus for as long as the bar is on screen for it, and gives it up otherwise.
+    fn sync_key_bar_focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let enabled = crate::settings::key_bar_always_visible();
+        self.terminal_view.update(cx, |terminal_view, _cx| {
+            terminal_view.retains_focus_without_keyboard = enabled;
+        });
+        if !enabled {
+            return;
+        }
+
+        let is_active = self.workspace_state.read(cx).active_main_view_terminal_id()
+            == Some(self.terminal_id.as_str());
+        let should_hold_focus = is_active && !any_drawer_open();
+        let is_focused = self.terminal_view.read(cx).is_focused(window);
+
+        if should_hold_focus && !is_focused {
+            self.terminal_view.update(cx, |terminal_view, cx| {
+                terminal_view.focus_without_keyboard(window, cx);
+            });
+        } else if !should_hold_focus && is_focused {
+            window.hide_soft_keyboard();
+            window.focus(&self.container_focus, cx);
+        }
     }
 
     pub fn deactivate(&mut self, cx: &mut Context<Self>) {
@@ -428,7 +456,17 @@ impl WorkspaceTerminal {
             },
         );
 
-        let mut subscriptions = vec![attach_sub, terminal_events_sub, keyboard_offset_hook];
+        // Which main view is active decides whether this terminal holds focus, and
+        // that change does not re-render this view on its own.
+        let main_view_sub = cx.observe_in(&workspace_state, window, |this, _, window, cx| {
+            this.sync_key_bar_focus(window, cx);
+        });
+        let mut subscriptions = vec![
+            attach_sub,
+            terminal_events_sub,
+            keyboard_offset_hook,
+            main_view_sub,
+        ];
         if let Some(theme_state) = theme_entity(cx) {
             subscriptions.push(
                 cx.subscribe(&theme_state, |this, _, _: &ThemeStateEvent, cx| {
@@ -605,8 +643,30 @@ impl Render for WorkspaceTerminal {
         let terminal_owns_keyboard = self.terminal_view.read(cx).is_focused(window)
             && window.is_soft_keyboard_visible()
             && window.has_active_keyboard_accessory();
+        // Drawer state and the settings toggle both reach this view only as a redraw,
+        // so reconcile focus here rather than from a subscription.
+        let key_bar_enabled = crate::settings::key_bar_always_visible();
+        let holds_focus = self.terminal_view.read(cx).is_focused(window);
+        let should_hold_focus = key_bar_enabled && !any_drawer_open();
+        if self.terminal_view.read(cx).retains_focus_without_keyboard != key_bar_enabled
+            || (key_bar_enabled && should_hold_focus != holds_focus)
+        {
+            let this = cx.entity();
+            window.defer(cx, move |window, cx| {
+                this.update(cx, |this, cx| this.sync_key_bar_focus(window, cx));
+            });
+        }
+
+        // The pinned bar replaces the keyboard accessory once the keyboard is
+        // down, so exactly one of the two ever reserves space.
+        let pinned_key_bar_visible =
+            !window.is_soft_keyboard_visible() && !any_drawer_open() && key_bar_enabled;
+        // Reserve the bar's space whenever the setting is on, even while the bar is
+        // hidden behind a drawer — otherwise terminal content jumps on every toggle.
         let keyboard_inset = if terminal_owns_keyboard {
             Self::keyboard_inset()
+        } else if key_bar_enabled && !window.is_soft_keyboard_visible() {
+            crate::key_bar::pinned_key_bar_inset()
         } else {
             px(0.0)
         };
@@ -655,6 +715,12 @@ impl Render for WorkspaceTerminal {
                 div.pb(keyboard_inset)
             })
             .child(self.terminal_view.clone())
+            .when(pinned_key_bar_visible, |container| {
+                container.child(crate::key_bar::pinned_key_bar((
+                    "terminal-pinned-key-bar",
+                    cx.entity_id(),
+                )))
+            })
             .when(self.scroll_to_bottom_button_visible, move |container| {
                 container.child(
                     native_floating_button(

--- a/crates/zedra/src/workspace_terminal.rs
+++ b/crates/zedra/src/workspace_terminal.rs
@@ -43,7 +43,6 @@ enum PasteMenuAction {
 
 pub struct WorkspaceTerminal {
     terminal_id: String,
-    #[allow(dead_code)]
     workspace_state: Entity<WorkspaceState>,
     terminal_state: Entity<TerminalState>,
     session_handle: SessionHandle,
@@ -367,6 +366,12 @@ impl WorkspaceTerminal {
                         },
                     );
                 }
+                TerminalEvent::StickyModifiersChanged(mask) => {
+                    crate::key_bar::set_modifier_mask(*mask);
+                }
+                TerminalEvent::SurfaceTapped => {
+                    platform_bridge::bridge().cancel_keypad_composer();
+                }
                 TerminalEvent::AltScreenChanged(is_alt) => {
                     this.is_alt_screen = *is_alt;
                     cx.notify();
@@ -657,10 +662,18 @@ impl Render for WorkspaceTerminal {
             });
         }
 
-        // The pinned bar replaces the keyboard accessory once the keyboard is
-        // down, so exactly one of the two ever reserves space.
-        let pinned_key_bar_visible =
-            !window.is_soft_keyboard_visible() && !any_drawer_open() && key_bar_enabled;
+        // The keypad is available whenever the terminal owns the screen; the key rows
+        // themselves hide while any keyboard is up, including the composer's own.
+        let keypad_available = key_bar_enabled && !any_drawer_open();
+        let pinned_key_bar_visible = keypad_available && !window.is_soft_keyboard_visible();
+
+        // Deferred so render itself stays free of native side effects; both calls
+        // are change-gated, so the deferred closure is a no-op on most frames.
+        let host_os = self.workspace_state.read(cx).host_os.clone();
+        window.defer(cx, move |_, _| {
+            crate::key_bar::sync_keypad_layout(host_os.as_deref());
+            crate::key_bar::sync_keys_visible(pinned_key_bar_visible);
+        });
         // Reserve the bar's space whenever the setting is on, even while the bar is
         // hidden behind a drawer — otherwise terminal content jumps on every toggle.
         let keyboard_inset = if terminal_owns_keyboard {
@@ -715,7 +728,7 @@ impl Render for WorkspaceTerminal {
                 div.pb(keyboard_inset)
             })
             .child(self.terminal_view.clone())
-            .when(pinned_key_bar_visible, |container| {
+            .when(keypad_available, |container| {
                 container.child(crate::key_bar::pinned_key_bar((
                     "terminal-pinned-key-bar",
                     cx.entity_id(),

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1128,6 +1128,31 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:41:1\033\\/tmp/zedra-long-code.rs
 6. Keep the same terminal active, show the software keyboard again, then press `Tab`, `Enter`, and an arrow key in the accessory bar
 7. Expected: each key still reaches the PTY after reconnect; the accessory bar does not keep sending to a stale terminal channel
 
+## 11g. Pinned Key Bar With The Keyboard Collapsed
+
+1. Connect to a session on iOS and on Android, then open the terminal view without tapping the terminal
+2. Expected: the key bar sits above the home indicator or navigation bar, styled exactly like the keyboard accessory bar
+3. Tap `Esc`, `Tab`, `Enter`, and each arrow in the pinned bar
+4. Expected: each key reaches the PTY exactly once with the keyboard still down
+5. Press and hold a pinned arrow, then release it
+6. Expected: the arrow repeats while held and stops on release
+7. Tap the terminal to raise the keyboard
+8. Expected: the pinned bar disappears as the keyboard accessory bar takes over; exactly one bar is visible at any time
+9. Dismiss the keyboard again
+10. Expected: the pinned bar returns and terminal content stays fully visible above it, never clipped behind it
+11. Open the workspace drawer
+12. Expected: the pinned bar hides while the drawer is open, the terminal gives up focus, and both return when the drawer closes — with the keyboard still down
+13. Navigate away from the terminal (settings, file preview, workspace list)
+14. Expected: the pinned bar hides immediately on every non-terminal screen and the terminal is no longer focused; returning to it refocuses without raising the keyboard
+15. Open the floating file search or the git commit message input over the terminal
+16. Expected: focus and the keyboard go to that input, and the terminal keeps no focus of its own
+17. Open a terminal, tap it to raise the keyboard, then tap again to dismiss it
+18. Expected: the keyboard drops but the terminal stays focused (active cursor), pinned keys keep reaching the PTY, and a further tap raises the keyboard again
+19. Set Settings → Terminal → Always show keypad to Off, then return to the terminal with the keyboard down
+20. Expected: no pinned bar; tap-to-dismiss drops both keyboard and focus as before, and the keyboard accessory bar still appears when the keyboard is raised
+21. Rotate the device with the pinned bar visible
+22. Expected: the bar spans the new width with evenly spaced keys
+
 ## 12. Quick Action Terminal Navigation
 
 1. Connect to a session with at least two open terminals

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1153,6 +1153,37 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:41:1\033\\/tmp/zedra-long-code.rs
 21. Rotate the device with the pinned bar visible
 22. Expected: the bar spans the new width with evenly spaced keys
 
+## 11h. Extended Keypad
+
+1. Set Settings → Terminal → Extended keypad to On, then open a terminal
+2. Expected: the keypad shows two rows — `Esc Shift Tab / - ↑ ⏎` over `⌫ Ctrl Alt Cmd ← ↓ →` — and terminal content sits above both rows
+3. Connect to a macOS host, then to a Linux host
+4. Expected: the fourth key of the bottom row is `Cmd` on macOS and `|` on Linux, updating on reconnect without restarting the app
+5. Tap `/` and `-`
+6. Expected: each character reaches the PTY exactly once
+7. Press and hold `⌫`
+8. Expected: characters delete one at a time and the repeat stops on release
+9. Tap `Ctrl` once, then tap `←` on the keypad
+10. Expected: `Ctrl` highlights faintly while armed, the terminal receives Ctrl+Left, and the highlight clears
+11. Tap `Ctrl` once, then type `c` on the software keyboard
+12. Expected: the running command is interrupted, exactly as a hardware Ctrl+C would
+13. Double-tap `Ctrl`, then press several keys
+14. Expected: `Ctrl` stays solidly highlighted and applies to every key until tapped a third time
+15. Arm `Alt` and `Shift` together, then press a key
+16. Expected: both modifiers apply to that key and both clear afterwards
+17. In an editor such as `vim`, arm nothing and press the arrows
+18. Expected: arrows navigate normally, including in app-cursor mode
+19. Drag left slowly across the keypad and hold mid-drag
+20. Expected: the keys slide out and the composing field slides in with the finger; releasing before halfway springs back to the keys with no keystroke sent
+21. Drag left past halfway and release
+22. Expected: the composer settles into place and the software keyboard opens
+23. Compose a multi-word message using IME features (autocorrect, prediction, a non-Latin IME), then tap `Send`
+24. Expected: nothing reaches the PTY while composing; on send the whole line arrives at the prompt without being run, and the field clears
+25. Drag right to return, then drag starting from inside the text field
+26. Expected: the first drag returns to the keys; the drag inside the field places the cursor instead of moving the page
+27. Set Extended keypad back to Off
+28. Expected: the single-row keypad returns immediately on both the pinned and keyboard-attached bars
+
 ## 12. Quick Action Terminal Navigation
 
 1. Connect to a session with at least two open terminals

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -64,6 +64,12 @@ void zedra_ios_set_screen_scale(float scale);
 void zedra_ios_set_keyboard_height(uint32_t height_px);
 
 /**
+ * Armed/locked keypad modifiers, for rendering key highlights. Bit layout is
+ * documented on `zedra_terminal::keyboard_accessory::sticky_modifier_mask`.
+ */
+uint32_t zedra_ios_key_bar_modifier_mask(void);
+
+/**
  * Called from Swift when the pinned key bar is shown, hidden, or re-laid out.
  *
  * `height_px` is the bar's full height (including safe-area padding) × scale, 0 when hidden.
@@ -276,6 +282,16 @@ extern void ios_set_keyboard_accessory_theme(bool is_dark);
  * Show or hide the key bar pinned above the safe area when the keyboard is down.
  */
 extern void ios_set_pinned_key_bar_visible(bool visible);
+
+/**
+ * Switch the keypad layout and its platform slot.
+ */
+extern void ios_set_keypad_layout(bool extended, bool cmd_slot);
+
+/**
+ * Drop the keypad composer and the keyboard it owns.
+ */
+extern void ios_cancel_keypad_composer(void);
 
 /**
  * Acquire an image natively. source: 0 = photo library, 1 = clipboard.

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -64,6 +64,13 @@ void zedra_ios_set_screen_scale(float scale);
 void zedra_ios_set_keyboard_height(uint32_t height_px);
 
 /**
+ * Called from Swift when the pinned key bar is shown, hidden, or re-laid out.
+ *
+ * `height_px` is the bar's full height (including safe-area padding) × scale, 0 when hidden.
+ */
+void zedra_ios_set_pinned_key_bar_height(uint32_t height_px);
+
+/**
  * Called from Obj-C with the current safe area insets in physical pixels
  * (UIEdgeInsets × UIScreen.scale). Re-called on orientation change.
  *
@@ -264,6 +271,11 @@ extern int32_t ios_system_prefers_dark_theme(void);
  * Apply the app appearance to the native keyboard accessory bar.
  */
 extern void ios_set_keyboard_accessory_theme(bool is_dark);
+
+/**
+ * Show or hide the key bar pinned above the safe area when the keyboard is down.
+ */
+extern void ios_set_pinned_key_bar_visible(bool visible);
 
 /**
  * Acquire an image natively. source: 0 = photo library, 1 = clipboard.

--- a/ios/Zedra/GPUIRuntimeController.swift
+++ b/ios/Zedra/GPUIRuntimeController.swift
@@ -15,8 +15,16 @@ private func gpui_ios_handle_key_bar_action(
     _ windowPtr: UnsafeMutableRawPointer?, _ action: UnsafePointer<CChar>?
 ) -> Bool
 
+@_silgen_name("gpui_ios_handle_key_bar_text")
+private func gpui_ios_handle_key_bar_text(
+    _ windowPtr: UnsafeMutableRawPointer?, _ text: UnsafePointer<CChar>?
+) -> Bool
+
 @_silgen_name("gpui_ios_hide_keyboard")
 private func gpui_ios_hide_keyboard(_ windowPtr: UnsafeMutableRawPointer?)
+
+@_silgen_name("gpui_ios_show_keyboard")
+private func gpui_ios_show_keyboard(_ windowPtr: UnsafeMutableRawPointer?)
 
 @_silgen_name("gpui_ios_request_frame_forced")
 private func gpui_ios_request_frame_forced(_ windowPtr: UnsafeMutableRawPointer?)
@@ -55,6 +63,9 @@ final class GPUIRuntimeController: NSObject {
     // Keep the keys clear of the home indicator's swipe region without spending the
     // whole 34pt safe-area inset on empty space.
     private static let maxPinnedKeyBarBottomPadding: CGFloat = 22.0
+    private var extendedKeypad = false
+    private var keypadCmdSlot = false
+    private var keyboardHeightPts: CGFloat = 0
 
     /// Dismiss the main GPUI window's software keyboard. Manual-focus surfaces
     /// (the terminal) keep `keyboard_session_requested` set, so a native sheet
@@ -75,7 +86,6 @@ final class GPUIRuntimeController: NSObject {
         zedra_launch_gpui()
         gpui_ios_did_finish_launching(gpuiApp)
         gpuiWindow = gpui_ios_get_window()
-
         if gpuiWindow != nil {
             setupKeyboardAccessoryView()
             startDisplayLink()
@@ -135,6 +145,8 @@ final class GPUIRuntimeController: NSObject {
     func applicationDidEnterBackground() {
         keyboardAccessoryController.stopRepeating()
         pinnedKeyBarController.stopRepeating()
+        keyboardAccessoryController.cancelComposing()
+        pinnedKeyBarController.cancelComposing()
         gpui_ios_did_enter_background(gpuiApp)
         zedra_ios_app_did_enter_background()
         stopDisplayLink()
@@ -178,13 +190,19 @@ final class GPUIRuntimeController: NSObject {
         }
 
         let heightPx = UInt32(endFrame.height * UIScreen.main.scale)
+        keyboardHeightPts = endFrame.height
         zedra_ios_set_keyboard_height(heightPx)
         gpui_ios_set_software_keyboard_visible(heightPx > 0)
+        // The composer lives in the bar, so the bar has to clear its own keyboard.
+        if pinnedKeyBarController.isComposing {
+            layoutPinnedKeyBar()
+        }
     }
 
     @objc
     func keyboardWillHide(_ notification: Notification) {
         keyboardAccessoryController.stopRepeating()
+        keyboardHeightPts = 0
         zedra_ios_set_keyboard_height(0)
         gpui_ios_set_software_keyboard_visible(false)
     }
@@ -212,6 +230,9 @@ final class GPUIRuntimeController: NSObject {
     @objc
     func renderFrame() {
         guard let gpuiWindow else { return }
+        // Modifiers are consumed by keys from either the bar or the software
+        // keyboard, so the highlight cannot be refreshed from bar presses alone.
+        refreshKeypadModifiers()
         if zedra_ios_check_pending_frame() {
             gpui_ios_request_frame_forced(gpuiWindow)
         } else {
@@ -229,17 +250,73 @@ final class GPUIRuntimeController: NSObject {
     private func setupKeyboardAccessoryView() {
         let width = UIScreen.main.bounds.width
         let bar = keyboardAccessoryController.makeAccessoryView(
-            width: width
-        ) { [weak self] key in
-            self?.sendKeyboardAccessoryKey(key)
-        }
+            width: width,
+            extended: extendedKeypad,
+            cmdSlot: keypadCmdSlot,
+            sendKey: { [weak self] key in
+                self?.sendKeyboardAccessoryKey(key)
+            },
+            sendComposedText: { [weak self] text in
+                self?.sendComposedText(text)
+            },
+            requestTerminalKeyboard: { [weak self] in
+                self?.requestTerminalKeyboard()
+            }
+        )
         gpui_ios_set_keyboard_accessory_view(Unmanaged.passUnretained(bar).toOpaque())
+    }
+
+    /// Rust pushes this when the setting changes; both bars rebuild their rows.
+    static func setKeypadLayout(extended: Bool, cmdSlot: Bool) {
+        DispatchQueue.main.async {
+            activeController?.applyKeypadLayout(extended: extended, cmdSlot: cmdSlot)
+        }
+    }
+
+    private func applyKeypadLayout(extended enabled: Bool, cmdSlot useCmdSlot: Bool) {
+        guard extendedKeypad != enabled || keypadCmdSlot != useCmdSlot else { return }
+        extendedKeypad = enabled
+        keypadCmdSlot = useCmdSlot
+        // UIKit sizes the keyboard-attached bar from the view it is handed, so
+        // that one is rebuilt rather than resized in place.
+        setupKeyboardAccessoryView()
+        pinnedKeyBarView?.removeFromSuperview()
+        pinnedKeyBarView = nil
+        updatePinnedKeyBar(visible: pinnedKeyBarVisible)
+    }
+
+    /// Give first responder back to the terminal, keeping the keyboard on screen.
+    private func requestTerminalKeyboard() {
+        guard let gpuiWindow else { return }
+        gpui_ios_show_keyboard(gpuiWindow)
+    }
+
+    /// Straight into the terminal's input handler. The generic text-input entry
+    /// point dispatches key events through GPUI's keymap instead, which never
+    /// reached the terminal from a bar hosted outside the keyboard.
+    private func sendComposedText(_ text: String) {
+        guard let gpuiWindow else {
+            NSLog("key-bar: composed text dropped, no GPUI window")
+            return
+        }
+        let handled = text.withCString { gpui_ios_handle_key_bar_text(gpuiWindow, $0) }
+        if !handled {
+            NSLog("key-bar: composed text rejected by the input handler")
+        }
     }
 
     static func setKeyboardAccessoryTheme(isDark: Bool) {
         DispatchQueue.main.async {
             activeController?.keyboardAccessoryController.applyTheme(isDark: isDark)
             activeController?.pinnedKeyBarController.applyTheme(isDark: isDark)
+        }
+    }
+
+    /// Tapping the terminal surface drops the composer and its keyboard.
+    static func cancelKeypadComposer() {
+        DispatchQueue.main.async {
+            activeController?.keyboardAccessoryController.cancelComposing()
+            activeController?.pinnedKeyBarController.cancelComposing()
         }
     }
 
@@ -251,7 +328,9 @@ final class GPUIRuntimeController: NSObject {
 
     private func updatePinnedKeyBar(visible: Bool) {
         pinnedKeyBarVisible = visible
-        guard visible else {
+        // Composing raises a keyboard, which is exactly when Rust hides the rows;
+        // the bar has to stay up or the composer would vanish behind it.
+        guard visible || pinnedKeyBarController.isComposing else {
             pinnedKeyBarController.stopRepeating()
             pinnedKeyBarView?.isHidden = true
             zedra_ios_set_pinned_key_bar_height(0)
@@ -263,24 +342,34 @@ final class GPUIRuntimeController: NSObject {
         // The full safe-area inset (34pt) leaves a large empty band under the keys;
         // clear the home indicator and no more.
         let bottomPadding = min(window.safeAreaInsets.bottom, Self.maxPinnedKeyBarBottomPadding)
-        let height = KeyboardSupporter.barHeight + bottomPadding
         let bar =
             pinnedKeyBarView
             ?? {
                 let bar = pinnedKeyBarController.makeAccessoryView(
                     width: width,
-                    bottomPadding: bottomPadding
-                ) { [weak self] key in
-                    self?.sendPinnedKeyBarKey(key)
-                }
+                    bottomPadding: bottomPadding,
+                    extended: extendedKeypad,
+                    cmdSlot: keypadCmdSlot,
+                    sendKey: { [weak self] key in
+                        self?.sendPinnedKeyBarKey(key)
+                    },
+                    sendComposedText: { [weak self] text in
+                        self?.sendComposedText(text)
+                    },
+                    requestTerminalKeyboard: { [weak self] in
+                        self?.requestTerminalKeyboard()
+                    },
+                    needsLayout: { [weak self] in
+                        self?.layoutPinnedKeyBar()
+                    }
+                )
                 window.addSubview(bar)
                 pinnedKeyBarView = bar
                 return bar
             }()
-        bar.frame = CGRect(x: 0, y: window.bounds.height - height, width: width, height: height)
         bar.isHidden = false
         window.bringSubviewToFront(bar)
-        zedra_ios_set_pinned_key_bar_height(UInt32(height * UIScreen.main.scale))
+        layoutPinnedKeyBar()
     }
 
     /// The pinned bar runs with no keyboard session, so the accessory entry point
@@ -294,6 +383,35 @@ final class GPUIRuntimeController: NSObject {
         if !handled {
             key.withCString { zedra_ios_send_key_input($0) }
         }
+    }
+
+    /// Sticky modifier state lives with the terminal; mirror it into both bars so
+    /// the armed and locked highlights match what the next keystroke will carry.
+    private func refreshKeypadModifiers() {
+        let mask = zedra_ios_key_bar_modifier_mask()
+        keyboardAccessoryController.setModifierMask(mask)
+        pinnedKeyBarController.setModifierMask(mask)
+    }
+
+    /// Re-place the pinned bar after its own layout changed (row count, composer).
+    private func layoutPinnedKeyBar() {
+        guard let window = uiWindow, let bar = pinnedKeyBarView else { return }
+        let composing = pinnedKeyBarController.isComposing
+        // While composing the bar rides its own keyboard; otherwise it sits above
+        // the home indicator.
+        let bottomPadding = composing
+            ? 0
+            : min(window.safeAreaInsets.bottom, Self.maxPinnedKeyBarBottomPadding)
+        let height = pinnedKeyBarController.keysHeight + bottomPadding
+        let bottom = composing ? window.bounds.height - keyboardHeightPts : window.bounds.height
+        bar.frame = CGRect(
+            x: 0,
+            y: bottom - height,
+            width: window.bounds.width,
+            height: height
+        )
+        window.bringSubviewToFront(bar)
+        zedra_ios_set_pinned_key_bar_height(UInt32(height * UIScreen.main.scale))
     }
 
     private func startDisplayLink() {

--- a/ios/Zedra/GPUIRuntimeController.swift
+++ b/ios/Zedra/GPUIRuntimeController.swift
@@ -10,6 +10,11 @@ private func gpui_ios_handle_keyboard_accessory_action(
     _ windowPtr: UnsafeMutableRawPointer?, _ action: UnsafePointer<CChar>?
 ) -> Bool
 
+@_silgen_name("gpui_ios_handle_key_bar_action")
+private func gpui_ios_handle_key_bar_action(
+    _ windowPtr: UnsafeMutableRawPointer?, _ action: UnsafePointer<CChar>?
+) -> Bool
+
 @_silgen_name("gpui_ios_hide_keyboard")
 private func gpui_ios_hide_keyboard(_ windowPtr: UnsafeMutableRawPointer?)
 
@@ -41,6 +46,15 @@ final class GPUIRuntimeController: NSObject {
     private var gpuiWindow: UnsafeMutableRawPointer?
     private var displayLink: CADisplayLink?
     private let keyboardAccessoryController = KeyboardSupporter()
+    /// Second instance of the same bar, hosted above the safe area while the
+    /// keyboard is down. Separate instance because each one owns its own buttons
+    /// and repeat timer.
+    private let pinnedKeyBarController = KeyboardSupporter()
+    private var pinnedKeyBarView: UIView?
+    private var pinnedKeyBarVisible = false
+    // Keep the keys clear of the home indicator's swipe region without spending the
+    // whole 34pt safe-area inset on empty space.
+    private static let maxPinnedKeyBarBottomPadding: CGFloat = 22.0
 
     /// Dismiss the main GPUI window's software keyboard. Manual-focus surfaces
     /// (the terminal) keep `keyboard_session_requested` set, so a native sheet
@@ -107,15 +121,20 @@ final class GPUIRuntimeController: NSObject {
     func applicationDidBecomeActive() {
         gpui_ios_did_become_active(gpuiApp)
         pushSafeAreaInsets()
+        // Rust pushes bar visibility once; re-apply in case the window was not
+        // attached yet when it did.
+        updatePinnedKeyBar(visible: pinnedKeyBarVisible)
     }
 
     func applicationWillResignActive() {
         keyboardAccessoryController.stopRepeating()
+        pinnedKeyBarController.stopRepeating()
         gpui_ios_will_resign_active(gpuiApp)
     }
 
     func applicationDidEnterBackground() {
         keyboardAccessoryController.stopRepeating()
+        pinnedKeyBarController.stopRepeating()
         gpui_ios_did_enter_background(gpuiApp)
         zedra_ios_app_did_enter_background()
         stopDisplayLink()
@@ -123,6 +142,7 @@ final class GPUIRuntimeController: NSObject {
 
     func applicationWillTerminate() {
         keyboardAccessoryController.stopRepeating()
+        pinnedKeyBarController.stopRepeating()
         stopDisplayLink()
         zedra_ios_app_will_terminate()
         gpui_ios_will_terminate(gpuiApp)
@@ -173,6 +193,10 @@ final class GPUIRuntimeController: NSObject {
     private func orientationDidChange() {
         pushSafeAreaInsets()
         pushWindowSize()
+        // The bar is laid out with frames for a fixed width; rebuild it on rotation.
+        pinnedKeyBarView?.removeFromSuperview()
+        pinnedKeyBarView = nil
+        updatePinnedKeyBar(visible: pinnedKeyBarVisible)
     }
 
     private func sendKeyboardAccessoryKey(_ key: String) {
@@ -215,6 +239,60 @@ final class GPUIRuntimeController: NSObject {
     static func setKeyboardAccessoryTheme(isDark: Bool) {
         DispatchQueue.main.async {
             activeController?.keyboardAccessoryController.applyTheme(isDark: isDark)
+            activeController?.pinnedKeyBarController.applyTheme(isDark: isDark)
+        }
+    }
+
+    static func setPinnedKeyBarVisible(_ visible: Bool) {
+        DispatchQueue.main.async {
+            activeController?.updatePinnedKeyBar(visible: visible)
+        }
+    }
+
+    private func updatePinnedKeyBar(visible: Bool) {
+        pinnedKeyBarVisible = visible
+        guard visible else {
+            pinnedKeyBarController.stopRepeating()
+            pinnedKeyBarView?.isHidden = true
+            zedra_ios_set_pinned_key_bar_height(0)
+            return
+        }
+        guard let window = uiWindow else { return }
+
+        let width = window.bounds.width
+        // The full safe-area inset (34pt) leaves a large empty band under the keys;
+        // clear the home indicator and no more.
+        let bottomPadding = min(window.safeAreaInsets.bottom, Self.maxPinnedKeyBarBottomPadding)
+        let height = KeyboardSupporter.barHeight + bottomPadding
+        let bar =
+            pinnedKeyBarView
+            ?? {
+                let bar = pinnedKeyBarController.makeAccessoryView(
+                    width: width,
+                    bottomPadding: bottomPadding
+                ) { [weak self] key in
+                    self?.sendPinnedKeyBarKey(key)
+                }
+                window.addSubview(bar)
+                pinnedKeyBarView = bar
+                return bar
+            }()
+        bar.frame = CGRect(x: 0, y: window.bounds.height - height, width: width, height: height)
+        bar.isHidden = false
+        window.bringSubviewToFront(bar)
+        zedra_ios_set_pinned_key_bar_height(UInt32(height * UIScreen.main.scale))
+    }
+
+    /// The pinned bar runs with no keyboard session, so the accessory entry point
+    /// rejects it; `handle_key_bar_action` reaches the same input handler, which
+    /// encodes keys against the terminal's live mode.
+    private func sendPinnedKeyBarKey(_ key: String) {
+        let handled =
+            key.withCString { action in
+                gpui_ios_handle_key_bar_action(gpuiWindow, action)
+            }
+        if !handled {
+            key.withCString { zedra_ios_send_key_input($0) }
         }
     }
 

--- a/ios/Zedra/KeyboardSupporter.swift
+++ b/ios/Zedra/KeyboardSupporter.swift
@@ -1,37 +1,103 @@
 import UIKit
 
+/// Terminal key bar. Renders either the compact single row or the extended
+/// two-row keypad, and swaps in an IME composing field on a left swipe.
+///
+/// Modifier state is owned by Rust (`zedra_terminal::keyboard_accessory`) because
+/// it must also apply to characters committed by the software keyboard; this view
+/// only renders the mask it is given.
 @objcMembers
-final class KeyboardSupporter: NSObject {
+final class KeyboardSupporter: NSObject, UITextFieldDelegate, UIGestureRecognizerDelegate {
     private struct KeySpec {
         let label: String
         let key: String
-        let repeats: Bool
+        var repeats: Bool = false
+        /// Set for Shift/Ctrl/Alt: the bit this key highlights from the mask.
+        var modifierBit: UInt32?
     }
 
-    private let keySpecs = [
-        KeySpec(label: "Esc", key: "escape", repeats: false),
-        KeySpec(label: "Tab", key: "tab", repeats: false),
+    private let compactRow = [
+        KeySpec(label: "Esc", key: "escape"),
+        KeySpec(label: "Tab", key: "tab"),
         KeySpec(label: "←", key: "left", repeats: true),
         KeySpec(label: "↓", key: "down", repeats: true),
         KeySpec(label: "↑", key: "up", repeats: true),
         KeySpec(label: "→", key: "right", repeats: true),
-        KeySpec(label: "⏎", key: "enter", repeats: false),
+        KeySpec(label: "⏎", key: "enter"),
     ]
+
+    private let extendedTopRow = [
+        KeySpec(label: "Esc", key: "escape"),
+        KeySpec(label: "Shift", key: "mod:shift", modifierBit: 1),
+        KeySpec(label: "Tab", key: "tab"),
+        KeySpec(label: "/", key: "char:/"),
+        KeySpec(label: "-", key: "char:-"),
+        KeySpec(label: "↑", key: "up", repeats: true),
+        KeySpec(label: "⏎", key: "enter"),
+    ]
+
+    /// Cmd only means anything to a macOS host; every other host gets a pipe,
+    /// which is real shell syntax and awkward to reach on a phone keyboard.
+    private var platformSlot: KeySpec {
+        cmdSlot
+            ? KeySpec(label: "Cmd", key: "mod:cmd", modifierBit: 8)
+            : KeySpec(label: "|", key: "char:|")
+    }
+
+    private var extendedBottomRow: [KeySpec] {
+        [
+            KeySpec(label: "⌫", key: "backspace", repeats: true),
+            KeySpec(label: "Ctrl", key: "mod:ctrl", modifierBit: 2),
+            KeySpec(label: "Alt", key: "mod:alt", modifierBit: 4),
+            platformSlot,
+            KeySpec(label: "←", key: "left", repeats: true),
+            KeySpec(label: "↓", key: "down", repeats: true),
+            KeySpec(label: "→", key: "right", repeats: true),
+        ]
+    }
 
     private let repeatInitialDelay: TimeInterval = 0.35
     private let repeatInterval: TimeInterval = 0.06
+
+    static let rowHeight: CGFloat = 44.0
+    /// Two stacked rows would eat too much of the screen at full row height.
+    static let extendedRowHeight: CGFloat = 32.0
+    private var currentRowHeight: CGFloat { extended && !composing ? Self.extendedRowHeight : Self.rowHeight }
+    /// Height of the key area for the current layout, before safe-area padding.
+    var keysHeight: CGFloat { extended && !composing ? Self.extendedRowHeight * 2 : Self.rowHeight }
 
     private(set) var accessoryView: UIView?
     private weak var topBorder: UIView?
     private weak var leftKeyboardCornerFill: UIView?
     private weak var rightKeyboardCornerFill: UIView?
     private var buttons: [UIButton] = []
+    private var specsByTag: [Int: KeySpec] = [:]
     private var sendKey: ((String) -> Void)?
+    private var sendComposedText: ((String) -> Void)?
     private var repeatTimer: Timer?
     private var repeatingKey: String?
+    private var repeatFired = false
     private var isDarkTheme = true
+    private var extended = false
+    private var cmdSlot = false
+    private var composing = false
+    private var modifierMask: UInt32 = 0
+    private var barWidth: CGFloat = 0
+    private var barBottomPadding: CGFloat = 0
+    private weak var composeField: UITextField?
+    private weak var keysPage: UIView?
+    private weak var composePage: UIView?
+    /// The bar's geometry changed (rows, composer): the host re-places it.
+    private var needsLayout: (() -> Void)?
+    /// Hand the keyboard back to the terminal when the user leaves the composer.
+    private var requestTerminalKeyboard: (() -> Void)?
+    private weak var panRecognizer: UIPanGestureRecognizer?
 
-    static let barHeight: CGFloat = 44.0
+    func setModifierMask(_ mask: UInt32) {
+        guard modifierMask != mask else { return }
+        modifierMask = mask
+        applyModifierHighlights()
+    }
 
     /// Builds the key bar. `bottomPadding` > 0 pins it above the safe area instead
     /// of riding the keyboard, so the background extends under the home indicator
@@ -39,14 +105,25 @@ final class KeyboardSupporter: NSObject {
     func makeAccessoryView(
         width: CGFloat,
         bottomPadding: CGFloat = 0.0,
-        sendKey: @escaping (String) -> Void
+        extended: Bool = false,
+        cmdSlot: Bool = false,
+        sendKey: @escaping (String) -> Void,
+        sendComposedText: ((String) -> Void)? = nil,
+        requestTerminalKeyboard: (() -> Void)? = nil,
+        needsLayout: (() -> Void)? = nil
     ) -> UIView {
         stopRepeating()
         self.sendKey = sendKey
-        buttons.removeAll()
+        self.sendComposedText = sendComposedText
+        self.requestTerminalKeyboard = requestTerminalKeyboard
+        self.needsLayout = needsLayout
+        self.extended = extended
+        self.cmdSlot = cmdSlot
+        self.barWidth = width
+        self.barBottomPadding = bottomPadding
+        composing = false
 
-        let height = Self.barHeight
-        let bar = UIView(frame: CGRect(x: 0, y: 0, width: width, height: height + bottomPadding))
+        let bar = UIView(frame: CGRect(x: 0, y: 0, width: width, height: keysHeight + bottomPadding))
         bar.clipsToBounds = false
 
         let border = UIView(frame: CGRect(x: 0, y: 0, width: width, height: 0.33))
@@ -59,12 +136,12 @@ final class KeyboardSupporter: NSObject {
             let cornerFillWidth: CGFloat = 18.0
             let cornerFillHeight: CGFloat = 12.0
             let leftFill = UIView(
-                frame: CGRect(x: 0, y: height, width: cornerFillWidth, height: cornerFillHeight)
+                frame: CGRect(x: 0, y: keysHeight, width: cornerFillWidth, height: cornerFillHeight)
             )
             let rightFill = UIView(
                 frame: CGRect(
                     x: width - cornerFillWidth,
-                    y: height,
+                    y: keysHeight,
                     width: cornerFillWidth,
                     height: cornerFillHeight
                 )
@@ -75,14 +152,73 @@ final class KeyboardSupporter: NSObject {
             rightKeyboardCornerFill = rightFill
         }
 
-        let buttonWidth = width / CGFloat(keySpecs.count)
+        accessoryView = bar
 
-        for (index, spec) in keySpecs.enumerated() {
+        // The two pages sit side by side and follow the finger, so the composer is
+        // visibly dragged in rather than swapped at the end of a gesture.
+        let keys = UIView(frame: CGRect(x: 0, y: 0, width: width, height: keysHeight))
+        let compose = UIView(frame: CGRect(x: width, y: 0, width: width, height: keysHeight))
+        compose.clipsToBounds = true
+        bar.addSubview(keys)
+        bar.addSubview(compose)
+        keysPage = keys
+        composePage = compose
+
+        let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+        pan.delegate = self
+        bar.addGestureRecognizer(pan)
+        panRecognizer = pan
+
+        rebuildRows()
+        return bar
+    }
+
+    private func rebuildRows() {
+        guard let bar = accessoryView, let keys = keysPage, let compose = composePage else { return }
+        stopRepeating()
+        for button in buttons {
+            button.removeFromSuperview()
+        }
+        buttons.removeAll()
+        specsByTag.removeAll()
+        composeField?.removeFromSuperview()
+        composeField = nil
+        bar.frame = CGRect(
+            x: bar.frame.origin.x,
+            y: bar.frame.origin.y,
+            width: barWidth,
+            height: keysHeight + barBottomPadding
+        )
+        keys.frame = CGRect(x: pageOffset(forComposing: composing), y: 0, width: barWidth, height: keysHeight)
+        compose.frame = CGRect(x: keys.frame.origin.x + barWidth, y: 0, width: barWidth, height: keysHeight)
+
+        if extended {
+            buildRow(extendedTopRow, in: keys, atY: 0)
+            buildRow(extendedBottomRow, in: keys, atY: Self.extendedRowHeight)
+        } else {
+            buildRow(compactRow, in: keys, atY: 0)
+        }
+        buildComposeRow(in: compose)
+
+        applyTheme(isDark: isDarkTheme)
+        applyModifierHighlights()
+        needsLayout?()
+    }
+
+    private func buildRow(_ specs: [KeySpec], in bar: UIView, atY y: CGFloat) {
+        let buttonWidth = barWidth / CGFloat(specs.count)
+        for (index, spec) in specs.enumerated() {
             let button = UIButton(type: .system)
-            button.frame = CGRect(x: buttonWidth * CGFloat(index), y: 0, width: buttonWidth, height: height)
+            button.frame = CGRect(
+                x: buttonWidth * CGFloat(index),
+                y: y,
+                width: buttonWidth,
+                height: currentRowHeight
+            )
             button.setTitle(spec.label, for: .normal)
-            button.titleLabel?.font = .systemFont(ofSize: 16.0)
-            button.tag = index
+            button.titleLabel?.font = .systemFont(ofSize: extended ? 14.0 : 16.0)
+            button.tag = buttons.count
+            specsByTag[button.tag] = spec
             button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
             button.addTarget(self, action: #selector(buttonTouchUpInside(_:)), for: .touchUpInside)
             button.addTarget(self, action: #selector(stopRepeating), for: .touchUpOutside)
@@ -91,10 +227,158 @@ final class KeyboardSupporter: NSObject {
             bar.addSubview(button)
             buttons.append(button)
         }
+    }
 
-        accessoryView = bar
-        applyTheme(isDark: isDarkTheme)
-        return bar
+    private func buildComposeRow(in page: UIView) {
+        let sendWidth: CGFloat = 64.0
+        let fieldHeight = Self.rowHeight
+        let fieldY = (keysHeight - fieldHeight) / 2
+
+        let field = UITextField(
+            frame: CGRect(
+                x: 12.0,
+                y: fieldY,
+                width: barWidth - sendWidth - 20.0,
+                height: fieldHeight
+            )
+        )
+        field.placeholder = "Compose, then send"
+        field.font = .systemFont(ofSize: 15.0)
+        field.returnKeyType = .send
+        field.delegate = self
+        page.addSubview(field)
+        composeField = field
+
+        // The keyboard's own return key submits, so this is the way out, not a
+        // second submit control.
+        let close = UIButton(type: .system)
+        close.frame = CGRect(x: barWidth - sendWidth, y: fieldY, width: sendWidth, height: fieldHeight)
+        close.setTitle("✕", for: .normal)
+        close.titleLabel?.font = .systemFont(ofSize: 17.0)
+        close.accessibilityLabel = "Close composer"
+        close.addTarget(self, action: #selector(closeComposer), for: .touchUpInside)
+        page.addSubview(close)
+        buttons.append(close)
+    }
+
+    @objc
+    private func handlePan(_ recognizer: UIPanGestureRecognizer) {
+        guard extended else { return }
+        let dx = recognizer.translation(in: recognizer.view).x
+        switch recognizer.state {
+        case .began:
+            stopRepeating()
+        case .changed:
+            applyDragOffset(dx)
+        case .ended, .cancelled:
+            // Past halfway, or thrown hard enough, the page flips.
+            let velocity = recognizer.velocity(in: recognizer.view).x
+            let flipped = abs(dx) > barWidth / 2 || abs(velocity) > 600
+            setComposing(composing != flipped, animated: true, keepKeyboard: true)
+        default:
+            break
+        }
+    }
+
+    private func pageOffset(forComposing composing: Bool) -> CGFloat {
+        composing ? -barWidth : 0
+    }
+
+    private func applyDragOffset(_ dx: CGFloat) {
+        let base = pageOffset(forComposing: composing)
+        let offset = min(max(base + dx, -barWidth), 0)
+        keysPage?.frame.origin.x = offset
+        composePage?.frame.origin.x = offset + barWidth
+    }
+
+    /// `keepKeyboard` distinguishes the user stepping back to the keys — where the
+    /// keyboard should stay up, now typing into the terminal — from a forced cancel
+    /// (drawer, navigation, terminal tap), where it must go away with the composer.
+    private func setComposing(_ enabled: Bool, animated: Bool, keepKeyboard: Bool = false) {
+        let changed = composing != enabled
+        composing = enabled
+        let offset = pageOffset(forComposing: enabled)
+        let settle = { [weak self] in
+            guard let self else { return }
+            self.keysPage?.frame.origin.x = offset
+            self.composePage?.frame.origin.x = offset + self.barWidth
+        }
+        if animated {
+            UIView.animate(withDuration: 0.18, animations: settle)
+        } else {
+            settle()
+        }
+        guard changed else { return }
+
+        if enabled {
+            composeField?.becomeFirstResponder()
+        } else if keepKeyboard {
+            // Handing first responder straight to the terminal keeps the keyboard
+            // up; resigning first would drop it and animate a new one back in.
+            requestTerminalKeyboard?()
+        } else {
+            composeField?.resignFirstResponder()
+        }
+        needsLayout?()
+    }
+
+    /// Horizontal drags belong to the pager. The composing field fills most of its
+    /// page, so refusing drags that start on it would strand the user there.
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let pan = gestureRecognizer as? UIPanGestureRecognizer else { return true }
+        let velocity = pan.velocity(in: pan.view)
+        return abs(velocity.x) > abs(velocity.y)
+    }
+
+    /// Drop the composer and its keyboard. Also the exit from the accessory's Keys
+    /// button, since the bar's own pager is not on screen while composing.
+    @objc
+    var isComposing: Bool { composing }
+
+    @objc
+    func cancelComposing() {
+        composeField?.resignFirstResponder()
+        guard composing else { return }
+        setComposing(false, animated: false)
+    }
+
+    @objc
+    private func submitComposedText() {
+        guard let text = composeField?.text, !text.isEmpty else { return }
+        NSLog("key-bar: submitting composed text (%d chars)", text.count)
+        // Text only: the composer fills the prompt, and the user decides when to run it.
+        sendComposedText?(text)
+        composeField?.text = ""
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        submitComposedText()
+        return false
+    }
+
+    private func applyModifierHighlights() {
+        // Accent blue marks an active modifier; a locked one is fully opaque, an
+        // armed one dimmer, so the two stay distinguishable without a fill.
+        let accent = NativePresentationTheme.accentBlue
+        let foreground = foregroundColor
+
+        for button in buttons {
+            guard let bit = specsByTag[button.tag]?.modifierBit else { continue }
+            let armed = modifierMask & bit != 0
+            let locked = modifierMask & (bit << 4) != 0
+            let color =
+                locked
+                ? accent
+                : (armed ? accent.withAlphaComponent(0.6) : foreground)
+            button.setTitleColor(color, for: .normal)
+            button.tintColor = color
+        }
+    }
+
+    private var foregroundColor: UIColor {
+        isDarkTheme
+            ? UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.0)
+            : UIColor(red: 0.102, green: 0.102, blue: 0.102, alpha: 1.0)
     }
 
     func applyTheme(isDark: Bool) {
@@ -103,9 +387,7 @@ final class KeyboardSupporter: NSObject {
         let backgroundColor = isDark
             ? UIColor(red: 0.055, green: 0.047, blue: 0.047, alpha: 0.96)
             : UIColor(red: 0.961, green: 0.961, blue: 0.961, alpha: 0.98)
-        let foregroundColor = isDark
-            ? UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.0)
-            : UIColor(red: 0.102, green: 0.102, blue: 0.102, alpha: 1.0)
+        let foregroundColor = self.foregroundColor
         let borderColor = isDark
             ? UIColor(white: 1.0, alpha: 0.12)
             : UIColor(white: 0.0, alpha: 0.10)
@@ -115,9 +397,13 @@ final class KeyboardSupporter: NSObject {
         leftKeyboardCornerFill?.backgroundColor = backgroundColor
         rightKeyboardCornerFill?.backgroundColor = backgroundColor
 
+        composeField?.textColor = foregroundColor
         let interfaceStyle: UIUserInterfaceStyle = isDark ? .dark : .light
         if #available(iOS 13.0, *) {
             accessoryView?.overrideUserInterfaceStyle = interfaceStyle
+        }
+        if #available(iOS 13.0, *) {
+            composeField?.overrideUserInterfaceStyle = interfaceStyle
         }
         for button in buttons {
             button.setTitleColor(foregroundColor, for: .normal)
@@ -126,27 +412,28 @@ final class KeyboardSupporter: NSObject {
                 button.overrideUserInterfaceStyle = interfaceStyle
             }
         }
+        applyModifierHighlights()
     }
 
     func stopRepeating() {
         repeatTimer?.invalidate()
         repeatTimer = nil
         repeatingKey = nil
+        repeatFired = false
     }
 
     private func keySpec(for sender: UIButton) -> KeySpec? {
-        guard keySpecs.indices.contains(sender.tag) else {
-            return nil
-        }
-        return keySpecs[sender.tag]
+        specsByTag[sender.tag]
     }
 
     @objc
     private func buttonTouchDown(_ sender: UIButton) {
+        // Nothing is sent yet: a horizontal drag starting on this key belongs to
+        // the pager, and a key already sent cannot be taken back. Holds emit from
+        // the repeat timer, taps on release.
         guard let spec = keySpec(for: sender), spec.repeats else {
             return
         }
-        sendKey?(spec.key)
         startRepeating(spec.key)
     }
 
@@ -157,9 +444,9 @@ final class KeyboardSupporter: NSObject {
             return
         }
 
-        if spec.repeats {
-            stopRepeating()
-        } else {
+        let repeated = repeatFired
+        stopRepeating()
+        if !repeated {
             sendKey?(spec.key)
         }
     }
@@ -174,6 +461,7 @@ final class KeyboardSupporter: NSObject {
             guard let self, self.repeatingKey == key else {
                 return
             }
+            self.repeatFired = true
             self.sendKey?(key)
         }
         timer.fireDate = Date(timeIntervalSinceNow: repeatInitialDelay)

--- a/ios/Zedra/KeyboardSupporter.swift
+++ b/ios/Zedra/KeyboardSupporter.swift
@@ -31,36 +31,49 @@ final class KeyboardSupporter: NSObject {
     private var repeatingKey: String?
     private var isDarkTheme = true
 
-    func makeAccessoryView(width: CGFloat, sendKey: @escaping (String) -> Void) -> UIView {
+    static let barHeight: CGFloat = 44.0
+
+    /// Builds the key bar. `bottomPadding` > 0 pins it above the safe area instead
+    /// of riding the keyboard, so the background extends under the home indicator
+    /// and the keyboard corner fills are left out.
+    func makeAccessoryView(
+        width: CGFloat,
+        bottomPadding: CGFloat = 0.0,
+        sendKey: @escaping (String) -> Void
+    ) -> UIView {
         stopRepeating()
         self.sendKey = sendKey
         buttons.removeAll()
 
-        let height: CGFloat = 44.0
-        let bar = UIView(frame: CGRect(x: 0, y: 0, width: width, height: height))
+        let height = Self.barHeight
+        let bar = UIView(frame: CGRect(x: 0, y: 0, width: width, height: height + bottomPadding))
         bar.clipsToBounds = false
 
         let border = UIView(frame: CGRect(x: 0, y: 0, width: width, height: 0.33))
         bar.addSubview(border)
         topBorder = border
 
-        // The system keyboard has rounded top corners, which can expose the window
-        // background beside an inputAccessoryView. Fill only those side gaps.
-        let cornerFillWidth: CGFloat = 18.0
-        let cornerFillHeight: CGFloat = 12.0
-        let leftFill = UIView(frame: CGRect(x: 0, y: height, width: cornerFillWidth, height: cornerFillHeight))
-        let rightFill = UIView(
-            frame: CGRect(
-                x: width - cornerFillWidth,
-                y: height,
-                width: cornerFillWidth,
-                height: cornerFillHeight
+        if bottomPadding == 0.0 {
+            // The system keyboard has rounded top corners, which can expose the window
+            // background beside an inputAccessoryView. Fill only those side gaps.
+            let cornerFillWidth: CGFloat = 18.0
+            let cornerFillHeight: CGFloat = 12.0
+            let leftFill = UIView(
+                frame: CGRect(x: 0, y: height, width: cornerFillWidth, height: cornerFillHeight)
             )
-        )
-        bar.addSubview(leftFill)
-        bar.addSubview(rightFill)
-        leftKeyboardCornerFill = leftFill
-        rightKeyboardCornerFill = rightFill
+            let rightFill = UIView(
+                frame: CGRect(
+                    x: width - cornerFillWidth,
+                    y: height,
+                    width: cornerFillWidth,
+                    height: cornerFillHeight
+                )
+            )
+            bar.addSubview(leftFill)
+            bar.addSubview(rightFill)
+            leftKeyboardCornerFill = leftFill
+            rightKeyboardCornerFill = rightFill
+        }
 
         let buttonWidth = width / CGFloat(keySpecs.count)
 

--- a/ios/Zedra/NativeBridge.swift
+++ b/ios/Zedra/NativeBridge.swift
@@ -107,6 +107,11 @@ func ios_set_keyboard_accessory_theme(_ isDark: Bool) {
     NativePresentationTheme.setDark(isDark)
 }
 
+@_cdecl("ios_set_pinned_key_bar_visible")
+func ios_set_pinned_key_bar_visible(_ visible: Bool) {
+    GPUIRuntimeController.setPinnedKeyBarVisible(visible)
+}
+
 #if !ZEDRA_NO_TELEMETRY
 @_cdecl("zedra_firebase_initialize")
 func zedra_firebase_initialize_bridge() {

--- a/ios/Zedra/NativeBridge.swift
+++ b/ios/Zedra/NativeBridge.swift
@@ -112,6 +112,16 @@ func ios_set_pinned_key_bar_visible(_ visible: Bool) {
     GPUIRuntimeController.setPinnedKeyBarVisible(visible)
 }
 
+@_cdecl("ios_cancel_keypad_composer")
+func ios_cancel_keypad_composer() {
+    GPUIRuntimeController.cancelKeypadComposer()
+}
+
+@_cdecl("ios_set_keypad_layout")
+func ios_set_keypad_layout(_ extended: Bool, _ cmdSlot: Bool) {
+    GPUIRuntimeController.setKeypadLayout(extended: extended, cmdSlot: cmdSlot)
+}
+
 #if !ZEDRA_NO_TELEMETRY
 @_cdecl("zedra_firebase_initialize")
 func zedra_firebase_initialize_bridge() {

--- a/ios/Zedra/Presentations.swift
+++ b/ios/Zedra/Presentations.swift
@@ -175,6 +175,10 @@ enum NativePresentationTheme {
         isDark ? UIColor(red: 0.898, green: 0.753, blue: 0.482, alpha: 1) : UIColor(red: 0.604, green: 0.404, blue: 0, alpha: 1)
     }
 
+    static var accentBlue: UIColor {
+        isDark ? UIColor(red: 0.38, green: 0.686, blue: 0.937, alpha: 1) : UIColor(red: 0.035, green: 0.412, blue: 0.855, alpha: 1)
+    }
+
     static var accentRed: UIColor {
         isDark ? UIColor(red: 0.878, green: 0.424, blue: 0.459, alpha: 1) : UIColor(red: 0.812, green: 0.133, blue: 0.18, alpha: 1)
     }

--- a/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
@@ -64,6 +64,22 @@ void zedra_ios_set_screen_scale(float scale);
 void zedra_ios_set_keyboard_height(uint32_t height_px);
 
 /**
+ * Armed/locked keypad modifiers, for rendering key highlights. Bit layout is
+ * documented on `zedra_terminal::keyboard_accessory::sticky_modifier_mask`.
+ */
+uint32_t zedra_ios_key_bar_modifier_mask(void);
+
+/**
+ * Whether the extended two-row keypad is enabled, for the initial layout.
+ */
+bool zedra_ios_extended_keypad(void);
+
+/**
+ * Whether the keypad's platform slot shows Cmd rather than `|`.
+ */
+bool zedra_ios_keypad_cmd_slot(void);
+
+/**
  * Called from Swift when the pinned key bar is shown, hidden, or re-laid out.
  *
  * `height_px` is the bar's full height (including safe-area padding) × scale, 0 when hidden.
@@ -276,6 +292,11 @@ extern void ios_set_keyboard_accessory_theme(bool is_dark);
  * Show or hide the key bar pinned above the safe area when the keyboard is down.
  */
 extern void ios_set_pinned_key_bar_visible(bool visible);
+
+/**
+ * Switch the keypad layout and its platform slot.
+ */
+extern void ios_set_keypad_layout(bool extended, bool cmd_slot);
 
 /**
  * Acquire an image natively. source: 0 = photo library, 1 = clipboard.

--- a/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
@@ -64,6 +64,13 @@ void zedra_ios_set_screen_scale(float scale);
 void zedra_ios_set_keyboard_height(uint32_t height_px);
 
 /**
+ * Called from Swift when the pinned key bar is shown, hidden, or re-laid out.
+ *
+ * `height_px` is the bar's full height (including safe-area padding) × scale, 0 when hidden.
+ */
+void zedra_ios_set_pinned_key_bar_height(uint32_t height_px);
+
+/**
  * Called from Obj-C with the current safe area insets in physical pixels
  * (UIEdgeInsets × UIScreen.scale). Re-called on orientation change.
  *
@@ -266,6 +273,32 @@ extern int32_t ios_system_prefers_dark_theme(void);
 extern void ios_set_keyboard_accessory_theme(bool is_dark);
 
 /**
+ * Show or hide the key bar pinned above the safe area when the keyboard is down.
+ */
+extern void ios_set_pinned_key_bar_visible(bool visible);
+
+/**
+ * Acquire an image natively. source: 0 = photo library, 1 = clipboard.
+ * Delivers exactly one of zedra_ios_image_acquire_{result,cancel,error}(callback_id, ..).
+ */
+extern void ios_acquire_image(uint32_t callback_id, int32_t source);
+
+/**
+ * Returns true when UIPasteboard currently holds an image (UIPasteboard.hasImages).
+ */
+extern bool ios_clipboard_has_image(void);
+
+/**
+ * Show or update a native progress HUD (spinner + message) for `id`.
+ */
+extern void ios_present_native_progress(uint32_t id, const char *message);
+
+/**
+ * Hide the native progress HUD for `id`.
+ */
+extern void ios_dismiss_native_progress(uint32_t id);
+
+/**
  * Called from the native alert handler after the user taps a button.
  *
  * `callback_id` matches the value passed to `ios_present_alert`.
@@ -314,6 +347,25 @@ bool zedra_ios_webview_navigate(uint32_t callback_id, const char *url);
  * Called when the webview is dismissed.
  */
 void zedra_ios_webview_dismiss(uint32_t callback_id);
+
+/**
+ * Called by Swift with the processed image bytes ready to upload.
+ * `extension` is "jpg" or "png" (lowercase, no dot).
+ */
+void zedra_ios_image_acquire_result(uint32_t callback_id,
+                                    const uint8_t *data,
+                                    uintptr_t len,
+                                    const char *extension);
+
+/**
+ * Called by Swift when the user cancels the picker, or the clipboard held no image.
+ */
+void zedra_ios_image_acquire_cancel(uint32_t callback_id);
+
+/**
+ * Called by Swift on a decode/processing failure.
+ */
+void zedra_ios_image_acquire_error(uint32_t callback_id, const char *message);
 
 /**
  * Called from the native app delegate when the app enters the background.

--- a/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
@@ -64,6 +64,12 @@ void zedra_ios_set_screen_scale(float scale);
 void zedra_ios_set_keyboard_height(uint32_t height_px);
 
 /**
+ * Armed/locked keypad modifiers, for rendering key highlights. Bit layout is
+ * documented on `zedra_terminal::keyboard_accessory::sticky_modifier_mask`.
+ */
+uint32_t zedra_ios_key_bar_modifier_mask(void);
+
+/**
  * Called from Swift when the pinned key bar is shown, hidden, or re-laid out.
  *
  * `height_px` is the bar's full height (including safe-area padding) × scale, 0 when hidden.
@@ -276,6 +282,16 @@ extern void ios_set_keyboard_accessory_theme(bool is_dark);
  * Show or hide the key bar pinned above the safe area when the keyboard is down.
  */
 extern void ios_set_pinned_key_bar_visible(bool visible);
+
+/**
+ * Switch the keypad layout and its platform slot.
+ */
+extern void ios_set_keypad_layout(bool extended, bool cmd_slot);
+
+/**
+ * Drop the keypad composer and the keyboard it owns.
+ */
+extern void ios_cancel_keypad_composer(void);
 
 /**
  * Acquire an image natively. source: 0 = photo library, 1 = clipboard.

--- a/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
@@ -64,6 +64,13 @@ void zedra_ios_set_screen_scale(float scale);
 void zedra_ios_set_keyboard_height(uint32_t height_px);
 
 /**
+ * Called from Swift when the pinned key bar is shown, hidden, or re-laid out.
+ *
+ * `height_px` is the bar's full height (including safe-area padding) × scale, 0 when hidden.
+ */
+void zedra_ios_set_pinned_key_bar_height(uint32_t height_px);
+
+/**
  * Called from Obj-C with the current safe area insets in physical pixels
  * (UIEdgeInsets × UIScreen.scale). Re-called on orientation change.
  *
@@ -264,6 +271,11 @@ extern int32_t ios_system_prefers_dark_theme(void);
  * Apply the app appearance to the native keyboard accessory bar.
  */
 extern void ios_set_keyboard_accessory_theme(bool is_dark);
+
+/**
+ * Show or hide the key bar pinned above the safe area when the keyboard is down.
+ */
+extern void ios_set_pinned_key_bar_visible(bool visible);
 
 /**
  * Acquire an image natively. source: 0 = photo library, 1 = clipboard.


### PR DESCRIPTION
## Summary

- Keep the Esc/Tab/arrow keypad on screen while the software keyboard is collapsed, so agent shortcuts stay reachable without raising it. Closes #195.
- Add an optional extended keypad (Settings → Terminal, default off): two rows with sticky modifiers and a drag-in IME composing field. Closes #182.

```
Esc  Shift  Tab  /  -  ↑  ⏎
 ⌫   Ctrl  Alt  Cmd  ←  ↓  →      Cmd → | on non-macOS hosts
```

- Modifiers arm on a tap, lock on a double tap, and apply to keys from the keypad *and* to characters committed by the software keyboard, so Ctrl on the bar followed by `c` reaches the PTY as Ctrl+C. State lives on the terminal entity, so it cannot leak between terminals.
- Both platforms reuse the existing native accessory view, so the pinned and keyboard-attached bars are identical by construction and only one is ever on screen.

## Notes

- `gpui_ios` gains two entry points, bumping the submodule to `tanlethanh/zed@8bcfddc`: `handle_key_bar_action` (the accessory path requires an active keyboard session) and `handle_key_bar_text` (the generic text entry fans a string into per-character key events through the keymap, which never reached the terminal).
- Android polls keypad state from a `Choreographer` callback rather than taking a push: GPUI renders into the `SurfaceView`, so the Android view tree does not invalidate when the bar mounts or a drawer opens.
- Composed text arrives at the prompt without a newline, and leaving the composer hands the keyboard back to the terminal instead of dismissing it.
- Manual verification: `docs/MANUAL_TEST.md` § 11g and § 11h. Behavioural paths need a live session, so they are untested by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pinned keyboard bar remains available when the software keyboard is hidden.
  * Bar automatically hides when drawers are open and adapts to rotation and safe-area changes.
  * Added settings for key-bar visibility and extended two-row keypad layouts.
  * Added compose mode for entering text, sticky modifier keys, key repetition, and backspace support.
  * Terminal focus can now be preserved when dismissing the keyboard.
* **Style**
  * Improved keypad theming and modifier-key highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->