### PR TITLE
fix(ios): let the home indicator fade while idle on iOS 18

### DIFF
--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1243,6 +1243,17 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:41:1\033\\/tmp/zedra-long-code.rs
 9. Repeat steps 1-6 with the QR scanner instead of the webview, including opening the photo picker from inside the scanner
 10. Expected: same behavior; returning from the photo picker to the scanner does not resume the GPUI window early, and cancelling the scanner restores it
 
+## 11g-3. Home Indicator Dimming (iOS 18)
+
+1. On an iOS 18 device, open any screen and leave the app untouched for a few seconds
+2. Expected: the home indicator dims and fades out instead of sitting at full contrast over the background
+3. Touch the screen
+4. Expected: the indicator fades back in, and the swipe-up gesture still works while it is faded
+5. Scroll a terminal, open the drawer, and type — all with the indicator faded
+6. Expected: no layout shift and no change to the bottom safe-area inset; only the indicator's own appearance changes
+7. Repeat step 1 on iOS 26
+8. Expected: unchanged from today — the indicator keeps its normal behavior, since the auto-hide opt-in is skipped there
+
 ## 11h. Extended Keypad
 
 1. Set Settings → Terminal → Always show keypad and Extended keypad both to On, then open a terminal

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1245,14 +1245,17 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:41:1\033\\/tmp/zedra-long-code.rs
 
 ## 11g-3. Home Indicator Dimming (iOS 18)
 
-1. On an iOS 18 device, open any screen and leave the app untouched for a few seconds
-2. Expected: the home indicator dims and fades out instead of sitting at full contrast over the background
+Both passes need a physical device: the simulator has no idle-touch timer, so the
+indicator never fades there regardless of the setting.
+
+1. On a physical iOS 18 device, open any screen and leave the app untouched for about 5 seconds
+2. Expected: the home indicator dims and then fades out instead of sitting at full contrast over the background
 3. Touch the screen
 4. Expected: the indicator fades back in, and the swipe-up gesture still works while it is faded
 5. Scroll a terminal, open the drawer, and type — all with the indicator faded
 6. Expected: no layout shift and no change to the bottom safe-area inset; only the indicator's own appearance changes
-7. Repeat step 1 on iOS 26
-8. Expected: unchanged from today — the indicator keeps its normal behavior, since the auto-hide opt-in is skipped there
+7. Repeat steps 1-4 on a physical iOS 26 device
+8. Expected: the indicator stays visible at its usual contrast for the whole idle period and never fades — the auto-hide opt-in is skipped on 26
 
 ## 11h. Extended Keypad
 

--- a/ios/Zedra/GPUIRuntimeController.swift
+++ b/ios/Zedra/GPUIRuntimeController.swift
@@ -136,6 +136,7 @@ final class GPUIRuntimeController: NSObject {
         pushScreenScale()
         DispatchQueue.main.async { [weak self] in
             self?.pushSafeAreaInsets()
+            self?.applyHomeIndicatorAutoHidden()
         }
 
         NotificationCenter.default.addObserver(
@@ -482,7 +483,29 @@ final class GPUIRuntimeController: NSObject {
         displayLink = nil
     }
 
+    /// iOS draws the home indicator at full contrast over the GPUI surface on 18;
+    /// 26 already blends it with what is behind. Opting the root view controller
+    /// into auto-hide lets the system dim and fade it while the user is idle, and
+    /// bring it back on the next touch. There is no API for its color.
+    ///
+    /// GPUI owns that controller, so the class is swapped in place rather than
+    /// patched in `vendor/zed`. The subclass adds no stored properties, which is
+    /// what makes the swap safe.
+    private func applyHomeIndicatorAutoHidden() {
+        if #available(iOS 26.0, *) { return }
+        guard let root = uiWindow?.rootViewController,
+              !(root is HomeIndicatorAutoHiddenViewController) else { return }
+        object_setClass(root, HomeIndicatorAutoHiddenViewController.self)
+        root.setNeedsUpdateOfHomeIndicatorAutoHidden()
+    }
+
     private func pushScreenScale() {
         zedra_ios_set_screen_scale(Float(UIScreen.main.scale))
     }
+}
+
+/// Class-swap target for the GPUI root view controller. Must stay free of stored
+/// properties: `object_setClass` cannot grow an already-allocated instance.
+private final class HomeIndicatorAutoHiddenViewController: UIViewController {
+    override var prefersHomeIndicatorAutoHidden: Bool { true }
 }


### PR DESCRIPTION
## Summary

On iOS 18 the home indicator sits at full contrast over the GPUI surface; iOS 26 already blends it with what is behind. UIKit exposes no API for the indicator's color or alpha — the system derives it from the content underneath — so the GPUI root view controller opts into `prefersHomeIndicatorAutoHidden` instead. The system dims and fades the indicator while the user is idle and brings it back on the next touch.

The root view controller belongs to GPUI, so its class is swapped in place rather than patched in `vendor/zed`: `vendor/zed/crates/gpui_ios/src/ios/window.rs:3249` allocates a plain `UIViewController`, and the subclass declares no stored properties, which is what makes `object_setClass` safe here. Same trick already used for WKWebView's input accessory. The swap is idempotent and skipped on iOS 26.

## Notes

- Safe-area insets are untouched, so no layout moves — only the indicator's own appearance changes.
- Auto-hide is app-wide and fades the indicator entirely after idle, which is a stronger effect than dimming it in place. The alternative, if that reads as too much, is drawing a lower-contrast band in the bottom safe area so the system picks a closer color.
- Verified with `swiftc -typecheck` against the iOS SDK. CI has no iOS compile step, so the behavior needs a device run on both iOS 18 and 26: `docs/MANUAL_TEST.md` §11g-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On iOS versions below 26, the home indicator now automatically dims after inactivity and reappears when touched.
  * Swipe-up navigation remains available, with safe-area and layout behavior unchanged.
  * iOS 26 home-indicator behavior remains unchanged.
* **Documentation**
  * Added manual testing guidance covering dimming, restoration, navigation gestures, layout stability, and iOS 26 behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->