### PR TITLE
feat(app): show progress while a web tunnel opens

### DIFF
--- a/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
@@ -449,6 +449,8 @@ class MainActivity : AppCompatActivity() {
 
         @JvmStatic external fun nativeWebViewDismiss(callbackId: Int)
 
+        @JvmStatic external fun nativeWebViewPresented(callbackId: Int)
+
         @JvmStatic external fun nativeFloatingButtonPressed(callbackId: Int)
 
         @JvmStatic external fun nativeDictationPreviewDismiss(previewId: Int)

--- a/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
@@ -451,6 +451,8 @@ class MainActivity : AppCompatActivity() {
 
         @JvmStatic external fun nativeWebViewPresented(callbackId: Int)
 
+        @JvmStatic external fun nativeWebViewFailed(callbackId: Int)
+
         @JvmStatic external fun nativeFloatingButtonPressed(callbackId: Int)
 
         @JvmStatic external fun nativeDictationPreviewDismiss(previewId: Int)

--- a/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
@@ -685,6 +685,7 @@ object NativePresentations {
             ViewGroup.LayoutParams.MATCH_PARENT,
         ))
         container.bringToFront()
+        MainActivity.nativeWebViewPresented(callbackId)
         applyWebViewProxy(activity, config.socksProxy) { loadWebView(webView, url) }
     }
 

--- a/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
@@ -619,13 +619,14 @@ object NativePresentations {
     }
 
     @JvmStatic
