### PR TITLE
fix(web-tunnel): survive the reconnect window after backgrounding

### DIFF
--- a/crates/zedra/src/web_tunnel/alias.rs
+++ b/crates/zedra/src/web_tunnel/alias.rs
@@ -106,7 +106,12 @@ fn spawn_accept_loop(listener: TcpListener) {
                 break;
             };
             tokio::spawn(async move {
-                let _ = handle_socks(stream).await;
+                // Never discard this: a rejected SOCKS connection is what the
+                // webview renders as its "cannot connect" page, and without a
+                // log the alias path fails invisibly.
+                if let Err(error) = handle_socks(stream).await {
+                    tracing::info!("web-tunnel: alias connect failed: {error}");
+                }
             });
         }
     });
@@ -197,11 +202,7 @@ async fn forward_via_session(
     endpoint_id: PublicKey,
     port: u16,
 ) -> Result<(), String> {
-    let Some(session) = super::session_for(&endpoint_id) else {
-        stream.write_all(&reply(0x05)).await.ok();
-        return Err("no session for alias host".to_string());
-    };
-    let (tx, rx, initial) = match bridge::connect(&session, port).await {
+    let (tx, rx, initial) = match bridge::connect_retrying(&endpoint_id, port).await {
         Ok(parts) => parts,
         Err(error) => {
             stream.write_all(&reply(0x05)).await.ok();

--- a/crates/zedra/src/web_tunnel/bridge.rs
+++ b/crates/zedra/src/web_tunnel/bridge.rs
@@ -61,17 +61,22 @@ pub(super) async fn connect_retrying(
 ) -> Result<(Tx, Rx, Option<WebTunnelOutput>), String> {
     let deadline = Instant::now() + CONNECT_RETRY_WINDOW;
     loop {
+        // A half-dead session can leave `connect` awaiting forever, so bound the
+        // attempt itself — otherwise the window is advisory and the page hangs.
+        let remaining = deadline.saturating_duration_since(Instant::now());
         let error = match super::session_for(endpoint_id) {
-            Some(session) => match connect(&session, port).await {
-                Ok(parts) => return Ok(parts),
-                Err(error) => error,
+            Some(session) => match tokio::time::timeout(remaining, connect(&session, port)).await {
+                Ok(Ok(parts)) => return Ok(parts),
+                Ok(Err(error)) => error,
+                Err(_) => "timed out waiting for the host".to_string(),
             },
             None => "no session for host".to_string(),
         };
-        if Instant::now() >= deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
             return Err(error);
         }
-        tokio::time::sleep(CONNECT_RETRY_DELAY).await;
+        tokio::time::sleep(CONNECT_RETRY_DELAY.min(remaining)).await;
     }
 }
 

--- a/crates/zedra/src/web_tunnel/bridge.rs
+++ b/crates/zedra/src/web_tunnel/bridge.rs
@@ -4,6 +4,9 @@
 //! adapter sniff response bytes for companion ports; the alias adapter passes a
 //! no-op.
 
+use std::time::{Duration, Instant};
+
+use iroh::PublicKey;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::net::tcp::OwnedWriteHalf;
@@ -14,6 +17,13 @@ use zedra_session::SessionHandle;
 
 type Tx = irpc::channel::mpsc::Sender<WebTunnelInput>;
 type Rx = irpc::channel::mpsc::Receiver<WebTunnelOutput>;
+
+// Returning from background leaves the QUIC session idled out (20s
+// max_idle_timeout) until the foreground reconnect lands, so the page's first
+// request would otherwise fail hard and render the webview's error page with
+// nothing to retry it. Cover that gap instead of failing on the first attempt.
+const CONNECT_RETRY_WINDOW: Duration = Duration::from_secs(15);
+const CONNECT_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 /// Open a `WebConnect` to the host's loopback `port` and wait for the host to
 /// confirm. Returns the paired channels plus the first output frame, or an
@@ -40,6 +50,29 @@ pub(super) async fn connect(
         Err(error) => return Err(format!("web tunnel handshake failed: {error:?}")),
     };
     Ok((tx, rx, initial))
+}
+
+/// [`connect`], retried until a live session answers or [`CONNECT_RETRY_WINDOW`]
+/// elapses. Resolves the session on every attempt: after a reconnect the entry
+/// is republished under the same endpoint id, so a stale lookup must not stick.
+pub(super) async fn connect_retrying(
+    endpoint_id: &PublicKey,
+    port: u16,
+) -> Result<(Tx, Rx, Option<WebTunnelOutput>), String> {
+    let deadline = Instant::now() + CONNECT_RETRY_WINDOW;
+    loop {
+        let error = match super::session_for(endpoint_id) {
+            Some(session) => match connect(&session, port).await {
+                Ok(parts) => return Ok(parts),
+                Err(error) => error,
+            },
+            None => "no session for host".to_string(),
+        };
+        if Instant::now() >= deadline {
+            return Err(error);
+        }
+        tokio::time::sleep(CONNECT_RETRY_DELAY).await;
+    }
 }
 
 /// Bridge `stream` to the paired `WebConnect` channels until either side closes.

--- a/crates/zedra/src/web_tunnel/exact_port.rs
+++ b/crates/zedra/src/web_tunnel/exact_port.rs
@@ -126,10 +126,7 @@ fn spawn_accept_loop(listener: TcpListener, endpoint_id: PublicKey) -> tokio::ta
 // the page asked for.
 async fn handle_connection(stream: TcpStream, endpoint_id: PublicKey) {
     let port = stream.local_addr().map(|a| a.port()).unwrap_or(0);
-    let Some(session) = super::session_for(&endpoint_id) else {
-        return;
-    };
-    let (tx, rx, initial) = match bridge::connect(&session, port).await {
+    let (tx, rx, initial) = match bridge::connect_retrying(&endpoint_id, port).await {
         Ok(parts) => parts,
         Err(error) => {
             tracing::info!("web-tunnel: exact-port connect {port} failed: {error}");

--- a/crates/zedra/src/web_tunnel/mod.rs
+++ b/crates/zedra/src/web_tunnel/mod.rs
@@ -139,6 +139,22 @@ fn session_for(endpoint_id: &PublicKey) -> Option<SessionHandle> {
         .cloned()
 }
 
+/// Publish `handle` as the live session for its host. Listeners and alias labels
+/// outlive any single session, so a workspace that gave up reconnecting and was
+/// reconnected from Home arrives with a *new* handle — without this the tunnel
+/// keeps dialing the dead one and never recovers. Replacing the entry also drops
+/// the old handle, letting it close its connection.
+pub fn register_session(handle: &SessionHandle) {
+    let Some(endpoint_id) = handle.endpoint_id() else {
+        return;
+    };
+    registry()
+        .sessions
+        .lock()
+        .unwrap()
+        .insert(endpoint_id, handle.clone());
+}
+
 /// Open `url` the best way: host-local http(s) URLs load in the in-app webview
 /// (exact-port by default, alias on a per-host opt-in fallback); anything else
 /// (or an unparseable target) falls back to the system browser. Single "open a

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -1372,8 +1372,9 @@ impl Workspace {
             request.ticket,
             request.signer,
             session_id.clone(),
-            move |_handle| {
+            move |handle| {
                 info!("session {:?} connected", session_id);
+                crate::web_tunnel::register_session(handle);
             },
         );
     }

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -838,7 +838,7 @@ nothing retries it.
 
 1. Open a tunneled page (`run.sh` test app, or an opencode web client card) and confirm it loads.
 2. Send the app to the home screen and leave it there **at least 30s**, so the session really idles out. On the simulator, background it and also `kill -STOP <app pid>` for the wait — the simulator never suspends app processes, so the keepalive otherwise holds the connection open and the case cannot occur.
-3. Foreground the app and immediately reload the page (↻), or interact so it issues a request.
+3. Resume the process (`kill -CONT <app pid>` on the simulator), foreground the app, and immediately reload the page (↻), or interact so it issues a request.
 4. Expected: the page loads. It may pause a second or two while the session reconnects, but must **not** show "Can't reach this page" / "cannot connect to the server".
 5. Log: `session … connected` after `AppForegrounded`, and **no** `exact-port connect <port> failed` / `alias connect failed` line.
 6. Negative check: stop the host daemon, then reload. Expected: after ~15s the error page does appear, with `alias connect failed: …` or `exact-port connect … failed: …` logged — failures are still reported, just not instantly.

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -843,6 +843,20 @@ nothing retries it.
 5. Log: `session … connected` after `AppForegrounded`, and **no** `exact-port connect <port> failed` / `alias connect failed` line.
 6. Negative check: stop the host daemon, then reload. Expected: after ~15s the error page does appear, with `alias connect failed: …` or `exact-port connect … failed: …` logged — failures are still reported, just not instantly.
 
+### Tunnel recovers after the session gave up reconnecting
+
+Reconnect gives up after 3 attempts (`reconnect exhausted, giving up attempts 3`).
+Reconnecting from Home then builds a *new* `SessionHandle`, while the bound
+listener/alias still resolves by endpoint id — so the tunnel must be re-pointed
+at the new session or it keeps dialing the dead one forever.
+
+1. Open a tunneled page and confirm it loads.
+2. Stop the host daemon (or drop the network) and wait ~1 min, until the log shows `reconnect exhausted, giving up attempts 3`.
+3. Reload the page. Expected: the error page, and `alias connect failed: … not connected` (or the exact-port equivalent) in the log.
+4. Restart the host daemon, return to Home, tap **Reconnect** on the workspace card, and wait for `session … connected`.
+5. Reopen the web client card. Expected: the page loads again. Before the fix this stayed broken — the tunnel kept resolving the dead handle, and only reopening the card refreshed it.
+6. Also check the still-open webview from step 1 recovers on reload, without needing the card reopened.
+
 ### Webview content process reclaimed (iOS)
 
 iOS kills the WKWebView content process while the app is backgrounded. The page

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -829,6 +829,30 @@ The default exact-port mode binds `127.0.0.1:<port>` on the device and opens the
 3. Start `./examples/webview-tunnel/run.sh` on the host, then tap **Try Again** (or the reload ↻ button).
 4. Expected: the retry loads the real page through the tunnel (not the error HTML, and no system browser), and the page renders.
 
+### Tunnel survives returning from background (iOS)
+
+Suspension idles out the QUIC session (20s `max_idle_timeout`), so the first
+request after resume lands while the foreground reconnect is still in flight.
+It must be held, not failed — a failed navigation renders the error page and
+nothing retries it.
+
+1. Open a tunneled page (`run.sh` test app, or an opencode web client card) and confirm it loads.
+2. Send the app to the home screen and leave it there **at least 30s**, so the session really idles out. On the simulator, background it and also `kill -STOP <app pid>` for the wait — the simulator never suspends app processes, so the keepalive otherwise holds the connection open and the case cannot occur.
+3. Foreground the app and immediately reload the page (↻), or interact so it issues a request.
+4. Expected: the page loads. It may pause a second or two while the session reconnects, but must **not** show "Can't reach this page" / "cannot connect to the server".
+5. Log: `session … connected` after `AppForegrounded`, and **no** `exact-port connect <port> failed` / `alias connect failed` line.
+6. Negative check: stop the host daemon, then reload. Expected: after ~15s the error page does appear, with `alias connect failed: …` or `exact-port connect … failed: …` logged — failures are still reported, just not instantly.
+
+### Webview content process reclaimed (iOS)
+
+iOS kills the WKWebView content process while the app is backgrounded. The page
+must reload itself rather than come back blank.
+
+1. Open a tunneled page and let it settle on a deep route (e.g. an opencode session).
+2. Kill the page's content process. Simulator: `ps -axo pid,lstart,command | grep WebKit.WebContent`, pick the CoreSimulator-path entry whose start time matches when the webview opened, `kill -9 <pid>`. On device, background the app and leave it under memory pressure until iOS reclaims it.
+3. Expected: the page reloads itself and comes back on the **same route**, not blank and not the base URL. Log: `webview: content process terminated url=<full url>`.
+4. Repeat the kill immediately (within 3s). Expected: instead of reloading again, the inline error page appears ("The page stopped responding.") — the loop guard.
+
 ### Tunnel modes (devtool)
 
 Exercise the exact-port / alias adapters without contriving two hosts. Fire deeplinks at a **running, connected** app — simulator: `xcrun simctl openurl booted '<deeplink>'`; device: `xcrun devicectl device process launch --terminate-existing --device <udid> --payload-url '<deeplink>' dev.zedra.app.debug` then reconnect the workspace. Debug builds only. See `docs/WEB_TUNNEL_MODES.md`.

--- a/ios/Zedra/Presentations.swift
+++ b/ios/Zedra/Presentations.swift
@@ -2546,7 +2546,10 @@ private final class NativeWebViewController: UIViewController, WKNavigationDeleg
     // Without this the page comes back permanently blank, with no signal to Rust
     // and nothing but the reload button to recover it.
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-        NSLog("webview: content process terminated url=%@", currentTarget.absoluteString)
+        // `currentTarget` only tracks explicit loads, so a followed link or an
+        // SPA route would otherwise reload the page the user started from.
+        let target = webView.url ?? currentTarget
+        NSLog("webview: content process terminated url=%@", target.absoluteString)
         // A page that kills its process on every load would otherwise reload forever.
         let now = Date()
         if let last = lastProcessReload, now.timeIntervalSince(last) < Self.processReloadMinInterval {
@@ -2560,7 +2563,7 @@ private final class NativeWebViewController: UIViewController, WKNavigationDeleg
             return
         }
         lastProcessReload = now
-        loadURL(currentTarget)
+        loadURL(target)
     }
 
     /// Replace the blank page with an inline error page for the failed target.

--- a/ios/Zedra/Presentations.swift
+++ b/ios/Zedra/Presentations.swift
@@ -2258,6 +2258,8 @@ private final class NativeWebViewController: UIViewController, WKNavigationDeleg
     // this real URL instead of the error HTML.
     private var currentTarget: URL
     private var showingErrorFor: URL?
+    private var lastProcessReload: Date?
+    private static let processReloadMinInterval: TimeInterval = 3
     var onDismiss: (() -> Void)?
 
     // Sentinel scheme the error page's "Try Again" button navigates to; caught
@@ -2538,6 +2540,27 @@ private final class NativeWebViewController: UIViewController, WKNavigationDeleg
             nsError.localizedDescription
         )
         showErrorPage(for: nsError)
+    }
+
+    // iOS reclaims the WKWebView content process while the app is backgrounded.
+    // Without this the page comes back permanently blank, with no signal to Rust
+    // and nothing but the reload button to recover it.
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        NSLog("webview: content process terminated url=%@", currentTarget.absoluteString)
+        // A page that kills its process on every load would otherwise reload forever.
+        let now = Date()
+        if let last = lastProcessReload, now.timeIntervalSince(last) < Self.processReloadMinInterval {
+            showErrorPage(
+                for: NSError(
+                    domain: "dev.zedra.webview",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "The page stopped responding."]
+                )
+            )
+            return
+        }
+        lastProcessReload = now
+        loadURL(currentTarget)
     }
 
     /// Replace the blank page with an inline error page for the failed target.


### PR DESCRIPTION
## Summary

Returning from background leaves the QUIC session idled out (20s `max_idle_timeout`) until the foreground reconnect lands. Both tunnel adapters failed the first request inside that gap — `exact_port::handle_connection` returned early, `alias::forward_via_session` replied SOCKS `0x05`. For the webview that is a failed provisional navigation, so the page renders "cannot connect to the server" and nothing retries it.

- Route both adapters through a shared `bridge::connect_retrying`, which re-resolves the session on every attempt (the entry is republished under the same endpoint id on reconnect) for up to 15s. A genuinely down host still fails rather than hanging the page.
- The alias path discarded every error (`let _ = handle_socks(...)`), so it failed invisibly — it now logs.
- iOS reclaims the `WKWebView` content process while backgrounded, which left the page permanently blank with nothing but the reload button to recover it. Handle `webViewWebContentProcessDidTerminate` and reload the current route, guarded against a crash loop.

## Notes

Reproduced and verified on the simulator across a 30s suspension. The simulator never suspends app processes, so the case cannot occur there without `SIGSTOP` on the app pid to freeze the 1s keepalive the way a device suspension does.

Same probe through the tunnel's own SOCKS proxy, before and after:

| | first request after resume |
|---|---|
| before | `FAIL http=000 curl_rc=97` |
| after | `OK http=200` |

Valid in both runs — every stream logged `Io error` and a fresh `holepunch` reconnect followed, so the session genuinely died. After the fix one probe is *held* ~2s by the retry instead of failing.

Content-process recovery verified by killing the WebContent process: logs `webview: content process terminated url=…` and reloads back onto the same deep SPA route instead of coming back blank.

The simulator shares the Mac's loopback, so the host's own `opencode serve` holds the port and the in-app bind falls back to the **alias** adapter — that is the path exercised end to end here. The exact-port path got the identical change and compiles, but is verified by reading rather than by running.

Checks: `cargo fmt --check` · `cargo check -p zedra --features ios-platform --target aarch64-apple-ios` · `cargo test -p zedra --features ios-platform` (195 passed) · Xcode build clean (CI has no iOS compile step). Manual verification steps added to `docs/MANUAL_TEST.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunneled web connections by retrying briefly when a connection or session is not immediately available.
  * Added more reliable recovery for iOS webviews after backgrounding or content-process termination.
  * Prevented repeated webview failures from triggering reload loops and showed the error page when recovery is unsuccessful.
  * Improved connection failure reporting to make troubleshooting clearer.

* **Documentation**
  * Added manual test coverage for reconnecting requests, delayed failures, route recovery, and repeated webview termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->