### PR TITLE
fix(android): restore back navigation hierarchy

### DIFF
--- a/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/MainActivity.kt
@@ -25,6 +25,7 @@ import android.view.Gravity
 import android.view.KeyEvent
 import android.view.View
 import android.widget.FrameLayout
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
@@ -110,6 +111,22 @@ class MainActivity : AppCompatActivity() {
         )
         installSplashScreen()
         super.onCreate(savedInstanceState)
+
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (dispatchAppBack()) return
+
+                    isEnabled = false
+                    try {
+                        onBackPressedDispatcher.onBackPressed()
+                    } finally {
+                        isEnabled = true
+                    }
+                }
+            },
+        )
 
         ZedraFirebase.initialize(this)
         createDeltaNotificationChannel(this)
@@ -280,16 +297,17 @@ class MainActivity : AppCompatActivity() {
     // GpuiSurfaceView.onKeyDown() can consume it. This covers hardware back buttons and MIUI's
     // gesture-nav implementation which sends KEYCODE_BACK as a key event (source=SOURCE_KEYBOARD).
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (event.keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
-            if (NativePresentations.handleBackPressed()) {
-                return true
+        if (event.keyCode == KeyEvent.KEYCODE_BACK) {
+            if (event.action == KeyEvent.ACTION_UP && !event.isCanceled) {
+                onBackPressedDispatcher.onBackPressed()
             }
-            if (nativeSystemBackPressed()) {
-                return true
-            }
+            return true
         }
         return super.dispatchKeyEvent(event)
     }
+
+    private fun dispatchAppBack(): Boolean =
+        NativePresentations.handleBackPressed() || nativeSystemBackPressed()
 
     private fun startKeyBarPolling() {
         if (keyBarPollActive) return

--- a/crates/zedra/src/android/jni.rs
+++ b/crates/zedra/src/android/jni.rs
@@ -692,7 +692,14 @@ pub extern "system" fn Java_dev_zedra_app_MainActivity_nativeSystemBackPressed(
     _env: JNIEnv,
     _class: JClass,
 ) -> jboolean {
-    crate::android::entry::handle_system_back() as jboolean
+    let mut handled = false;
+    jni_call(
+        "system_back_pressed",
+        std::panic::AssertUnwindSafe(|| {
+            handled = crate::android::entry::handle_system_back();
+        }),
+    );
+    handled as jboolean
 }
 
 /// Foreground/background state from the Android activity lifecycle

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -44,6 +44,29 @@ fn should_update_drawer_content(current: AppScreen, next: AppScreen) -> bool {
     current != next || next == AppScreen::Workspace
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WorkspaceEntryPolicy {
+    PreserveHistory,
+    ResetActiveRoot,
+    ResetTargetRoot,
+}
+
+fn quick_action_workspace_entry_policy(
+    screen: AppScreen,
+    event: &QuickActionEvent,
+) -> WorkspaceEntryPolicy {
+    if screen != AppScreen::Home {
+        return WorkspaceEntryPolicy::PreserveHistory;
+    }
+    match event {
+        QuickActionEvent::NavigateToWorkspace | QuickActionEvent::OpenWebClient { .. } => {
+            WorkspaceEntryPolicy::ResetActiveRoot
+        }
+        QuickActionEvent::OpenTerminal { .. } => WorkspaceEntryPolicy::ResetTargetRoot,
+        _ => WorkspaceEntryPolicy::PreserveHistory,
+    }
+}
+
 fn open_project_return_screen_for(source: AppScreen) -> AppScreen {
     match source {
         AppScreen::Workspace => AppScreen::Workspace,
@@ -201,7 +224,7 @@ impl ZedraApp {
 
         // --- Home view ---
         let home_view = cx.new(|cx| HomeView::new(workspaces.clone(), cx));
-        let sub = cx.subscribe(&home_view, Self::on_home_event);
+        let sub = cx.subscribe_in(&home_view, window, Self::on_home_event);
         subscriptions.push(sub);
 
         let settings_view =
@@ -220,7 +243,7 @@ impl ZedraApp {
 
         // --- Quick action panel ---
         let quick_action = cx.new(|cx| QuickActionPanel::new(workspaces.clone(), cx));
-        let sub = cx.subscribe(&quick_action, Self::on_quick_action_event);
+        let sub = cx.subscribe_in(&quick_action, window, Self::on_quick_action_event);
         subscriptions.push(sub);
 
         // --- Workspaces events ---
@@ -332,9 +355,16 @@ impl ZedraApp {
         }
     }
 
-    fn on_home_event(&mut self, _: Entity<HomeView>, event: &HomeEvent, cx: &mut Context<Self>) {
+    fn on_home_event(
+        &mut self,
+        _: &Entity<HomeView>,
+        event: &HomeEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         match event {
             HomeEvent::NavigateToWorkspace => {
+                self.prepare_active_workspace_for_home_entry(window, cx);
                 self.set_screen(AppScreen::Workspace, cx);
             }
             HomeEvent::NavigateToSettings => {
@@ -402,10 +432,12 @@ impl ZedraApp {
 
     fn on_quick_action_event(
         &mut self,
-        _: Entity<QuickActionPanel>,
+        _: &Entity<QuickActionPanel>,
         event: &QuickActionEvent,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let entry_policy = quick_action_workspace_entry_policy(self.screen, event);
         match event {
             QuickActionEvent::Close => {
                 self.quick_action_drawer.update(cx, |h, cx| h.close(cx));
@@ -414,6 +446,9 @@ impl ZedraApp {
                 self.set_screen(AppScreen::Home, cx);
             }
             QuickActionEvent::NavigateToWorkspace => {
+                if entry_policy == WorkspaceEntryPolicy::ResetActiveRoot {
+                    self.prepare_active_workspace_for_home_entry(window, cx);
+                }
                 self.set_screen(AppScreen::Workspace, cx);
             }
             QuickActionEvent::NavigateToOpenProject => {
@@ -421,12 +456,20 @@ impl ZedraApp {
             }
             QuickActionEvent::OpenTerminal { tid, ws_index } => {
                 self.set_screen(AppScreen::Workspace, cx);
-                self.open_terminal_from_quick_action(*ws_index, tid, cx);
+                self.open_terminal_from_quick_action(
+                    *ws_index,
+                    tid,
+                    entry_policy == WorkspaceEntryPolicy::ResetTargetRoot,
+                    cx,
+                );
             }
             QuickActionEvent::CloseTerminal { tid, ws_index } => {
                 self.close_terminal_from_quick_action(*ws_index, tid, cx);
             }
             QuickActionEvent::OpenWebClient { id, ws_index } => {
+                if entry_policy == WorkspaceEntryPolicy::ResetActiveRoot {
+                    self.prepare_active_workspace_for_home_entry(window, cx);
+                }
                 self.set_screen(AppScreen::Workspace, cx);
                 self.web_client_from_quick_action(*ws_index, id, false, cx);
             }
@@ -434,6 +477,12 @@ impl ZedraApp {
                 self.web_client_from_quick_action(*ws_index, id, true, cx);
             }
         }
+    }
+
+    fn prepare_active_workspace_for_home_entry(&self, window: &mut Window, cx: &mut Context<Self>) {
+        self.workspaces.update(cx, |workspaces, cx| {
+            workspaces.prepare_active_for_home_entry(window, cx);
+        });
     }
 
     fn web_client_from_quick_action(
@@ -485,6 +534,7 @@ impl ZedraApp {
         &self,
         ws_index: usize,
         terminal_id: &str,
+        reset_navigation_root: bool,
         cx: &mut Context<Self>,
     ) {
         if let Some(workspace) = self
@@ -494,7 +544,11 @@ impl ZedraApp {
             .cloned()
         {
             workspace.update(cx, |ws, cx| {
-                ws.open_terminal_from_quick_action(terminal_id.to_string(), cx);
+                if reset_navigation_root {
+                    ws.open_terminal_from_home_entry(terminal_id.to_string(), cx);
+                } else {
+                    ws.open_terminal_from_quick_action(terminal_id.to_string(), cx);
+                }
             });
         } else {
             tracing::warn!(
@@ -755,10 +809,12 @@ pub fn open_zedra_window(app: &mut App, window_options: WindowOptions) -> Result
 #[cfg(test)]
 mod tests {
     use super::{
-        AppScreen, app_view_descriptor, open_project_return_screen_for,
-        screen_after_unhandled_workspace_back, screen_after_workspace_disconnect,
-        should_process_pending_ticket, should_update_drawer_content,
+        AppScreen, WorkspaceEntryPolicy, app_view_descriptor, open_project_return_screen_for,
+        quick_action_workspace_entry_policy, screen_after_unhandled_workspace_back,
+        screen_after_workspace_disconnect, should_process_pending_ticket,
+        should_update_drawer_content,
     };
+    use crate::quick_action_panel::QuickActionEvent;
     use crate::telemetry::view_telemetry;
 
     #[test]
@@ -801,6 +857,34 @@ mod tests {
         assert_eq!(
             open_project_return_screen_for(AppScreen::Home),
             AppScreen::Home
+        );
+    }
+
+    #[test]
+    fn home_quick_actions_reset_the_workspace_entry_root() {
+        assert_eq!(
+            quick_action_workspace_entry_policy(
+                AppScreen::Home,
+                &QuickActionEvent::NavigateToWorkspace,
+            ),
+            WorkspaceEntryPolicy::ResetActiveRoot
+        );
+        assert_eq!(
+            quick_action_workspace_entry_policy(
+                AppScreen::Home,
+                &QuickActionEvent::OpenTerminal {
+                    tid: "terminal-2".into(),
+                    ws_index: 1,
+                },
+            ),
+            WorkspaceEntryPolicy::ResetTargetRoot
+        );
+        assert_eq!(
+            quick_action_workspace_entry_policy(
+                AppScreen::Workspace,
+                &QuickActionEvent::NavigateToWorkspace,
+            ),
+            WorkspaceEntryPolicy::PreserveHistory
         );
     }
 

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -30,7 +30,7 @@ enum AppScreen {
 
 fn app_view_descriptor(screen: AppScreen) -> Option<ViewDescriptor> {
     match screen {
-        // Open project is a Home subscreen; report it as Home.
+        // Open Project shares the Home telemetry descriptor in every launch context.
         AppScreen::Home | AppScreen::OpenProject => Some(view_telemetry::HOME),
         // Web tunnel is a Settings subscreen; report it as Settings.
         AppScreen::Settings | AppScreen::WebTunnel => Some(view_telemetry::SETTINGS),
@@ -44,8 +44,16 @@ fn should_update_drawer_content(current: AppScreen, next: AppScreen) -> bool {
     current != next || next == AppScreen::Workspace
 }
 
+fn open_project_return_screen_for(source: AppScreen) -> AppScreen {
+    match source {
+        AppScreen::Workspace => AppScreen::Workspace,
+        _ => AppScreen::Home,
+    }
+}
+
 pub struct ZedraApp {
     screen: AppScreen,
+    open_project_return_screen: AppScreen,
     home_view: Entity<HomeView>,
     settings_view: Entity<SettingsView>,
     web_tunnel_manager: Entity<WebTunnelManager>,
@@ -155,7 +163,13 @@ impl ZedraApp {
                 };
                 let app = app.clone();
                 cx.defer(move |cx| {
-                    let _ = app.update(cx, |app, cx| app.set_screen(screen, cx));
+                    let _ = app.update(cx, |app, cx| {
+                        if screen == AppScreen::OpenProject {
+                            app.present_open_project(cx);
+                        } else {
+                            app.set_screen(screen, cx);
+                        }
+                    });
                 });
                 serde_json::json!({"ok": true})
             });
@@ -244,6 +258,7 @@ impl ZedraApp {
 
         let app = Self {
             screen: AppScreen::Home,
+            open_project_return_screen: AppScreen::Home,
             home_view,
             settings_view,
             web_tunnel_manager,
@@ -332,6 +347,7 @@ impl ZedraApp {
     }
 
     fn present_open_project(&mut self, cx: &mut Context<Self>) {
+        self.open_project_return_screen = open_project_return_screen_for(self.screen);
         self.open_project_view.update(cx, |view, cx| view.reset(cx));
         self.set_screen(AppScreen::OpenProject, cx);
     }
@@ -344,7 +360,7 @@ impl ZedraApp {
     ) {
         match event {
             OpenProjectEvent::Close => {
-                self.set_screen(AppScreen::Home, cx);
+                self.set_screen(self.open_project_return_screen, cx);
             }
             OpenProjectEvent::NavigateToWorkspace => {
                 self.set_screen(AppScreen::Workspace, cx);
@@ -609,12 +625,18 @@ impl ZedraApp {
                 {
                     return true;
                 }
-                self.set_screen(AppScreen::Home, cx);
+                self.set_screen(self.open_project_return_screen, cx);
                 true
             }
-            AppScreen::Workspace => self.workspaces.update(cx, |workspaces, cx| {
-                workspaces.handle_system_back(window, cx)
-            }),
+            AppScreen::Workspace => {
+                if self.workspaces.update(cx, |workspaces, cx| {
+                    workspaces.handle_system_back(window, cx)
+                }) {
+                    return true;
+                }
+                self.set_screen(screen_after_unhandled_workspace_back(), cx);
+                true
+            }
         }
     }
 
@@ -695,6 +717,10 @@ fn screen_after_workspace_disconnect() -> AppScreen {
     AppScreen::Home
 }
 
+fn screen_after_unhandled_workspace_back() -> AppScreen {
+    AppScreen::Home
+}
+
 /// Shared platform bootstrap (both `ios/app.rs` and `android/entry.rs`): register
 /// the bridge, build the `App`, and init the gpui_tokio runtime that owns all
 /// session/network work.
@@ -729,7 +755,8 @@ pub fn open_zedra_window(app: &mut App, window_options: WindowOptions) -> Result
 #[cfg(test)]
 mod tests {
     use super::{
-        AppScreen, app_view_descriptor, screen_after_workspace_disconnect,
+        AppScreen, app_view_descriptor, open_project_return_screen_for,
+        screen_after_unhandled_workspace_back, screen_after_workspace_disconnect,
         should_process_pending_ticket, should_update_drawer_content,
     };
     use crate::telemetry::view_telemetry;
@@ -758,6 +785,23 @@ mod tests {
     #[test]
     fn manual_workspace_disconnect_returns_home() {
         assert_eq!(screen_after_workspace_disconnect(), AppScreen::Home);
+    }
+
+    #[test]
+    fn unhandled_workspace_system_back_returns_home() {
+        assert_eq!(screen_after_unhandled_workspace_back(), AppScreen::Home);
+    }
+
+    #[test]
+    fn open_project_returns_to_its_launching_context() {
+        assert_eq!(
+            open_project_return_screen_for(AppScreen::Workspace),
+            AppScreen::Workspace
+        );
+        assert_eq!(
+            open_project_return_screen_for(AppScreen::Home),
+            AppScreen::Home
+        );
     }
 
     #[test]

--- a/crates/zedra/src/app.rs
+++ b/crates/zedra/src/app.rs
@@ -67,6 +67,23 @@ fn quick_action_workspace_entry_policy(
     }
 }
 
+fn connected_workspace_entry_policy(
+    screen: AppScreen,
+    open_project_return_screen: AppScreen,
+    preserve_history: bool,
+) -> WorkspaceEntryPolicy {
+    if preserve_history {
+        return WorkspaceEntryPolicy::PreserveHistory;
+    }
+    if screen == AppScreen::Home
+        || (screen == AppScreen::OpenProject && open_project_return_screen == AppScreen::Home)
+    {
+        WorkspaceEntryPolicy::ResetActiveRoot
+    } else {
+        WorkspaceEntryPolicy::PreserveHistory
+    }
+}
+
 fn open_project_return_screen_for(source: AppScreen) -> AppScreen {
     match source {
         AppScreen::Workspace => AppScreen::Workspace,
@@ -247,7 +264,7 @@ impl ZedraApp {
         subscriptions.push(sub);
 
         // --- Workspaces events ---
-        let sub = cx.subscribe(&workspaces, Self::on_workspaces_event);
+        let sub = cx.subscribe_in(&workspaces, window, Self::on_workspaces_event);
         subscriptions.push(sub);
 
         // --- Window activation: check deeplinks + sync state ---
@@ -585,12 +602,23 @@ impl ZedraApp {
 
     fn on_workspaces_event(
         &mut self,
-        _: Entity<Workspaces>,
+        _: &Entity<Workspaces>,
         event: &WorkspacesEvent,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         match event {
-            WorkspacesEvent::Connected { .. } => {
+            WorkspacesEvent::Connected {
+                preserve_history, ..
+            } => {
+                if connected_workspace_entry_policy(
+                    self.screen,
+                    self.open_project_return_screen,
+                    *preserve_history,
+                ) == WorkspaceEntryPolicy::ResetActiveRoot
+                {
+                    self.prepare_active_workspace_for_home_entry(window, cx);
+                }
                 let screen_changed = self.screen != AppScreen::Workspace;
                 self.set_screen(AppScreen::Workspace, cx);
                 if !screen_changed {
@@ -809,10 +837,10 @@ pub fn open_zedra_window(app: &mut App, window_options: WindowOptions) -> Result
 #[cfg(test)]
 mod tests {
     use super::{
-        AppScreen, WorkspaceEntryPolicy, app_view_descriptor, open_project_return_screen_for,
-        quick_action_workspace_entry_policy, screen_after_unhandled_workspace_back,
-        screen_after_workspace_disconnect, should_process_pending_ticket,
-        should_update_drawer_content,
+        AppScreen, WorkspaceEntryPolicy, app_view_descriptor, connected_workspace_entry_policy,
+        open_project_return_screen_for, quick_action_workspace_entry_policy,
+        screen_after_unhandled_workspace_back, screen_after_workspace_disconnect,
+        should_process_pending_ticket, should_update_drawer_content,
     };
     use crate::quick_action_panel::QuickActionEvent;
     use crate::telemetry::view_telemetry;
@@ -884,6 +912,30 @@ mod tests {
                 AppScreen::Workspace,
                 &QuickActionEvent::NavigateToWorkspace,
             ),
+            WorkspaceEntryPolicy::PreserveHistory
+        );
+    }
+
+    #[test]
+    fn asynchronous_home_entries_reset_unless_they_are_terminal_deeplinks() {
+        assert_eq!(
+            connected_workspace_entry_policy(AppScreen::Home, AppScreen::Home, false),
+            WorkspaceEntryPolicy::ResetActiveRoot
+        );
+        assert_eq!(
+            connected_workspace_entry_policy(AppScreen::OpenProject, AppScreen::Home, false),
+            WorkspaceEntryPolicy::ResetActiveRoot
+        );
+        assert_eq!(
+            connected_workspace_entry_policy(AppScreen::OpenProject, AppScreen::Workspace, false),
+            WorkspaceEntryPolicy::PreserveHistory
+        );
+        assert_eq!(
+            connected_workspace_entry_policy(AppScreen::Workspace, AppScreen::Home, false),
+            WorkspaceEntryPolicy::PreserveHistory
+        );
+        assert_eq!(
+            connected_workspace_entry_policy(AppScreen::Home, AppScreen::Home, true),
             WorkspaceEntryPolicy::PreserveHistory
         );
     }

--- a/crates/zedra/src/home_view.rs
+++ b/crates/zedra/src/home_view.rs
@@ -115,6 +115,9 @@ impl HomeView {
                 ws.connect_saved(state_index, window, cx);
             });
         }
+        self.workspaces.update(cx, |ws, cx| {
+            ws.prepare_active_for_home_entry(window, cx);
+        });
         cx.emit(HomeEvent::NavigateToWorkspace);
     }
 

--- a/crates/zedra/src/home_view.rs
+++ b/crates/zedra/src/home_view.rs
@@ -115,9 +115,6 @@ impl HomeView {
                 ws.connect_saved(state_index, window, cx);
             });
         }
-        self.workspaces.update(cx, |ws, cx| {
-            ws.prepare_active_for_home_entry(window, cx);
-        });
         cx.emit(HomeEvent::NavigateToWorkspace);
     }
 

--- a/crates/zedra/src/quick_action_panel.rs
+++ b/crates/zedra/src/quick_action_panel.rs
@@ -12,7 +12,7 @@ use crate::theme;
 use crate::transport_badge::ConnectionStatusIndicator;
 use crate::workspaces::Workspaces;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum QuickActionEvent {
     Close,
     GoHome,
@@ -33,6 +33,21 @@ fn is_active_terminal_card(
     terminal_id: &str,
 ) -> bool {
     active_workspace_index == Some(workspace_index) && active_terminal_id == Some(terminal_id)
+}
+
+fn terminal_selection_events(ws_index: usize, tid: String) -> [QuickActionEvent; 2] {
+    [
+        QuickActionEvent::Close,
+        QuickActionEvent::OpenTerminal { tid, ws_index },
+    ]
+}
+
+fn web_client_selection_events(ws_index: usize, id: String) -> [QuickActionEvent; 3] {
+    [
+        QuickActionEvent::Close,
+        QuickActionEvent::NavigateToWorkspace,
+        QuickActionEvent::OpenWebClient { id, ws_index },
+    ]
 }
 
 enum QuickActionPickerPending {
@@ -72,11 +87,11 @@ impl QuickActionPanel {
         action: QuickActionPickerPending,
         cx: &mut Context<Self>,
     ) {
-        let ws_index = match action {
+        let ws_index = match &action {
             QuickActionPickerPending::CreateAgent { ws_index }
             | QuickActionPickerPending::NewTerminal { ws_index }
             | QuickActionPickerPending::ViewSessions { ws_index }
-            | QuickActionPickerPending::ManageAgents { ws_index } => ws_index,
+            | QuickActionPickerPending::ManageAgents { ws_index } => *ws_index,
         };
         self.workspaces
             .update(cx, |ws, cx| ws.switch_to(ws_index, cx));
@@ -90,26 +105,24 @@ impl QuickActionPanel {
         else {
             return;
         };
-        match action {
+        let ws = ws.downgrade();
+        // Let Home-entry navigation clear stale history before applying the selected target.
+        cx.defer(move |cx| match action {
             QuickActionPickerPending::CreateAgent { .. } => {
-                ws.update(cx, |w, cx| w.create_agent_from_quick_action(cx));
+                let _ = ws.update(cx, |w, cx| w.create_agent_from_quick_action(cx));
             }
             QuickActionPickerPending::NewTerminal { .. } => {
-                let ws_weak = ws.downgrade();
-                cx.spawn(async move |_this, cx| {
-                    let _ = ws_weak.update_in(cx, |w, window, cx| {
-                        w.create_terminal_from_quick_action(window, cx);
-                    });
-                })
-                .detach();
+                let _ = ws.update_in(cx, |w, window, cx| {
+                    w.create_terminal_from_quick_action(window, cx);
+                });
             }
             QuickActionPickerPending::ViewSessions { .. } => {
-                ws.update(cx, |w, cx| w.open_agent_sessions_from_quick_action(cx));
+                let _ = ws.update(cx, |w, cx| w.open_agent_sessions_from_quick_action(cx));
             }
             QuickActionPickerPending::ManageAgents { .. } => {
-                ws.update(cx, |w, cx| w.open_agent_manage_from_quick_action(cx));
+                let _ = ws.update(cx, |w, cx| w.open_agent_manage_from_quick_action(cx));
             }
-        }
+        });
     }
 
     fn handle_show_quick_action_picker(&mut self, ws_index: usize, _cx: &mut Context<Self>) {
@@ -186,9 +199,9 @@ impl QuickActionPanel {
     fn handle_switch_terminal(&self, ws_index: usize, tid: String, cx: &mut Context<Self>) {
         self.workspaces
             .update(cx, |ws, cx| ws.switch_to(ws_index, cx));
-        cx.emit(QuickActionEvent::Close);
-        cx.emit(QuickActionEvent::NavigateToWorkspace);
-        cx.emit(QuickActionEvent::OpenTerminal { tid, ws_index });
+        for event in terminal_selection_events(ws_index, tid) {
+            cx.emit(event);
+        }
     }
 
     fn handle_terminal_delete(&self, ws_index: usize, tid: String, cx: &mut Context<Self>) {
@@ -196,8 +209,11 @@ impl QuickActionPanel {
     }
 
     fn handle_open_web_client(&self, ws_index: usize, id: String, cx: &mut Context<Self>) {
-        cx.emit(QuickActionEvent::NavigateToWorkspace);
-        cx.emit(QuickActionEvent::OpenWebClient { id, ws_index });
+        self.workspaces
+            .update(cx, |ws, cx| ws.switch_to(ws_index, cx));
+        for event in web_client_selection_events(ws_index, id) {
+            cx.emit(event);
+        }
     }
 
     fn handle_close_web_client(&self, ws_index: usize, id: String, cx: &mut Context<Self>) {
@@ -541,7 +557,10 @@ impl Render for QuickActionPanel {
 
 #[cfg(test)]
 mod tests {
-    use super::is_active_terminal_card;
+    use super::{
+        QuickActionEvent, is_active_terminal_card, terminal_selection_events,
+        web_client_selection_events,
+    };
 
     #[test]
     fn terminal_card_active_requires_active_workspace_and_terminal() {
@@ -564,5 +583,34 @@ mod tests {
             "term-2"
         ));
         assert!(!is_active_terminal_card(None, 1, Some("term-2"), "term-2"));
+    }
+
+    #[test]
+    fn terminal_selection_keeps_home_as_the_event_origin() {
+        assert_eq!(
+            terminal_selection_events(1, "term-2".into()),
+            [
+                QuickActionEvent::Close,
+                QuickActionEvent::OpenTerminal {
+                    tid: "term-2".into(),
+                    ws_index: 1,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn web_client_selection_enters_its_workspace_before_opening() {
+        assert_eq!(
+            web_client_selection_events(1, "client-2".into()),
+            [
+                QuickActionEvent::Close,
+                QuickActionEvent::NavigateToWorkspace,
+                QuickActionEvent::OpenWebClient {
+                    id: "client-2".into(),
+                    ws_index: 1,
+                },
+            ]
+        );
     }
 }

--- a/crates/zedra/src/ui/drawer_host.rs
+++ b/crates/zedra/src/ui/drawer_host.rs
@@ -93,6 +93,8 @@ pub struct DrawerHost {
     gesture_state: GestureState,
     /// Dropping this cancels the pending state commit task.
     _snap_task: Option<Task<()>>,
+    /// A close requested while the opening animation is still running.
+    close_after_snap: bool,
 }
 
 impl DrawerHost {
@@ -121,6 +123,7 @@ impl DrawerHost {
             last_drag_dx: 0.0,
             gesture_state: GestureState::Idle,
             _snap_task: None,
+            close_after_snap: false,
         }
     }
 
@@ -167,6 +170,11 @@ impl DrawerHost {
 
     fn close_impl(&mut self, window: Option<&mut Window>, cx: &mut Context<Self>) {
         if self.is_snap_animating() {
+            if self.snap_target.is_some_and(|target| target > 0.0) && !self.close_after_snap {
+                Self::hide_soft_keyboard(window);
+                self.close_after_snap = true;
+                cx.emit(DrawerEvent::Closed);
+            }
             return;
         }
         self.start_snap(0.0, window, cx);
@@ -454,14 +462,20 @@ impl DrawerHost {
                 .await;
             this.update(cx, |this, cx| {
                 this.drawer_offset = target;
+                let close_after_snap = target > 0.0 && this.close_after_snap;
+                this.close_after_snap = false;
+                this.snap_target = None;
+                this.snap_started_at = None;
+                if close_after_snap {
+                    this.start_snap(0.0, None, cx);
+                    return;
+                }
                 let state = if target > 0.0 {
                     DrawerState::Opened
                 } else {
                     DrawerState::Closed
                 };
                 this.set_drawer_state(state, cx);
-                this.snap_target = None;
-                this.snap_started_at = None;
                 cx.notify();
             })
             .ok();
@@ -663,7 +677,10 @@ impl Render for DrawerHost {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::{DragOrigin, DrawerHost, DrawerSide, DrawerState, GestureState};
+    use crate::theme;
     use gpui::{
         AppContext as _, Empty, Modifiers, PlatformInput, PointerButton, PointerDownEvent,
         PointerKind, PointerMoveEvent, TestAppContext, point, px,
@@ -822,6 +839,54 @@ mod tests {
 
                 assert_eq!(drawer_host.gesture_state, GestureState::Idle);
                 assert_eq!(drawer_host.drawer_state, DrawerState::Closing);
+            })
+            .unwrap();
+
+        cx.quit();
+    }
+
+    #[test]
+    fn close_during_open_snap_finishes_closed() {
+        let mut cx = TestAppContext::single();
+        let window = cx.update(|cx| {
+            cx.open_window(Default::default(), |_, cx| {
+                let content = cx.new(|_| Empty);
+                let drawer = cx.new(|_| Empty);
+                cx.new(|cx| DrawerHost::new(content.into(), drawer.into(), DrawerSide::Left, cx))
+            })
+            .unwrap()
+        });
+
+        window
+            .update(&mut cx, |drawer_host, window, cx| {
+                drawer_host.open_with_window(window, cx);
+                assert_eq!(drawer_host.drawer_state, DrawerState::Snapping);
+
+                drawer_host.close_with_window(window, cx);
+                assert!(drawer_host.close_after_snap);
+            })
+            .unwrap();
+
+        cx.run_until_parked();
+        cx.executor().advance_clock(Duration::from_millis(
+            theme::DRAWER_OPEN_ANIMATION_DURATION_MS,
+        ));
+        cx.run_until_parked();
+        window
+            .update(&mut cx, |drawer_host, _window, _cx| {
+                assert_eq!(drawer_host.drawer_state, DrawerState::Closing);
+                assert!(!drawer_host.close_after_snap);
+            })
+            .unwrap();
+
+        cx.executor().advance_clock(Duration::from_millis(
+            theme::DRAWER_CLOSE_ANIMATION_DURATION_MS,
+        ));
+        cx.run_until_parked();
+        window
+            .update(&mut cx, |drawer_host, _window, _cx| {
+                assert_eq!(drawer_host.drawer_state, DrawerState::Closed);
+                assert_eq!(drawer_host.drawer_offset, 0.0);
             })
             .unwrap();
 

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -126,6 +126,8 @@ pub struct Workspace {
     _pending_platform_action_task: Task<()>,
     /// Terminal to open immediately after the first sync completes (set by notification deeplink).
     pending_terminal_after_sync: Option<String>,
+    /// Reset the first synchronized terminal as the root after entering from Home.
+    pending_home_entry_root: bool,
     _subscriptions: Vec<Subscription>,
     delta_host_reconciling: bool,
 }
@@ -305,6 +307,16 @@ fn should_initialize_terminals_after_sync(
             matches!(active_main_view, WorkspaceMainView::Default) || terminal_ids.is_empty()
         }
     }
+}
+
+fn home_entry_terminal_id(
+    active_terminal_id: Option<&str>,
+    terminal_ids: &[String],
+) -> Option<String> {
+    active_terminal_id
+        .filter(|active_id| terminal_ids.iter().any(|id| id == active_id))
+        .map(ToOwned::to_owned)
+        .or_else(|| terminal_ids.first().cloned())
 }
 
 fn should_apply_connect_event(_event: &ConnectEvent, user_disconnect: bool) -> bool {
@@ -1185,6 +1197,7 @@ impl Workspace {
             pending_platform_action,
             _pending_platform_action_task: pending_platform_action_task,
             pending_terminal_after_sync: None,
+            pending_home_entry_root: false,
             delta_host_reconciling: false,
             _subscriptions: vec![
                 drawer_host_subscription,
@@ -1317,7 +1330,7 @@ impl Workspace {
                                 });
                             });
                             ws.reconcile_terminals_after_sync(cx);
-                            let should_initialize = {
+                            let should_initialize = ws.pending_home_entry_root || {
                                 let state = ws.workspace_state.read(cx);
                                 should_initialize_terminals_after_sync(
                                     sync_refresh_mode,
@@ -1720,6 +1733,37 @@ impl Workspace {
         }
     }
 
+    pub(crate) fn prepare_for_home_entry(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.pending_terminal_after_sync.is_some() {
+            return;
+        }
+
+        self.pending_home_entry_root = true;
+        let (target, connection_ready) = {
+            let state = self.workspace_state.read(cx);
+            (
+                home_entry_terminal_id(state.active_terminal_id.as_deref(), &state.terminal_ids),
+                matches!(
+                    state.connect_phase,
+                    Some(ConnectPhase::Connected | ConnectPhase::Idle { .. })
+                ),
+            )
+        };
+
+        if let Some(id) = target {
+            if self.terminal_by_id(&id, cx).is_none() {
+                self.create_terminal_entity(id.clone(), window, cx);
+            }
+            if self.terminal_by_id(&id, cx).is_some() {
+                self.reset_navigation_root(WorkspaceMainView::Terminal { id }, cx);
+                self.pending_home_entry_root = false;
+            }
+        } else if connection_ready {
+            self.reset_navigation_root(WorkspaceMainView::Default, cx);
+            self.pending_home_entry_root = false;
+        }
+    }
+
     pub fn open_terminal_from_quick_action(&mut self, id: String, cx: &mut Context<Self>) {
         self.activate_existing_terminal(id, cx);
     }
@@ -1998,6 +2042,23 @@ impl Workspace {
         let prev_terminal_id = self.workspace_state.read(cx).active_terminal_id.clone();
         self.workspace_state.update(cx, |state, cx| {
             state.navigate(route.clone(), cx);
+        });
+        self.apply_route(route, prev_terminal_id, cx);
+    }
+
+    fn reset_navigation_root(&mut self, route: WorkspaceMainView, cx: &mut Context<Self>) {
+        if let WorkspaceMainView::Terminal { ref id } = route {
+            if self.terminal_by_id(id, cx).is_none() {
+                warn!(
+                    terminal_id = id,
+                    "reset_navigation_root: terminal entity missing, skipping"
+                );
+                return;
+            }
+        }
+        let prev_terminal_id = self.workspace_state.read(cx).active_terminal_id.clone();
+        self.workspace_state.update(cx, |state, cx| {
+            state.reset_navigation_root(route.clone(), cx);
         });
         self.apply_route(route, prev_terminal_id, cx);
     }
@@ -3143,15 +3204,27 @@ impl Workspace {
             }
         }
 
-        let target = self
+        let pending_terminal = self
             .pending_terminal_after_sync
             .take()
-            .filter(|id| terminal_ids.contains(id))
+            .filter(|id| terminal_ids.contains(id));
+        let reset_home_entry_root = self.pending_home_entry_root && pending_terminal.is_none();
+        let home_terminal = self.pending_home_entry_root.then(|| {
+            let state = self.workspace_state.read(cx);
+            home_entry_terminal_id(state.active_terminal_id.as_deref(), &terminal_ids)
+        });
+        self.pending_home_entry_root = false;
+        let target = pending_terminal
+            .or_else(|| home_terminal.flatten())
             .or_else(|| terminal_ids.first().cloned());
 
         if let Some(id) = target {
             info!("auto-opening terminal on connect: {}", id);
-            self.handle_open_terminal(&OpenTerminal { id }, window, cx);
+            if reset_home_entry_root {
+                self.reset_navigation_root(WorkspaceMainView::Terminal { id }, cx);
+            } else {
+                self.handle_open_terminal(&OpenTerminal { id }, window, cx);
+            }
         } else {
             info!("no terminals on connect, showing workspace start");
             self.workspace_state
@@ -3470,6 +3543,31 @@ mod tests {
                 path: "src/main.rs".into(),
             },
         ));
+    }
+
+    #[::core::prelude::v1::test]
+    fn home_entry_prefers_valid_active_terminal() {
+        let terminal_ids = vec!["terminal-1".to_string(), "terminal-2".to_string()];
+
+        assert_eq!(
+            home_entry_terminal_id(Some("terminal-2"), &terminal_ids),
+            Some("terminal-2".to_string())
+        );
+    }
+
+    #[::core::prelude::v1::test]
+    fn home_entry_falls_back_to_first_terminal() {
+        let terminal_ids = vec!["terminal-1".to_string(), "terminal-2".to_string()];
+
+        assert_eq!(
+            home_entry_terminal_id(Some("stale-terminal"), &terminal_ids),
+            Some("terminal-1".to_string())
+        );
+        assert_eq!(
+            home_entry_terminal_id(None, &terminal_ids),
+            Some("terminal-1".to_string())
+        );
+        assert_eq!(home_entry_terminal_id(None, &[]), None);
     }
 
     #[::core::prelude::v1::test]

--- a/crates/zedra/src/workspace.rs
+++ b/crates/zedra/src/workspace.rs
@@ -1768,6 +1768,16 @@ impl Workspace {
         self.activate_existing_terminal(id, cx);
     }
 
+    pub(crate) fn open_terminal_from_home_entry(&mut self, id: String, cx: &mut Context<Self>) {
+        self.drawer_host.update(cx, |host, cx| host.close(cx));
+        if self.terminal_by_id(&id, cx).is_some() {
+            self.reset_navigation_root(WorkspaceMainView::Terminal { id }, cx);
+            self.pending_home_entry_root = false;
+        } else {
+            warn!("requested uninitialized terminal {}", id);
+        }
+    }
+
     fn activate_existing_terminal(&mut self, id: String, cx: &mut Context<Self>) {
         self.drawer_host.update(cx, |host, cx| host.close(cx));
         if self.terminal_by_id(&id, cx).is_some() {

--- a/crates/zedra/src/workspace_state.rs
+++ b/crates/zedra/src/workspace_state.rs
@@ -488,8 +488,20 @@ impl WorkspaceState {
     /// navigation stack, never a pushed route, so this clears the stack rather
     /// than navigating onto it.
     pub fn reset_to_default(&mut self, cx: &mut Context<Self>) {
-        self.main_view_stack.reset(WorkspaceMainView::Default);
-        self.set_active_main_view(WorkspaceMainView::Default, cx);
+        self.reset_navigation_root(WorkspaceMainView::Default, cx);
+    }
+
+    pub(crate) fn reset_navigation_root(
+        &mut self,
+        route: WorkspaceMainView,
+        cx: &mut Context<Self>,
+    ) {
+        self.main_view_stack.reset(route.clone());
+        if let WorkspaceMainView::Terminal { ref id } = route {
+            self.active_terminal_id = Some(id.clone());
+            cx.emit(WorkspaceStateEvent::TerminalOpened { id: id.clone() });
+        }
+        self.set_active_main_view(route, cx);
     }
 
     pub fn navigate(&mut self, route: WorkspaceMainView, cx: &mut Context<Self>) {
@@ -809,6 +821,22 @@ mod tests {
         assert_eq!(stack.active(), terminal);
         assert_eq!(stack.go_back(), Some(diff));
         assert_eq!(stack.go_back(), Some(file));
+        assert_eq!(stack.go_back(), None);
+    }
+
+    #[test]
+    fn navigation_stack_reset_discards_history() {
+        let mut stack = WorkspaceNavigationStack::default();
+        stack.open(WorkspaceMainView::File {
+            path: "src/main.rs".into(),
+        });
+        let terminal = WorkspaceMainView::Terminal {
+            id: "terminal-1".into(),
+        };
+
+        stack.reset(terminal.clone());
+
+        assert_eq!(stack.active(), terminal);
         assert_eq!(stack.go_back(), None);
     }
 

--- a/crates/zedra/src/workspaces.rs
+++ b/crates/zedra/src/workspaces.rs
@@ -18,8 +18,13 @@ static PENDING_WORKSPACE_NAV: PendingSlot<(String, Option<String>)> = PendingSlo
 
 #[derive(Clone, Debug)]
 pub enum WorkspacesEvent {
-    Connected { index: usize },
-    Disconnected { index: usize },
+    Connected {
+        index: usize,
+        preserve_history: bool,
+    },
+    Disconnected {
+        index: usize,
+    },
     StatesChanged,
     GoHome,
     OpenQuickAction,
@@ -263,7 +268,7 @@ impl Workspaces {
             return;
         }
 
-        self.connect_and_intialize_workspace(addr, Some(ticket), None, None, window, cx);
+        self.connect_and_intialize_workspace(addr, Some(ticket), None, None, false, window, cx);
     }
 
     /// Queue a ticket for deferred connection (when window not available).
@@ -304,13 +309,18 @@ impl Workspaces {
         let Some((endpoint_addr, terminal_id)) = PENDING_WORKSPACE_NAV.take() else {
             return;
         };
+        // Terminal deeplinks intentionally retain the workspace MRU stack.
+        let preserve_history = terminal_id.is_some();
 
         // Workspace already open for this endpoint: switch to it (connecting if stale),
         // then open the requested terminal if one was specified.
         if let Some(index) = self.entry_index_by_endpoint_addr(&endpoint_addr, cx) {
             self.switch_to(index, cx);
             platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
-            cx.emit(WorkspacesEvent::Connected { index });
+            cx.emit(WorkspacesEvent::Connected {
+                index,
+                preserve_history,
+            });
 
             let Some(entry) = self.entries.get(index).cloned() else {
                 return;
@@ -348,7 +358,7 @@ impl Workspaces {
             return;
         };
 
-        self.connect_saved(state_index, window, cx);
+        self.connect_saved_with_history(state_index, preserve_history, window, cx);
 
         // connect_saved can early-return without pushing an entry (bad index, decode
         // error), so re-resolve by endpoint instead of trusting entries.last().
@@ -375,6 +385,16 @@ impl Workspaces {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.connect_saved_with_history(state_index, false, window, cx);
+    }
+
+    fn connect_saved_with_history(
+        &mut self,
+        state_index: usize,
+        preserve_history: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let state = match self.states.get(state_index) {
             Some(s) => s.clone(),
             None => {
@@ -393,6 +413,7 @@ impl Workspaces {
                     None,
                     Some(session_id),
                     Some(state.clone()),
+                    preserve_history,
                     window,
                     cx,
                 );
@@ -435,7 +456,10 @@ impl Workspaces {
     fn activate_entry(&mut self, index: usize, cx: &mut Context<Self>) {
         self.switch_to(index, cx);
         platform_bridge::trigger_haptic(HapticFeedback::ImpactLight);
-        cx.emit(WorkspacesEvent::Connected { index });
+        cx.emit(WorkspacesEvent::Connected {
+            index,
+            preserve_history: false,
+        });
     }
 
     fn saved_state_by_endpoint_addr(
@@ -466,7 +490,15 @@ impl Workspaces {
         };
 
         info!("Connecting to saved workspace from ticket. sid={session_id:?}");
-        self.connect_and_intialize_workspace(addr, ticket, session_id, Some(saved), window, cx);
+        self.connect_and_intialize_workspace(
+            addr,
+            ticket,
+            session_id,
+            Some(saved),
+            false,
+            window,
+            cx,
+        );
     }
 
     fn connect_and_intialize_workspace(
@@ -475,6 +507,7 @@ impl Workspaces {
         ticket: Option<ZedraPairingTicket>,
         session_id: Option<String>,
         saved: Option<Entity<WorkspaceState>>,
+        preserve_history: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -520,7 +553,10 @@ impl Workspaces {
         self.sync_active_workspace(cx);
 
         // TODO: this is not connected yet, it's just a signal to navigate to the workspace.
-        cx.emit(WorkspacesEvent::Connected { index: ws_idx });
+        cx.emit(WorkspacesEvent::Connected {
+            index: ws_idx,
+            preserve_history,
+        });
         cx.notify();
     }
 

--- a/crates/zedra/src/workspaces.rs
+++ b/crates/zedra/src/workspaces.rs
@@ -208,12 +208,28 @@ impl Workspaces {
 
         let endpoint_addr = state.read(cx).endpoint_addr.clone();
         if let Some(entry_index) = self.entry_index_by_endpoint_addr(&endpoint_addr, cx) {
+            self.switch_to(entry_index, cx);
+            self.prepare_active_for_home_entry(window, cx);
             self.open_connecting_for_entry(entry_index, window, cx);
             OpenConnectingForState::ActiveEntry
         } else {
             self.connect_saved(state_index, window, cx);
+            self.prepare_active_for_home_entry(window, cx);
             OpenConnectingForState::StartedConnect
         }
+    }
+
+    pub(crate) fn prepare_active_for_home_entry(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(workspace) = self.active().cloned() else {
+            return;
+        };
+        workspace.update(cx, |workspace, cx| {
+            workspace.prepare_for_home_entry(window, cx);
+        });
     }
 
     /// Connect via QR pairing ticket (new device pairing).

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1300,14 +1300,15 @@ indicator never fades there regardless of the setting.
 ## 12. Quick Action Terminal Navigation
 
 1. Connect to a session with at least two open terminals
-2. Return to the home screen
-3. Open the quick action panel and tap the add icon in the connected workspace header
-4. Expected: the quick action panel closes, the app switches to the workspace screen, and a new terminal becomes the main view
-5. Return to the home screen
-6. Open the quick action panel and tap a terminal card under the connected workspace
-7. Expected: the quick action panel closes, the app switches to the workspace screen, and the tapped terminal becomes the main view
-8. Repeat from the workspace screen with a different terminal card
-9. Expected: the selected terminal becomes active immediately without getting stuck on the previous screen or terminal
+2. Open a file or managed-agent page to seed workspace history, then return to Home
+3. From Home, open the quick action panel and tap a terminal card under the connected workspace
+4. Expected: the panel closes, the app switches to the tapped terminal, and system Back returns directly to Home instead of the previous file or agent page
+5. From Home, open the quick action panel, tap the add icon in the connected workspace header, and choose **Manage Agents**
+6. Expected: the app opens Manage Agents; system Back returns to the terminal root, then a second Back returns to Home without visiting older workspace history
+7. Repeat the add flow and choose **New Terminal**
+8. Expected: the quick action panel closes, the app switches to the workspace screen, and a new terminal becomes the main view
+9. Repeat from the workspace screen with a different terminal card
+10. Expected: the selected terminal becomes active immediately and normal workspace MRU navigation remains available
 
 ## 12a. Drawer Terminal List Stability During Network Reports
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -465,23 +465,32 @@ app still builds, but push registration reports an error instead of a token.
 22. Expected: a second daemon is running for the chosen workdir
 23. Return Home, tap "Open Project", and open the same folder again
 24. Expected: no second daemon is spawned; the app switches to the existing workspace
-25. Repeat step 3 from the workspaces drawer's "Open Project" button (above its "Scan QR Code")
-26. Expected: the drawer closes and the same screen opens
+25. Repeat step 3 from the Quick Actions drawer's "Open Project" button (above its "Scan QR Code")
+26. Expected: the drawer closes and the same screen opens; back at the host root and the close button both return to the workspace that launched it, not Home
 
 ## 1a-Android. System Back Navigation
 
-1. On Android, connect to a workspace and open Quick Actions from the workspace header
-2. Press the system Back button or gesture
-3. Expected: Quick Actions closes and the app remains on the workspace
-4. Open Settings from Home, then press system Back
-5. Expected: Settings returns to Home
-6. Connect to a workspace, open the workspace drawer, then press system Back
-7. Expected: the workspace drawer closes
-8. Open the connecting overlay from the Session tab, then press system Back
-9. Expected: the connecting overlay closes and the workspace content remains visible
-10. Open a terminal, then a file, then a git diff, then reopen the same terminal
-11. Press system Back repeatedly
-12. Expected: Back visits the previous distinct main content views in order, without duplicate entries for the reopened terminal
+1. Open Settings from Home, then press system Back
+2. Expected: Settings returns to Home
+3. Press system Back again
+4. Expected: Android returns to the launcher
+5. Reopen the app, tap a saved workspace, and wait for its terminal
+6. Press system Back
+7. Expected: the app returns to Home; pressing Back again returns to the launcher
+8. Reopen the terminal and open Quick Actions from the workspace header
+9. Immediately press system Back before the opening animation finishes
+10. Expected: Quick Actions closes and the terminal remains visible
+11. Open the workspace drawer, then immediately press system Back before the opening animation finishes
+12. Expected: the workspace drawer closes and the terminal remains visible
+13. Open the connecting overlay from the Session tab, then press system Back
+14. Expected: the connecting overlay closes and the workspace content remains visible
+15. From the terminal's Quick Actions, open Open Project and press system Back at the host root
+16. Expected: Open Project returns to the terminal, not Home
+17. Repeat Settings, terminal, both drawer checks, and Open Project with the Back button and both edge gestures
+18. Expected: all three inputs follow the same hierarchy
+19. Inside a workspace, open a terminal, a file, a git diff, then the same terminal
+20. Use the workspace's in-app navigation to go back repeatedly
+21. Expected: navigation visits the previous distinct main views without duplicate terminal entries
 
 ## 1a. Host Info Subscription
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -463,9 +463,9 @@ app still builds, but push registration reports an error instead of a token.
 20. Expected: the screen shows "Starting the host daemon…", then the app navigates to the newly opened workspace and connects
 21. On the host, run `zedra list`
 22. Expected: a second daemon is running for the chosen workdir
-23. Return Home, tap "Open Project", and open the same folder again
-24. Expected: no second daemon is spawned; the app switches to the existing workspace
-25. Repeat step 3 from the Quick Actions drawer's "Open Project" button (above its "Scan QR Code")
+23. Open a file or managed-agent page, return Home, tap "Open Project", and open the same folder again
+24. Expected: no second daemon is spawned; the app switches to the existing workspace, and system Back returns directly to Home instead of older workspace history
+25. Re-enter the workspace and repeat step 3 from the Quick Actions drawer's "Open Project" button (above its "Scan QR Code")
 26. Expected: the drawer closes and the same screen opens; back at the host root and the close button both return to the workspace that launched it, not Home
 
 ## 1a-Android. System Back Navigation
@@ -626,8 +626,8 @@ or beyond.
    ~10s mid-auth, then rescan a fresh QR before the entry times out)
 6. Expected: in-flight attempt is aborted and the fresh ticket drives a new
    Register/Authenticate round on the same entry
-7. While the entry is `Connected`, rescan a still-valid QR for the same endpoint
-8. Expected: just switches to the entry; no restart, no flicker of the connecting view
+7. While the entry is `Connected`, open a file or managed-agent page, return Home, and rescan a still-valid QR for the same endpoint
+8. Expected: just switches to the entry; no restart, no flicker of the connecting view, and system Back returns directly to Home instead of older workspace history
 9. Rescan twice in rapid succession (two fresh QRs back-to-back)
 10. Expected: only the last attempt is alive; no overlapping connect loops
     (`grep` logs for `start connect to` — two entries are fine, but the first


### PR DESCRIPTION
## Summary

- route Android system Back through the existing Rust navigation hierarchy and exit only from Home
- establish a terminal navigation root when entering a workspace from Home while preserving workspace MRU and deep-link behavior
- return Open Project to its launch context and honor Back requested during drawer opening animations

## Notes

- manually exercised Settings, terminal, both drawers, connecting overlay, Open Project, WebView, IME, button Back, and both edge gestures on an API 36 emulator
- no protocol, persistence format, or vendor submodule changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android back navigation across Home, Settings, terminals, Quick Actions, drawers, overlays, and project views.
  * Open Project now returns to the correct launching workspace and location when closed or navigated back.
  * Fixed navigation history and terminal selection when entering workspaces from Home or Quick Actions.
  * Improved drawer behavior when closed during opening animations.

* **Tests**
  * Expanded coverage for back navigation, workspace transitions, terminal selection, and Quick Action flows.

* **Documentation**
  * Updated the manual testing checklist for navigation and project workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->