### PR TITLE
feat(host): manage omp (Oh My Pi) sessions, hooks, and setup

### DIFF
--- a/crates/zedra-host/src/agent/mod.rs
+++ b/crates/zedra-host/src/agent/mod.rs
@@ -56,6 +56,7 @@ mod installed;
 mod junie;
 mod kilocode;
 mod maki;
+mod omp;
 mod openclaw;
 pub(crate) mod opencode;
 mod openhands;
@@ -722,11 +723,12 @@ pub(crate) trait AgentActor: Sync {
 
 // Registry order is the app's agent-picker order; `agents.order` in the user
 // config reorders it.
-static ACTORS: [&dyn AgentActor; 22] = [
+static ACTORS: [&dyn AgentActor; 23] = [
     &claude::ClaudeActor,
     &codex::CodexActor,
     &opencode::OpenCodeActor,
     &pi::PiActor,
+    &omp::OmpActor,
     &cursor::CursorActor,
     &grok::GrokActor,
     &antigravity::AntigravityActor,

--- a/crates/zedra-host/src/agent/omp.rs
+++ b/crates/zedra-host/src/agent/omp.rs
@@ -1,0 +1,653 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use zedra_rpc::proto::*;
+
+use super::utils::{
+    command_on_path, cwd_matches, file_size_bytes, home_path, info_field, parse_rfc3339,
+    resume_summary, session_title, sorted_jsonl_candidates, spawn_blocking_opt, string_field,
+    user_message_text,
+};
+use super::{
+    hook_file_mentions_zedra, hooks_enabled, setup_status, ActorFuture, AgentActor,
+    AgentSetupSummary, HookContext, ScanCtx, SessionCounts as ActorSessionCounts,
+};
+
+const LIST_HEAD_SCAN_MAX_LINES: usize = 32;
+
+#[derive(Debug, Clone)]
+struct OmpSessionFile {
+    path: PathBuf,
+    session_id: String,
+    cwd: Option<String>,
+    created_at: Option<DateTime<Utc>>,
+    last_activity_at: Option<DateTime<Utc>>,
+    title: Option<String>,
+}
+
+impl OmpActor {
+    pub fn cli_available() -> bool {
+        command_on_path("omp") || Self::omp_agent_dir().is_dir()
+    }
+
+    pub fn session_counts(workdir: &Path) -> Result<ActorSessionCounts, String> {
+        let (files, total) =
+            Self::collect_session_files(workdir, Some(1)).map_err(|e| e.to_string())?;
+        let latest = files.first();
+        Ok(ActorSessionCounts::from_latest(
+            total,
+            latest.map(|f| f.session_id.clone()),
+            latest.and_then(|f| f.title.clone()),
+            latest.and_then(|f| f.last_activity_at),
+        ))
+    }
+
+    pub fn sessions(
+        workdir: &Path,
+        _cli: &AgentCliSummary,
+        limit: usize,
+    ) -> Result<(Vec<AgentSessionSummary>, usize), String> {
+        let (files, total) =
+            Self::collect_session_files(workdir, Some(limit)).map_err(|e| e.to_string())?;
+        let summaries = files.iter().map(Self::session_summary).collect();
+        Ok((summaries, total))
+    }
+
+    /// Title of a single omp session by id within the workdir. Used to fill the
+    /// notification body on a `Stop` hook.
+    pub fn title_for_session(workdir: &Path, session_id: &str) -> Option<String> {
+        let (files, _) = Self::collect_session_files(workdir, None).ok()?;
+        let file = files.into_iter().find(|f| f.session_id == session_id)?;
+        session_title(file.title)
+    }
+
+    pub fn account_fields(workdir: &Path) -> Vec<AgentInfoField> {
+        let mut fields = Vec::new();
+        let config = Self::read_yaml(&Self::omp_agent_dir().join("config.yml"));
+        if let Some(model) = config.and_then(|cfg| Self::default_model(&cfg)) {
+            fields.push(info_field("Default model", &model));
+        }
+        let models = Self::read_yaml(&Self::omp_agent_dir().join("models.yml"));
+        if let Some(count) = models
+            .as_ref()
+            .map(Self::custom_providers)
+            .filter(|n| *n > 0)
+        {
+            fields.push(info_field("Custom providers", &format!("{count}")));
+        }
+        fields.push(info_field(
+            "Project config",
+            if workdir.join(".omp").join("config.yml").is_file() {
+                "yes"
+            } else {
+                "no"
+            },
+        ));
+        fields
+    }
+
+    // ---------------------------------------------------------------------------
+    // File-system scan
+    // ---------------------------------------------------------------------------
+
+    fn omp_agent_dir() -> PathBuf {
+        home_path(&[".omp", "agent"])
+    }
+
+    fn omp_sessions_root() -> PathBuf {
+        Self::omp_agent_dir().join("sessions")
+    }
+
+    /// Newest sessions for `workdir` (by header `cwd`) plus the matching total.
+    /// Scans every project bucket so bucket-name encoding drift across omp
+    /// versions (legacy path-based, the reverted hashed scheme, migrations)
+    /// never hides sessions; the recorded cwd is the authoritative scope.
+    fn collect_session_files(
+        workdir: &Path,
+        limit: Option<usize>,
+    ) -> Result<(Vec<OmpSessionFile>, usize)> {
+        Self::collect_session_files_from(&Self::omp_sessions_root(), workdir, limit)
+    }
+
+    fn collect_session_files_from(
+        root: &Path,
+        workdir: &Path,
+        limit: Option<usize>,
+    ) -> Result<(Vec<OmpSessionFile>, usize)> {
+        let mut files = Vec::new();
+        for bucket in std::fs::read_dir(root).into_iter().flatten().flatten() {
+            if !bucket.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            for (path, mtime) in sorted_jsonl_candidates(&bucket.path())? {
+                let Ok(file) = Self::read_session_file(&path, mtime) else {
+                    continue;
+                };
+                if cwd_matches(workdir, file.cwd.as_deref()) {
+                    files.push(file);
+                }
+            }
+        }
+        let total = files.len();
+        files.sort_by(|a, b| b.last_activity_at.cmp(&a.last_activity_at));
+        if let Some(limit) = limit {
+            files.truncate(limit);
+        }
+        Ok((files, total))
+    }
+
+    /// Parse a session JSONL head. Current omp files begin with a fixed-width
+    /// `type: "title"` slot (a skipped record here), then the `type: "session"`
+    /// header and entries; legacy files start at the header directly.
+    fn read_session_file(path: &Path, mtime_unix_secs: Option<u64>) -> Result<OmpSessionFile> {
+        let file = File::open(path)
+            .with_context(|| format!("failed to read omp transcript {}", path.display()))?;
+        let mut session_id = String::new();
+        let mut cwd = None;
+        let mut created_at = None;
+        let mut last_timestamp: Option<DateTime<Utc>> = None;
+        let mut title: Option<String> = None;
+        let mut scanned_lines = 0usize;
+
+        for line in BufReader::new(file).lines() {
+            let line =
+                line.with_context(|| format!("failed to read line in {}", path.display()))?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let record = match serde_json::from_str::<Value>(trimmed) {
+                Ok(Value::Object(record)) => Value::Object(record),
+                _ => continue,
+            };
+            scanned_lines += 1;
+
+            let record_type = string_field(&record, &["type"]).unwrap_or("");
+            match record_type {
+                "session" => {
+                    if session_id.is_empty() {
+                        if let Some(id) = string_field(&record, &["id"]) {
+                            session_id = id.to_string();
+                        }
+                    }
+                    if cwd.is_none() {
+                        cwd = string_field(&record, &["cwd"]).map(str::to_string);
+                    }
+                    if title.is_none() {
+                        title = string_field(&record, &["title"]).map(str::to_string);
+                    }
+                    if created_at.is_none() {
+                        created_at = parse_rfc3339(string_field(&record, &["timestamp"]));
+                    }
+                }
+                // Fixed-width title slot written at the physical file head.
+                "title" => {
+                    if title.is_none() {
+                        title = string_field(&record, &["title", "name"]).map(str::to_string);
+                    }
+                }
+                "session_info" => {
+                    if let Some(name) =
+                        string_field(&record, &["displayName", "display_name", "name"])
+                    {
+                        title = Some(name.to_string());
+                    }
+                }
+                "label" => {
+                    if title.is_none() {
+                        if let Some(label) = string_field(&record, &["label", "text", "value"]) {
+                            title = Some(label.to_string());
+                        }
+                    }
+                }
+                "message" => {
+                    if title.is_none() {
+                        // Length is clamped centrally in `session_title`.
+                        title = Self::first_user_text(&record);
+                    }
+                }
+                _ => {}
+            }
+
+            if let Some(ts) = parse_rfc3339(string_field(&record, &["timestamp"])) {
+                last_timestamp = match last_timestamp {
+                    Some(current) if current >= ts => Some(current),
+                    _ => Some(ts),
+                };
+            }
+
+            if !session_id.is_empty()
+                && title.is_some()
+                && scanned_lines >= LIST_HEAD_SCAN_MAX_LINES
+            {
+                break;
+            }
+        }
+
+        if session_id.is_empty() {
+            session_id = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+        }
+
+        // Head scans see only opening records; trust mtime (append time) for
+        // activity, falling back to the newest scanned timestamp.
+        let mtime_activity =
+            mtime_unix_secs.and_then(|secs| DateTime::<Utc>::from_timestamp(secs as i64, 0));
+        let last_activity_at = mtime_activity.or(last_timestamp);
+
+        Ok(OmpSessionFile {
+            path: path.to_path_buf(),
+            session_id,
+            cwd,
+            created_at,
+            last_activity_at,
+            title,
+        })
+    }
+
+    fn session_summary(file: &OmpSessionFile) -> AgentSessionSummary {
+        AgentSessionSummary {
+            slug: "omp".to_string(),
+            session_id: file.session_id.clone(),
+            title: session_title(file.title.clone()),
+            cwd: file.cwd.clone(),
+            created_at: file.created_at,
+            last_activity_at: file.last_activity_at,
+            resume: resume_summary("omp", &file.session_id),
+            git: None,
+            usage: None,
+            transcript_size_bytes: file_size_bytes(&file.path),
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Config / auth (account info)
+    // ---------------------------------------------------------------------------
+
+    fn read_yaml(path: &Path) -> Option<serde_yaml::Value> {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|raw| serde_yaml::from_str(&raw).ok())
+    }
+
+    /// `modelRoles.default` (e.g. `spark/minimax-m3`) from `config.yml`.
+    fn default_model(config: &serde_yaml::Value) -> Option<String> {
+        config
+            .get("modelRoles")?
+            .get("default")?
+            .as_str()
+            .map(str::to_string)
+            .filter(|value| !value.is_empty())
+    }
+
+    /// Custom provider count from `models.yml` `providers` map.
+    fn custom_providers(models: &serde_yaml::Value) -> usize {
+        models
+            .get("providers")
+            .and_then(serde_yaml::Value::as_mapping)
+            .map_or(0, |map| map.len())
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    fn first_user_text(record: &Value) -> Option<String> {
+        user_message_text(record.get("message").unwrap_or(record))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global hook extension written by `AgentActor::setup` and `zedra setup omp`
+// ---------------------------------------------------------------------------
+
+impl OmpActor {
+    /// Writes the global omp hook extension; shared by `setup` and `setup_cli`.
+    fn write_hook_extension(force: bool, cli_path: &str) -> Result<PathBuf> {
+        let path = Self::hook_extension_path();
+        let contents = Self::hook_extension_contents(cli_path);
+        super::utils::write_file_checked(&path, &contents, force, "omp hook extension")?;
+        Ok(path)
+    }
+
+    fn hook_extension_path() -> PathBuf {
+        home_path(&[".omp", "agent", "extensions", "zedra-agent-hooks.ts"])
+    }
+
+    fn hook_extension_contents(cli_path: &str) -> String {
+        let cli_json =
+            serde_json::to_string(cli_path).unwrap_or_else(|_| format!("\"{}\"", cli_path));
+        format!(
+            r#"import type {{ ExtensionAPI }} from "@oh-my-pi/pi-coding-agent";
+import {{ spawn }} from "node:child_process";
+
+// Zedra hook extension for omp: forwards lifecycle events to the daemon for
+// state + push notifications. Active only inside a Zedra terminal
+// (ZEDRA_TERMINAL_ID); failures are swallowed so hooks never break omp.
+export default function (omp: ExtensionAPI) {{
+  if (!process.env.ZEDRA_TERMINAL_ID) return;
+
+  const CLI = process.env.ZEDRA_CLI || {cli};
+
+  const fire = (hookEventName: string, sessionId?: string) => {{
+    try {{
+      const child = spawn(
+        CLI,
+        ["agent", "hook", "receive", "--agent", "omp", "--quiet"],
+        {{
+          stdio: ["pipe", "ignore", "ignore"],
+          detached: true,
+          // ZEDRA_TERMINAL_ID and ZEDRA_WORKDIR are inherited from process.env
+          // and picked up by `agent hook receive` as --terminal-id / --workdir.
+        }},
+      );
+      child.on("error", () => {{}});
+      child.stdin?.on("error", () => {{}});
+      const payload: Record<string, string> = {{ hook_event_name: hookEventName }};
+      if (sessionId) payload.session_id = sessionId;
+      child.stdin?.end(JSON.stringify(payload));
+      child.unref();
+    }} catch {{
+      // spawn() can throw synchronously (EACCES, ENOENT). Stay silent.
+    }}
+  }};
+
+  // Gate on ctx.hasUI: skip non-interactive (print / RPC / subagent) runs.
+  // Check `=== false` so older omp versions without hasUI still fire hooks.
+  const skip = (ctx: {{ hasUI?: boolean }}) => ctx.hasUI === false;
+
+  omp.on("before_agent_start", (event, ctx) => {{
+    if (skip(ctx)) return;
+    fire("UserPromptSubmit", (event as any)?.sessionId);
+  }});
+
+  omp.on("agent_end", (event, ctx) => {{
+    if (skip(ctx)) return;
+    fire("Stop", (event as any)?.sessionId);
+  }});
+
+  // Fires on Ctrl+C, SIGTERM, /quit, /reload, /new, /resume, /fork.
+  // Ensures Running indicator clears if omp is killed mid-turn.
+  omp.on("session_shutdown", (event, ctx) => {{
+    if (skip(ctx)) return;
+    fire("Stop", (event as any)?.sessionId);
+  }});
+}}
+"#,
+            cli = cli_json
+        )
+    }
+}
+
+pub(super) struct OmpActor;
+
+impl AgentActor for OmpActor {
+    fn shows_detail(&self) -> bool {
+        true
+    }
+
+    fn slug(&self) -> &'static str {
+        "omp"
+    }
+    fn display_name(&self) -> &'static str {
+        "Oh My Pi"
+    }
+    fn icon_name(&self) -> &'static str {
+        "omp"
+    }
+    fn programs(&self) -> &'static [&'static str] {
+        &["omp"]
+    }
+    // Short token: match only as the entire command so `curl .../omp.sh/install`
+    // and word-boundary hits never latch an agent identity (pi.rs pattern).
+    fn detect_exact(&self) -> &'static [&'static str] {
+        &["omp"]
+    }
+    fn detect_aliases(&self) -> &'static [&'static str] {
+        &["@oh-my-pi/pi-coding-agent"]
+    }
+
+    fn cli_available(&self, _workdir: &Path) -> bool {
+        Self::cli_available()
+    }
+
+    fn session_counts(&self, ctx: &ScanCtx) -> Result<ActorSessionCounts, String> {
+        Self::session_counts(ctx.workdir)
+    }
+
+    fn sessions(
+        &self,
+        ctx: &ScanCtx,
+        limit: usize,
+    ) -> Result<(Vec<AgentSessionSummary>, usize), String> {
+        Self::sessions(ctx.workdir, ctx.cli, limit)
+    }
+
+    fn account_fields(&self, workdir: &Path) -> Vec<AgentInfoField> {
+        Self::account_fields(workdir)
+    }
+
+    fn setup_summary(&self, available: bool, _workdir: &Path) -> AgentSetupSummary {
+        setup_status(
+            available,
+            false,
+            false,
+            hooks_enabled()
+                && hook_file_mentions_zedra(&home_path(&[
+                    ".omp",
+                    "agent",
+                    "extensions",
+                    "zedra-agent-hooks.ts",
+                ])),
+            None,
+        )
+    }
+
+    fn resume_launch_command(&self, quoted: &str) -> Option<String> {
+        Some(format!("omp --resume {quoted}"))
+    }
+
+    // No remote plan/usage endpoint: `subscription_plan`/`account_usage` keep
+    // the trait's None defaults.
+
+    fn supports_hooks(&self) -> bool {
+        true
+    }
+
+    // omp exposes no approval hook (default `tools.approvalMode: yolo`), so
+    // there is no WaitingApproval transition.
+    fn hook_state(&self, event_name: &str, _payload: &Value) -> Option<AgentState> {
+        match event_name {
+            "UserPromptSubmit" => Some(AgentState::Running),
+            "Stop" => Some(AgentState::Completed),
+            _ => None,
+        }
+    }
+
+    // Only notify on completion — Stop is the single user-meaningful turn boundary.
+    fn hook_notify_title(&self, event_name: &str) -> Option<String> {
+        (event_name == "Stop").then(|| format!("{} completed", self.display_name()))
+    }
+
+    // omp stores transcripts per workdir; look up the session title for the body.
+    fn hook_notify_body(
+        &self,
+        ctx: &HookContext,
+        agent_session_id: Option<String>,
+    ) -> ActorFuture<'static, Option<String>> {
+        let workdir = ctx.workdir.clone();
+        spawn_blocking_opt(move || {
+            agent_session_id
+                .as_deref()
+                .and_then(|id| Self::title_for_session(&workdir, id))
+        })
+    }
+
+    fn supports_setup(&self) -> bool {
+        true
+    }
+
+    fn setup(&self, _workdir: &Path, force: bool) -> anyhow::Result<Vec<PathBuf>> {
+        let cli = std::env::current_exe().context("failed to resolve current zedra binary")?;
+        Ok(vec![Self::write_hook_extension(
+            force,
+            &cli.display().to_string(),
+        )?])
+    }
+
+    fn supports_setup_cli(&self) -> bool {
+        true
+    }
+
+    fn setup_cli<'a>(
+        &'a self,
+        action: super::SetupAction,
+        ctx: super::SetupCliCtx,
+    ) -> ActorFuture<'a, anyhow::Result<()>> {
+        Box::pin(async move {
+            match action {
+                super::SetupAction::Install => {
+                    ctx.section("Setting up omp");
+                    let binary = ctx.hook_binary()?;
+                    let path = Self::write_hook_extension(true, &binary)?;
+                    ctx.step("hooks");
+                    ctx.detail(&format!("write {}", path.display()));
+                    ctx.message("omp setup complete.");
+                }
+                super::SetupAction::Remove => {
+                    ctx.message("Removing Zedra lifecycle-hook extension for omp:");
+                    let path = Self::hook_extension_path();
+                    if ctx.remove_path(&path)? {
+                        ctx.step("hooks");
+                        ctx.detail(&format!("remove {}", path.display()));
+                    }
+                    ctx.message("");
+                    ctx.message("omp setup removed.");
+                    ctx.message("Restart any running omp session to apply the change.");
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_title_slot_header_and_first_user_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let bucket = dir.path().join("-dev-project");
+        std::fs::create_dir_all(&bucket).unwrap();
+        let path = bucket.join("2026-05-28_abc.jsonl");
+        // Physical title slot (fixed-width in real files; a plain record here),
+        // then the session header and a user message.
+        std::fs::write(
+            &path,
+            r#"{"type":"title","title":"Fix terminal paste","source":"auto"}
+{"type":"session","version":3,"id":"abc","timestamp":"2026-05-28T10:00:00Z","cwd":"/Users/me/project"}
+{"type":"message","id":"a","message":{"role":"user","content":[{"type":"text","text":"Refactor terminal scrollback"}]}}
+{"type":"message","id":"b","message":{"role":"assistant","content":[]}}
+"#,
+        )
+        .unwrap();
+
+        let file = OmpActor::read_session_file(&path, None).unwrap();
+        assert_eq!(file.session_id, "abc");
+        assert_eq!(file.cwd.as_deref(), Some("/Users/me/project"));
+        assert_eq!(file.title.as_deref(), Some("Fix terminal paste"));
+    }
+
+    #[test]
+    fn falls_back_to_filename_when_session_id_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("2026-05-28_xyz.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"message","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}
+"#,
+        )
+        .unwrap();
+        let file = OmpActor::read_session_file(&path, None).unwrap();
+        assert_eq!(file.session_id, "2026-05-28_xyz");
+    }
+
+    #[test]
+    fn scan_filters_sessions_to_workdir_across_buckets() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let workdir = Path::new("/Users/me/project");
+
+        let mine = root.join("-dev-project");
+        std::fs::create_dir_all(&mine).unwrap();
+        std::fs::write(
+            mine.join("2026-05-28_a.jsonl"),
+            r#"{"type":"session","id":"a","timestamp":"2026-05-28T10:00:00Z","cwd":"/Users/me/project"}
+{"type":"message","message":{"role":"user","content":[{"type":"text","text":"mine"}]}}
+"#,
+        )
+        .unwrap();
+
+        let other = root.join("--tmp-other--");
+        std::fs::create_dir_all(&other).unwrap();
+        std::fs::write(
+            other.join("2026-05-29_b.jsonl"),
+            r#"{"type":"session","id":"b","timestamp":"2026-05-29T10:00:00Z","cwd":"/tmp/other"}
+{"type":"message","message":{"role":"user","content":[{"type":"text","text":"other"}]}}
+"#,
+        )
+        .unwrap();
+
+        let (files, total) = OmpActor::collect_session_files_from(root, workdir, None).unwrap();
+        assert_eq!(total, 1);
+        assert_eq!(files[0].session_id, "a");
+    }
+
+    #[test]
+    fn config_yaml_surfaces_model_roles_and_providers() {
+        let config: serde_yaml::Value =
+            serde_yaml::from_str("modelRoles:\n  default: spark/minimax-m3\n").unwrap();
+        assert_eq!(
+            OmpActor::default_model(&config).as_deref(),
+            Some("spark/minimax-m3")
+        );
+
+        let models: serde_yaml::Value =
+            serde_yaml::from_str("providers:\n  spark: { models: [] }\n  ollama: { models: [] }\n")
+                .unwrap();
+        assert_eq!(OmpActor::custom_providers(&models), 2);
+        assert_eq!(OmpActor::custom_providers(&serde_yaml::Value::Null), 0);
+    }
+
+    #[test]
+    fn hook_state_maps_lifecycle_events() {
+        let actor = OmpActor;
+        assert_eq!(
+            actor.hook_state("UserPromptSubmit", &Value::Null),
+            Some(AgentState::Running)
+        );
+        assert_eq!(
+            actor.hook_state("Stop", &Value::Null),
+            Some(AgentState::Completed)
+        );
+        assert_eq!(actor.hook_state("WaitingApproval", &Value::Null), None);
+    }
+
+    #[test]
+    fn hook_extension_contents_embed_cli_and_slug() {
+        let contents = OmpActor::hook_extension_contents("/usr/local/bin/zedra");
+        assert!(contents.contains("@oh-my-pi/pi-coding-agent"));
+        assert!(contents.contains("\"--agent\", \"omp\""));
+        assert!(contents.contains("/usr/local/bin/zedra"));
+        assert!(contents.contains("before_agent_start"));
+        assert!(contents.contains("session_shutdown"));
+    }
+}

