### PR TITLE
fix(android): pin androidx.core for PendingIntentCompat

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -191,6 +191,11 @@ dependencies {
     // Build-time only: drives the icon SVG -> VectorDrawable conversion task.
     iconConverter 'com.android.tools:sdk-common:31.13.2'
 
+    // Pinned: transitive resolution lands on core 1.9.0, but play-services-basement
+    // calls androidx.core.app.PendingIntentCompat, added in core 1.10.0 (crash on
+    // GMS error-resolution path for devices without Play Services).
+    implementation 'androidx.core:core:1.13.1'
+
     // EdgeToEdge.enable replaces the deprecated Window.setStatusBarColor path.
     implementation 'androidx.activity:activity:1.8.0'
     implementation 'androidx.core:core-splashscreen:1.0.1'

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -2245,3 +2245,26 @@ to spawn (`pkill -f "opencode serve"` on the host first).
 7. **Workspace switch**: start a slow web client in workspace A, switch to
    workspace B, then cancel an open in B. Expected: A's open remains owned by A;
    B cannot dismiss it or cause A's webview to appear over B.
+
+## AndroidX Core pin (Play Services error-resolution path)
+
+`androidx.core:core` is pinned to 1.13.1 because `play-services-basement` calls
+`androidx.core.app.PendingIntentCompat` (added in core 1.10.0). Transitive
+resolution landed on 1.9.0, so the GMS error-resolution path crashed with
+`NoClassDefFoundError` on the `GoogleApiHandler` thread.
+
+1. **Resolved version**: run `./gradlew :app:dependencies --configuration releaseRuntimeClasspath | grep 'androidx.core:core:'` in `android/`.
+   Expected: every line resolves to `1.13.1`, no `1.9.0`.
+2. **Class present in the APK**: build with `./scripts/run-android.sh` and check
+   `androidx.core.app.PendingIntentCompat` is in the dex — e.g.
+   `unzip -p android/app/build/outputs/apk/debug/app-debug.apk classes*.dex | strings | grep PendingIntentCompat`.
+   Expected: at least one hit.
+3. **Missing Play Services**: launch on an emulator image without Google APIs
+   (or a device with Play Services disabled in Settings → Apps). Sign in and let
+   push registration run so `GoogleApiManager` hits its error-resolution path.
+   Expected: no crash and no `NoClassDefFoundError` for
+   `androidx.core.app.PendingIntentCompat` in `./scripts/log-android.sh`; the app
+   stays usable with push simply unavailable.
+4. **Outdated Play Services**: on a device with an old Play Services build,
+   repeat step 3 and confirm the "update Google Play services" resolution dialog
+   appears instead of a crash.


### PR DESCRIPTION
## Summary

Fatal Android crash on v0.6 (Crashlytics `f06b80a34cdde4decb4cbb4d18f0c61c`):

```
java.lang.NoClassDefFoundError: Failed resolution of: Landroidx/core/app/PendingIntentCompat;
  at com.google.android.gms.common.GoogleApiAvailabilityLight.getErrorResolutionPendingIntent
  ... thread GoogleApiHandler
```

`androidx.core:core` had no direct declaration, so it resolved transitively to **1.9.0** (highest requester: appcompat 1.6.1). `play-services-basement` 18.9.0 (via firebase-bom 34.13.0) calls `androidx.core.app.PendingIntentCompat`, added in core **1.10.0**. On a device with missing or outdated Play Services, `GoogleApiManager` builds an error-resolution PendingIntent and hits the missing class.

Pins `androidx.core:core:1.13.1`.

## Notes

- Repro needs a device/emulator without Google Play Services (report came from a OnePlus PJD110 on Android 16) plus a GMS API call (QR scanner / ML Kit, Google sign-in).
- Verified via `./gradlew dependencies --configuration releaseRuntimeClasspath`: all transitive requests now upgrade to 1.13.1.
- Gradle dependency change only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android support dependencies to improve compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->