### PR TITLE
fix(host): follow redirects when resolving the latest release tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10144,7 +10144,7 @@ dependencies = [
 
 [[package]]
 name = "zedra"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "android_logger",
  "anyhow",
@@ -10203,7 +10203,7 @@ dependencies = [
 
 [[package]]
 name = "zedra-host"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10254,11 +10254,11 @@ dependencies = [
 
 [[package]]
 name = "zedra-osc"
-version = "0.4.3"
+version = "0.4.4"
 
 [[package]]
 name = "zedra-rpc"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "base64-url",
@@ -10281,7 +10281,7 @@ dependencies = [
 
 [[package]]
 name = "zedra-session"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "ed25519-dalek 2.2.0",
@@ -10303,14 +10303,14 @@ dependencies = [
 
 [[package]]
 name = "zedra-telemetry"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "zedra-terminal"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "alacritty_terminal",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["vendor"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 
 [workspace.dependencies]

--- a/crates/zedra-host/src/version_check.rs
+++ b/crates/zedra-host/src/version_check.rs
@@ -252,19 +252,11 @@ fn spawn_windows_update_helper(
 
 async fn resolve_latest_tag() -> Result<String> {
     let url = format!("https://github.com/{REPO}/releases/latest");
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .build()?;
-    let resp = client.head(&url).send().await?;
+    let resp = reqwest::Client::new().head(&url).send().await?;
 
-    // GitHub responds with 302 → Location: .../releases/tag/vX.Y.Z
-    let location = resp
-        .headers()
-        .get(reqwest::header::LOCATION)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-
-    let tag = location.rsplit('/').next().unwrap_or("");
+    // Redirects must be followed: /releases/latest lands on .../releases/tag/vX.Y.Z,
+    // and a renamed repo adds an extra 301 before that.
+    let tag = resp.url().path().rsplit('/').next().unwrap_or("");
     if tag.is_empty() || !tag.starts_with('v') {
         bail!("failed to resolve latest release tag from GitHub");
     }


### PR DESCRIPTION
## Summary

`zedra update` failed for every installed host with `failed to resolve latest release tag from GitHub`.

`resolve_latest_tag` used `redirect::Policy::none()` and read hop #1's `Location`, assuming GitHub answers `/releases/latest` with a single 302 to `/releases/tag/vX.Y.Z`. After the repository moved owners, hop #1 became the rename 301 to the new owner's `/releases/latest`, so the parsed tag was `latest` and the `starts_with('v')` guard rejected it.

Now the client follows redirects and reads the tag off the final URL, which makes any future owner or name change transparent to the updater.

## Notes

- The download path already used a redirect-following client, so `zedra update --version vX.Y.Z` kept working — only tag resolution broke.
- The repository has been moved back to `tanlethanh/zedra`, so old binaries resolve tags again without this fix; the fix is what makes a future move safe.
- Ships as `v0.4.4`, published as a pre-release so `/releases/latest` stays on `v0.4.3` until it is promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rucg8rUeVtQhjeJfAGs4Uk