### PR TITLE
feat(release): publish signed Android APK in GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,77 @@ jobs:
             target/${{ matrix.target }}/release/zedra-${{ matrix.target }}.tar.gz
             target/${{ matrix.target }}/release/zedra-${{ matrix.target }}.tar.gz.sha256
 
+  android:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: android-release
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+
+      - name: Install Android NDK
+        id: ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27b
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Write signing keystore
+        working-directory: android
+        env:
+          ZEDRA_KEYSTORE_BASE64: ${{ secrets.ZEDRA_KEYSTORE_BASE64 }}
+        run: echo "$ZEDRA_KEYSTORE_BASE64" | base64 -d > zedra-release.keystore
+
+      - name: Write google-services.json
+        working-directory: android
+        env:
+          ZEDRA_GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.ZEDRA_GOOGLE_SERVICES_JSON_BASE64 }}
+        run: echo "$ZEDRA_GOOGLE_SERVICES_JSON_BASE64" | base64 -d > google-services.json
+
+      - name: Build signed release APK
+        working-directory: android
+        env:
+          ANDROID_NDK_ROOT: ${{ steps.ndk.outputs.ndk-path }}
+        run: |
+          chmod +x gradlew
+          ./gradlew assembleRelease \
+            -PZEDRA_KEYSTORE=zedra-release.keystore \
+            -PZEDRA_KEYSTORE_ALIAS="${{ secrets.ZEDRA_KEYSTORE_ALIAS }}" \
+            -PZEDRA_KEYSTORE_PASSWORD="${{ secrets.ZEDRA_KEYSTORE_PASSWORD }}"
+
+      - name: Package APK
+        working-directory: android
+        run: |
+          apk="$(find app/build/outputs/apk/release -name '*-release.apk' | head -n1)"
+          cp "$apk" zedra-android-arm64-v8a.apk
+          shasum -a 256 zedra-android-arm64-v8a.apk > zedra-android-arm64-v8a.apk.sha256
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zedra-android-arm64-v8a
+          path: |
+            android/zedra-android-arm64-v8a.apk
+            android/zedra-android-arm64-v8a.apk.sha256
+
   release:
-    needs: build
+    needs: [build, android]
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
@@ -127,4 +196,5 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/**/*.tar.gz
+            artifacts/**/*.apk
             artifacts/**/*.sha256

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -23,7 +23,40 @@
 Pushing the tag triggers `.github/workflows/release.yml`, which:
 - Builds `zedra` for macOS arm64/x86_64 and Linux x86_64/aarch64
 - Packages each binary as `zedra-<target>.tar.gz` with a `.sha256` checksum
+- Builds a signed Android release APK (arm64-v8a) and packages it as
+  `zedra-android-arm64-v8a.apk` with a `.sha256` checksum
 - Creates a GitHub Release with all artifacts and auto-generated notes
+
+## Android APK in GitHub Releases
+
+The same `v*` tag that releases the host CLI also builds and attaches a
+signed Android APK. This is a sideload path alongside the Play Store listing,
+not a replacement for it — until Android gets its own release pipeline
+(separate from Play Store submission and any future manual-upload flow), the
+CI job here is deliberately simple:
+
+- **CI never bumps the Android version.** It builds `android/build.gradle`
+  exactly as committed. Bump `versionCode` (and `versionName` if it changed)
+  in `android/build.gradle` yourself before tagging — the same discipline as
+  the iOS `CURRENT_PROJECT_VERSION` bump described below. If you forget,
+  the tag ships an APK with a stale/duplicate version number.
+- The APK is signed with the real release keystore (`ZEDRA_KEYSTORE*` Gradle
+  properties, see `android/build.gradle`'s `validateZedraReleaseSigning`
+  task), sourced from repo secrets:
+
+  | Secret name | Value |
+  |---|---|
+  | `ZEDRA_KEYSTORE_BASE64` | `base64 -i release.keystore` output |
+  | `ZEDRA_KEYSTORE_ALIAS` | key alias |
+  | `ZEDRA_KEYSTORE_PASSWORD` | keystore password |
+  | `ZEDRA_GOOGLE_SERVICES_JSON_BASE64` | `base64 -i google-services.json` output — release builds hard-require this file |
+
+  `ZEDRA_KEY_PASSWORD` is intentionally not set — `build.gradle` falls back to
+  `ZEDRA_KEYSTORE_PASSWORD` when the key password matches the store password
+  (the common case), same as the local `~/.gradle/gradle.properties` setup.
+
+  This is the same keystore used for local `installRelease`/Play Store
+  builds — see the `~/.gradle/gradle.properties` setup in `docs/GET_STARTED.md`.
 
 ## How users install / update
 


### PR DESCRIPTION
## Summary
- Add an `android` job to `release.yml`, triggered by the same `v*` tag as the host CLI build, that assembles a signed arm64-v8a release APK using the existing `ZEDRA_KEYSTORE*` Gradle signing properties (sourced from new repo secrets) and attaches it to the GitHub Release alongside the host binaries.

Closes #212