-    fun openWebView(callbackId: Int, configJson: String?) = onUi {
+    fun openWebView(callbackId: Int, configJson: String?) =
+        onUiOrDismiss({ MainActivity.nativeWebViewDismiss(callbackId) }) {
         // Rust already registered handlers, so a rejected config must report
         // failure or the opening progress never settles.
         val config = parseWebViewConfig(configJson)
         if (config == null || config.url.isBlank()) {
             MainActivity.nativeWebViewFailed(callbackId)
-            return@onUi
+            return@onUiOrDismiss
         }
         closeWebViewNow()
 

--- a/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/NativePresentations.kt
@@ -620,8 +620,13 @@ object NativePresentations {
 
     @JvmStatic
     fun openWebView(callbackId: Int, configJson: String?) = onUi {
-        val config = parseWebViewConfig(configJson) ?: return@onUi
-        if (config.url.isBlank()) return@onUi
+        // Rust already registered handlers, so a rejected config must report
+        // failure or the opening progress never settles.
+        val config = parseWebViewConfig(configJson)
+        if (config == null || config.url.isBlank()) {
+            MainActivity.nativeWebViewFailed(callbackId)
+            return@onUi
+        }
         closeWebViewNow()
 
         val activity = requireActivity()

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -526,6 +526,17 @@ pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeWebViewDismiss(
 }
 
 #[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeWebViewPresented(
+    _env: JNIEnv,
+    _class: JClass,
+    callback_id: jint,
+) {
+    if callback_id > 0 {
+        crate::webview::dispatch_presented(callback_id as u32);
+    }
+}
+
+#[unsafe(no_mangle)]
 pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeFloatingButtonPressed(
     _env: JNIEnv,
     _class: JClass,

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -537,6 +537,17 @@ pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeWebViewPresented(
 }
 
 #[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeWebViewFailed(
+    _env: JNIEnv,
+    _class: JClass,
+    callback_id: jint,
+) {
+    if callback_id > 0 {
+        crate::webview::dispatch_failed(callback_id as u32);
+    }
+}
+
+#[unsafe(no_mangle)]
 pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeFloatingButtonPressed(
     _env: JNIEnv,
     _class: JClass,

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -775,6 +775,12 @@ pub extern "C" fn zedra_ios_webview_dismiss(callback_id: u32) {
     crate::webview::dispatch_dismiss(callback_id);
 }
 
+/// Called once UIKit has presented the webview over the workspace.
+#[unsafe(no_mangle)]
+pub extern "C" fn zedra_ios_webview_presented(callback_id: u32) {
+    crate::webview::dispatch_presented(callback_id);
+}
+
 /// Called by Swift with the processed image bytes ready to upload.
 /// `extension` is "jpg" or "png" (lowercase, no dot).
 #[unsafe(no_mangle)]

--- a/crates/zedra/src/ios/bridge.rs
+++ b/crates/zedra/src/ios/bridge.rs
@@ -781,6 +781,12 @@ pub extern "C" fn zedra_ios_webview_presented(callback_id: u32) {
     crate::webview::dispatch_presented(callback_id);
 }
 
+/// Called when UIKit could not begin presenting the webview.
+#[unsafe(no_mangle)]
+pub extern "C" fn zedra_ios_webview_failed(callback_id: u32) {
+    crate::webview::dispatch_failed(callback_id);
+}
+
 /// Called by Swift with the processed image bytes ready to upload.
 /// `extension` is "jpg" or "png" (lowercase, no dot).
 #[unsafe(no_mangle)]

--- a/crates/zedra/src/lib.rs
+++ b/crates/zedra/src/lib.rs
@@ -68,6 +68,7 @@ pub mod platform_bridge;
 pub mod telemetry;
 pub mod web_tunnel;
 pub mod web_tunnel_manager;
+pub mod web_tunnel_opening;
 pub mod webview;
 
 // Embedded assets (SVG icons) — shared across platforms

--- a/crates/zedra/src/web_tunnel/alias.rs
+++ b/crates/zedra/src/web_tunnel/alias.rs
@@ -15,7 +15,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::OnceCell;
 
-use super::bridge;
+use super::{bridge, recover_lock};
 
 const ALIAS_SUFFIX: &str = ".zedra.test";
 
@@ -51,18 +51,14 @@ fn state() -> &'static State {
 /// per host and reused, so the origin stays stable across reopens; the label is
 /// registered so the proxy can route its CONNECTs back to `endpoint_id`.
 pub(super) fn alias_host(endpoint_id: &PublicKey) -> String {
-    if let Some(label) = state().by_endpoint.lock().unwrap().get(endpoint_id) {
+    if let Some(label) = recover_lock(&state().by_endpoint, "alias endpoints").get(endpoint_id) {
         return format!("{label}{ALIAS_SUFFIX}");
     }
-    let mut labels = state().labels.lock().unwrap();
+    let mut labels = recover_lock(&state().labels, "alias labels");
     let label = mint_label(endpoint_id, &labels);
     labels.insert(label.clone(), *endpoint_id);
     drop(labels);
-    state()
-        .by_endpoint
-        .lock()
-        .unwrap()
-        .insert(*endpoint_id, label.clone());
+    recover_lock(&state().by_endpoint, "alias endpoints").insert(*endpoint_id, label.clone());
     format!("{label}{ALIAS_SUFFIX}")
 }
 
@@ -194,7 +190,9 @@ async fn handle_socks(mut stream: TcpStream) -> Result<(), String> {
 /// Resolve `<label>.zedra.test` back to the owning host endpoint id.
 fn endpoint_for_host(host: &str) -> Option<PublicKey> {
     let label = host.strip_suffix(ALIAS_SUFFIX)?;
-    state().labels.lock().unwrap().get(label).copied()
+    recover_lock(&state().labels, "alias labels")
+        .get(label)
+        .copied()
 }
 
 async fn forward_via_session(

--- a/crates/zedra/src/web_tunnel/exact_port.rs
+++ b/crates/zedra/src/web_tunnel/exact_port.rs
@@ -13,7 +13,7 @@ use std::sync::{Mutex, OnceLock};
 use iroh::PublicKey;
 use tokio::net::{TcpListener, TcpStream};
 
-use super::bridge;
+use super::{bridge, recover_lock};
 
 // `owner` reserves a port for a host before the fallible bind (race guard) and is
 // the ownership source of truth. `bound` tracks the live accept task per port so
@@ -45,10 +45,7 @@ pub(crate) struct ListenerInfo {
 
 /// Live listeners sorted by device port.
 pub(crate) fn list_listeners() -> Vec<ListenerInfo> {
-    let mut listeners: Vec<ListenerInfo> = state()
-        .bound
-        .lock()
-        .unwrap()
+    let mut listeners: Vec<ListenerInfo> = recover_lock(&state().bound, "exact-port listeners")
         .iter()
         .map(|(&port, bound)| ListenerInfo {
             port,
@@ -62,8 +59,8 @@ pub(crate) fn list_listeners() -> Vec<ListenerInfo> {
 /// Stop the listener on `port`, freeing the device port. Aborting the accept task
 /// drops its `TcpListener`. Returns whether a listener was present.
 pub(crate) fn stop(port: u16) -> bool {
-    state().owner.lock().unwrap().remove(&port);
-    match state().bound.lock().unwrap().remove(&port) {
+    recover_lock(&state().owner, "exact-port owners").remove(&port);
+    match recover_lock(&state().bound, "exact-port listeners").remove(&port) {
         Some(bound) => {
             bound.task.abort();
             tracing::info!("web-tunnel: exact-port stopped 127.0.0.1:{port}");
@@ -80,7 +77,7 @@ pub(super) async fn ensure(endpoint_id: PublicKey, port: u16) -> Result<(), ()> 
     // Reserve ownership before the fallible bind so racing callers for the same
     // host reuse the listener and racing callers for another host get Err.
     {
-        let mut owner = state().owner.lock().unwrap();
+        let mut owner = recover_lock(&state().owner, "exact-port owners");
         match owner.get(&port) {
             Some(existing) if *existing == endpoint_id => return Ok(()),
             Some(_) => return Err(()),
@@ -93,15 +90,12 @@ pub(super) async fn ensure(endpoint_id: PublicKey, port: u16) -> Result<(), ()> 
         Ok(listener) => {
             tracing::info!("web-tunnel: exact-port bound 127.0.0.1:{port}");
             let task = spawn_accept_loop(listener, endpoint_id);
-            state()
-                .bound
-                .lock()
-                .unwrap()
+            recover_lock(&state().bound, "exact-port listeners")
                 .insert(port, Bound { endpoint_id, task });
             Ok(())
         }
         Err(_) => {
-            state().owner.lock().unwrap().remove(&port);
+            recover_lock(&state().owner, "exact-port owners").remove(&port);
             Err(())
         }
     }
@@ -186,7 +180,7 @@ impl CompanionSniffer {
 
 #[cfg(debug_assertions)]
 pub(super) fn debug_clear_owners() {
-    state().owner.lock().unwrap().clear();
+    recover_lock(&state().owner, "exact-port owners").clear();
 }
 
 #[cfg(debug_assertions)]
@@ -194,7 +188,7 @@ pub(super) fn debug_mark_foreign(port: u16) {
     // A deterministic key no real host will have, so the next `ensure` for this
     // port by a real host returns Unavailable (simulates a same-port collision).
     let foreign = iroh::SecretKey::from([0x7fu8; 32]).public();
-    state().owner.lock().unwrap().insert(port, foreign);
+    recover_lock(&state().owner, "exact-port owners").insert(port, foreign);
 }
 
 fn find_localhost_ports(data: &[u8]) -> Vec<u16> {

--- a/crates/zedra/src/web_tunnel/mod.rs
+++ b/crates/zedra/src/web_tunnel/mod.rs
@@ -310,8 +310,16 @@ fn present(
         return;
     }
     progress.advance(generation, OpenStep::LoadingPage);
+    let presented_progress = progress.clone();
     crate::webview::open(configure(
-        tunnel_webview(url, title, on_route).on_presented(move || progress.finish(generation)),
+        tunnel_webview(url, title, on_route)
+            .on_presented(move || presented_progress.finish(generation))
+            .on_failed(move || {
+                progress.fail(
+                    generation,
+                    "The native webview could not be presented. Try again.",
+                )
+            }),
     ));
 }
 

--- a/crates/zedra/src/web_tunnel/mod.rs
+++ b/crates/zedra/src/web_tunnel/mod.rs
@@ -4,10 +4,12 @@
 //! - [`exact_port`] (default): bind a real `127.0.0.1:<port>` listener so the
 //!   webview loads the unmodified `http://localhost:<port>` — honest loopback
 //!   origin, so CORS/cookies/OAuth behave. One host owns a port at a time.
-//! - [`alias`] (opt-in fallback): when a port can't be bound (another app, or a
-//!   second host colliding on the same port), route this host through a
+//! - [`alias`] (automatic fallback): when a port can't be bound (another app, or
+//!   a second host colliding on the same port), route this host through a
 //!   `<label>.zedra.test` alias + in-app SOCKS proxy. A real device bypasses the
 //!   proxy for loopback, so a non-loopback alias is the only proxy-viable form.
+//!   Taken without asking and remembered per host — the bind won't start working
+//!   on a retry, so a prompt would only delay the same page.
 //!
 //! Routing is keyed by the session's stable non-relay endpoint id, so bound
 //! listeners and aliases survive reconnects. See `docs/WEB_TUNNEL_MODES.md`.
@@ -15,6 +17,7 @@
 mod alias;
 mod bridge;
 mod exact_port;
+pub mod progress;
 
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
@@ -26,6 +29,7 @@ use zedra_rpc::proto::is_loopback_host;
 use zedra_session::SessionHandle;
 
 use crate::platform_bridge::{self, NativeNotificationKind, NativeNotificationOptions};
+use progress::OpenStep;
 
 /// Live exact-port listeners + a stop control, for the manager view
 /// (`web_tunnel_manager.rs`) to free a device port that conflicts with another app.
@@ -156,7 +160,7 @@ pub fn register_session(handle: &SessionHandle) {
 }
 
 /// Open `url` the best way: host-local http(s) URLs load in the in-app webview
-/// (exact-port by default, alias on a per-host opt-in fallback); anything else
+/// (exact-port by default, alias as an automatic per-host fallback); anything else
 /// (or an unparseable target) falls back to the system browser. Single "open a
 /// link" seam for the tunnel.
 /// Returns the `host:port` label for a trackable loopback target (so the caller
@@ -180,12 +184,14 @@ pub fn open_url_with(
     let origin = webview_title(url);
     let Ok(port) = parse_loopback_target(url) else {
         tracing::info!("web-tunnel: {origin} not host-local -> system browser");
+        progress::cancel();
         platform_bridge::bridge().open_url(url);
         return None;
     };
     let (Some(endpoint_id), Ok(runtime)) = (session_handle.endpoint_id(), session_handle.runtime())
     else {
         tracing::info!("web-tunnel: no session endpoint -> system browser: {origin}");
+        progress::cancel();
         platform_bridge::bridge().open_url(url);
         return None;
     };
@@ -195,9 +201,22 @@ pub fn open_url_with(
         .lock()
         .unwrap()
         .insert(endpoint_id, session_handle);
+    // Joins the caller's open when it already reported an earlier step (the
+    // agent web client starts its server first), else starts one here.
+    let generation = progress::begin_or_join(&origin, "icons/globe.svg", OpenStep::OpeningTunnel);
     let spawn_url = url.to_string();
     let spawn_title = origin.clone();
-    runtime.spawn(async move { serve(endpoint_id, spawn_url, spawn_title, port, on_route).await });
+    runtime.spawn(async move {
+        serve(
+            endpoint_id,
+            spawn_url,
+            spawn_title,
+            port,
+            on_route,
+            generation,
+        )
+        .await
+    });
     Some(origin)
 }
 
@@ -223,6 +242,7 @@ async fn serve(
     title: String,
     port: u16,
     on_route: Option<RouteHook>,
+    generation: u64,
 ) {
     // The alias rewrites the webview host to `<word>.zedra.test`, which changes
     // the TLS SNI; an https host still presents its `localhost` certificate, so
@@ -230,19 +250,52 @@ async fn serve(
     let alias_ok = is_cleartext_http(&url);
     if registry().prefs.lock().unwrap().get(&endpoint_id) == Some(&AdapterKind::Alias) {
         if alias_ok {
-            serve_alias(endpoint_id, &url, title, on_route).await;
+            serve_alias(endpoint_id, &url, title, on_route, generation).await;
         } else {
+            progress::finish(generation);
             notify_https_needs_exact_port(port);
         }
         return;
     }
     match exact_port::ensure(endpoint_id, port).await {
-        Ok(()) => {
-            crate::webview::open(tunnel_webview(url, title, on_route));
+        Ok(()) => present(url, title, on_route, generation, |config| config),
+        // Fall through to the alias without asking: a port this device can't bind
+        // stays unbindable, so a prompt only delays the same outcome. Remembering
+        // the choice skips the doomed bind on later opens for this host.
+        Err(()) if alias_ok => {
+            tracing::info!("web-tunnel: exact-port unavailable for :{port} -> alias");
+            registry()
+                .prefs
+                .lock()
+                .unwrap()
+                .insert(endpoint_id, AdapterKind::Alias);
+            serve_alias(endpoint_id, &url, title, on_route, generation).await;
         }
-        Err(()) if alias_ok => prompt_alias_fallback(endpoint_id, url, title, port, on_route),
-        Err(()) => notify_https_needs_exact_port(port),
+        Err(()) => {
+            progress::finish(generation);
+            notify_https_needs_exact_port(port);
+        }
     }
+}
+
+/// Present the tunnelled page, unless the user cancelled while the tunnel was
+/// coming up — a webview appearing after a cancel is the one outcome the
+/// progress overlay must never produce.
+fn present(
+    url: String,
+    title: String,
+    on_route: Option<RouteHook>,
+    generation: u64,
+    configure: impl FnOnce(crate::webview::WebviewConfig) -> crate::webview::WebviewConfig,
+) {
+    if !progress::is_active(generation) {
+        tracing::info!("web-tunnel: open cancelled before the webview was presented");
+        return;
+    }
+    progress::advance(generation, OpenStep::LoadingPage);
+    crate::webview::open(configure(tunnel_webview(url, title, on_route)));
+    // The webview now covers the workspace, so the overlay has nothing to add.
+    progress::finish(generation);
 }
 
 /// The webview both adapters present: a tunnelled page the user drives with its
@@ -278,7 +331,8 @@ fn notify_https_needs_exact_port(port: u16) {
         NativeNotificationOptions::new("Web tunnel: port unavailable")
             .message(format!(
                 "localhost:{port} can't be bound on this device, and the alias fallback \
-                 can't serve https (its certificate is for localhost). Free the port to load this page."
+                 can't serve https (its certificate is for localhost). Free the port to load \
+                 this page. Learn more: {MODES_DOC_URL}"
             ))
             .kind(NativeNotificationKind::Warning),
     );
@@ -289,56 +343,24 @@ async fn serve_alias(
     url: &str,
     title: String,
     on_route: Option<RouteHook>,
+    generation: u64,
 ) {
     let proxy_port = match alias::ensure_proxy().await {
         Ok(port) => port,
         Err(error) => {
             tracing::warn!("web-tunnel: alias proxy setup failed: {error}");
+            progress::fail(generation, error.clone());
             notify_failed(&error);
             return;
         }
     };
-    crate::webview::open(
-        tunnel_webview(alias_url(url, &endpoint_id), title, on_route)
-            .socks_proxy(Ipv4Addr::LOCALHOST, proxy_port),
+    present(
+        alias_url(url, &endpoint_id),
+        title,
+        on_route,
+        generation,
+        |config| config.socks_proxy(Ipv4Addr::LOCALHOST, proxy_port),
     );
-}
-
-/// Surface the exact-port failure and let the user opt this host into the alias.
-fn prompt_alias_fallback(
-    endpoint_id: PublicKey,
-    url: String,
-    title: String,
-    port: u16,
-    on_route: Option<RouteHook>,
-) {
-    tracing::info!("web-tunnel: exact-port unavailable for :{port}, offering alias");
-    let message = format!(
-        "localhost:{port} can't be bound on this device (another host or app holds it). \
-         Tap to route this workspace through an alias instead. Learn more: {MODES_DOC_URL}"
-    );
-    platform_bridge::show_native_notification_with_action(
-        NativeNotificationOptions::new("Web tunnel: port unavailable")
-            .message(message)
-            .kind(NativeNotificationKind::Warning),
-        move || approve_alias(endpoint_id, url, title, on_route),
-    );
-}
-
-/// The user approved the alias for this host: remember it and serve now.
-fn approve_alias(endpoint_id: PublicKey, url: String, title: String, on_route: Option<RouteHook>) {
-    registry()
-        .prefs
-        .lock()
-        .unwrap()
-        .insert(endpoint_id, AdapterKind::Alias);
-    let Some(session) = session_for(&endpoint_id) else {
-        return;
-    };
-    let Ok(runtime) = session.runtime() else {
-        return;
-    };
-    runtime.spawn(async move { serve_alias(endpoint_id, &url, title, on_route).await });
 }
 
 fn notify_failed(error: &str) {

--- a/crates/zedra/src/web_tunnel/mod.rs
+++ b/crates/zedra/src/web_tunnel/mod.rs
@@ -29,7 +29,7 @@ use zedra_rpc::proto::is_loopback_host;
 use zedra_session::SessionHandle;
 
 use crate::platform_bridge::{self, NativeNotificationKind, NativeNotificationOptions};
-use progress::OpenStep;
+use progress::{OpenStep, Progress};
 
 /// Live exact-port listeners + a stop control, for the manager view
 /// (`web_tunnel_manager.rs`) to free a device port that conflicts with another app.
@@ -179,19 +179,32 @@ pub fn open_url_with(
     url: &str,
     on_route: Option<RouteHook>,
 ) -> Option<String> {
+    open_url_with_progress(session_handle, url, on_route, Progress::new(), None)
+}
+
+/// [`open_url_with`] with progress owned by the workspace that initiated the
+/// open. `generation` is supplied when an earlier step (such as starting an
+/// agent server) already owns this exact operation.
+pub fn open_url_with_progress(
+    session_handle: SessionHandle,
+    url: &str,
+    on_route: Option<RouteHook>,
+    progress: Progress,
+    generation: Option<u64>,
+) -> Option<String> {
     // Log only the origin, never the raw URL: the path/query of a user's local
     // web app can carry session tokens or OAuth params.
     let origin = webview_title(url);
     let Ok(port) = parse_loopback_target(url) else {
         tracing::info!("web-tunnel: {origin} not host-local -> system browser");
-        progress::cancel();
+        progress.cancel();
         platform_bridge::bridge().open_url(url);
         return None;
     };
     let (Some(endpoint_id), Ok(runtime)) = (session_handle.endpoint_id(), session_handle.runtime())
     else {
         tracing::info!("web-tunnel: no session endpoint -> system browser: {origin}");
-        progress::cancel();
+        progress.cancel();
         platform_bridge::bridge().open_url(url);
         return None;
     };
@@ -201,9 +214,14 @@ pub fn open_url_with(
         .lock()
         .unwrap()
         .insert(endpoint_id, session_handle);
-    // Joins the caller's open when it already reported an earlier step (the
-    // agent web client starts its server first), else starts one here.
-    let generation = progress::begin_or_join(&origin, "icons/globe.svg", OpenStep::OpeningTunnel);
+    let generation = generation
+        .unwrap_or_else(|| progress.begin(&origin, "icons/globe.svg", OpenStep::OpeningTunnel));
+    // A cancellation or another user action may have settled the caller's
+    // generation while the server start RPC was completing.
+    if !progress.is_active(generation) {
+        return None;
+    }
+    progress.advance(generation, OpenStep::OpeningTunnel);
     let spawn_url = url.to_string();
     let spawn_title = origin.clone();
     runtime.spawn(async move {
@@ -213,6 +231,7 @@ pub fn open_url_with(
             spawn_title,
             port,
             on_route,
+            progress,
             generation,
         )
         .await
@@ -242,23 +261,33 @@ async fn serve(
     title: String,
     port: u16,
     on_route: Option<RouteHook>,
+    progress: Progress,
     generation: u64,
 ) {
     // The alias rewrites the webview host to `<word>.zedra.test`, which changes
     // the TLS SNI; an https host still presents its `localhost` certificate, so
     // validation fails. Alias mode therefore only serves cleartext http.
     let alias_ok = is_cleartext_http(&url);
-    if registry().prefs.lock().unwrap().get(&endpoint_id) == Some(&AdapterKind::Alias) {
+    let prefers_alias = registry()
+        .prefs
+        .lock()
+        .unwrap_or_else(|poisoned| {
+            tracing::warn!("web-tunnel: alias preference lock poisoned; recovering");
+            poisoned.into_inner()
+        })
+        .get(&endpoint_id)
+        == Some(&AdapterKind::Alias);
+    if prefers_alias {
         if alias_ok {
-            serve_alias(endpoint_id, &url, title, on_route, generation).await;
+            serve_alias(endpoint_id, &url, title, on_route, progress, generation).await;
         } else {
-            progress::finish(generation);
+            progress.finish(generation);
             notify_https_needs_exact_port(port);
         }
         return;
     }
     match exact_port::ensure(endpoint_id, port).await {
-        Ok(()) => present(url, title, on_route, generation, |config| config),
+        Ok(()) => present(url, title, on_route, progress, generation, |config| config),
         // Fall through to the alias without asking: a port this device can't bind
         // stays unbindable, so a prompt only delays the same outcome. Remembering
         // the choice skips the doomed bind on later opens for this host.
@@ -267,12 +296,15 @@ async fn serve(
             registry()
                 .prefs
                 .lock()
-                .unwrap()
+                .unwrap_or_else(|poisoned| {
+                    tracing::warn!("web-tunnel: alias preference lock poisoned; recovering");
+                    poisoned.into_inner()
+                })
                 .insert(endpoint_id, AdapterKind::Alias);
-            serve_alias(endpoint_id, &url, title, on_route, generation).await;
+            serve_alias(endpoint_id, &url, title, on_route, progress, generation).await;
         }
         Err(()) => {
-            progress::finish(generation);
+            progress.finish(generation);
             notify_https_needs_exact_port(port);
         }
     }
@@ -285,17 +317,18 @@ fn present(
     url: String,
     title: String,
     on_route: Option<RouteHook>,
+    progress: Progress,
     generation: u64,
     configure: impl FnOnce(crate::webview::WebviewConfig) -> crate::webview::WebviewConfig,
 ) {
-    if !progress::is_active(generation) {
+    if !progress.is_active(generation) {
         tracing::info!("web-tunnel: open cancelled before the webview was presented");
         return;
     }
-    progress::advance(generation, OpenStep::LoadingPage);
-    crate::webview::open(configure(tunnel_webview(url, title, on_route)));
-    // The webview now covers the workspace, so the overlay has nothing to add.
-    progress::finish(generation);
+    progress.advance(generation, OpenStep::LoadingPage);
+    crate::webview::open(configure(
+        tunnel_webview(url, title, on_route).on_presented(move || progress.finish(generation)),
+    ));
 }
 
 /// The webview both adapters present: a tunnelled page the user drives with its
@@ -343,13 +376,14 @@ async fn serve_alias(
     url: &str,
     title: String,
     on_route: Option<RouteHook>,
+    progress: Progress,
     generation: u64,
 ) {
     let proxy_port = match alias::ensure_proxy().await {
         Ok(port) => port,
         Err(error) => {
             tracing::warn!("web-tunnel: alias proxy setup failed: {error}");
-            progress::fail(generation, error.clone());
+            progress.fail(generation, error.clone());
             notify_failed(&error);
             return;
         }
@@ -358,6 +392,7 @@ async fn serve_alias(
         alias_url(url, &endpoint_id),
         title,
         on_route,
+        progress,
         generation,
         |config| config.socks_proxy(Ipv4Addr::LOCALHOST, proxy_port),
     );

--- a/crates/zedra/src/web_tunnel/mod.rs
+++ b/crates/zedra/src/web_tunnel/mod.rs
@@ -21,7 +21,7 @@ pub mod progress;
 
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use iroh::PublicKey;
 use reqwest::Url;
@@ -131,14 +131,19 @@ fn registry() -> &'static Registry {
     })
 }
 
+/// Continue serving tunnels if a prior panic poisoned an in-memory registry.
+pub(super) fn recover_lock<'a, T>(lock: &'a Mutex<T>, name: &'static str) -> MutexGuard<'a, T> {
+    lock.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!(lock = name, "web-tunnel: recovering poisoned lock");
+        poisoned.into_inner()
+    })
+}
+
 /// The latest session for a host, resolved by its stable endpoint id. Both
 /// adapters route through this so listeners/aliases survive reconnects (the
 /// session handle changes on reconnect; the endpoint id stays).
 fn session_for(endpoint_id: &PublicKey) -> Option<SessionHandle> {
-    registry()
-        .sessions
-        .lock()
-        .unwrap()
+    recover_lock(&registry().sessions, "session registry")
         .get(endpoint_id)
         .cloned()
 }
@@ -152,11 +157,7 @@ pub fn register_session(handle: &SessionHandle) {
     let Some(endpoint_id) = handle.endpoint_id() else {
         return;
     };
-    registry()
-        .sessions
-        .lock()
-        .unwrap()
-        .insert(endpoint_id, handle.clone());
+    recover_lock(&registry().sessions, "session registry").insert(endpoint_id, handle.clone());
 }
 
 /// Open `url` the best way: host-local http(s) URLs load in the in-app webview
@@ -209,11 +210,7 @@ pub fn open_url_with_progress(
         return None;
     };
     tracing::info!("web-tunnel: open {origin} (loopback :{port}) via {endpoint_id}");
-    registry()
-        .sessions
-        .lock()
-        .unwrap()
-        .insert(endpoint_id, session_handle);
+    recover_lock(&registry().sessions, "session registry").insert(endpoint_id, session_handle);
     let generation = generation
         .unwrap_or_else(|| progress.begin(&origin, "icons/globe.svg", OpenStep::OpeningTunnel));
     // A cancellation or another user action may have settled the caller's
@@ -268,14 +265,7 @@ async fn serve(
     // the TLS SNI; an https host still presents its `localhost` certificate, so
     // validation fails. Alias mode therefore only serves cleartext http.
     let alias_ok = is_cleartext_http(&url);
-    let prefers_alias = registry()
-        .prefs
-        .lock()
-        .unwrap_or_else(|poisoned| {
-            tracing::warn!("web-tunnel: alias preference lock poisoned; recovering");
-            poisoned.into_inner()
-        })
-        .get(&endpoint_id)
+    let prefers_alias = recover_lock(&registry().prefs, "alias preferences").get(&endpoint_id)
         == Some(&AdapterKind::Alias);
     if prefers_alias {
         if alias_ok {
@@ -293,13 +283,7 @@ async fn serve(
         // the choice skips the doomed bind on later opens for this host.
         Err(()) if alias_ok => {
             tracing::info!("web-tunnel: exact-port unavailable for :{port} -> alias");
-            registry()
-                .prefs
-                .lock()
-                .unwrap_or_else(|poisoned| {
-                    tracing::warn!("web-tunnel: alias preference lock poisoned; recovering");
-                    poisoned.into_inner()
-                })
+            recover_lock(&registry().prefs, "alias preferences")
                 .insert(endpoint_id, AdapterKind::Alias);
             serve_alias(endpoint_id, &url, title, on_route, progress, generation).await;
         }
@@ -446,18 +430,14 @@ fn webview_title(url: &str) -> String {
 // two real hosts. See docs/WEB_TUNNEL_MODES.md.
 #[cfg(debug_assertions)]
 pub(crate) fn debug_reset() {
-    registry().prefs.lock().unwrap().clear();
+    recover_lock(&registry().prefs, "alias preferences").clear();
     exact_port::debug_clear_owners();
 }
 
 #[cfg(debug_assertions)]
 pub(crate) fn debug_force_alias(session: &SessionHandle) {
     if let Some(id) = session.endpoint_id() {
-        registry()
-            .prefs
-            .lock()
-            .unwrap()
-            .insert(id, AdapterKind::Alias);
+        recover_lock(&registry().prefs, "alias preferences").insert(id, AdapterKind::Alias);
     }
 }
 
@@ -468,7 +448,26 @@ pub(crate) fn debug_collide(port: u16) {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_target, parse_loopback_target, webview_title};
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::sync::Mutex;
+
+    use super::{normalize_target, parse_loopback_target, recover_lock, webview_title};
+
+    #[test]
+    fn recover_lock_preserves_a_poisoned_value() {
+        let lock = Mutex::new(4);
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = match lock.lock() {
+                Ok(guard) => guard,
+                Err(_) => return,
+            };
+            panic!("poison test lock");
+        }));
+
+        let mut guard = recover_lock(&lock, "test");
+        *guard += 1;
+        assert_eq!(*guard, 5);
+    }
 
     #[test]
     fn parse_loopback_accepts_localhost_and_loopback_ips() {

--- a/crates/zedra/src/web_tunnel/progress.rs
+++ b/crates/zedra/src/web_tunnel/progress.rs
@@ -1,0 +1,237 @@
+//! Shared progress for opening a tunnelled page in the in-app webview.
+//!
+//! Every open path funnels through here, so one overlay
+//! (`web_tunnel_opening.rs`) can report what stage the open is in no matter
+//! which entry point started it. The tunnel steps run on the session runtime,
+//! so this is a plain global the GPUI view polls — no entity handle crosses
+//! threads.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpenStep {
+    /// Host is spawning the agent's server and creating a session.
+    StartingServer,
+    /// Device is binding the loopback listener that fronts the host port.
+    OpeningTunnel,
+    /// Webview is up and loading the page.
+    LoadingPage,
+}
+
+impl OpenStep {
+    pub fn label(self, subject: &str) -> String {
+        match self {
+            Self::StartingServer => format!("Starting {subject} server"),
+            Self::OpeningTunnel => "Opening tunnel".into(),
+            Self::LoadingPage => "Loading page".into(),
+        }
+    }
+}
+
+/// A single in-flight open. Only one runs at a time: the overlay covers the
+/// workspace, so a second open can't be started until this one settles.
+#[derive(Clone)]
+pub struct OpenProgress {
+    pub generation: u64,
+    /// What is being opened — an agent's display name, or the `host:port` label.
+    pub subject: String,
+    pub icon: String,
+    pub step: OpenStep,
+    /// Set once the open failed; the overlay stays up until dismissed.
+    pub error: Option<String>,
+    pub started_at: Instant,
+}
+
+impl OpenProgress {
+    pub fn elapsed_secs(&self) -> u64 {
+        self.started_at.elapsed().as_secs()
+    }
+}
+
+fn state() -> &'static Mutex<Option<OpenProgress>> {
+    static STATE: OnceLock<Mutex<Option<OpenProgress>>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(None))
+}
+
+static VERSION: AtomicU64 = AtomicU64::new(0);
+static GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// Bumped on every change so the overlay can poll cheaply for a redraw.
+pub fn version() -> u64 {
+    VERSION.load(Ordering::Relaxed)
+}
+
+pub fn current() -> Option<OpenProgress> {
+    state().lock().ok().and_then(|s| s.clone())
+}
+
+/// Whether `generation` is still the live open — false once it was cancelled or
+/// superseded, which is the guard against presenting a webview the user backed
+/// out of.
+pub fn is_active(generation: u64) -> bool {
+    state()
+        .lock()
+        .ok()
+        .and_then(|s| s.as_ref().map(|p| p.generation == generation))
+        .unwrap_or(false)
+}
+
+/// Start reporting a new open, replacing anything stale. Returns the generation
+/// every later call must pass back.
+pub fn begin(subject: impl Into<String>, icon: impl Into<String>, step: OpenStep) -> u64 {
+    let generation = GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
+    if let Ok(mut slot) = state().lock() {
+        *slot = Some(OpenProgress {
+            generation,
+            subject: subject.into(),
+            icon: icon.into(),
+            step,
+            error: None,
+            started_at: Instant::now(),
+        });
+    }
+    VERSION.fetch_add(1, Ordering::Relaxed);
+    generation
+}
+
+/// Join the open a caller already started (keeping its subject and elapsed
+/// time), or start one at `step` when this is the entry point.
+pub fn begin_or_join(subject: impl Into<String>, icon: impl Into<String>, step: OpenStep) -> u64 {
+    let joined = state().lock().ok().and_then(|mut slot| {
+        let progress = slot.as_mut().filter(|p| p.error.is_none())?;
+        progress.step = step;
+        Some(progress.generation)
+    });
+    match joined {
+        Some(generation) => {
+            VERSION.fetch_add(1, Ordering::Relaxed);
+            generation
+        }
+        None => begin(subject, icon, step),
+    }
+}
+
+pub fn advance(generation: u64, step: OpenStep) {
+    update(generation, |progress| progress.step = step);
+}
+
+pub fn fail(generation: u64, error: impl Into<String>) {
+    let error = error.into();
+    update(generation, |progress| progress.error = Some(error.clone()));
+}
+
+/// Clear a settled open. No-op once superseded, so a late finish from an
+/// abandoned open can't hide a newer one.
+pub fn finish(generation: u64) {
+    let cleared = state()
+        .lock()
+        .ok()
+        .map(|mut slot| {
+            let matches = slot.as_ref().is_some_and(|p| p.generation == generation);
+            if matches {
+                *slot = None;
+            }
+            matches
+        })
+        .unwrap_or(false);
+    if cleared {
+        VERSION.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Drop the overlay and invalidate the in-flight open so it stops short of
+/// presenting a webview.
+pub fn cancel() {
+    if let Ok(mut slot) = state().lock() {
+        *slot = None;
+    }
+    GENERATION.fetch_add(1, Ordering::Relaxed);
+    VERSION.fetch_add(1, Ordering::Relaxed);
+}
+
+fn update(generation: u64, apply: impl FnOnce(&mut OpenProgress)) {
+    let changed = state()
+        .lock()
+        .ok()
+        .and_then(|mut slot| {
+            let progress = slot.as_mut().filter(|p| p.generation == generation)?;
+            apply(progress);
+            Some(())
+        })
+        .is_some();
+    if changed {
+        VERSION.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The state is global, so these run behind one lock to stay deterministic.
+    fn guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: Mutex<()> = Mutex::new(());
+        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn begin_or_join_keeps_the_original_subject() {
+        let _g = guard();
+        let started = begin("opencode", "icons/opencode.svg", OpenStep::StartingServer);
+        let joined = begin_or_join("localhost:4096", "icons/globe.svg", OpenStep::OpeningTunnel);
+        assert_eq!(started, joined);
+        let progress = current().unwrap();
+        assert_eq!(progress.subject, "opencode");
+        assert_eq!(progress.step, OpenStep::OpeningTunnel);
+        finish(started);
+    }
+
+    #[test]
+    fn begin_or_join_starts_fresh_when_nothing_is_open() {
+        let _g = guard();
+        cancel();
+        let generation =
+            begin_or_join("localhost:4096", "icons/globe.svg", OpenStep::OpeningTunnel);
+        let progress = current().unwrap();
+        assert_eq!(progress.subject, "localhost:4096");
+        assert_eq!(progress.step, OpenStep::OpeningTunnel);
+        finish(generation);
+        assert!(current().is_none());
+    }
+
+    #[test]
+    fn cancel_invalidates_the_in_flight_generation() {
+        let _g = guard();
+        let generation = begin("opencode", "icons/opencode.svg", OpenStep::StartingServer);
+        assert!(is_active(generation));
+        cancel();
+        assert!(!is_active(generation));
+        // A late step from the abandoned open must not resurrect the overlay.
+        advance(generation, OpenStep::LoadingPage);
+        assert!(current().is_none());
+    }
+
+    #[test]
+    fn finish_from_a_stale_generation_leaves_the_live_open_alone() {
+        let _g = guard();
+        let stale = begin("a", "icons/globe.svg", OpenStep::StartingServer);
+        let live = begin("b", "icons/globe.svg", OpenStep::StartingServer);
+        finish(stale);
+        assert!(is_active(live));
+        finish(live);
+    }
+
+    #[test]
+    fn fail_records_the_error_and_keeps_the_overlay() {
+        let _g = guard();
+        let generation = begin("opencode", "icons/opencode.svg", OpenStep::StartingServer);
+        fail(generation, "boom");
+        assert_eq!(current().unwrap().error.as_deref(), Some("boom"));
+        // A failed open is settled: a later join starts a new one.
+        let next = begin_or_join("localhost:1", "icons/globe.svg", OpenStep::OpeningTunnel);
+        assert_ne!(next, generation);
+        finish(next);
+    }
+}

--- a/crates/zedra/src/web_tunnel/progress.rs
+++ b/crates/zedra/src/web_tunnel/progress.rs
@@ -88,18 +88,22 @@ impl Progress {
         icon: impl Into<String>,
         step: OpenStep,
     ) -> u64 {
-        let generation = self.0.generation.fetch_add(1, Ordering::Relaxed) + 1;
-        if let Ok(mut slot) = self.0.current.lock() {
-            *slot = Some(OpenProgress {
-                generation,
-                subject: subject.into(),
-                icon: icon.into(),
-                step,
-                error: None,
-                started_at: Instant::now(),
-            });
-            self.bump();
-        }
+        let generation = match self.0.current.lock() {
+            Ok(mut slot) => {
+                let generation = self.0.generation.fetch_add(1, Ordering::Relaxed) + 1;
+                *slot = Some(OpenProgress {
+                    generation,
+                    subject: subject.into(),
+                    icon: icon.into(),
+                    step,
+                    error: None,
+                    started_at: Instant::now(),
+                });
+                generation
+            }
+            Err(_) => return self.0.generation.fetch_add(1, Ordering::Relaxed) + 1,
+        };
+        self.bump();
         generation
     }
 
@@ -134,10 +138,15 @@ impl Progress {
     }
 
     pub fn cancel(&self) {
-        if let Ok(mut slot) = self.0.current.lock() {
-            *slot = None;
+        match self.0.current.lock() {
+            Ok(mut slot) => {
+                *slot = None;
+                self.0.generation.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(_) => {
+                self.0.generation.fetch_add(1, Ordering::Relaxed);
+            }
         }
-        self.0.generation.fetch_add(1, Ordering::Relaxed);
         self.bump();
     }
 

--- a/crates/zedra/src/web_tunnel/progress.rs
+++ b/crates/zedra/src/web_tunnel/progress.rs
@@ -1,22 +1,17 @@
-//! Shared progress for opening a tunnelled page in the in-app webview.
+//! Progress for one workspace opening a tunnelled page.
 //!
-//! Every open path funnels through here, so one overlay
-//! (`web_tunnel_opening.rs`) can report what stage the open is in no matter
-//! which entry point started it. The tunnel steps run on the session runtime,
-//! so this is a plain global the GPUI view polls — no entity handle crosses
-//! threads.
+//! Tunnel setup runs on the session runtime, while the owning workspace polls
+//! this handle from GPUI. Each workspace creates its own handle so cancelling
+//! or switching one workspace cannot affect another.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OpenStep {
-    /// Host is spawning the agent's server and creating a session.
     StartingServer,
-    /// Device is binding the loopback listener that fronts the host port.
     OpeningTunnel,
-    /// Webview is up and loading the page.
     LoadingPage,
 }
 
@@ -30,16 +25,12 @@ impl OpenStep {
     }
 }
 
-/// A single in-flight open. Only one runs at a time: the overlay covers the
-/// workspace, so a second open can't be started until this one settles.
 #[derive(Clone)]
 pub struct OpenProgress {
     pub generation: u64,
-    /// What is being opened — an agent's display name, or the `host:port` label.
     pub subject: String,
     pub icon: String,
     pub step: OpenStep,
-    /// Set once the open failed; the overlay stays up until dismissed.
     pub error: Option<String>,
     pub started_at: Instant,
 }
@@ -50,119 +41,133 @@ impl OpenProgress {
     }
 }
 
-fn state() -> &'static Mutex<Option<OpenProgress>> {
-    static STATE: OnceLock<Mutex<Option<OpenProgress>>> = OnceLock::new();
-    STATE.get_or_init(|| Mutex::new(None))
+struct State {
+    current: Mutex<Option<OpenProgress>>,
+    version: AtomicU64,
+    generation: AtomicU64,
 }
 
-static VERSION: AtomicU64 = AtomicU64::new(0);
-static GENERATION: AtomicU64 = AtomicU64::new(0);
+/// A workspace-owned, thread-safe progress channel.
+#[derive(Clone)]
+pub struct Progress(Arc<State>);
 
-/// Bumped on every change so the overlay can poll cheaply for a redraw.
-pub fn version() -> u64 {
-    VERSION.load(Ordering::Relaxed)
-}
-
-pub fn current() -> Option<OpenProgress> {
-    state().lock().ok().and_then(|s| s.clone())
-}
-
-/// Whether `generation` is still the live open — false once it was cancelled or
-/// superseded, which is the guard against presenting a webview the user backed
-/// out of.
-pub fn is_active(generation: u64) -> bool {
-    state()
-        .lock()
-        .ok()
-        .and_then(|s| s.as_ref().map(|p| p.generation == generation))
-        .unwrap_or(false)
-}
-
-/// Start reporting a new open, replacing anything stale. Returns the generation
-/// every later call must pass back.
-pub fn begin(subject: impl Into<String>, icon: impl Into<String>, step: OpenStep) -> u64 {
-    let generation = GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
-    if let Ok(mut slot) = state().lock() {
-        *slot = Some(OpenProgress {
-            generation,
-            subject: subject.into(),
-            icon: icon.into(),
-            step,
-            error: None,
-            started_at: Instant::now(),
-        });
+impl Progress {
+    pub fn new() -> Self {
+        Self(Arc::new(State {
+            current: Mutex::new(None),
+            version: AtomicU64::new(0),
+            generation: AtomicU64::new(0),
+        }))
     }
-    VERSION.fetch_add(1, Ordering::Relaxed);
-    generation
-}
 
-/// Join the open a caller already started (keeping its subject and elapsed
-/// time), or start one at `step` when this is the entry point.
-pub fn begin_or_join(subject: impl Into<String>, icon: impl Into<String>, step: OpenStep) -> u64 {
-    let joined = state().lock().ok().and_then(|mut slot| {
-        let progress = slot.as_mut().filter(|p| p.error.is_none())?;
-        progress.step = step;
-        Some(progress.generation)
-    });
-    match joined {
-        Some(generation) => {
-            VERSION.fetch_add(1, Ordering::Relaxed);
-            generation
+    pub fn version(&self) -> u64 {
+        self.0.version.load(Ordering::Relaxed)
+    }
+
+    pub fn current(&self) -> Option<OpenProgress> {
+        self.0.current.lock().ok().and_then(|slot| slot.clone())
+    }
+
+    pub fn is_active(&self, generation: u64) -> bool {
+        self.0
+            .current
+            .lock()
+            .ok()
+            .and_then(|slot| {
+                slot.as_ref()
+                    .map(|progress| progress.generation == generation)
+            })
+            .unwrap_or(false)
+    }
+
+    /// Starts a new open. A second user action supersedes the prior open in
+    /// this workspace, but cannot disturb another workspace's handle.
+    pub fn begin(
+        &self,
+        subject: impl Into<String>,
+        icon: impl Into<String>,
+        step: OpenStep,
+    ) -> u64 {
+        let generation = self.0.generation.fetch_add(1, Ordering::Relaxed) + 1;
+        if let Ok(mut slot) = self.0.current.lock() {
+            *slot = Some(OpenProgress {
+                generation,
+                subject: subject.into(),
+                icon: icon.into(),
+                step,
+                error: None,
+                started_at: Instant::now(),
+            });
+            self.bump();
         }
-        None => begin(subject, icon, step),
+        generation
+    }
+
+    pub fn advance(&self, generation: u64, step: OpenStep) {
+        self.update(generation, |progress| progress.step = step);
+    }
+
+    pub fn fail(&self, generation: u64, error: impl Into<String>) {
+        let error = error.into();
+        self.update(generation, |progress| progress.error = Some(error));
+    }
+
+    pub fn finish(&self, generation: u64) {
+        let cleared = self
+            .0
+            .current
+            .lock()
+            .ok()
+            .map(|mut slot| {
+                let matches = slot
+                    .as_ref()
+                    .is_some_and(|progress| progress.generation == generation);
+                if matches {
+                    *slot = None;
+                }
+                matches
+            })
+            .unwrap_or(false);
+        if cleared {
+            self.bump();
+        }
+    }
+
+    pub fn cancel(&self) {
+        if let Ok(mut slot) = self.0.current.lock() {
+            *slot = None;
+        }
+        self.0.generation.fetch_add(1, Ordering::Relaxed);
+        self.bump();
+    }
+
+    fn update(&self, generation: u64, apply: impl FnOnce(&mut OpenProgress)) {
+        let changed = self
+            .0
+            .current
+            .lock()
+            .ok()
+            .and_then(|mut slot| {
+                let progress = slot
+                    .as_mut()
+                    .filter(|progress| progress.generation == generation)?;
+                apply(progress);
+                Some(())
+            })
+            .is_some();
+        if changed {
+            self.bump();
+        }
+    }
+
+    fn bump(&self) {
+        self.0.version.fetch_add(1, Ordering::Relaxed);
     }
 }
 
-pub fn advance(generation: u64, step: OpenStep) {
-    update(generation, |progress| progress.step = step);
-}
-
-pub fn fail(generation: u64, error: impl Into<String>) {
-    let error = error.into();
-    update(generation, |progress| progress.error = Some(error.clone()));
-}
-
-/// Clear a settled open. No-op once superseded, so a late finish from an
-/// abandoned open can't hide a newer one.
-pub fn finish(generation: u64) {
-    let cleared = state()
-        .lock()
-        .ok()
-        .map(|mut slot| {
-            let matches = slot.as_ref().is_some_and(|p| p.generation == generation);
-            if matches {
-                *slot = None;
-            }
-            matches
-        })
-        .unwrap_or(false);
-    if cleared {
-        VERSION.fetch_add(1, Ordering::Relaxed);
-    }
-}
-
-/// Drop the overlay and invalidate the in-flight open so it stops short of
-/// presenting a webview.
-pub fn cancel() {
-    if let Ok(mut slot) = state().lock() {
-        *slot = None;
-    }
-    GENERATION.fetch_add(1, Ordering::Relaxed);
-    VERSION.fetch_add(1, Ordering::Relaxed);
-}
-
-fn update(generation: u64, apply: impl FnOnce(&mut OpenProgress)) {
-    let changed = state()
-        .lock()
-        .ok()
-        .and_then(|mut slot| {
-            let progress = slot.as_mut().filter(|p| p.generation == generation)?;
-            apply(progress);
-            Some(())
-        })
-        .is_some();
-    if changed {
-        VERSION.fetch_add(1, Ordering::Relaxed);
+impl Default for Progress {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -170,68 +175,25 @@ fn update(generation: u64, apply: impl FnOnce(&mut OpenProgress)) {
 mod tests {
     use super::*;
 
-    // The state is global, so these run behind one lock to stay deterministic.
-    fn guard() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: Mutex<()> = Mutex::new(());
-        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    #[test]
+    fn separate_workspaces_cannot_join_or_cancel_each_other() {
+        let first = Progress::new();
+        let second = Progress::new();
+        let first_generation = first.begin("first", "icons/globe.svg", OpenStep::StartingServer);
+        let second_generation = second.begin("second", "icons/globe.svg", OpenStep::OpeningTunnel);
+
+        second.cancel();
+
+        assert!(first.is_active(first_generation));
+        assert!(!second.is_active(second_generation));
     }
 
     #[test]
-    fn begin_or_join_keeps_the_original_subject() {
-        let _g = guard();
-        let started = begin("opencode", "icons/opencode.svg", OpenStep::StartingServer);
-        let joined = begin_or_join("localhost:4096", "icons/globe.svg", OpenStep::OpeningTunnel);
-        assert_eq!(started, joined);
-        let progress = current().unwrap();
-        assert_eq!(progress.subject, "opencode");
-        assert_eq!(progress.step, OpenStep::OpeningTunnel);
-        finish(started);
-    }
-
-    #[test]
-    fn begin_or_join_starts_fresh_when_nothing_is_open() {
-        let _g = guard();
-        cancel();
-        let generation =
-            begin_or_join("localhost:4096", "icons/globe.svg", OpenStep::OpeningTunnel);
-        let progress = current().unwrap();
-        assert_eq!(progress.subject, "localhost:4096");
-        assert_eq!(progress.step, OpenStep::OpeningTunnel);
-        finish(generation);
-        assert!(current().is_none());
-    }
-
-    #[test]
-    fn cancel_invalidates_the_in_flight_generation() {
-        let _g = guard();
-        let generation = begin("opencode", "icons/opencode.svg", OpenStep::StartingServer);
-        assert!(is_active(generation));
-        cancel();
-        assert!(!is_active(generation));
-        // A late step from the abandoned open must not resurrect the overlay.
-        advance(generation, OpenStep::LoadingPage);
-        assert!(current().is_none());
-    }
-
-    #[test]
-    fn finish_from_a_stale_generation_leaves_the_live_open_alone() {
-        let _g = guard();
-        let stale = begin("a", "icons/globe.svg", OpenStep::StartingServer);
-        let live = begin("b", "icons/globe.svg", OpenStep::StartingServer);
-        finish(stale);
-        assert!(is_active(live));
-        finish(live);
-    }
-
-    #[test]
-    fn fail_records_the_error_and_keeps_the_overlay() {
-        let _g = guard();
-        let generation = begin("opencode", "icons/opencode.svg", OpenStep::StartingServer);
-        fail(generation, "boom");
-        assert_eq!(current().unwrap().error.as_deref(), Some("boom"));
-        // A failed open is settled: a later join starts a new one.
-        let next = begin_or_join("localhost:1", "icons/globe.svg", OpenStep::OpeningTunnel);
-        assert_ne!(next, generation);
-        finish(next);
+    fn stale_finish_leaves_a_new_open_visible() {
+        let progress = Progress::new();
+        let stale = progress.begin("a", "icons/globe.svg", OpenStep::StartingServer);
+        let live = progress.begin("b", "icons/globe.svg", OpenStep::OpeningTunnel);
+        progress.finish(stale);
+        assert!(progress.is_active(live));
     }
 }

--- a/crates/zedra/src/web_tunnel_opening.rs
+++ b/crates/zedra/src/web_tunnel_opening.rs
@@ -55,8 +55,8 @@ impl Render for WebTunnelOpening {
             return div().into_any_element();
         };
 
-        // The close button anchors to this layer, so the centred column below is
-        // laid out on its own and stays centred whatever the corner holds.
+        // The close button anchors to this layer, so the content can sit a
+        // touch above centre without being displaced by the corner affordance.
         div()
             .id("web-tunnel-opening")
             .absolute()
@@ -71,6 +71,7 @@ impl Render for WebTunnelOpening {
                     .flex_col()
                     .items_center()
                     .justify_center()
+                    .top(px(-theme::SPACING_XL))
                     .gap(px(theme::SPACING_XL))
                     .px(px(theme::SPACING_LG))
                     .child(render_subject(&progress, cx))

--- a/crates/zedra/src/web_tunnel_opening.rs
+++ b/crates/zedra/src/web_tunnel_opening.rs
@@ -11,7 +11,7 @@ use gpui::{prelude::FluentBuilder as _, *};
 
 use crate::pending::spawn_periodic_task;
 use crate::theme;
-use crate::web_tunnel::progress::{self, OpenProgress};
+use crate::web_tunnel::progress::{OpenProgress, Progress};
 use crate::workspace_action;
 
 /// Poll cadence: fast enough that a step change reads as immediate, and it also
@@ -23,24 +23,27 @@ const POLL_INTERVAL: Duration = Duration::from_millis(250);
 const SLOW_OPEN_SECS: u64 = 2;
 
 pub struct WebTunnelOpening {
+    progress: Progress,
     version: u64,
     _poll: Task<()>,
 }
 
 impl WebTunnelOpening {
-    pub fn new(cx: &mut Context<Self>) -> Self {
-        let poll = spawn_periodic_task(cx, POLL_INTERVAL, |this: &mut Self, cx| {
-            let version = progress::version();
+    pub fn new(progress: Progress, cx: &mut Context<Self>) -> Self {
+        let poll_progress = progress.clone();
+        let poll = spawn_periodic_task(cx, POLL_INTERVAL, move |this: &mut Self, cx| {
+            let version = poll_progress.version();
             // Repaint on any change, and keep repainting while an open is live so
             // the spinner and elapsed counter advance.
-            if version != this.version || progress::current().is_some() {
+            if version != this.version || poll_progress.current().is_some() {
                 this.version = version;
                 cx.notify();
             }
         });
 
         Self {
-            version: progress::version(),
+            version: progress.version(),
+            progress,
             _poll: poll,
         }
     }
@@ -48,7 +51,7 @@ impl WebTunnelOpening {
 
 impl Render for WebTunnelOpening {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let Some(progress) = progress::current() else {
+        let Some(progress) = self.progress.current() else {
             return div().into_any_element();
         };
 

--- a/crates/zedra/src/web_tunnel_opening.rs
+++ b/crates/zedra/src/web_tunnel_opening.rs
@@ -1,0 +1,199 @@
+//! Temporary overlay shown while a tunnelled page is being opened in the in-app
+//! webview. Opening an agent web client spawns a server host-side, so seconds
+//! pass with nothing on screen otherwise; this names the step in flight.
+//!
+//! State lives in [`crate::web_tunnel::progress`] because the tunnel steps run
+//! on the session runtime. This view polls it and repaints.
+
+use std::{f32::consts::TAU, time::Duration};
+
+use gpui::{prelude::FluentBuilder as _, *};
+
+use crate::pending::spawn_periodic_task;
+use crate::theme;
+use crate::web_tunnel::progress::{self, OpenProgress};
+use crate::workspace_action;
+
+/// Poll cadence: fast enough that a step change reads as immediate, and it also
+/// ticks the elapsed counter.
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Elapsed seconds past which the step gets an elapsed counter. Below this a
+/// timer just adds noise to an open that is about to succeed.
+const SLOW_OPEN_SECS: u64 = 2;
+
+pub struct WebTunnelOpening {
+    version: u64,
+    _poll: Task<()>,
+}
+
+impl WebTunnelOpening {
+    pub fn new(cx: &mut Context<Self>) -> Self {
+        let poll = spawn_periodic_task(cx, POLL_INTERVAL, |this: &mut Self, cx| {
+            let version = progress::version();
+            // Repaint on any change, and keep repainting while an open is live so
+            // the spinner and elapsed counter advance.
+            if version != this.version || progress::current().is_some() {
+                this.version = version;
+                cx.notify();
+            }
+        });
+
+        Self {
+            version: progress::version(),
+            _poll: poll,
+        }
+    }
+}
+
+impl Render for WebTunnelOpening {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(progress) = progress::current() else {
+            return div().into_any_element();
+        };
+
+        // The close button anchors to this layer, so the centred column below is
+        // laid out on its own and stays centred whatever the corner holds.
+        div()
+            .id("web-tunnel-opening")
+            .absolute()
+            .inset_0()
+            .bg(rgb(theme::bg_primary(cx)))
+            // Swallow presses so the covered view can't be driven blind.
+            .on_press(|_, _, _| {})
+            .child(
+                div()
+                    .size_full()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .justify_center()
+                    .gap(px(theme::SPACING_XL))
+                    .px(px(theme::SPACING_LG))
+                    .child(render_subject(&progress, cx))
+                    .child(render_step(&progress, cx))
+                    .when_some(progress.error.clone(), |d, error| {
+                        d.child(render_error(&error, cx))
+                    }),
+            )
+            .child(render_close_button(cx))
+            .into_any_element()
+    }
+}
+
+fn render_subject(progress: &OpenProgress, cx: &App) -> Div {
+    div()
+        .flex()
+        .flex_col()
+        .items_center()
+        .gap(px(theme::SPACING_SM))
+        .child(
+            svg()
+                .path(progress.icon.clone())
+                .size(px(theme::ICON_LG))
+                .text_color(rgb(theme::text_secondary(cx))),
+        )
+        .child(
+            div()
+                .max_w_full()
+                .min_w_0()
+                .truncate()
+                .text_color(rgb(theme::text_primary(cx)))
+                .text_size(px(theme::FONT_HEADING))
+                .font_weight(FontWeight::MEDIUM)
+                .child(progress.subject.clone()),
+        )
+}
+
+/// Only the step in flight: the earlier ones are done and the later ones say
+/// nothing about whether this open is moving.
+fn render_step(progress: &OpenProgress, cx: &App) -> Div {
+    let failed = progress.error.is_some();
+    let elapsed = progress.elapsed_secs();
+    let mut label = progress.step.label(&progress.subject);
+    if !failed && elapsed >= SLOW_OPEN_SECS {
+        label = format!("{label}\u{2026} {elapsed}s");
+    }
+    let color = if failed {
+        theme::accent_red(cx)
+    } else {
+        theme::text_secondary(cx)
+    };
+
+    div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap(px(theme::SPACING_SM))
+        .child(
+            div()
+                .w(px(theme::ICON_XS))
+                .h(px(theme::ICON_XS))
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(render_step_marker(failed, cx)),
+        )
+        .child(
+            div()
+                .text_color(rgb(color))
+                .text_size(px(theme::FONT_BODY))
+                .child(label),
+        )
+}
+
+fn render_step_marker(failed: bool, cx: &App) -> AnyElement {
+    if failed {
+        return svg()
+            .path("icons/x.svg")
+            .size(px(theme::ICON_FILE))
+            .text_color(rgb(theme::accent_red(cx)))
+            .into_any_element();
+    }
+
+    svg()
+        .path("icons/refresh-ccw.svg")
+        .size(px(theme::ICON_FILE))
+        .text_color(rgb(theme::text_secondary(cx)))
+        .with_animation(
+            ElementId::Name("web-tunnel-opening-spin".into()),
+            Animation::new(Duration::from_millis(700)).repeat(),
+            |icon, delta| icon.with_transformation(Transformation::rotate(radians(TAU * delta))),
+        )
+        .into_any_element()
+}
+
+fn render_error(error: &str, cx: &App) -> Div {
+    div()
+        .max_w(px(theme::CONNECT_DETAIL_WIDTH))
+        .text_align(TextAlign::Center)
+        .text_color(rgb(theme::text_muted(cx)))
+        .text_size(px(theme::FONT_DETAIL))
+        .child(error.to_string())
+}
+
+/// Same corner affordance as the connecting view; closing also abandons the
+/// open, so a webview can't arrive after the user has left.
+fn render_close_button(cx: &mut Context<WebTunnelOpening>) -> Stateful<Div> {
+    div()
+        .id("web-tunnel-opening-close")
+        .absolute()
+        .top(px((theme::HEADER_BUTTON_SIZE - theme::ICON_SM) / 2.0))
+        .right(px((theme::HEADER_BUTTON_SIZE - theme::ICON_SM) / 2.0))
+        .w(px(theme::ICON_SM))
+        .h(px(theme::ICON_SM))
+        .flex()
+        .items_center()
+        .justify_center()
+        .cursor_pointer()
+        .hit_slop(px(20.0))
+        .on_press(cx.listener(|_this, _event, window, cx| {
+            window.dispatch_action(workspace_action::CancelWebTunnelOpen.boxed_clone(), cx);
+        }))
+        .child(
+            svg()
+                .path("icons/x.svg")
+                .size(px(16.0))
+                .text_color(rgb(theme::text_muted(cx))),
+        )
+}

--- a/crates/zedra/src/webview.rs
+++ b/crates/zedra/src/webview.rs
@@ -9,7 +9,7 @@
 //! Flow:
 //! - [`open`] serializes the config to JSON, stores its callbacks under a fresh
 //!   id, and asks the platform bridge to present the webview.
-//! - The native layer calls back into [`dispatch_presented`],
+//! - The native layer calls back into [`dispatch_presented`], [`dispatch_failed`],
 //!   [`dispatch_message`], [`dispatch_navigate`], and [`dispatch_dismiss`].
 //! - [`eval_js`] and [`close`] drive the currently presented webview.
 //!
@@ -20,7 +20,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 use serde::Serialize;
 
@@ -43,12 +43,14 @@ type MessageHandler = Arc<dyn Fn(String) + Send + Sync>;
 type NavigationHandler = Arc<dyn Fn(&str) -> NavigationPolicy + Send + Sync>;
 type DismissHandler = Box<dyn FnOnce() + Send>;
 type PresentedHandler = Box<dyn FnOnce() + Send>;
+type FailedHandler = Box<dyn FnOnce() + Send>;
 
 struct Handlers {
     on_message: Option<MessageHandler>,
     on_navigate: Option<NavigationHandler>,
     on_dismiss: Option<DismissHandler>,
     on_presented: Option<PresentedHandler>,
+    on_failed: Option<FailedHandler>,
 }
 
 static NEXT_ID: AtomicU32 = AtomicU32::new(1);
@@ -59,6 +61,13 @@ static HANDLERS: OnceLock<Mutex<HashMap<u32, Handlers>>> = OnceLock::new();
 
 fn handlers() -> &'static Mutex<HashMap<u32, Handlers>> {
     HANDLERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn handlers_lock() -> MutexGuard<'static, HashMap<u32, Handlers>> {
+    handlers().lock().unwrap_or_else(|poisoned| {
+        tracing::warn!("webview: recovering poisoned handler registry lock");
+        poisoned.into_inner()
+    })
 }
 
 /// Description of a native webview to present. Build with [`WebviewConfig::new`]
@@ -74,6 +83,7 @@ pub struct WebviewConfig {
     on_navigate: Option<NavigationHandler>,
     on_dismiss: Option<DismissHandler>,
     on_presented: Option<PresentedHandler>,
+    on_failed: Option<FailedHandler>,
 }
 
 impl WebviewConfig {
@@ -88,6 +98,7 @@ impl WebviewConfig {
             on_navigate: None,
             on_dismiss: None,
             on_presented: None,
+            on_failed: None,
         }
     }
 
@@ -153,6 +164,12 @@ impl WebviewConfig {
         self.on_presented = Some(Box::new(handler));
         self
     }
+
+    /// Called once when native presentation cannot begin.
+    pub fn on_failed(mut self, handler: impl FnOnce() + Send + 'static) -> Self {
+        self.on_failed = Some(Box::new(handler));
+        self
+    }
 }
 
 /// Data half of [`WebviewConfig`] sent to the native layer. Callbacks stay in
@@ -188,13 +205,14 @@ pub fn open(config: WebviewConfig) -> u32 {
     };
     let config_json = serde_json::to_string(&wire).unwrap_or_default();
 
-    handlers().lock().unwrap().insert(
+    handlers_lock().insert(
         id,
         Handlers {
             on_message: config.on_message,
             on_navigate: config.on_navigate,
             on_dismiss: config.on_dismiss,
             on_presented: config.on_presented,
+            on_failed: config.on_failed,
         },
     );
 
@@ -207,12 +225,26 @@ pub fn open(config: WebviewConfig) -> u32 {
 /// Report that native UI has presented the webview. This is deliberately
 /// separate from [`open`], which only schedules a main-thread presentation.
 pub fn dispatch_presented(id: u32) {
-    let handler = handlers()
-        .lock()
-        .unwrap()
+    let handler = handlers_lock()
         .get_mut(&id)
         .and_then(|handlers| handlers.on_presented.take());
     if let Some(handler) = handler {
+        handler();
+    }
+}
+
+/// Report that native UI could not present the webview. Drops its handlers and
+/// fires `on_failed`, so callers can settle loading state without treating it as
+/// a user dismissal.
+pub fn dispatch_failed(id: u32) {
+    if CURRENT_ID
+        .compare_exchange(id, 0, Ordering::Relaxed, Ordering::Relaxed)
+        .is_ok()
+    {
+        crate::native_presentation::set_native_webview_presented(false);
+    }
+    let entry = handlers_lock().remove(&id);
+    if let Some(handler) = entry.and_then(|handlers| handlers.on_failed) {
         handler();
     }
 }
@@ -230,9 +262,7 @@ pub fn eval_js(js: &str) {
 /// Deliver a message the page posted through the JS bridge. Called by the
 /// native layer.
 pub fn dispatch_message(id: u32, message: String) {
-    let handler = handlers()
-        .lock()
-        .unwrap()
+    let handler = handlers_lock()
         .get(&id)
         .and_then(|handlers| handlers.on_message.clone());
     if let Some(handler) = handler {
@@ -244,9 +274,7 @@ pub fn dispatch_message(id: u32, message: String) {
 /// layer synchronously; returns `true` to allow. Allows by default when no
 /// handler is registered.
 pub fn dispatch_navigate(id: u32, url: &str) -> bool {
-    let handler = handlers()
-        .lock()
-        .unwrap()
+    let handler = handlers_lock()
         .get(&id)
         .and_then(|handlers| handlers.on_navigate.clone());
     match handler {
@@ -264,7 +292,7 @@ pub fn dispatch_dismiss(id: u32) {
     {
         crate::native_presentation::set_native_webview_presented(false);
     }
-    let entry = handlers().lock().unwrap().remove(&id);
+    let entry = handlers_lock().remove(&id);
     if let Some(handler) = entry.and_then(|h| h.on_dismiss) {
         handler();
     }
@@ -289,6 +317,7 @@ mod tests {
                 })),
                 on_dismiss: None,
                 on_presented: None,
+                on_failed: None,
             },
         );
 
@@ -311,6 +340,7 @@ mod tests {
                 on_presented: Some(Box::new(move || {
                     callback_calls.fetch_add(1, Ordering::Relaxed);
                 })),
+                on_failed: None,
             },
         );
 
@@ -319,5 +349,30 @@ mod tests {
 
         assert_eq!(calls.load(Ordering::Relaxed), 1);
         handlers().lock().unwrap().remove(&id);
+    }
+
+    #[test]
+    fn failed_callback_removes_the_handler() {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let calls = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let callback_calls = calls.clone();
+        handlers().lock().unwrap().insert(
+            id,
+            Handlers {
+                on_message: None,
+                on_navigate: None,
+                on_dismiss: None,
+                on_presented: None,
+                on_failed: Some(Box::new(move || {
+                    callback_calls.fetch_add(1, Ordering::Relaxed);
+                })),
+            },
+        );
+
+        dispatch_failed(id);
+        dispatch_failed(id);
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert!(handlers_lock().get(&id).is_none());
     }
 }

--- a/crates/zedra/src/webview.rs
+++ b/crates/zedra/src/webview.rs
@@ -9,8 +9,8 @@
 //! Flow:
 //! - [`open`] serializes the config to JSON, stores its callbacks under a fresh
 //!   id, and asks the platform bridge to present the webview.
-//! - The native layer calls back into [`dispatch_message`],
-//!   [`dispatch_navigate`], and [`dispatch_dismiss`] with that id.
+//! - The native layer calls back into [`dispatch_presented`],
+//!   [`dispatch_message`], [`dispatch_navigate`], and [`dispatch_dismiss`].
 //! - [`eval_js`] and [`close`] drive the currently presented webview.
 //!
 //! Callbacks run on the native UI thread, off the GPUI thread. Keep them cheap
@@ -42,11 +42,13 @@ pub const MESSAGE_HANDLER_NAME: &str = "zedra";
 type MessageHandler = Arc<dyn Fn(String) + Send + Sync>;
 type NavigationHandler = Arc<dyn Fn(&str) -> NavigationPolicy + Send + Sync>;
 type DismissHandler = Box<dyn FnOnce() + Send>;
+type PresentedHandler = Box<dyn FnOnce() + Send>;
 
 struct Handlers {
     on_message: Option<MessageHandler>,
     on_navigate: Option<NavigationHandler>,
     on_dismiss: Option<DismissHandler>,
+    on_presented: Option<PresentedHandler>,
 }
 
 static NEXT_ID: AtomicU32 = AtomicU32::new(1);
@@ -71,6 +73,7 @@ pub struct WebviewConfig {
     on_message: Option<MessageHandler>,
     on_navigate: Option<NavigationHandler>,
     on_dismiss: Option<DismissHandler>,
+    on_presented: Option<PresentedHandler>,
 }
 
 impl WebviewConfig {
@@ -84,6 +87,7 @@ impl WebviewConfig {
             on_message: None,
             on_navigate: None,
             on_dismiss: None,
+            on_presented: None,
         }
     }
 
@@ -143,6 +147,12 @@ impl WebviewConfig {
         self.on_dismiss = Some(Box::new(handler));
         self
     }
+
+    /// Called once when the native webview is actually covering the app.
+    pub fn on_presented(mut self, handler: impl FnOnce() + Send + 'static) -> Self {
+        self.on_presented = Some(Box::new(handler));
+        self
+    }
 }
 
 /// Data half of [`WebviewConfig`] sent to the native layer. Callbacks stay in
@@ -184,6 +194,7 @@ pub fn open(config: WebviewConfig) -> u32 {
             on_message: config.on_message,
             on_navigate: config.on_navigate,
             on_dismiss: config.on_dismiss,
+            on_presented: config.on_presented,
         },
     );
 
@@ -191,6 +202,19 @@ pub fn open(config: WebviewConfig) -> u32 {
     crate::native_presentation::set_native_webview_presented(true);
     platform_bridge::bridge().open_webview(id, &config.url, &config_json);
     id
+}
+
+/// Report that native UI has presented the webview. This is deliberately
+/// separate from [`open`], which only schedules a main-thread presentation.
+pub fn dispatch_presented(id: u32) {
+    let handler = handlers()
+        .lock()
+        .unwrap()
+        .get_mut(&id)
+        .and_then(|handlers| handlers.on_presented.take());
+    if let Some(handler) = handler {
+        handler();
+    }
 }
 
 /// Dismiss the currently presented webview, if any.
@@ -264,11 +288,36 @@ mod tests {
                     NavigationPolicy::Allow
                 })),
                 on_dismiss: None,
+                on_presented: None,
             },
         );
 
         dispatch_message(id, String::new());
         assert!(dispatch_navigate(id, "https://example.com"));
+        handlers().lock().unwrap().remove(&id);
+    }
+
+    #[test]
+    fn presented_callback_runs_once() {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let calls = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let callback_calls = calls.clone();
+        handlers().lock().unwrap().insert(
+            id,
+            Handlers {
+                on_message: None,
+                on_navigate: None,
+                on_dismiss: None,
+                on_presented: Some(Box::new(move || {
+                    callback_calls.fetch_add(1, Ordering::Relaxed);
+                })),
+            },
+        );
+
+        dispatch_presented(id);
+        dispatch_presented(id);
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
         handlers().lock().unwrap().remove(&id);
     }
 }

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -114,6 +114,7 @@ pub struct Workspace {
     /// In-flight `web_client_start`; dropping it cancels the open the progress
     /// overlay is reporting.
     web_client_open_task: Option<Task<()>>,
+    web_tunnel_progress: crate::web_tunnel::progress::Progress,
     /// Listens for foreground resume events and checks the live session phase.
     _foreground_resume_listener: Option<Task<()>>,
     /// Notifies the host when app foreground/background state changes.
@@ -763,6 +764,7 @@ impl Workspace {
         let gitdiff = cx.new(|cx| WorkspaceGitdiff::new(session.handle().clone(), cx));
 
         let connection_banner = cx.new(|cx| ConnectionBanner::new(session_state.clone(), cx));
+        let web_tunnel_progress = crate::web_tunnel::progress::Progress::new();
         let content = cx.new(|cx| {
             WorkspaceContent::new(
                 workspace_state.clone(),
@@ -770,6 +772,7 @@ impl Workspace {
                 session_state.clone(),
                 session.handle().clone(),
                 connection_banner.clone(),
+                web_tunnel_progress.clone(),
                 cx,
             )
         });
@@ -1181,6 +1184,7 @@ impl Workspace {
             _host_info_listener: Some(host_info_listener),
             _web_client_listener: Some(web_client_listener),
             web_client_open_task: None,
+            web_tunnel_progress,
             _foreground_resume_listener: Some(foreground_resume_listener),
             _foreground_state_listener: Some(foreground_state_listener.into()),
             agent_picker,
@@ -2749,18 +2753,25 @@ impl Workspace {
         };
         // The server is already up on this path, so the open starts at the tunnel
         // step; naming the agent keeps the overlay consistent with a fresh start.
-        crate::web_tunnel::progress::begin(
+        let generation = self.web_tunnel_progress.begin(
             crate::agent::name(&slug),
             crate::agent::icon(&slug),
             crate::web_tunnel::progress::OpenStep::OpeningTunnel,
         );
-        self.open_web_client_url(id.to_string(), port, &path, cx);
+        self.open_web_client_url(id.to_string(), port, &path, generation, cx);
     }
 
     /// Open a host loopback port in the in-app webview over the tunnel, tracking
     /// it for quick reopen from the session panel. Routes the user takes inside
     /// the web UI are reported back to the host, so the card reopens there.
-    fn open_web_client_url(&mut self, id: String, port: u16, path: &str, cx: &mut Context<Self>) {
+    fn open_web_client_url(
+        &mut self,
+        id: String,
+        port: u16,
+        path: &str,
+        generation: u64,
+        cx: &mut Context<Self>,
+    ) {
         let url = format!("http://localhost:{port}{path}");
         let session_handle = self.session.handle().clone();
         let hook_handle = session_handle.clone();
@@ -2775,8 +2786,13 @@ impl Workspace {
                 }
             });
         });
-        if let Some(title) = crate::web_tunnel::open_url_with(session_handle, &url, Some(on_route))
-        {
+        if let Some(title) = crate::web_tunnel::open_url_with_progress(
+            session_handle,
+            &url,
+            Some(on_route),
+            self.web_tunnel_progress.clone(),
+            Some(generation),
+        ) {
             // Track the origin, not `url`: the path identifies a session, and the
             // card already reopens at it. Keeps it out of persisted state.
             let origin = format!("http://localhost:{port}");
@@ -2832,7 +2848,7 @@ impl Workspace {
         let slug = action.slug.clone();
         // Spawning the agent's server takes seconds; the overlay owns the screen
         // from here until the webview is up or the open fails.
-        let generation = crate::web_tunnel::progress::begin(
+        let generation = self.web_tunnel_progress.begin(
             crate::agent::name(&slug),
             crate::agent::icon(&slug),
             crate::web_tunnel::progress::OpenStep::StartingServer,
@@ -2841,15 +2857,18 @@ impl Workspace {
             match session_handle.web_client_start(slug.clone()).await {
                 // The card appears via the WebClientWatch stream; open it now.
                 Ok((id, port, path)) => {
-                    let _ =
-                        workspace.update(cx, |ws, cx| ws.open_web_client_url(id, port, &path, cx));
+                    let _ = workspace.update(cx, |ws, cx| {
+                        ws.open_web_client_url(id, port, &path, generation, cx)
+                    });
                 }
                 Err(e) => {
                     tracing::error!(agent = slug, "web client start failed: {}", e);
-                    crate::web_tunnel::progress::fail(
-                        generation,
-                        "The host could not start this agent's web server.",
-                    );
+                    let _ = workspace.update(cx, |ws, _cx| {
+                        ws.web_tunnel_progress.fail(
+                            generation,
+                            "The host could not start this agent's web server.",
+                        )
+                    });
                 }
             }
         }));
@@ -2865,7 +2884,7 @@ impl Workspace {
     ) {
         info!("web-tunnel: open cancelled from the progress overlay");
         self.web_client_open_task = None;
-        crate::web_tunnel::progress::cancel();
+        self.web_tunnel_progress.cancel();
         cx.notify();
     }
 
@@ -3917,6 +3936,7 @@ impl WorkspaceContent {
         session_state: Entity<SessionState>,
         session_handle: SessionHandle,
         connection_banner: Entity<ConnectionBanner>,
+        web_tunnel_progress: crate::web_tunnel::progress::Progress,
         cx: &mut Context<Self>,
     ) -> Self {
         let empty_view = cx.new(|_cx| Empty);
@@ -3935,7 +3955,7 @@ impl WorkspaceContent {
             show_connecting: false,
             connecting_view: connecting,
             connection_banner,
-            web_tunnel_opening: cx.new(WebTunnelOpening::new),
+            web_tunnel_opening: cx.new(|cx| WebTunnelOpening::new(web_tunnel_progress, cx)),
             mainview_bounds: None,
             _subscriptions: vec![terminal_state_sub, workspace_state_sub],
         }
@@ -4086,6 +4106,7 @@ impl Render for WorkspaceContent {
 
         div()
             .size_full()
+            .relative()
             .flex()
             .flex_col()
             .min_h_0()
@@ -4215,9 +4236,10 @@ impl Render for WorkspaceContent {
                     // the connecting detail already conveys full connection status.
                     .when(!self.show_connecting, |d| {
                         d.child(self.connection_banner.clone())
-                    })
-                    // Above both: an open in flight owns the view until it settles.
-                    .child(self.web_tunnel_opening.clone()),
+                    }),
             )
+            // This is a workspace-level layer: it must also block the header,
+            // drawer toggle, and quick actions while the native webview opens.
+            .child(self.web_tunnel_opening.clone())
     }
 }

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -4106,7 +4106,6 @@ impl Render for WorkspaceContent {
 
         div()
             .size_full()
-            .relative()
             .flex()
             .flex_col()
             .min_h_0()
@@ -4236,10 +4235,10 @@ impl Render for WorkspaceContent {
                     // the connecting detail already conveys full connection status.
                     .when(!self.show_connecting, |d| {
                         d.child(self.connection_banner.clone())
-                    }),
+                    })
+                    // Opening a web client owns the main view, but leaves
+                    // workspace navigation available above it.
+                    .child(self.web_tunnel_opening.clone()),
             )
-            // This is a workspace-level layer: it must also block the header,
-            // drawer toggle, and quick actions while the native webview opens.
-            .child(self.web_tunnel_opening.clone())
     }
 }

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -31,6 +31,7 @@ use crate::terminal_state::TerminalState;
 use crate::theme;
 use crate::transport_badge::ConnectionStatusIndicator;
 use crate::ui::{DrawerEvent, DrawerHost, DrawerSide};
+use crate::web_tunnel_opening::WebTunnelOpening;
 use crate::workspace_action::{self, GoHome, OpenFileSearch, OpenQuickAction, RequestDisconnect};
 use crate::workspace_action::{
     AddSelectionToChat, CloseDrawer, CloseTerminal, CloseWebClient, CreateAgent, CreateNewTerminal,
@@ -110,6 +111,9 @@ pub struct Workspace {
     /// Listens for periodic host resource snapshots.
     _host_info_listener: Option<Task<()>>,
     _web_client_listener: Option<Task<()>>,
+    /// In-flight `web_client_start`; dropping it cancels the open the progress
+    /// overlay is reporting.
+    web_client_open_task: Option<Task<()>>,
     /// Listens for foreground resume events and checks the live session phase.
     _foreground_resume_listener: Option<Task<()>>,
     /// Notifies the host when app foreground/background state changes.
@@ -1176,6 +1180,7 @@ impl Workspace {
             _host_event_listener: Some(host_event_listener),
             _host_info_listener: Some(host_info_listener),
             _web_client_listener: Some(web_client_listener),
+            web_client_open_task: None,
             _foreground_resume_listener: Some(foreground_resume_listener),
             _foreground_state_listener: Some(foreground_state_listener.into()),
             agent_picker,
@@ -2732,16 +2737,23 @@ impl Workspace {
 
     /// Open the card's web client at the path it was last left on.
     fn open_web_client(&mut self, id: &str, cx: &mut Context<Self>) {
-        let Some((port, path)) = self
+        let Some((slug, port, path)) = self
             .workspace_state
             .read(cx)
             .web_clients
             .iter()
             .find(|card| card.id == id)
-            .map(|card| (card.port, card.path.clone()))
+            .map(|card| (card.slug.clone(), card.port, card.path.clone()))
         else {
             return;
         };
+        // The server is already up on this path, so the open starts at the tunnel
+        // step; naming the agent keeps the overlay consistent with a fresh start.
+        crate::web_tunnel::progress::begin(
+            crate::agent::name(&slug),
+            crate::agent::icon(&slug),
+            crate::web_tunnel::progress::OpenStep::OpeningTunnel,
+        );
         self.open_web_client_url(id.to_string(), port, &path, cx);
     }
 
@@ -2818,7 +2830,14 @@ impl Workspace {
             .update(cx, |host, cx| host.close_with_window(&mut *window, cx));
         let session_handle = self.session.handle().clone();
         let slug = action.slug.clone();
-        cx.spawn(async move |workspace, cx| {
+        // Spawning the agent's server takes seconds; the overlay owns the screen
+        // from here until the webview is up or the open fails.
+        let generation = crate::web_tunnel::progress::begin(
+            crate::agent::name(&slug),
+            crate::agent::icon(&slug),
+            crate::web_tunnel::progress::OpenStep::StartingServer,
+        );
+        self.web_client_open_task = Some(cx.spawn(async move |workspace, cx| {
             match session_handle.web_client_start(slug.clone()).await {
                 // The card appears via the WebClientWatch stream; open it now.
                 Ok((id, port, path)) => {
@@ -2827,18 +2846,27 @@ impl Workspace {
                 }
                 Err(e) => {
                     tracing::error!(agent = slug, "web client start failed: {}", e);
-                    let _ = workspace.update(cx, |_ws, _cx| {
-                        platform_bridge::show_alert(
-                            "Web client",
-                            "Failed to start the web client.",
-                            vec![AlertButton::default("OK")],
-                            |_| {},
-                        );
-                    });
+                    crate::web_tunnel::progress::fail(
+                        generation,
+                        "The host could not start this agent's web server.",
+                    );
                 }
             }
-        })
-        .detach();
+        }));
+    }
+
+    /// Abandon the in-flight web-tunnel open behind the progress overlay. The
+    /// generation bump stops a tunnel that finishes later from presenting.
+    fn handle_cancel_web_tunnel_open(
+        &mut self,
+        _action: &workspace_action::CancelWebTunnelOpen,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        info!("web-tunnel: open cancelled from the progress overlay");
+        self.web_client_open_task = None;
+        crate::web_tunnel::progress::cancel();
+        cx.notify();
     }
 
     /// Terminal-specific view effects: deactivate the previous terminal and swap the content
@@ -3170,6 +3198,7 @@ impl Render for Workspace {
             .on_action(cx.listener(Self::handle_open_quick_action))
             .on_action(cx.listener(Self::handle_open_file_search))
             .on_action(cx.listener(Self::handle_request_disconnect))
+            .on_action(cx.listener(Self::handle_cancel_web_tunnel_open))
             .on_action(cx.listener(Self::handle_toggle_drawer))
             .on_action(cx.listener(Self::handle_open_drawer))
             .on_action(cx.listener(Self::handle_close_drawer))
@@ -3800,6 +3829,7 @@ pub struct WorkspaceContent {
     show_connecting: bool,
     connecting_view: Entity<WorkspaceConnecting>,
     connection_banner: Entity<ConnectionBanner>,
+    web_tunnel_opening: Entity<WebTunnelOpening>,
     mainview_bounds: Option<Bounds<Pixels>>,
     _subscriptions: Vec<Subscription>,
 }
@@ -3905,6 +3935,7 @@ impl WorkspaceContent {
             show_connecting: false,
             connecting_view: connecting,
             connection_banner,
+            web_tunnel_opening: cx.new(WebTunnelOpening::new),
             mainview_bounds: None,
             _subscriptions: vec![terminal_state_sub, workspace_state_sub],
         }
@@ -4184,7 +4215,9 @@ impl Render for WorkspaceContent {
                     // the connecting detail already conveys full connection status.
                     .when(!self.show_connecting, |d| {
                         d.child(self.connection_banner.clone())
-                    }),
+                    })
+                    // Above both: an open in flight owns the view until it settles.
+                    .child(self.web_tunnel_opening.clone()),
             )
     }
 }

--- a/crates/zedra/src/workspace_action.rs
+++ b/crates/zedra/src/workspace_action.rs
@@ -79,6 +79,11 @@ pub struct ShowHomeWorkspaceConnecting {
 #[action(namespace = workspace, no_json)]
 pub struct HideConnecting;
 
+/// Dismiss the web-tunnel opening overlay, abandoning an open still in flight.
+#[derive(Clone, PartialEq, Action)]
+#[action(namespace = workspace, no_json)]
+pub struct CancelWebTunnelOpen;
+
 #[derive(Clone, PartialEq, Action)]
 #[action(namespace = workspace, no_json)]
 pub struct RestartConnection;

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -2222,9 +2222,9 @@ to spawn (`pkill -f "opencode serve"` on the host first).
    name, a ✕ in the top-right corner, and a single spinning line naming the step
    in flight: `Starting opencode server` → `Opening tunnel` → `Loading page`.
    Past ~2s the line gains an elapsed counter (`… 4s`).
-2. **Handoff**: the overlay disappears exactly as the webview appears — no gap
-   showing the bare workspace, and no overlay left behind the webview (dismiss
-   the webview to confirm the workspace is back).
+2. **Handoff**: the overlay remains until the native webview covers the app,
+   then disappears with no bare-workspace gap. Dismiss the webview to confirm
+   the workspace is back.
 3. **Reopen**: dismiss the webview and tap the card. Expected: the overlay opens
    straight at `Opening tunnel` (the server is already up); usually too fast to
    read, which is correct.
@@ -2241,3 +2241,6 @@ to spawn (`pkill -f "opencode serve"` on the host first).
    no dead end** — the overlay runs `Opening tunnel` straight through the alias
    and the opencode page loads at `<label>.zedra.test:<port>`. Tap the card again:
    it opens via the alias without retrying the bind.
+7. **Workspace switch**: start a slow web client in workspace A, switch to
+   workspace B, then cancel an open in B. Expected: A's open remains owned by A;
+   B cannot dismiss it or cause A's webview to appear over B.

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -827,7 +827,7 @@ printf '\033]8;;https://zedra.dev\033\\zedra.dev\033]8;;\033\\\n'
 
 ## 9a. Terminal Localhost Web Tunnel
 
-The default exact-port mode binds `127.0.0.1:<port>` on the device and opens the literal localhost URL. If that port is unavailable, you can opt the workspace into alias mode, which rewrites the host and routes traffic through the in-app SOCKS5 proxy. On the iOS simulator, exact-port can collide with a server using the same Mac loopback port. In alias mode, use `localhost` rather than `127.0.0.1`, which WKWebView can route outside the proxy.
+The default exact-port mode binds `127.0.0.1:<port>` on the device and opens the literal localhost URL. If that port is unavailable, the workspace falls over to alias mode automatically, which rewrites the host and routes traffic through the in-app SOCKS5 proxy. On the iOS simulator, exact-port can collide with a server using the same Mac loopback port. In alias mode, use `localhost` rather than `127.0.0.1`, which WKWebView can route outside the proxy.
 
 1. On the host, run `./examples/webview-tunnel/run.sh` (multi-port test app: page on `5173`, JSON API + SSE on `5174`, WebSocket on `5175`; see `examples/webview-tunnel/README.md`).
 2. Connect to the same workspace from iOS or Android and open a terminal.
@@ -892,11 +892,11 @@ Exercise the exact-port / alias adapters without contriving two hosts. Fire deep
 Devtool actions — `zedra://devtool/tunnel?…`: `url=<url>` open via the real orchestration · `mode=alias` force the alias for this host · `collide=<port>` mark a port as owned by a foreign host (forces the fallback) · `reset=1` clear per-host prefs + port owners. Prereq: `./examples/webview-tunnel/run.sh` on the host, workspace connected.
 
 1. **Exact-port (device)** — `zedra://devtool/tunnel?url=http://localhost:5173`. Expected: webview at the literal `localhost:5173`; page loads; BACKEND/SSE/WS cards work (companion ports sniffed). Log: `exact-port bound 127.0.0.1:5173`.
-2. **Collision → alias prompt** — `zedra://devtool/tunnel?url=http://localhost:5173&reset=1&collide=5173`. Expected: a native notice "localhost:5173 can't be bound…" with **Use alias** + doc link; tapping it reopens the webview at `<label>.zedra.test:5173` and loads. Log: `exact-port unavailable … offering alias`, then `alias SOCKS proxy on …`.
+2. **Collision → automatic alias** — `zedra://devtool/tunnel?url=http://localhost:5173&reset=1&collide=5173`. Expected: **no prompt** — the webview opens straight at `<label>.zedra.test:5173` and loads. Log: `exact-port unavailable for :5173 -> alias`, then `alias SOCKS proxy on …`.
 3. **Alias direct** — `zedra://devtool/tunnel?url=http://localhost:5173&reset=1&mode=alias`. Expected: straight to the alias — address bar shows `<label>.zedra.test:5173` (honest, not spoofed), page loads.
-4. **Per-host memory** — after 2 or 3, fire `zedra://devtool/tunnel?url=http://localhost:5173` again (no reset). Expected: goes straight to the alias, no prompt.
+4. **Per-host memory** — after 2 or 3, fire `zedra://devtool/tunnel?url=http://localhost:5173` again (no reset). Expected: goes straight to the alias without retrying the bind (no `exact-port unavailable` line this time).
 5. **Non-loopback** — `zedra://devtool/tunnel?url=https://example.com`. Expected: opens in the system browser (not tunneled).
-6. **Simulator note** — the simulator shares the Mac's loopback, so exact-port `:5173` collides with `run.sh` and lands on the prompt (case 2) on its own; use a real device for the exact-port happy path (case 1).
+6. **Simulator note** — the simulator shares the Mac's loopback, so exact-port `:5173` collides with `run.sh` and takes the alias (case 2) on its own; use a real device for the exact-port happy path (case 1).
 
 ### Listener manager (devtool)
 
@@ -904,7 +904,7 @@ The **Web tunnel** manager (Settings → Developer → Web tunnel) lists and sto
 
 1. After case 1 binds a listener, open **Settings → Developer → Web tunnel**.
 2. Expected: one `:<port>  <workspace name>` row per bound listener (e.g. `:5173`, plus any companion ports like `:5174`/`:5175` from the sniffer), each with a red **Stop** button. With none bound, an empty "No web tunnel listeners are bound" state.
-3. Tap **Stop** on a row. Expected: a native confirmation alert ("Stop web tunnel listener" / "Free port :&lt;port&gt; for &lt;host&gt;?…") with a destructive **Stop** and **Cancel**. **Cancel** leaves the row untouched. **Stop** removes the row and frees the device port (a fresh open of that port re-binds it, or offers the alias if another app now holds it). Log: `exact-port stopped 127.0.0.1:<port>`.
+3. Tap **Stop** on a row. Expected: a native confirmation alert ("Stop web tunnel listener" / "Free port :&lt;port&gt; for &lt;host&gt;?…") with a destructive **Stop** and **Cancel**. **Cancel** leaves the row untouched. **Stop** removes the row and frees the device port (a fresh open of that port re-binds it, or falls over to the alias if another app now holds it). Log: `exact-port stopped 127.0.0.1:<port>`.
 4. Tap refresh (↻). Expected: the list re-reads live listeners.
 
 ### CLI open + tracked tunnels
@@ -2210,3 +2210,34 @@ Requires `opencode` on the host's PATH and a web-tunnel-capable build.
    shows none).
 10. **Non-web agent**: a non-web agent (e.g. claude) has no globe and creating it
    still opens a terminal, unchanged.
+
+## Web tunnel opening progress
+
+The overlay that reports what an in-app-webview open is doing while it takes
+seconds. Cold-start the first card of the run so `opencode serve` actually has
+to spawn (`pkill -f "opencode serve"` on the host first).
+
+1. **Steps**: tap the globe in **Create Agent**. Expected: the drawer closes and
+   a full-view overlay replaces the workspace immediately — OpenCode icon and
+   name, a ✕ in the top-right corner, and a single spinning line naming the step
+   in flight: `Starting opencode server` → `Opening tunnel` → `Loading page`.
+   Past ~2s the line gains an elapsed counter (`… 4s`).
+2. **Handoff**: the overlay disappears exactly as the webview appears — no gap
+   showing the bare workspace, and no overlay left behind the webview (dismiss
+   the webview to confirm the workspace is back).
+3. **Reopen**: dismiss the webview and tap the card. Expected: the overlay opens
+   straight at `Opening tunnel` (the server is already up); usually too fast to
+   read, which is correct.
+4. **Close mid-open**: cold-start again and tap the ✕ while `Starting opencode
+   server` spins. Expected: the overlay closes and returns to the workspace, and
+   **no webview appears afterwards** even though the host finishes the start.
+   Re-tapping the globe opens normally.
+5. **Failure**: make the start fail (stop the host mid-open, or rename the
+   `opencode` binary on PATH). Expected: the spinner turns into a red ✕ and the
+   step line goes red with an explanation below — the overlay stays put until the
+   corner ✕ is tapped instead of vanishing into an unexplained workspace.
+6. **Port conflict**: on the **simulator** (its loopback is the Mac's, so the
+   card's port is already taken) tap the globe. Expected: **no notification and
+   no dead end** — the overlay runs `Opening tunnel` straight through the alias
+   and the opencode page loads at `<label>.zedra.test:<port>`. Tap the card again:
+   it opens via the alias without retrying the bind.

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -2218,10 +2218,11 @@ seconds. Cold-start the first card of the run so `opencode serve` actually has
 to spawn (`pkill -f "opencode serve"` on the host first).
 
 1. **Steps**: tap the globe in **Create Agent**. Expected: the drawer closes and
-   a full-view overlay replaces the workspace immediately — OpenCode icon and
-   name, a ✕ in the top-right corner, and a single spinning line naming the step
-   in flight: `Starting opencode server` → `Opening tunnel` → `Loading page`.
-   Past ~2s the line gains an elapsed counter (`… 4s`).
+   an overlay replaces the main view immediately while the workspace header and
+   actions remain usable. The OpenCode icon and status sit slightly above the
+   main-view centre; a ✕ in the top-right corner and a single spinning line name
+   the step in flight: `Starting opencode server` → `Opening tunnel` → `Loading
+   page`. Past ~2s the line gains an elapsed counter (`… 4s`).
 2. **Handoff**: the overlay remains until the native webview covers the app,
    then disappears with no bare-workspace gap. Dismiss the webview to confirm
    the workspace is back.

--- a/docs/WEB_TUNNEL.md
+++ b/docs/WEB_TUNNEL.md
@@ -92,7 +92,8 @@ Two ways to open a host web app on the phone:
 Opening an agent web client can take seconds — the host spawns the server and
 polls it for readiness before the app has a URL to tunnel. Each workspace owns a
 thread-safe `web_tunnel::progress::Progress` handle, which
-`web_tunnel_opening.rs` polls and renders as a full-workspace overlay. Three
+`web_tunnel_opening.rs` polls and renders as an overlay in the workspace main
+view. Three
 steps — starting the server, opening the tunnel, loading the page — show only the
 step in flight, next to a corner ✕ that dismisses like the connecting view.
 

--- a/docs/WEB_TUNNEL.md
+++ b/docs/WEB_TUNNEL.md
@@ -90,22 +90,21 @@ Two ways to open a host web app on the phone:
 ## Opening progress
 
 Opening an agent web client can take seconds — the host spawns the server and
-polls it for readiness before the app has a URL to tunnel — so every open path
-reports its stage through `web_tunnel::progress`, and `web_tunnel_opening.rs`
-renders it as a full-view overlay above the workspace. Three steps — starting the
-server, opening the tunnel, loading the page — of which only the one in flight is
-shown, next to a corner ✕ that dismisses like the connecting view.
+polls it for readiness before the app has a URL to tunnel. Each workspace owns a
+thread-safe `web_tunnel::progress::Progress` handle, which
+`web_tunnel_opening.rs` polls and renders as a full-workspace overlay. Three
+steps — starting the server, opening the tunnel, loading the page — show only the
+step in flight, next to a corner ✕ that dismisses like the connecting view.
 
-The state is a module-level global rather than a `WorkspaceState` field because
-the tunnel steps run on the session runtime, off the GPUI thread; the view polls
-a version counter and repaints. One open is live at a time, identified by a
-generation. **Cancel bumps the generation**, and the presenting step checks it
-before calling `webview::open` — the invariant is that a cancelled open can
-never pop a webview later, however long the host takes to answer.
+Each open has a generation. Cancel clears that workspace's generation, and the
+presenting step checks it before calling `webview::open`; a cancelled open can
+never pop a webview later. The overlay remains through the native main-thread
+handoff and clears only when UIKit or Android has actually presented the webview.
 
 Failure keeps the overlay up with the failed step marked and an explanation,
-except where a native notification already owns the outcome (the alias-fallback
-prompt), which clears the overlay so only one surface asks for a decision.
+except when an HTTPS page cannot use the alias fallback. That case shows the
+native exact-port notification and clears the overlay so only one surface reports
+the failure.
 
 ## Keyboard and the tunnelled page
 

--- a/docs/WEB_TUNNEL.md
+++ b/docs/WEB_TUNNEL.md
@@ -87,6 +87,26 @@ Two ways to open a host web app on the phone:
   session with an active `Subscribe` stream; the app opens it through the same
   seam. Requires a phone connected to that workspace's daemon.
 
+## Opening progress
+
+Opening an agent web client can take seconds — the host spawns the server and
+polls it for readiness before the app has a URL to tunnel — so every open path
+reports its stage through `web_tunnel::progress`, and `web_tunnel_opening.rs`
+renders it as a full-view overlay above the workspace. Three steps — starting the
+server, opening the tunnel, loading the page — of which only the one in flight is
+shown, next to a corner ✕ that dismisses like the connecting view.
+
+The state is a module-level global rather than a `WorkspaceState` field because
+the tunnel steps run on the session runtime, off the GPUI thread; the view polls
+a version counter and repaints. One open is live at a time, identified by a
+generation. **Cancel bumps the generation**, and the presenting step checks it
+before calling `webview::open` — the invariant is that a cancelled open can
+never pop a webview later, however long the host takes to answer.
+
+Failure keeps the overlay up with the failed step marked and an explanation,
+except where a native notification already owns the outcome (the alias-fallback
+prompt), which clears the overlay so only one surface asks for a decision.
+
 ## Keyboard and the tunnelled page
 
 A tunnelled page is a full app the user drives with its own UI, so the webview

--- a/docs/WEB_TUNNEL_MODES.md
+++ b/docs/WEB_TUNNEL_MODES.md
@@ -3,8 +3,9 @@
 The web tunnel opens a host's localhost web app in the in-app webview over the
 authenticated Zedra session. It has two adapters behind one seam, picked per
 host and keyed by the session's stable non-relay **endpoint id** (so routing
-survives reconnects). Default is **exact-port**; **alias** is an opt-in
-fallback. Implementation: `crates/zedra/src/web_tunnel/`.
+survives reconnects). Default is **exact-port**; **alias** is the automatic
+fallback when a port can't be bound. Implementation:
+`crates/zedra/src/web_tunnel/`.
 
 ## Why two modes
 
@@ -31,11 +32,11 @@ Neither is strictly better; they trade origin honesty for multi-host reach.
   by a plaintext byte sniffer and bound the same way.
 - Each device port is owned by **one host** (endpoint id). A second host
   colliding on the same port — or a hard bind failure (another app holds the
-  port, or an OS restriction) — is "exact-port unavailable" and triggers the
-  fallback prompt.
+  port, or an OS restriction) — is "exact-port unavailable" and falls the host
+  over to the alias.
 - Origin stays `localhost` → no CORS/OAuth/navigation surprises.
 
-## Alias (opt-in fallback)
+## Alias (automatic fallback)
 
 - Serves the host under a per-host alias `**<word>.zedra.test**` (`word` = a
   short label from a curated wordlist, assigned per host by `alias::mint_label`
@@ -66,18 +67,22 @@ Neither is strictly better; they trade origin honesty for multi-host reach.
 1. Non-loopback / non-http(s) targets → system browser.
 2. Resolve the host endpoint id; if the host already opted into the alias, use it.
 3. Otherwise try exact-port. Success → load literal `localhost`.
-4. Unavailable → a native notice ("localhost:PORT can't be bound on this
-   device") with a **Use alias** action and a link to this doc. Approving records
-   the choice **for that host** and serves via the alias from then on.
+4. Unavailable → fall over to the alias immediately, recording the choice **for
+   that host** so later opens skip the doomed bind. No prompt: the port won't
+   become bindable on a retry, so asking would only delay the same page. The
+   address bar shows the alias, which is where the user sees the switch.
+5. Unavailable **and** the target is https → the alias can't serve it (its
+   certificate is for `localhost`), so the open stops with a native notice
+   linking this doc.
 
 ## Choosing
 
-| | Exact-port (default) | Alias (opt-in) |
+| | Exact-port (default) | Alias (fallback) |
 |---|---|---|
 | Origin | honest `localhost` | honest `<label>.zedra.test` |
 | CORS / cookies / `localhost` OAuth | work unchanged | need the alias origin configured |
 | Same-port, multiple hosts concurrently | one host per port | each host disambiguated |
-| Port already taken (app/OS) | fails → offers alias | works (one ephemeral proxy port) |
+| Port already taken (app/OS) | falls over to alias | works (one ephemeral proxy port) |
 | Companion ports | sniffer binds them | same-origin/relative only |
 
 Use exact-port for origin-sensitive apps (sign-in, cookies, strict CORS); use
@@ -98,4 +103,5 @@ alias if the port is now taken). `web_tunnel::active_listeners()` /
 
 - **Switch a host to alias from the manager**: the manager only stops listeners
   today. Add a per-row action to opt a host into the alias adapter directly,
-  without waiting for a bind conflict to surface the prompt.
+  without waiting for a bind conflict, and to undo an automatic fallback once the
+  port is free again.

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -370,6 +370,11 @@ void zedra_ios_webview_dismiss(uint32_t callback_id);
 void zedra_ios_webview_presented(uint32_t callback_id);
 
 /**
+ * Called when UIKit could not begin presenting the webview.
+ */
+void zedra_ios_webview_failed(uint32_t callback_id);
+
+/**
  * Called by Swift with the processed image bytes ready to upload.
  * `extension` is "jpg" or "png" (lowercase, no dot).
  */

--- a/include/zedra_ios.h
+++ b/include/zedra_ios.h
@@ -365,6 +365,11 @@ bool zedra_ios_webview_navigate(uint32_t callback_id, const char *url);
 void zedra_ios_webview_dismiss(uint32_t callback_id);
 
 /**
+ * Called once UIKit has presented the webview over the workspace.
+ */
+void zedra_ios_webview_presented(uint32_t callback_id);
+
+/**
  * Called by Swift with the processed image bytes ready to upload.
  * `extension` is "jpg" or "png" (lowercase, no dot).
  */

--- a/ios/Zedra/Presentations.swift
+++ b/ios/Zedra/Presentations.swift
@@ -2895,7 +2895,10 @@ private enum NativeWebViewPresenter {
                 }
                 presentedController = nav
                 activeController = controller
-                NativePresentationBridge.topViewController()?.present(nav, animated: true)
+                guard let presenter = NativePresentationBridge.topViewController() else { return }
+                presenter.present(nav, animated: true) {
+                    zedra_ios_webview_presented(callbackID)
+                }
             }
             // Present only after any existing webview finishes dismissing — dismiss
             // and present in the same runloop makes UIKit silently drop the new one.

--- a/ios/Zedra/Presentations.swift
+++ b/ios/Zedra/Presentations.swift
@@ -2895,7 +2895,14 @@ private enum NativeWebViewPresenter {
                 }
                 presentedController = nav
                 activeController = controller
-                guard let presenter = NativePresentationBridge.topViewController() else { return }
+                guard let presenter = NativePresentationBridge.topViewController() else {
+                    if presentedController === nav {
+                        presentedController = nil
+                        activeController = nil
+                    }
+                    zedra_ios_webview_failed(callbackID)
+                    return
+                }
                 presenter.present(nav, animated: true) {
                     zedra_ios_webview_presented(callbackID)
                 }

--- a/ios/Zedra/Presentations.swift
+++ b/ios/Zedra/Presentations.swift
@@ -2878,7 +2878,12 @@ private enum NativeWebViewPresenter {
               let data = configJSON.data(using: .utf8),
               let config = try? JSONDecoder().decode(NativeWebViewConfig.self, from: data),
               let url = URL(string: config.url)
-        else { return }
+        else {
+            // Rust already registered handlers, so a rejected config must report
+            // failure or the opening progress never settles.
+            zedra_ios_webview_failed(callbackID)
+            return
+        }
         DispatchQueue.main.async {
             let present = {
                 let controller = NativeWebViewController(callbackID: callbackID, config: config, url: url)

--- a/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64-simulator/Headers/zedra_ios.h
@@ -370,6 +370,16 @@ bool zedra_ios_webview_navigate(uint32_t callback_id, const char *url);
 void zedra_ios_webview_dismiss(uint32_t callback_id);
 
 /**
+ * Called once UIKit has presented the webview over the workspace.
+ */
+void zedra_ios_webview_presented(uint32_t callback_id);
+
+/**
+ * Called when UIKit could not begin presenting the webview.
+ */
+void zedra_ios_webview_failed(uint32_t callback_id);
+
+/**
  * Called by Swift with the processed image bytes ready to upload.
  * `extension` is "jpg" or "png" (lowercase, no dot).
  */

--- a/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
+++ b/ios/ZedraFFI.xcframework/ios-arm64/Headers/zedra_ios.h
@@ -365,6 +365,16 @@ bool zedra_ios_webview_navigate(uint32_t callback_id, const char *url);
 void zedra_ios_webview_dismiss(uint32_t callback_id);
 
 /**
+ * Called once UIKit has presented the webview over the workspace.
+ */
+void zedra_ios_webview_presented(uint32_t callback_id);
+
+/**
+ * Called when UIKit could not begin presenting the webview.
+ */
+void zedra_ios_webview_failed(uint32_t callback_id);
+
+/**
  * Called by Swift with the processed image bytes ready to upload.
  * `extension` is "jpg" or "png" (lowercase, no dot).
  */


### PR DESCRIPTION
## Summary

- Restore the missing web-tunnel opening progress overlay.
- Show server, tunnel, and page-loading stages; allow cancellation and retain failures for review.

## Notes

- The reconnect-route follow-up was already patch-equivalent on main, so it is not duplicated here.
- Validated with cargo fmt --check, focused progress tests, and cargo check -p zedra.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a full-screen web tunnel opening overlay with staged progress, elapsed time, loading status, and error feedback.
  - Added cancellation support for in-progress web tunnel openings.
  - Added automatic alias-mode fallback when cleartext HTTP cannot bind to the requested port.
  - Added webview presentation success and failure handling on Android and iOS.
- **Bug Fixes**
  - Prevented cancelled or outdated opening attempts from launching delayed web views.
  - HTTPS tunnel failures now provide clearer guidance when exact-port binding is unavailable.
- **Documentation**
  - Updated web tunnel behavior and manual testing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->