--- a/crates/zedra-host/src/agent/omp.rs
+++ b/crates/zedra-host/src/agent/omp.rs
@@ -31,7 +31,9 @@ struct OmpSessionFile {
 
 impl OmpActor {
     pub fn cli_available() -> bool {
-        command_on_path("omp") || Self::omp_agent_dir().is_dir()
+        // Fall back to the sessions root, never `~/.omp/agent`: `zedra setup omp`
+        // creates the agent dir itself, so it would report omp forever.
+        command_on_path("omp") || Self::omp_sessions_root().is_dir()
     }
 
     pub fn session_counts(workdir: &Path) -> Result<ActorSessionCounts, String> {
@@ -103,9 +105,9 @@ impl OmpActor {
     }
 
     /// Newest sessions for `workdir` (by header `cwd`) plus the matching total.
-    /// Scans every project bucket so bucket-name encoding drift across omp
-    /// versions (legacy path-based, the reverted hashed scheme, migrations)
-    /// never hides sessions; the recorded cwd is the authoritative scope.
+    /// Scans every project bucket because bucket names strip `$HOME`
+    /// (`/Users/me/dev/app` -> `-dev-app`) and drift across omp versions; the
+    /// recorded cwd is the authoritative scope, so the total needs every header.
     fn collect_session_files(
         workdir: &Path,
         limit: Option<usize>,
@@ -124,8 +126,12 @@ impl OmpActor {
                 continue;
             }
             for (path, mtime) in sorted_jsonl_candidates(&bucket.path())? {
-                let Ok(file) = Self::read_session_file(&path, mtime) else {
-                    continue;
+                let file = match Self::read_session_file(&path, mtime) {
+                    Ok(file) => file,
+                    Err(err) => {
+                        tracing::info!("omp: skipping unreadable transcript: {err:#}");
+                        continue;
+                    }
                 };
                 if cwd_matches(workdir, file.cwd.as_deref()) {
                     files.push(file);
@@ -140,8 +146,8 @@ impl OmpActor {
         Ok((files, total))
     }
 
-    /// Parse a session JSONL head. Current omp files begin with a fixed-width
-    /// `type: "title"` slot (a skipped record here), then the `type: "session"`
+    /// Parse a session JSONL head. Current omp files begin with a padded
+    /// `type: "title"` slot omp rewrites in place, then the `type: "session"`
     /// header and entries; legacy files start at the header directly.
     fn read_session_file(path: &Path, mtime_unix_secs: Option<u64>) -> Result<OmpSessionFile> {
         let file = File::open(path)
@@ -184,7 +190,8 @@ impl OmpActor {
                         created_at = parse_rfc3339(string_field(&record, &["timestamp"]));
                     }
                 }
-                // Fixed-width title slot written at the physical file head.
+                // Padded title slot at the file head; empty until omp titles the
+                // session, so the first user message stays the usual fallback.
                 "title" => {
                     if title.is_none() {
                         title = string_field(&record, &["title", "name"]).map(str::to_string);
@@ -220,10 +227,9 @@ impl OmpActor {
                 };
             }
 
-            if !session_id.is_empty()
-                && title.is_some()
-                && scanned_lines >= LIST_HEAD_SCAN_MAX_LINES
-            {
+            // Title is best-effort: every scan reads every transcript, so an
+            // untitled session must not drag the read to EOF.
+            if !session_id.is_empty() && scanned_lines >= LIST_HEAD_SCAN_MAX_LINES {
                 break;
             }
         }
@@ -363,21 +369,39 @@ export default function (omp: ExtensionAPI) {{
   // Check `=== false` so older omp versions without hasUI still fire hooks.
   const skip = (ctx: {{ hasUI?: boolean }}) => ctx.hasUI === false;
 
-  omp.on("before_agent_start", (event, ctx) => {{
-    if (skip(ctx)) return;
-    fire("UserPromptSubmit", (event as any)?.sessionId);
+  // No lifecycle event carries a session id; the context does.
+  type Ctx = {{ hasUI?: boolean; sessionManager?: {{ getSessionId?: () => string }} }};
+  const sessionId = (ctx: Ctx) => {{
+    try {{
+      return ctx.sessionManager?.getSessionId?.();
+    }} catch {{
+      return undefined;
+    }}
+  }};
+
+  // omp names each turn's events natively; Zedra state keys on Claude's names.
+  let running = false;
+
+  omp.on("before_agent_start", (_event, ctx) => {{
+    if (skip(ctx as Ctx)) return;
+    running = true;
+    fire("UserPromptSubmit", sessionId(ctx as Ctx));
   }});
 
   omp.on("agent_end", (event, ctx) => {{
-    if (skip(ctx)) return;
-    fire("Stop", (event as any)?.sessionId);
+    if (skip(ctx as Ctx)) return;
+    // willContinue means omp already scheduled a continuation: not a settle.
+    if ((event as any)?.willContinue) return;
+    running = false;
+    fire("Stop", sessionId(ctx as Ctx));
   }});
 
-  // Fires on Ctrl+C, SIGTERM, /quit, /reload, /new, /resume, /fork.
-  // Ensures Running indicator clears if omp is killed mid-turn.
-  omp.on("session_shutdown", (event, ctx) => {{
-    if (skip(ctx)) return;
-    fire("Stop", (event as any)?.sessionId);
+  // Fires on Ctrl+C, SIGTERM, /quit, /reload, /new, /resume, /fork. Only clears
+  // a turn killed mid-flight; agent_end already reported a completed one.
+  omp.on("session_shutdown", (_event, ctx) => {{
+    if (skip(ctx as Ctx) || !running) return;
+    running = false;
+    fire("Stop", sessionId(ctx as Ctx));
   }});
 }}
 "#,
@@ -461,8 +485,9 @@ impl AgentActor for OmpActor {
         true
     }
 
-    // omp exposes no approval hook (default `tools.approvalMode: yolo`), so
-    // there is no WaitingApproval transition.
+    // The extension renames omp's native events to these Claude-compatible
+    // names. State holds Running between them, so no per-tool ping is sent, and
+    // omp exposes no approval hook (default `tools.approvalMode: yolo`).
     fn hook_state(&self, event_name: &str, _payload: &Value) -> Option<AgentState> {
         match event_name {
             "UserPromptSubmit" => Some(AgentState::Running),
@@ -476,7 +501,8 @@ impl AgentActor for OmpActor {
         (event_name == "Stop").then(|| format!("{} completed", self.display_name()))
     }
 
-    // omp stores transcripts per workdir; look up the session title for the body.
+    // Transcripts are global; the title comes from the session whose recorded
+    // cwd is this workdir.
     fn hook_notify_body(
         &self,
         ctx: &HookContext,
@@ -567,6 +593,24 @@ mod tests {
     }
 
     #[test]
+    fn empty_title_slot_falls_back_to_first_user_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("2026-05-28_abc.jsonl");
+        // omp writes the padded slot with an empty title until it names the session.
+        std::fs::write(
+            &path,
+            r#"{"type":"title","v":"1","title":"","updatedAt":"2026-05-28T10:00:00Z","pad":"   "}
+{"type":"session","id":"abc","timestamp":"2026-05-28T10:00:00Z","cwd":"/Users/me/project"}
+{"type":"message","message":{"role":"user","content":[{"type":"text","text":"Refactor scrollback"}]}}
+"#,
+        )
+        .unwrap();
+
+        let file = OmpActor::read_session_file(&path, None).unwrap();
+        assert_eq!(file.title.as_deref(), Some("Refactor scrollback"));
+    }
+
+    #[test]
     fn falls_back_to_filename_when_session_id_missing() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("2026-05-28_xyz.jsonl");
@@ -649,5 +693,9 @@ mod tests {
         assert!(contents.contains("/usr/local/bin/zedra"));
         assert!(contents.contains("before_agent_start"));
         assert!(contents.contains("session_shutdown"));
+        // Session id comes from the context; no lifecycle event carries one.
+        assert!(contents.contains("getSessionId"));
+        assert!(!contents.contains("event as any)?.sessionId"));
+        assert!(contents.contains("willContinue"));
     }
 }

--- a/crates/zedra/assets/icons/omp.svg
+++ b/crates/zedra/assets/icons/omp.svg
@@ -1,0 +1,1 @@
+<svg role="img" fill="currentColor" fill-rule="evenodd" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><title>Oh My Pi</title><path d="M140 160h360v80H400v320h-80V240h-60v220h-80V240h-40z"></path></svg>

--- a/docs/MANAGED_AGENTS.md
+++ b/docs/MANAGED_AGENTS.md
@@ -102,7 +102,7 @@ in their launch command; the rest keep their default.
 | opencode | `--mini` only | Alt screen — `--mini` is a reduced interface, not a rendering toggle, so it stays opt-in via `launch_cmd` |
 | amp, copilot | none | Alt screen |
 | hermes | `--cli` (classic REPL) | Config-driven (`display.interface`) |
-| omp | none | Alt screen (differential TUI; verify `\e[?1049h` under a pty) |
+| omp | none needed | Already inline (pty capture shows no `\e[?1049h`) |
 
 Verify a CLI's behavior by running it under a pty and looking for the
 `\e[?1049h` (alt screen enter) sequence rather than trusting its help text.

--- a/docs/MANAGED_AGENTS.md
+++ b/docs/MANAGED_AGENTS.md
@@ -85,6 +85,7 @@ managed agents override `default_launch_command` (and put the flag in
 | gemini | `--yolo` | Downgraded to prompting in an untrusted folder; trust it once interactively or set `GEMINI_CLI_TRUST_WORKSPACE=true` |
 | amp | none | Bypass is a config setting (`amp.dangerouslyAllowAll`), not a flag |
 | openclaw, pi, maki | none | No such flag in their CLIs |
+| omp | none | `tools.approvalMode: yolo` is the default; critical destructive patterns and pending provider safety checks still prompt |
 
 ### Alt screen
 
@@ -101,6 +102,7 @@ in their launch command; the rest keep their default.
 | opencode | `--mini` only | Alt screen — `--mini` is a reduced interface, not a rendering toggle, so it stays opt-in via `launch_cmd` |
 | amp, copilot | none | Alt screen |
 | hermes | `--cli` (classic REPL) | Config-driven (`display.interface`) |
+| omp | none | Alt screen (differential TUI; verify `\e[?1049h` under a pty) |
 
 Verify a CLI's behavior by running it under a pty and looking for the
 `\e[?1049h` (alt screen enter) sequence rather than trusting its help text.

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1650,6 +1650,43 @@ Expected:
     the header (see `docs/CONVENTIONS.md` GPUI flex width rules and
     `ui::subscreen_layout`).
 
+## 18b-1. Managed Agent: omp (Oh My Pi)
+
+omp runs as a full managed agent: detection, sessions/resume, `zedra setup omp`,
+lifecycle hooks, and account fields. Install omp first:
+`curl -fsSL https://omp.sh/install | sh`.
+
+1. Connect to a workspace and open a shell terminal.
+2. Run `omp`.
+3. Expected: the terminal card shows the OMP icon and `Oh My Pi` identity once
+   OSC metadata arrives, and the foreground command `omp` is resolved by the
+   host as the `omp` agent.
+4. In the workspace drawer Terminals tab, tap `Create agent`.
+5. Expected: the native list picker shows **Oh My Pi** with the OMP icon and a
+   version subtitle (from the host `omp --version` probe).
+6. Run a few prompts inside omp, then quit.
+7. Tap `View sessions`.
+8. Expected: the unified session list shows the omp sessions for this workspace
+   (recorded cwd must match the workspace), each with icon, title, datetime,
+   transcript size, and a resume action. omp transcripts live at
+   `~/.omp/agent/sessions/*/<timestamp>_<id>.jsonl`; resume should run
+   `omp --resume <id>` in a new terminal.
+9. In manage detail for omp, verify account fields: Default model (from
+   `~/.omp/agent/config.yml` `modelRoles.default`), Custom providers (from
+   `~/.omp/agent/models.yml`), and Project config (workspace `.omp/config.yml`).
+10. Run `zedra setup omp`.
+11. Expected: setup writes the lifecycle-hook extension and reports
+    `hooks` written; `zedra setup omp` again reports hooks ready.
+12. Start an omp session from the app and submit a prompt, then end the turn.
+13. Expected: the terminal card shows a running indicator while omp works and a
+    `Oh My Pi completed` notification fires on turn end; omp has no approval
+    hook (default yolo), so no waiting/approval notification is expected.
+14. Run `zedra setup omp` → remove and confirm the extension is deleted.
+15. Quit `omp` and run `curl -fsSL https://omp.sh/install | sh`.
+16. Expected: the terminal card does **not** latch an OMP agent identity — the
+    install command is not detected as an agent session (`omp` matches only as
+    the entire foreground command).
+
 ## 18c. Unified Session List Virtualization
 
 1. Connect to a workspace with several agents that each have many sessions


### PR DESCRIPTION
## Summary

Add full managed-agent support for omp (Oh My Pi, https://omp.sh), a TUI coding
agent and fork of Pi:

- New `OmpActor` (`crates/zedra-host/src/agent/omp.rs`): slug `omp`,
  display "Oh My Pi", icon `omp`, detected only as the exact `omp` command
  (plus the `@oh-my-pi/pi-coding-agent` alias) so `curl https://omp.sh/install`
  never latches an agent identity.
- Sessions + resume: scans `~/.omp/agent/sessions/*/*.jsonl`, filters by the
  recorded `cwd` (encoding-agnostic across legacy/hashed bucket schemes),
  resumes via `omp --resume <id>`.
- Lifecycle hooks: auto-discovered extension
  `~/.omp/agent/extensions/zedra-agent-hooks.ts` forwarding
  `before_agent_start` / `agent_end` / `session_shutdown` ->
  Running/Completed state + push notifications. omp's default
  `tools.approvalMode: yolo` means no WaitingApproval (same as Pi).
- Setup: `zedra setup omp` writes/removes the hook extension.
- Account fields: default model from `config.yml` `modelRoles.default`,
  custom providers from `models.yml`, project config presence.
- New `omp.svg` icon (Pi-glyph, currentColor) for iOS/Android + in-app.
- Docs: `docs/MANAGED_AGENTS.md` tables, `docs/MANUAL_TEST.md` section.

Registered in the `ACTORS` registry after `pi`; no protocol/RPC changes.

## Notes

- Host-only change; validated with `cargo check -p zedra-host` and
  `cargo test -p zedra-host` (273 tests pass, incl. the omp unit tests and the
  registry/detect/icon tests).
- Runtime verification on a machine with the real `omp` CLI is still needed:
  `omp --version` output shape, TUI alt-screen usage, and that the hook
  extension actually fires (covered in `docs/MANUAL_TEST.md` § 18b-1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Oh My Pi (OMP) agent.
  * Detect and launch OMP sessions, view session details, resume conversations, and display model/provider information.
  * Added lifecycle notifications and setup support for OMP integrations.

* **Documentation**
  * Documented OMP launch behavior and alternate-screen usage.
  * Added manual testing guidance covering detection, sessions, setup, and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->