### PR TITLE
fix(ios): make the IME composer reachable from the compact key bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10319,6 +10319,7 @@ dependencies = [
  "smallvec",
  "tokio",
  "tracing",
+ "unicode-width",
  "zedra-osc",
 ]
 

--- a/android/app/src/main/kotlin/dev/zedra/app/KeyboardAccessoryBar.kt
+++ b/android/app/src/main/kotlin/dev/zedra/app/KeyboardAccessoryBar.kt
@@ -162,11 +162,20 @@ class KeyboardAccessoryBar(
             }
         }
 
+    // ImpactLight — normal key taps use light haptics (matches
+    // HapticFeedback::to_i32() in platform_bridge.rs).
+    private fun triggerKeyHaptic() = MainActivity.triggerHaptic(0)
+
     private val repeatRunnable =
         object : Runnable {
             override fun run() {
                 val key = repeatingKey ?: return
-                repeatFired = true
+                // Held keys haptic on their first repeat only, not on every 60 ms
+                // tick, so a held arrow stays non-buzzy.
+                if (!repeatFired) {
+                    repeatFired = true
+                    triggerKeyHaptic()
+                }
                 sendKey(key)
                 handler.postDelayed(this, repeatIntervalMs)
             }
@@ -494,6 +503,7 @@ class KeyboardAccessoryBar(
                     val repeated = repeatFired
                     stopRepeating()
                     if (!repeated) {
+                        triggerKeyHaptic()
                         sendKey(spec.key)
                     }
                     true

--- a/crates/zedra-terminal/Cargo.toml
+++ b/crates/zedra-terminal/Cargo.toml
@@ -11,6 +11,7 @@ itertools.workspace = true
 futures.workspace = true
 tokio.workspace = true
 smallvec = "1"
+unicode-width = "0.2"
 zedra-osc = { path = "../zedra-osc" }
 
 [dev-dependencies]

--- a/crates/zedra-terminal/src/element.rs
+++ b/crates/zedra-terminal/src/element.rs
@@ -709,19 +709,37 @@ impl Element for TerminalElement {
             underline.paint(origin, cell_width, line_height, window);
         }
 
-        // Paint cursor (following Zed's cursor positioning)
-        paint_cursor(
-            window,
-            &layout.content.cursor,
-            origin,
-            layout.content.display_offset as i32,
-            layout.content.grid_rows,
-            layout.content.grid_cols,
-            cell_width,
-            line_height,
-            self.focused,
-            &theme,
-        );
+        // An IME composition owns the caret until it commits, so it replaces the
+        // terminal cursor instead of being painted under it.
+        match &layout.content.preedit {
+            Some(preedit) => paint_preedit(
+                window,
+                cx,
+                preedit,
+                &layout.content.cursor,
+                origin,
+                layout.content.display_offset as i32,
+                layout.content.grid_rows,
+                layout.content.grid_cols,
+                cell_width,
+                line_height,
+                layout.font_size,
+                &layout.font,
+                &theme,
+            ),
+            None => paint_cursor(
+                window,
+                &layout.content.cursor,
+                origin,
+                layout.content.display_offset as i32,
+                layout.content.grid_rows,
+                layout.content.grid_cols,
+                cell_width,
+                line_height,
+                self.focused,
+                &theme,
+            ),
+        }
 
         // Store the actual painted origin (which already incorporates the
         // smooth-scroll and keyboard-cursor offsets) so tap-to-grid conversion
@@ -765,9 +783,10 @@ impl Element for TerminalElement {
 mod tests {
     use gpui::px;
 
-    use super::{LayoutUnderline, TerminalElement};
+    use super::{LayoutUnderline, TerminalElement, layout_preedit};
     use crate::Terminal;
     use crate::TerminalTheme;
+    use crate::terminal::TerminalPreedit;
 
     fn underline_spans(output: &[u8]) -> Vec<LayoutUnderline> {
         let mut terminal = Terminal::new(160, 8, px(10.0), px(20.0));
@@ -882,6 +901,211 @@ mod tests {
         assert_eq!(underlines[0].col, 5);
         assert_eq!(underlines[0].num_cells, 13);
     }
+
+    fn preedit(text: &str, caret_utf16: usize) -> TerminalPreedit {
+        TerminalPreedit {
+            text: text.to_string(),
+            caret_utf16,
+        }
+    }
+
+    #[test]
+    fn preedit_lays_out_wide_characters_as_two_cells() {
+        let (runs, caret) = layout_preedit(&preedit("\u{6765}\u{5709}", 2), 0, 4, 4, 20);
+
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].col, 4);
+        assert_eq!(runs[0].cells, 2);
+        assert_eq!(runs[0].cell_span, 2);
+        assert_eq!(caret, Some((0, 8)));
+    }
+
+    #[test]
+    fn preedit_splits_runs_when_cell_width_changes() {
+        let (runs, _) = layout_preedit(&preedit("a\u{6765}", 2), 1, 0, 4, 20);
+
+        assert_eq!(runs.len(), 2);
+        assert_eq!((runs[0].col, runs[0].cell_span), (0, 1));
+        assert_eq!((runs[1].col, runs[1].cell_span), (1, 2));
+    }
+
+    #[test]
+    fn preedit_wraps_at_the_right_edge() {
+        let (runs, caret) = layout_preedit(&preedit("abc", 3), 0, 2, 4, 4);
+
+        assert_eq!(runs.len(), 2);
+        assert_eq!((runs[0].line, runs[0].col, runs[0].cells), (0, 2, 2));
+        assert_eq!((runs[1].line, runs[1].col, runs[1].cells), (1, 0, 1));
+        assert_eq!(caret, Some((1, 1)));
+    }
+
+    #[test]
+    fn preedit_stops_at_the_last_visible_row() {
+        let (runs, _) = layout_preedit(&preedit("abcdef", 6), 1, 0, 2, 2);
+
+        assert!(runs.iter().all(|run| run.line < 2));
+        assert_eq!(runs.iter().map(|run| run.cells).sum::<usize>(), 2);
+    }
+}
+
+/// One run of composition characters that share a cell width, placed on the grid.
+struct PreeditRun {
+    line: i32,
+    col: i32,
+    text: String,
+    cells: usize,
+    cell_span: usize,
+}
+
+/// Lay the composition out from `start` across the grid, wrapping at the right
+/// edge and stopping at the last visible row. Returns the runs plus the caret
+/// cell, which is `None` when the caret falls past the visible grid.
+fn layout_preedit(
+    preedit: &TerminalPreedit,
+    start_line: i32,
+    start_col: i32,
+    grid_rows: usize,
+    grid_cols: usize,
+) -> (Vec<PreeditRun>, Option<(i32, i32)>) {
+    use unicode_width::UnicodeWidthChar;
+
+    let mut runs: Vec<PreeditRun> = Vec::new();
+    let mut caret = None;
+    let mut line = start_line;
+    let mut col = start_col;
+    let mut consumed_utf16 = 0usize;
+
+    if preedit.caret_utf16 == 0 {
+        caret = Some((line, col));
+    }
+
+    for ch in preedit.text.chars() {
+        let cell_span = UnicodeWidthChar::width(ch).unwrap_or(1).max(1);
+        if col + cell_span as i32 > grid_cols as i32 {
+            line += 1;
+            col = 0;
+        }
+        if line >= grid_rows as i32 {
+            return (runs, caret);
+        }
+
+        match runs.last_mut() {
+            Some(run)
+                if run.line == line
+                    && run.col + (run.cells * run.cell_span) as i32 == col
+                    && run.cell_span == cell_span =>
+            {
+                run.text.push(ch);
+                run.cells += 1;
+            }
+            _ => runs.push(PreeditRun {
+                line,
+                col,
+                text: ch.to_string(),
+                cells: 1,
+                cell_span,
+            }),
+        }
+
+        col += cell_span as i32;
+        consumed_utf16 += ch.len_utf16();
+        if consumed_utf16 == preedit.caret_utf16 {
+            caret = if col >= grid_cols as i32 {
+                Some((line + 1, 0))
+            } else {
+                Some((line, col))
+            };
+        }
+    }
+
+    (runs, caret)
+}
+
+/// Draw the uncommitted composition at the cursor: tinted background, text, a
+/// 1px underline marking it as provisional, and a beam at the IME caret.
+#[allow(clippy::too_many_arguments)]
+fn paint_preedit(
+    window: &mut Window,
+    cx: &mut App,
+    preedit: &TerminalPreedit,
+    cursor: &CursorState,
+    origin: Point<Pixels>,
+    display_offset: i32,
+    grid_rows: usize,
+    grid_cols: usize,
+    cell_width: Pixels,
+    line_height: Pixels,
+    font_size: Pixels,
+    font: &Font,
+    theme: &TerminalTheme,
+) {
+    let start_col = cursor.point.column.0 as i32;
+    let start_line = cursor.point.line.0 + display_offset;
+    if start_line < 0 || start_line >= grid_rows as i32 || start_col < 0 {
+        return;
+    }
+
+    let (runs, caret) = layout_preedit(preedit, start_line, start_col, grid_rows, grid_cols);
+
+    let underline_color: Hsla = rgb(theme.cursor).into();
+    let text_color: Hsla = rgb(theme.bright_foreground).into();
+    let mut background: Hsla = rgb(theme.cursor).into();
+    background.a = 0.60;
+
+    for run in &runs {
+        let cells = run.cells * run.cell_span;
+        LayoutRect::new(run.line, run.col, cells, background).paint(
+            origin,
+            cell_width,
+            line_height,
+            window,
+        );
+        let text_origin = point(
+            origin.x + run.col as f32 * cell_width,
+            origin.y + run.line as f32 * line_height,
+        );
+        let text_runs = vec![TextRun {
+            len: run.text.len(),
+            font: font.clone(),
+            color: text_color,
+            ..Default::default()
+        }];
+        let shaped = window.text_system().shape_line(
+            run.text.clone().into(),
+            font_size,
+            &text_runs,
+            Some(cell_width * run.cell_span as f32),
+        );
+        let _ = shaped.paint(text_origin, line_height, TextAlign::Left, None, window, cx);
+        LayoutUnderline::new(run.line, run.col, cells, underline_color).paint(
+            origin,
+            cell_width,
+            line_height,
+            window,
+        );
+    }
+
+    let Some((caret_line, caret_col)) = caret else {
+        return;
+    };
+    if caret_line >= grid_rows as i32 {
+        return;
+    }
+    let beam_width = px(2.0);
+    let beam_origin = point(
+        (origin.x + caret_col as f32 * cell_width).floor(),
+        (origin.y + caret_line as f32 * line_height).floor(),
+    );
+    window.paint_quad(fill(
+        Bounds::new(
+            beam_origin,
+            gpui::Size {
+                width: beam_width,
+                height: line_height,
+            },
+        ),
+        underline_color,
+    ));
 }
 
 fn paint_cursor(

--- a/crates/zedra-terminal/src/input.rs
+++ b/crates/zedra-terminal/src/input.rs
@@ -979,6 +979,16 @@ impl InputHandler for TerminalInputHandler {
         self.clear_text_input_preflight();
         let entity = self.entity.clone();
         let _ = entity.update(cx, |term, cx| {
+            // Critical: Chinese stroke/handwriting IMEs commit with unmarkText
+            // and never send insertText, so the preedit has to be committed
+            // here or it is dropped instead of reaching the PTY.
+            if term.has_uncommitted_marked_text() {
+                let text = term.marked_text().unwrap_or_default().to_string();
+                Self::commit_marked_text(term, &text);
+                cx.notify();
+                return;
+            }
+
             // UIKit can call unmarkText between dictation hypothesis updates
             // without first calling insertDictationResultPlaceholder on custom
             // UITextInput clients. Preserve the marked range until a real
@@ -1161,6 +1171,7 @@ mod tests {
         PlatformTextInputTrait, PlatformTextInputTraits, TestAppContext, WindowHandle, point, px,
         size,
     };
+    use tokio::sync::mpsc;
 
     fn terminal_handler_for_output(
         cx: &mut TestAppContext,
@@ -1515,5 +1526,30 @@ mod tests {
                 false
             )
         );
+    }
+
+    #[test]
+    fn unmark_commits_marked_text_to_terminal() {
+        let mut cx = TestAppContext::single();
+        let (terminal, mut handler, window) = terminal_handler_for_output(&mut cx, b"", false);
+        let (input_tx, mut input_rx) = mpsc::channel(4);
+        let (_output_tx, output_rx) = mpsc::channel(4);
+        terminal.update(&mut cx, |term, cx| {
+            term.attach_channel(input_tx, output_rx, cx);
+        });
+
+        window
+            .update(&mut cx, |_, window, cx| {
+                handler.replace_and_mark_text_in_range(None, "\u{6211}", Some(1..1), window, cx);
+                handler.unmark_text(window, cx);
+            })
+            .unwrap();
+
+        let bytes = String::from_utf8(input_rx.try_recv().expect("committed bytes")).unwrap();
+        assert_eq!(bytes, "\u{6211}");
+        terminal.update(&mut cx, |term, _| {
+            assert_eq!(term.marked_text_range(), None);
+            assert!(!term.has_uncommitted_marked_text());
+        });
     }
 }

--- a/crates/zedra-terminal/src/terminal.rs
+++ b/crates/zedra-terminal/src/terminal.rs
@@ -38,6 +38,8 @@ pub enum TerminalEvent {
     /// `keyboard_accessory::sticky_modifier_mask`.
     StickyModifiersChanged(u32),
     DictationPreviewChanged(Option<String>),
+    /// The inline IME composition changed and the grid has to repaint.
+    PreeditChanged,
     ScrollbackPositionChanged {
         display_offset: usize,
         history_size: usize,
@@ -113,6 +115,16 @@ pub struct TerminalContent {
     pub grid_rows: usize,
     pub grid_cols: usize,
     pub detected_links: Vec<DetectedLink>,
+    /// Uncommitted IME composition, drawn at the cursor and never sent to the PTY.
+    pub preedit: Option<TerminalPreedit>,
+}
+
+/// IME composition still owned by the keyboard, with the caret offset (UTF-16)
+/// the IME reports inside it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerminalPreedit {
+    pub text: String,
+    pub caret_utf16: usize,
 }
 
 /// A terminal cell with its grid position
@@ -504,7 +516,33 @@ impl Terminal {
             grid_rows: self.size.rows,
             grid_cols: self.size.columns,
             detected_links,
+            preedit: self.preedit(),
         }
+    }
+
+    /// Composition to draw inline. Dictation keeps its own preview overlay, so
+    /// only an uncommitted IME composition renders here.
+    fn preedit(&self) -> Option<TerminalPreedit> {
+        if !self.has_uncommitted_marked_text() {
+            return None;
+        }
+
+        let state = self.ime_state.as_ref()?;
+        if state.dictation_active {
+            return None;
+        }
+        let marked_start = state.marked_range.as_ref().map(|range| range.start)?;
+        let marked_len = Self::utf16_len(&state.marked_text);
+        let caret_utf16 = state
+            .selected_range
+            .as_ref()
+            .map(|range| range.end.saturating_sub(marked_start).min(marked_len))
+            .unwrap_or(marked_len);
+
+        Some(TerminalPreedit {
+            text: state.marked_text.clone(),
+            caret_utf16,
+        })
     }
 
     /// Handle a keystroke, converting to escape sequence and sending via SSH or RPC session
@@ -728,6 +766,14 @@ impl Terminal {
                 display_offset: self.display_offset(),
                 history_size: self.history_size(),
             });
+    }
+
+    /// Terminal is a model entity, so its own `notify` never reaches the view.
+    /// Composition changes repaint through the event relay like PTY output does.
+    fn emit_preedit_changed_from(&self, before: Option<TerminalPreedit>) {
+        if before != self.preedit() {
+            let _ = self.event_tx.send(TerminalEvent::PreeditChanged);
+        }
     }
 
     pub fn emit_dictation_preview_changed(&self, text: Option<String>) {
@@ -1088,6 +1134,7 @@ impl Terminal {
         &mut self,
         text: &str,
     ) -> KeyboardInputContextEdit {
+        let preedit_before = self.preedit();
         let state = self.ime_state_mut();
         let committed_before = state.committed_text.clone();
         let document_len = Self::utf16_len(&state.document_text);
@@ -1114,12 +1161,14 @@ impl Terminal {
         let (backspaces, text_to_insert) =
             Self::diff_keyboard_input_context(&committed_before, &state.document_text);
         state.committed_text = state.document_text.clone();
-        KeyboardInputContextEdit {
+        let edit = KeyboardInputContextEdit {
             backspaces,
             text_to_insert,
             document_text: state.document_text.clone(),
             selection_range,
-        }
+        };
+        self.emit_preedit_changed_from(preedit_before);
+        edit
     }
 
     /// Set the marked/composing text. When dictation is active this is the live hypothesis.
@@ -1180,6 +1229,12 @@ impl Terminal {
 
     /// Clear the marked text.
     pub fn clear_marked_state(&mut self) {
+        let preedit_before = self.preedit();
+        self.clear_marked_state_without_preedit_event();
+        self.emit_preedit_changed_from(preedit_before);
+    }
+
+    fn clear_marked_state_without_preedit_event(&mut self) {
         if let Some(state) = self.ime_state.as_mut() {
             let restore_committed_text = !state.dictation_active
                 && !state.committed_dictation_pending_cleanup
@@ -1399,6 +1454,7 @@ impl Terminal {
         text: String,
         selected_range: Option<Range<usize>>,
     ) -> bool {
+        let preedit_before = self.preedit();
         let (dictation_active, preview_visible) = {
             let state = self.ime_state_mut();
             if state.dictation_active && state.document_text.is_empty() {
@@ -1436,6 +1492,7 @@ impl Terminal {
         };
 
         let _ = (dictation_active, preview_visible);
+        self.emit_preedit_changed_from(preedit_before);
         dictation_active
     }
 
@@ -1566,6 +1623,9 @@ impl Terminal {
     }
 
     pub fn cancel_dictation(&mut self) {
+        // Dictation owns the native preview, never the inline composition, so the
+        // snapshot is taken before the flag flips to keep a stray repaint event out.
+        let preedit_before = self.preedit();
         let mut should_hide_preview = false;
         if let Some(state) = self.ime_state.as_mut() {
             state.dictation_active = false;
@@ -1576,7 +1636,8 @@ impl Terminal {
             state.late_dictation_result_after_cleanup = None;
             state.committed_text.clear();
         }
-        self.clear_marked_state();
+        self.clear_marked_state_without_preedit_event();
+        self.emit_preedit_changed_from(preedit_before);
         if should_hide_preview {
             self.emit_dictation_preview_changed(None);
         }

--- a/crates/zedra/src/settings_view.rs
+++ b/crates/zedra/src/settings_view.rs
@@ -711,7 +711,7 @@ impl Render for SettingsView {
                                 "settings-key-bar-off",
                                 "settings-key-bar-toggle",
                                 "Always show keypad",
-                                "Esc, Tab, and arrows stay up when the keyboard is down",
+                                "Keypad stays up when keyboard is down",
                                 key_bar_always_visible,
                                 cx.listener(|this, _event, _window, cx| {
                                     this.set_key_bar_always_visible(true, cx);
@@ -726,7 +726,7 @@ impl Render for SettingsView {
                                 "settings-extended-keypad-off",
                                 "settings-extended-keypad-toggle",
                                 "Extended keypad",
-                                "Adds modifiers, symbols, and a swipe-left composer",
+                                "Add more modifiers, symbols",
                                 extended_keypad,
                                 cx.listener(|this, _event, _window, cx| {
                                     this.set_extended_keypad(true, cx);
@@ -734,6 +734,10 @@ impl Render for SettingsView {
                                 cx.listener(|this, _event, _window, cx| {
                                     this.set_extended_keypad(false, cx);
                                 }),
+                            ))
+                            .child(tip_row(
+                                cx,
+                                "Tip: swipe keypad left to open IME composer",
                             ))
                             .child(section_header(cx, "Privacy"))
                             .child(telemetry_toggle(
@@ -855,6 +859,16 @@ fn section_header(cx: &App, title: &'static str) -> Div {
                 .font_weight(FontWeight::MEDIUM)
                 .child(title),
         )
+}
+
+/// Muted hint under a section's controls: no control, nothing to press.
+fn tip_row(cx: &App, text: &'static str) -> Div {
+    div()
+        .py(px(6.0))
+        .text_color(rgb(theme::text_muted(cx)))
+        .text_size(px(theme::FONT_DETAIL))
+        .font_family(fonts::MONO_FONT_FAMILY)
+        .child(text)
 }
 
 /// Settings row with a compact segmented appearance control.

--- a/crates/zedra/src/ui/drawer_host.rs
+++ b/crates/zedra/src/ui/drawer_host.rs
@@ -171,7 +171,7 @@ impl DrawerHost {
     fn close_impl(&mut self, window: Option<&mut Window>, cx: &mut Context<Self>) {
         if self.is_snap_animating() {
             if self.snap_target.is_some_and(|target| target > 0.0) && !self.close_after_snap {
-                Self::hide_soft_keyboard(window);
+                Self::dismiss_terminal_keyboard(window);
                 self.close_after_snap = true;
                 cx.emit(DrawerEvent::Closed);
             }
@@ -244,7 +244,12 @@ impl DrawerHost {
         }
     }
 
-    fn hide_soft_keyboard(window: Option<&mut Window>) {
+    /// Drop the terminal's keyboard affordances as a drawer takes over the screen.
+    /// The soft keyboard and the keypad composer's own keyboard are separate native
+    /// surfaces, so hiding the former alone leaves the composer's field as first
+    /// responder with its keyboard still up.
+    fn dismiss_terminal_keyboard(window: Option<&mut Window>) {
+        crate::platform_bridge::bridge().cancel_keypad_composer();
         if let Some(window) = window {
             window.hide_soft_keyboard();
         }
@@ -376,7 +381,7 @@ impl DrawerHost {
     ) {
         window.prevent_default();
         self.focus_handle.focus(window, cx);
-        window.hide_soft_keyboard();
+        Self::dismiss_terminal_keyboard(Some(window));
         self.gesture_state = GestureState::Dragging { pointer_id };
         self.last_drag_x = position_x;
         self.last_drag_dx = 0.0;
@@ -444,7 +449,7 @@ impl DrawerHost {
             return;
         }
 
-        Self::hide_soft_keyboard(window);
+        Self::dismiss_terminal_keyboard(window);
         self.snap_from = current_offset;
         self.snap_target = Some(target);
         self.snap_started_at = Some(std::time::Instant::now());

--- a/crates/zedra/src/workspace_terminal.rs
+++ b/crates/zedra/src/workspace_terminal.rs
@@ -250,6 +250,7 @@ impl WorkspaceTerminal {
             cx.new(|cx| FilePreviewView::new(session_handle.clone(), workspace_state.clone(), cx));
         let terminal_events_sub =
             cx.subscribe(&terminal_view, |this, _terminal, event, cx| match event {
+                TerminalEvent::PreeditChanged => {}
                 TerminalEvent::RequestResize { cols, rows } => {
                     Self::resize_remote_terminal(
                         this.session_handle.clone(),

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1200,6 +1200,10 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:41:1\033\\/tmp/zedra-long-code.rs
 20. Expected: the dictated phrase remains in the input after UIKit commits, the final cleanup delete does not clear the field, and any late `insertDictationResult` does not duplicate the phrase
 21. Terminal, Chinese Simplified Stroke: switch to 简体中文 – 笔画, tap strokes, and accept candidates such as 我, 也, 很多
 22. Expected: each accepted candidate reaches the PTY once, even though the keyboard commits with `unmarkText` and never sends `insertText`; no candidate is dropped and none is inserted twice
+23. Terminal, inline composition: keep composing a stroke phrase without committing, then delete strokes and commit with a punctuation key
+24. Expected: the composition is drawn at the cursor with a tinted background and underline while the terminal cursor is replaced by a caret at the IME's insertion point; it wraps at the right edge, updates on every stroke, never reaches the PTY until commit, and leaves no residue after committing or cancelling
+25. Terminal, dictation vs composition: dictate a phrase and watch the preview
+26. Expected: dictation still uses the native preview overlay only — no inline underlined composition appears at the cursor
 
 ## 11e. Terminal Keyboard Accessory Arrow Repeat On iOS
 

--- a/docs/MANUAL_TEST.md
+++ b/docs/MANUAL_TEST.md
@@ -1198,14 +1198,16 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:41:1\033\\/tmp/zedra-long-code.rs
 18. Expected: normal input uses the same native IME protocol correctly, with marked text committed once and suggestions replacing only the requested range
 19. Commit message input, dictation: tap the microphone, dictate a short phrase, then stop dictation
 20. Expected: the dictated phrase remains in the input after UIKit commits, the final cleanup delete does not clear the field, and any late `insertDictationResult` does not duplicate the phrase
+21. Terminal, Chinese Simplified Stroke: switch to 简体中文 – 笔画, tap strokes, and accept candidates such as 我, 也, 很多
+22. Expected: each accepted candidate reaches the PTY once, even though the keyboard commits with `unmarkText` and never sends `insertText`; no candidate is dropped and none is inserted twice
 
 ## 11e. Terminal Keyboard Accessory Arrow Repeat On iOS
 
 1. Connect to a session on iPhone or iOS simulator and open the terminal view
 2. Tap each arrow button in the keyboard accessory once
-3. Expected: each tap sends exactly one corresponding arrow keystroke
+3. Expected: each tap sends exactly one corresponding arrow keystroke and fires a light haptic
 4. Press and hold each arrow button, then release it
-5. Expected: the corresponding arrow input repeats continuously while held and stops immediately on release
+5. Expected: the corresponding arrow input repeats continuously while held and stops immediately on release; haptics fire on the first repeat only, not on every repeat tick
 6. Start holding an arrow button, then dismiss the keyboard or background the app
 7. Expected: repeat stops and does not resume when the keyboard or app returns
 8. Open floating file search or the git commit message input while a terminal is visible behind it
@@ -1226,9 +1228,9 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:41:1\033\\/tmp/zedra-long-code.rs
 1. Connect to a session on iOS and on Android, turn Settings → Terminal → Always show keypad On (it ships Off), then open the terminal view without tapping the terminal
 2. Expected: the key bar sits above the home indicator or navigation bar, styled exactly like the keyboard accessory bar
 3. Tap `Esc`, `Tab`, `Enter`, and each arrow in the pinned bar
-4. Expected: each key reaches the PTY exactly once with the keyboard still down
+4. Expected: each key reaches the PTY exactly once with the keyboard still down and fires a light haptic
 5. Press and hold a pinned arrow, then release it
-6. Expected: the arrow repeats while held and stops on release
+6. Expected: the arrow repeats while held and stops on release; haptics fire on the first repeat only, not on every repeat tick
 7. Tap the terminal to raise the keyboard
 8. Expected: the pinned bar disappears as the keyboard accessory bar takes over; exactly one bar is visible at any time
 9. Dismiss the keyboard again
@@ -1267,7 +1269,18 @@ printf '\033]8;;file:///tmp/zedra-long-code.rs:41:1\033\\/tmp/zedra-long-code.rs
 13. From the terminal, tap Upload Image and pick the photo library
 14. Expected: the pinned bar hides while the photo picker is up and returns after a pick or a cancel; pasting an image from the clipboard never hides it, since it presents no UI
 
-## 11g-2. Full-Screen Presentations Pause The GPUI Window (iOS)
+## 11g-2. Composer Keyboard Yields On Focus Leave (iOS)
+
+1. Connect on iOS and open a terminal, then raise the keyboard so the accessory bar shows (Settings → Terminal → Always show keypad may be On or Off)
+2. Swipe the key bar left to the compose page, so the compose field is first responder and its keyboard is up
+3. Open the workspace drawer over the terminal
+4. Expected: the compose keyboard collapses along with the terminal keyboard — no keyboard stays over or beside the drawer
+5. Close the drawer
+6. Expected: the terminal and pinned bar (if enabled) return with the keyboard still down; re-raising the keyboard returns the normal accessory bar, not compose mode
+7. Repeat steps 2-4 from compose mode entered via the pinned bar with Always show keypad On and the keyboard down
+8. Expected: same — the drawer hides the pinned bar and drops the composer's keyboard
+
+## 11g-3. Full-Screen Presentations Pause The GPUI Window (iOS)
 
 1. Start a noisy command in a terminal (`yes`, a build, a running agent), then open the opencode web client webview over it
 2. Expected: page scrolling, dropdowns, and typing stay smooth while the command keeps producing output behind the webview — no stutter that tracks the terminal's output rate

--- a/ios/Zedra/KeyboardSupporter.swift
+++ b/ios/Zedra/KeyboardSupporter.swift
@@ -1,7 +1,8 @@
 import UIKit
 
 /// Terminal key bar. Renders either the compact single row or the extended
-/// two-row keypad, and swaps in an IME composing field on a left swipe.
+/// two-row keypad, and swaps in an IME composing field on a left swipe or a tap
+/// on the ⌨ key.
 ///
 /// Modifier state is owned by Rust (`zedra_terminal::keyboard_accessory`) because
 /// it must also apply to characters committed by the software keyboard; this view
@@ -14,7 +15,13 @@ final class KeyboardSupporter: NSObject, UITextFieldDelegate, UIGestureRecognize
         var repeats: Bool = false
         /// Set for Shift/Ctrl/Alt: the bit this key highlights from the mask.
         var modifierBit: UInt32?
+        /// Spoken name for keys whose glyph does not read as a word.
+        var accessibilityLabel: String?
     }
+
+    /// Opens the composer instead of reaching the terminal. Handled locally in
+    /// `buttonTouchUpInside`, so it is never forwarded as a key to Rust.
+    private static let composerKey = "zedra:composer"
 
     private let compactRow = [
         KeySpec(label: "Esc", key: "escape"),
@@ -24,6 +31,7 @@ final class KeyboardSupporter: NSObject, UITextFieldDelegate, UIGestureRecognize
         KeySpec(label: "↑", key: "up", repeats: true),
         KeySpec(label: "→", key: "right", repeats: true),
         KeySpec(label: "⏎", key: "enter"),
+        KeySpec(label: "⌨", key: Self.composerKey, accessibilityLabel: "Open composer"),
     ]
 
     private let extendedTopRow = [
@@ -217,6 +225,7 @@ final class KeyboardSupporter: NSObject, UITextFieldDelegate, UIGestureRecognize
             )
             button.setTitle(spec.label, for: .normal)
             button.titleLabel?.font = .systemFont(ofSize: extended ? 14.0 : 16.0)
+            button.accessibilityLabel = spec.accessibilityLabel
             button.tag = buttons.count
             specsByTag[button.tag] = spec
             button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
@@ -263,7 +272,6 @@ final class KeyboardSupporter: NSObject, UITextFieldDelegate, UIGestureRecognize
 
     @objc
     private func handlePan(_ recognizer: UIPanGestureRecognizer) {
-        guard extended else { return }
         let dx = recognizer.translation(in: recognizer.view).x
         switch recognizer.state {
         case .began:
@@ -452,9 +460,13 @@ final class KeyboardSupporter: NSObject, UITextFieldDelegate, UIGestureRecognize
 
         let repeated = repeatFired
         stopRepeating()
-        if !repeated {
-            sendKey?(spec.key)
+        guard !repeated else { return }
+
+        if spec.key == Self.composerKey {
+            setComposing(true, animated: true)
+            return
         }
+        sendKey?(spec.key)
     }
 
     private func startRepeating(_ key: String) {

--- a/ios/Zedra/KeyboardSupporter.swift
+++ b/ios/Zedra/KeyboardSupporter.swift
@@ -1,8 +1,7 @@
 import UIKit
 
 /// Terminal key bar. Renders either the compact single row or the extended
-/// two-row keypad, and swaps in an IME composing field on a left swipe or a tap
-/// on the ⌨ key.
+/// two-row keypad, and swaps in an IME composing field on a left swipe.
 ///
 /// Modifier state is owned by Rust (`zedra_terminal::keyboard_accessory`) because
 /// it must also apply to characters committed by the software keyboard; this view
@@ -15,13 +14,7 @@ final class KeyboardSupporter: NSObject, UITextFieldDelegate, UIGestureRecognize
         var repeats: Bool = false
         /// Set for Shift/Ctrl/Alt: the bit this key highlights from the mask.
         var modifierBit: UInt32?
-        /// Spoken name for keys whose glyph does not read as a word.
-        var accessibilityLabel: String?
     }
-
-    /// Opens the composer instead of reaching the terminal. Handled locally in
-    /// `buttonTouchUpInside`, so it is never forwarded as a key to Rust.
-    private static let composerKey = "zedra:composer"
 
     private let compactRow = [
         KeySpec(label: "Esc", key: "escape"),
@@ -31,7 +24,6 @@ final class KeyboardSupporter: NSObject, UITextFieldDelegate, UIGestureRecognize
         KeySpec(label: "↑", key: "up", repeats: true),
         KeySpec(label: "→", key: "right", repeats: true),
         KeySpec(label: "⏎", key: "enter"),
-        KeySpec(label: "⌨", key: Self.composerKey, accessibilityLabel: "Open composer"),
     ]
 
     private let extendedTopRow = [
@@ -225,7 +217,6 @@ final class KeyboardSupporter: NSObject, UITextFieldDelegate, UIGestureRecognize
             )
             button.setTitle(spec.label, for: .normal)
             button.titleLabel?.font = .systemFont(ofSize: extended ? 14.0 : 16.0)
-            button.accessibilityLabel = spec.accessibilityLabel
             button.tag = buttons.count
             specsByTag[button.tag] = spec
             button.addTarget(self, action: #selector(buttonTouchDown(_:)), for: .touchDown)
@@ -462,11 +453,14 @@ final class KeyboardSupporter: NSObject, UITextFieldDelegate, UIGestureRecognize
         stopRepeating()
         guard !repeated else { return }
 
-        if spec.key == Self.composerKey {
-            setComposing(true, animated: true)
-            return
-        }
+        fireKeyHaptic()
         sendKey?(spec.key)
+    }
+
+    /// Haptic for a committed key. Held keys haptic on their first repeat only,
+    /// not on every 60 ms tick, so a held arrow stays non-buzzy.
+    private func fireKeyHaptic() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
     }
 
     private func startRepeating(_ key: String) {
@@ -479,7 +473,10 @@ final class KeyboardSupporter: NSObject, UITextFieldDelegate, UIGestureRecognize
             guard let self, self.repeatingKey == key else {
                 return
             }
-            self.repeatFired = true
+            if !self.repeatFired {
+                self.repeatFired = true
+                self.fireKeyHaptic()
+            }
             self.sendKey?(key)
         }
         timer.fireDate = Date(timeIntervalSinceNow: repeatInitialDelay)


### PR DESCRIPTION
Refs #214.

### Correction to the issue

I filed #214 guessing the input surface never implemented the iOS `UITextInput`
marked-text protocol. Reading the code, that guess was wrong in an important way:
**IME input already works on iOS.** `KeyboardSupporter.buildComposeRow` creates a real
`UITextField`, so UIKit drives composition inside it natively — Stroke, Pinyin,
Handwriting included.

The real problem is that the composer cannot be found and, in the default layout, cannot
be reached at all:

- the only entry point was a left swipe on the accessory bar — no button, no hint
- `handlePan` opened with `guard extended else { return }`, so the swipe was inert unless
  the two-row keypad was already showing
- `extended` defaults to `false`

On a fresh install the bar is compact, so the gesture does nothing and the composer is
unreachable. That presents exactly as "Chinese cannot be typed", which is how I
originally reported it.

### Change

- Add a `⌨` key to `compactRow` that calls `setComposing(true, animated: true)`.
  It is dispatched locally in `buttonTouchUpInside` and returns before `sendKey`, so
  `zedra:composer` is never forwarded to Rust as a keystroke.
- Drop the `guard extended` line in `handlePan` so the swipe works in both layouts.
  `rebuildRows` always builds the compose page, so nothing else gated this.
- Carry an optional `accessibilityLabel` on `KeySpec` and apply it in `buildRow`, so the
  new key announces as "Open composer" rather than as a glyph. This mirrors the existing
  `close.accessibilityLabel = "Close composer"`.
- Update the file header comment, which still described the swipe as the only way in.

The extended rows are untouched: both are full at seven keys, and the swipe covers them.

### Testing

`swiftc -parse ios/Zedra/KeyboardSupporter.swift` passes.

**Not verified on a device or simulator.** I have no iOS SDK on this machine
(`xcrun --sdk iphoneos --show-sdk-path` fails), so I could not build the app or confirm
the behaviour by hand, and CI only covers the Rust crates — nothing here is exercised by
it. The change is small and confined to one file, but it needs a real run before merge.
Two things worth checking:

1. Tapping `⌨` on the compact bar opens the composer with the keyboard focused, and
   Chinese can be typed and sent.
2. The swipe still behaves in the extended layout, and the eighth key does not crowd the
   compact row on smaller devices such as an iPhone SE.

### Scope

This makes the existing composer usable. It does not add IME support to the terminal
surface itself — text typed straight into the terminal still bypasses composition,
because `include/gpui_ios.h` exposes only `gpui_ios_handle_text_input(void*, void*)`,
which carries committed text and has no marked-text state in the ABI. Inline composition
in the terminal would mean extending that boundary plus the GPUI iOS platform layer in
the `vendor/zed` submodule (`tanlethanh/zed@feat/gpui-mobile`), which belongs in a
separate change. Happy to open an issue there if that is the direction you want.

Reported from iPhone, iOS 18.3.1, App Store build.
