### PR TITLE
fix(host): match Claude project dir encoding for non-alphanumeric paths

### DIFF
--- a/crates/zedra-host/src/agent/claude.rs
+++ b/crates/zedra-host/src/agent/claude.rs
@@ -10,6 +10,31 @@ use serde_json::Value;
 
 const LIST_HEAD_SCAN_MAX_LINES: usize = 64;
 const LIST_HEAD_SCAN_MAX_BYTES: usize = 32 * 1024;
+/// Claude CLI truncates a project dir name past this length and appends a hash.
+const PROJECT_NAME_MAX_LEN: usize = 200;
+
+/// Claude CLI `Math.abs(hash).toString(36)` over the unsanitized path, where
+/// `hash` is the `(h << 5) - h + code_unit | 0` variant over UTF-16 units.
+fn project_name_hash(path: &str) -> String {
+    let mut hash: i32 = 0;
+    for unit in path.encode_utf16() {
+        hash = hash
+            .wrapping_shl(5)
+            .wrapping_sub(hash)
+            .wrapping_add(i32::from(unit));
+    }
+    // i32::MIN has no positive i32 counterpart; JS abs widens to a double.
+    let mut value = i64::from(hash).unsigned_abs();
+    if value == 0 {
+        return "0".to_string();
+    }
+    let mut digits = Vec::new();
+    while value > 0 {
+        digits.push(char::from_digit((value % 36) as u32, 36).unwrap_or('0'));
+        value /= 36;
+    }
+    digits.iter().rev().collect()
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ClaudeSessionList {
@@ -225,14 +250,29 @@ impl ClaudeActor {
         Self::claude_config_dir().unwrap_or_else(|_| home_path(&[".claude"]))
     }
 
-    /// Mirrors Claude CLI: every non-alphanumeric char becomes `-`, so workdirs
-    /// with dots or underscores still resolve to their project dir.
+    /// Mirrors Claude CLI `replace(/[^a-zA-Z0-9]/g, "-")`, then its 200-char cap
+    /// with a hash suffix. Iterates UTF-16 units because the CLI regex has no
+    /// `u` flag, so a surrogate pair yields two `-`, not one.
     fn encoded_project_name(workdir: &Path) -> String {
-        workdir
-            .to_string_lossy()
-            .chars()
-            .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
-            .collect()
+        let path = workdir.to_string_lossy();
+        let sanitized: String = path
+            .encode_utf16()
+            .map(|unit| match u8::try_from(unit) {
+                Ok(byte) if byte.is_ascii_alphanumeric() => byte as char,
+                _ => '-',
+            })
+            .collect();
+
+        // Sanitized output is pure ASCII, so byte length matches the CLI's
+        // UTF-16 `.length` and slicing at the cap stays on a char boundary.
+        if sanitized.len() <= PROJECT_NAME_MAX_LEN {
+            return sanitized;
+        }
+        format!(
+            "{}-{}",
+            &sanitized[..PROJECT_NAME_MAX_LEN],
+            project_name_hash(&path)
+        )
     }
 
     fn worktree_from_project_dir(project_dir: &Path) -> Option<String> {
@@ -846,6 +886,34 @@ mod tests {
             ClaudeActor::encoded_project_name(Path::new("/Users/me/my.app_v2 beta")),
             "-Users-me-my-app-v2-beta"
         );
+    }
+
+    // The CLI regex has no `u` flag, so a surrogate pair becomes two `-`.
+    #[test]
+    fn project_name_encodes_non_bmp_char_as_two_dashes() {
+        assert_eq!(
+            ClaudeActor::encoded_project_name(Path::new("/Users/me/\u{1F4C1}repo")),
+            "-Users-me---repo"
+        );
+    }
+
+    #[test]
+    fn project_name_truncates_long_paths_with_hash_suffix() {
+        let workdir = format!("/Users/me/{}", "a".repeat(300));
+        let encoded = ClaudeActor::encoded_project_name(Path::new(&workdir));
+
+        // 10 leading chars + 190 `a` fills the 200-char cap, then the hash.
+        let expected = format!("-Users-me-{}-cgp8v3", "a".repeat(190));
+        assert_eq!(encoded, expected);
+        assert_eq!(encoded.len(), PROJECT_NAME_MAX_LEN + 7);
+    }
+
+    #[test]
+    fn project_name_hash_matches_cli_for_deep_paths() {
+        let workdir = format!("/Users/me/{}leaf", "deep/".repeat(60));
+        let encoded = ClaudeActor::encoded_project_name(Path::new(&workdir));
+
+        assert!(encoded.ends_with("-hpaxfl"), "got {encoded}");
     }
 
     #[test]

--- a/crates/zedra-host/src/agent/claude.rs
+++ b/crates/zedra-host/src/agent/claude.rs
@@ -225,14 +225,13 @@ impl ClaudeActor {
         Self::claude_config_dir().unwrap_or_else(|_| home_path(&[".claude"]))
     }
 
+    /// Mirrors Claude CLI: every non-alphanumeric char becomes `-`, so workdirs
+    /// with dots or underscores still resolve to their project dir.
     fn encoded_project_name(workdir: &Path) -> String {
         workdir
             .to_string_lossy()
             .chars()
-            .map(|ch| match ch {
-                '/' | '\\' => '-',
-                _ => ch,
-            })
+            .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
             .collect()
     }
 
@@ -837,8 +836,35 @@ mod tests {
         );
         assert_eq!(
             ClaudeActor::encoded_project_name(Path::new(r"C:\Users\me\project")),
-            "C:-Users-me-project"
+            "C--Users-me-project"
         );
+    }
+
+    #[test]
+    fn project_name_encodes_every_non_alphanumeric_char() {
+        assert_eq!(
+            ClaudeActor::encoded_project_name(Path::new("/Users/me/my.app_v2 beta")),
+            "-Users-me-my-app-v2-beta"
+        );
+    }
+
+    #[test]
+    fn list_sessions_finds_dotted_workdir_transcripts() {
+        let config = tempfile::tempdir().unwrap();
+        let workdir = Path::new("/Users/me/my.app");
+        let project_dir = config.path().join("projects").join("-Users-me-my-app");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("session.jsonl"),
+            r#"{"sessionId":"dotted-session","cwd":"/Users/me/my.app","timestamp":"2026-05-09T10:00:00Z"}
+"#,
+        )
+        .unwrap();
+
+        let list = ClaudeActor::list_sessions_in_config(workdir, config.path(), None).unwrap();
+
+        assert_eq!(list.sessions.len(), 1);
+        assert_eq!(list.sessions[0].session_id, "dotted-session");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Agent History showed an empty list for any workspace whose path contains a dot, underscore, or space.

`ClaudeActor::encoded_project_name` mapped only `/` and `\` to `-`, but the Claude CLI sanitizes **every** non-alphanumeric character. So a workdir like `~/work/my.app` encoded to `-Users-me-work-my.app`, which never exists under `~/.claude/projects`. `project_dirs_for_workdir` then found no directory, the scan returned zero transcripts, and the UI rendered an empty list with no error.

Confirmed by the reporter's screenshot: their workspace is `~/spartan/loanbud/loanbud.io-be`, which contains a dot. Also confirmed on disk locally: no directory under `~/.claude/projects` contains `.` or `_`, and a worktree for branch `iroh-v1.0.0` appears as `...-iroh-v1-0-0`.

Fixes #123

## Notes

- Encoding now mirrors the CLI: any non-ASCII-alphanumeric char becomes `-`. `is_ascii_alphanumeric` (not `is_alphanumeric`) matches the CLI's `[^a-zA-Z0-9]` behavior on accented characters.
- The Windows assertion changed to `C--Users-me-project`, since the drive colon is now sanitized too — this matches the real CLI.
- Also fixes worktree session discovery, which builds its prefix from the same encoder.
- `crates/zedra-host/src/agent/pi.rs:111` has the same slash-only encoder. Left unchanged: pi uses a different directory scheme (`-{encoded}--`) and nothing under `~/.pi/agent/sessions` on my machine proves how it sanitizes dots. Worth confirming separately.

## Testing

`cargo test -p zedra-host claude` — 32 passed, and `cargo fmt --check` clean. Added `project_name_encodes_every_non_alphanumeric_char` and `list_sessions_finds_dotted_workdir_transcripts` (the latter fails on `main`).

Tests were run in my primary worktree; this branch's diff is byte-identical. The PR worktree can't build locally because `vendor/zed` isn't populated there and the shallow local mirror can't be used as a clone reference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude project-name handling for special characters, Windows paths, dotted directories, spaces, and non-ASCII characters.
  * Added support for long project names by truncating them consistently with Claude CLI behavior.
  * Improved session discovery for encoded project names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->